### PR TITLE
Disable cache for Push events to pull-request branches

### DIFF
--- a/.github/workflows/container-build-test.yml
+++ b/.github/workflows/container-build-test.yml
@@ -135,7 +135,7 @@ jobs:
         uses: ./.github/actions/build-container
         env:
           # Disable registry cache for pull requests to avoid permission issues
-          DISABLE_REGISTRY_CACHE: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          DISABLE_REGISTRY_CACHE: ${{ (github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/pull-request/')) && 'true' || 'false' }}
         with:
           safe_ref_name: ${{ needs.prepare-environment.outputs.safe_ref_name }}
           nvcr_container_repo: ${{ needs.prepare-environment.outputs.nvcr_container_repo }}


### PR DESCRIPTION
to make copy-pr-bot happy we removed pull_request from workflows... now that it creates branches correctly, we need to change how/when we disable the cache.

## Summary

<!-- Brief description of your changes -->

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Health Monitors
- [ ] Core Services
- [ ] Fault Management
- [ ] Documentation/CI
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review
