### PR TITLE
Better fix for post merge failure of container-build-test

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -29,13 +29,18 @@ SAFE_REF_NAME := $(if $(SAFE_REF_NAME),$(SAFE_REF_NAME),local)
 BUILDX_BUILDER ?= nvsentinel-builder
 PLATFORMS ?= linux/arm64,linux/amd64
 
-# Cache configuration (can be disabled via environment variables)
-DISABLE_REGISTRY_CACHE ?= false
-CACHE_FROM_ARG := $(if $(filter true,$(DISABLE_REGISTRY_CACHE)),,--cache-from=type=registry,ref=$(NVCR_CONTAINER_REPO)/$(NGC_ORG)/nvsentinel-buildcache:$(MODULE_NAME))
-CACHE_TO_ARG := $(if $(filter true,$(DISABLE_REGISTRY_CACHE)),,--cache-to=type=registry,ref=$(NVCR_CONTAINER_REPO)/$(NGC_ORG)/nvsentinel-buildcache:$(MODULE_NAME),mode=max)
-
 # Auto-detect current module name from directory
 MODULE_NAME := $(shell basename $(CURDIR))
+
+# Cache configuration (can be disabled via environment variables)
+DISABLE_REGISTRY_CACHE ?= false
+ifeq ($(DISABLE_REGISTRY_CACHE),true)
+CACHE_FROM_ARG :=
+CACHE_TO_ARG :=
+else
+CACHE_FROM_ARG := --cache-from=type=registry,ref=$(NVCR_CONTAINER_REPO)/$(NGC_ORG)/nvsentinel-buildcache:$(MODULE_NAME)
+CACHE_TO_ARG := --cache-to=type=registry,ref=$(NVCR_CONTAINER_REPO)/$(NGC_ORG)/nvsentinel-buildcache:$(MODULE_NAME),mode=max
+endif
 
 # Repository root path calculation (works from any subdirectory depth)
 REPO_ROOT := $(shell git rev-parse --show-toplevel)

--- a/health-monitors/gpu-health-monitor/Makefile
+++ b/health-monitors/gpu-health-monitor/Makefile
@@ -42,10 +42,17 @@ LINT_EXTRA_FLAGS :=
 include ../../common.mk
 
 # Cache configuration for specialized builds (respect DISABLE_REGISTRY_CACHE)
-CACHE_FROM_ARG_DCGM3 := $(if $(filter true,$(DISABLE_REGISTRY_CACHE)),,--cache-from=type=registry,ref=$(NVCR_CONTAINER_REPO)/$(NGC_ORG)/nvsentinel-buildcache:$(MODULE_NAME)-3)
-CACHE_TO_ARG_DCGM3 := $(if $(filter true,$(DISABLE_REGISTRY_CACHE)),,--cache-to=type=registry,ref=$(NVCR_CONTAINER_REPO)/$(NGC_ORG)/nvsentinel-buildcache:$(MODULE_NAME)-3,mode=max)
-CACHE_FROM_ARG_DCGM4 := $(if $(filter true,$(DISABLE_REGISTRY_CACHE)),,--cache-from=type=registry,ref=$(NVCR_CONTAINER_REPO)/$(NGC_ORG)/nvsentinel-buildcache:$(MODULE_NAME)-4)
-CACHE_TO_ARG_DCGM4 := $(if $(filter true,$(DISABLE_REGISTRY_CACHE)),,--cache-to=type=registry,ref=$(NVCR_CONTAINER_REPO)/$(NGC_ORG)/nvsentinel-buildcache:$(MODULE_NAME)-4,mode=max)
+ifeq ($(DISABLE_REGISTRY_CACHE),true)
+CACHE_FROM_ARG_DCGM3 :=
+CACHE_TO_ARG_DCGM3 :=
+CACHE_FROM_ARG_DCGM4 :=
+CACHE_TO_ARG_DCGM4 :=
+else
+CACHE_FROM_ARG_DCGM3 := --cache-from=type=registry,ref=$(NVCR_CONTAINER_REPO)/$(NGC_ORG)/nvsentinel-buildcache:$(MODULE_NAME)-3
+CACHE_TO_ARG_DCGM3 := --cache-to=type=registry,ref=$(NVCR_CONTAINER_REPO)/$(NGC_ORG)/nvsentinel-buildcache:$(MODULE_NAME)-3,mode=max
+CACHE_FROM_ARG_DCGM4 := --cache-from=type=registry,ref=$(NVCR_CONTAINER_REPO)/$(NGC_ORG)/nvsentinel-buildcache:$(MODULE_NAME)-4
+CACHE_TO_ARG_DCGM4 := --cache-to=type=registry,ref=$(NVCR_CONTAINER_REPO)/$(NGC_ORG)/nvsentinel-buildcache:$(MODULE_NAME)-4,mode=max
+endif
 
 # =============================================================================
 # DEFAULT TARGET

--- a/node-drainer-module/Makefile
+++ b/node-drainer-module/Makefile
@@ -58,7 +58,7 @@ docker-build-with-cache: setup-buildx
 		$(DOCKER_EXTRA_ARGS) \
 		$(DOCKER_LOAD_ARG) \
 		-t $(NVCR_CONTAINER_REPO)/$(NGC_ORG)/nvsentinel-$(MODULE_NAME):$(SAFE_REF_NAME) \
-		-f $(MODULE_NAME)/Dockerfile \
+		-f $(DOCKER_MODULE_PATH)/Dockerfile \
 		.
 
 # =============================================================================

--- a/nvsentinel-log-collector/Makefile
+++ b/nvsentinel-log-collector/Makefile
@@ -13,10 +13,17 @@ DOCKER_LOAD_ARG ?= --load
 
 # Cache configuration (can be disabled via environment variables)
 DISABLE_REGISTRY_CACHE ?= false
-CACHE_FROM_ARG_LOG := $(if $(filter true,$(DISABLE_REGISTRY_CACHE)),,--cache-from=type=registry,ref=$(NVCR_CONTAINER_REPO)/$(NGC_ORG)/nvsentinel-buildcache:log-collector)
-CACHE_TO_ARG_LOG := $(if $(filter true,$(DISABLE_REGISTRY_CACHE)),,--cache-to=type=registry,ref=$(NVCR_CONTAINER_REPO)/$(NGC_ORG)/nvsentinel-buildcache:log-collector,mode=max)
-CACHE_FROM_ARG_CLEANUP := $(if $(filter true,$(DISABLE_REGISTRY_CACHE)),,--cache-from=type=registry,ref=$(NVCR_CONTAINER_REPO)/$(NGC_ORG)/nvsentinel-buildcache:file-server-cleanup)
-CACHE_TO_ARG_CLEANUP := $(if $(filter true,$(DISABLE_REGISTRY_CACHE)),,--cache-to=type=registry,ref=$(NVCR_CONTAINER_REPO)/$(NGC_ORG)/nvsentinel-buildcache:file-server-cleanup,mode=max)
+ifeq ($(DISABLE_REGISTRY_CACHE),true)
+CACHE_FROM_ARG_LOG :=
+CACHE_TO_ARG_LOG :=
+CACHE_FROM_ARG_CLEANUP :=
+CACHE_TO_ARG_CLEANUP :=
+else
+CACHE_FROM_ARG_LOG := --cache-from=type=registry,ref=$(NVCR_CONTAINER_REPO)/$(NGC_ORG)/nvsentinel-buildcache:log-collector
+CACHE_TO_ARG_LOG := --cache-to=type=registry,ref=$(NVCR_CONTAINER_REPO)/$(NGC_ORG)/nvsentinel-buildcache:log-collector,mode=max
+CACHE_FROM_ARG_CLEANUP := --cache-from=type=registry,ref=$(NVCR_CONTAINER_REPO)/$(NGC_ORG)/nvsentinel-buildcache:file-server-cleanup
+CACHE_TO_ARG_CLEANUP := --cache-to=type=registry,ref=$(NVCR_CONTAINER_REPO)/$(NGC_ORG)/nvsentinel-buildcache:file-server-cleanup,mode=max
+endif
 
 # Default target
 .PHONY: all


### PR DESCRIPTION
## Summary

We fixed a bug where Docker builds were failing with "invalid reference format" because the cache variables in the Makefiles were missing the module names - they ended up looking like
  --cache-from=type=registry,ref=ghcr.io/nvidia/nvsentinel-buildcache: with nothing after the colon. The problem was that MODULE_NAME was being defined after the cache variables, so when the cache
  references were built, the module name was empty. I moved the module name definition to the top and switched from complex $(if ...) syntax to clearer ifeq/else/endif blocks, and now all the cache
  references properly include the module names like nvsentinel-buildcache:health-events-analyzer.

Example failure:
https://github.com/NVIDIA/NVSentinel/actions/runs/18603830071/job/53048542926

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [x] 🔨 Build/CI

## Component(s) Affected
- [ ] Health Monitors
- [ ] Core Services
- [ ] Fault Management
- [ ] Documentation/CI
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
