### PR TITLE
add missing tag suffix for gpu health monitor images

### DIFF
--- a/.github/actions/publish-container/action.yml
+++ b/.github/actions/publish-container/action.yml
@@ -42,6 +42,9 @@ inputs:
   container_name: 
     description: 'Container image being pushed'
     required: true
+  tag_suffix:
+    description: 'Optional tag that has to be appended to the image tag'
+    default: ''
 
 runs:
   using: 'composite'
@@ -79,7 +82,7 @@ runs:
       run: |
         ${{ inputs.make_command }}
 
-        DIGEST="$(crane digest ${{ inputs.nvcr_container_repo }}/${{ inputs.container_org }}/${{ inputs.container_name }}:${{ inputs.safe_ref_name }})"
+        DIGEST="$(crane digest ${{ inputs.nvcr_container_repo }}/${{ inputs.container_org }}/${{ inputs.container_name }}:${{ inputs.safe_ref_name }}${{ inputs.tag_suffix }})"
         echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
         echo "name=${{ inputs.nvcr_container_repo }}/${{ inputs.container_org }}/${{ inputs.container_name }}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,9 +94,11 @@ jobs:
           - component: gpu-health-monitor-dcgm3
             make_command: 'make -C health-monitors/gpu-health-monitor docker-publish-dcgm3'
             container_name: 'nvsentinel-gpu-health-monitor'
+            tag_suffix: '-dcgm-3.x'
           - component: gpu-health-monitor-dcgm4
             make_command: 'make -C health-monitors/gpu-health-monitor docker-publish-dcgm4'
             container_name: 'nvsentinel-gpu-health-monitor'
+            tag_suffix: '-dcgm-4.x'
           - component: syslog-health-monitor
             make_command: 'make -C health-monitors/syslog-health-monitor docker-publish'
             container_name: 'nvsentinel-syslog-health-monitor'


### PR DESCRIPTION
## Summary

gpu health monitor images have tag suffixes based on the DCGM version they support, this was not included in the crane command, updated to fix that

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [X] 🔨 Build/CI

## Component(s) Affected
- [ ] Health Monitors
- [ ] Core Services
- [ ] Fault Management
- [ ] Documentation/CI
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review
