### PR TITLE
add support for using DCGM with NVML_INJECTION_MODE in tests

### DIFF
--- a/labeler-module/pkg/labeler/labeler.go
+++ b/labeler-module/pkg/labeler/labeler.go
@@ -41,8 +41,8 @@ const (
 )
 
 var (
-	dcgm4Regex = regexp.MustCompile(`.*/dcgm:4\..*`)
-	dcgm3Regex = regexp.MustCompile(`.*/dcgm:3\..*`)
+	dcgm4Regex = regexp.MustCompile(`.*dcgm:4\..*`)
+	dcgm3Regex = regexp.MustCompile(`.*dcgm:3\..*`)
 )
 
 // Labeler manages node labeling based on pod information

--- a/tilt/dcgm-fake/Dockerfile
+++ b/tilt/dcgm-fake/Dockerfile
@@ -12,24 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: nvidia-driver-daemonset
-  namespace: gpu-operator
-spec:
-  selector:
-    matchLabels:
-      app: nvidia-driver-daemonset
-  template:
-    metadata:
-      labels:
-        app: nvidia-driver-daemonset
-    spec:
-      containers:
-      - image: ubuntu:22.04
-        command: ["sleep", "infinity"]
-        name: nvidia-driver-ctr
-      tolerations:
-      - key: nvidia.com/gpu
-        operator: Exists
+FROM nvcr.io/nvidia/cloud-native/dcgm:4.2.0-1-ubuntu22.04
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update || true && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates && \
+    apt-get update && apt list -a datacenter-gpu-manager-4-dev && \
+    apt-get install -y --no-install-recommends \
+        datacenter-gpu-manager-4-dev=1:4.2.0 && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY gpu-spec.yaml /gpu-spec.yaml
+
+ENV NVML_INJECTION_MODE=True
+ENV NVML_YAML_FILE=/gpu-spec.yaml

--- a/tilt/dcgm-fake/gpu-spec.yaml
+++ b/tilt/dcgm-fake/gpu-spec.yaml
@@ -1,0 +1,138 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Global:
+  Count:
+    FunctionReturn: 0
+    ReturnValue: 1
+  
+  DeviceOrder:
+    - GPU-00000000-0000-0000-0000-000000000000
+  
+  DriverVersion:
+    FunctionReturn: 0
+    ReturnValue: '550.90.07'
+  
+  CudaDriverVersion:
+    FunctionReturn: 0
+    ReturnValue: 12040
+  
+  CudaDriverVersion_v2:
+    FunctionReturn: 0
+    ReturnValue: 12040
+  
+  NVMLVersion:
+    FunctionReturn: 0
+    ReturnValue: 12.550.90
+  
+  ExcludedDeviceCount:
+    FunctionReturn: 0
+    ReturnValue: 0
+  
+  ConfComputeState:
+    FunctionReturn: 0
+    ReturnValue:
+      ccFeature: 0
+      devMode: 0
+      environment: 0
+
+Device:
+  GPU-00000000-0000-0000-0000-000000000000:
+    Index:
+      FunctionReturn: 0
+      ReturnValue: 0
+    
+    Name:
+      FunctionReturn: 0
+      ReturnValue: 'Test GPU'
+    
+    UUID:
+      FunctionReturn: 0
+      ReturnValue: 'GPU-00000000-0000-0000-0000-000000000000'
+    
+    Serial:
+      FunctionReturn: 0
+      ReturnValue: '0000000000000'
+    
+    PciInfo:
+      FunctionReturn: 0
+      ReturnValue:
+        bus: 0
+        busId: '00000000:00:00.0'
+        busIdLegacy: '0000:00:00.0'
+        device: 0
+        domain: 0
+        pciDeviceId: 0x00000000
+        pciSubSystemId: 0x00000000
+    
+    MemoryInfo:
+      FunctionReturn: 0
+      ReturnValue:
+        free: 10737418240    # 10 GB
+        total: 17179869184   # 16 GB
+        used: 6442450944     # 6 GB
+    
+    PowerUsage:
+      FunctionReturn: 0
+      ReturnValue: 100000  # 100W
+    
+    Temperature:
+      0:  # NVML_TEMPERATURE_GPU
+        FunctionReturn: 0
+        ReturnValue: 50
+    
+    UtilizationRates:
+      FunctionReturn: 0
+      ReturnValue:
+        gpu: 30
+        memory: 20
+    
+    EccMode:
+      FunctionReturn: 0
+      ReturnValue:
+        current: 1   # Enabled
+        pending: 1   # Enabled
+    
+    PersistenceMode:
+      FunctionReturn: 0
+      ReturnValue: 1  # Enabled
+    
+    MigMode:
+      FunctionReturn: 0
+      ReturnValue:
+        currentMode: 0  # 0 = Disabled
+        pendingMode: 0
+    
+    # NVLink Fields - Mark as not supported for simple test GPU
+    # This tells the health check to skip NVLink monitoring
+    FieldValues:
+      FunctionReturn: 0
+      ReturnValue:
+        effective_ber:
+          fieldId: 220
+          scopeId: 0
+          timestamp: 0
+          latencyUsec: 0
+          valueType: 3
+          nvmlReturn: 3  # NVML_ERROR_NOT_SUPPORTED
+          value: 0
+        symbol_errors:
+          fieldId: 221
+          scopeId: 0
+          timestamp: 0
+          latencyUsec: 0
+          valueType: 3
+          nvmlReturn: 3  # NVML_ERROR_NOT_SUPPORTED
+          value: 0
+

--- a/tilt/nvidia-dcgm-daemonset.yaml
+++ b/tilt/nvidia-dcgm-daemonset.yaml
@@ -30,8 +30,7 @@ spec:
         app: nvidia-dcgm
     spec:
       containers:
-        # TODO(ladithyav): replace this with an image from nvcr/ghcr
-      - image: lalitadithya/fake-dcgm:4.2.0
+      - image: ghcr.io/nvidia/nvsentinel-fake-dcgm:4.2.0
         name: nvidia-dcgm-ctr
       tolerations:
       - key: nvidia.com/gpu

--- a/tilt/nvidia-dcgm-daemonset.yaml
+++ b/tilt/nvidia-dcgm-daemonset.yaml
@@ -30,15 +30,32 @@ spec:
         app: nvidia-dcgm
     spec:
       containers:
-      - image: nvcr.io/nvidia/cloud-native/dcgm:4.3.1-1-ubuntu22.04
+        # TODO(ladithyav): replace this with an image from nvcr/ghcr
+      - image: lalitadithya/fake-dcgm:4.2.0
         name: nvidia-dcgm-ctr
-      initContainers:
-      - image: nvcr.io/nvidia/cloud-native/gpu-operator-validator:v25.3.2
-        name: toolkit-validation
-      nodeSelector:
-        nvidia.com/gpu.deploy.dcgm: "true"
       tolerations:
-      - key: dedicated
-        operator: Exists
       - key: nvidia.com/gpu
         operator: Exists
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2025-07-18T18:39:40Z"
+  labels:
+    app: nvidia-dcgm
+  name: nvidia-dcgm
+  namespace: gpu-operator
+spec:
+  internalTrafficPolicy: Local
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: dcgm
+    port: 5555
+    protocol: TCP
+    targetPort: 5555
+  selector:
+    app: nvidia-dcgm
+  sessionAffinity: None
+  type: ClusterIP


### PR DESCRIPTION
## Summary

Dev packages of DCGM work without any GPUs and they also allow setting up fake GPUs which can be used for error injection and tests in CI. The PR only introduces the fake DCGM with a single GPU set up that passes all GPU health monitor tests. 

## Type of Change
- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [X] 🔨 Build/CI

## Component(s) Affected
- [X] Health Monitors
- [ ] Core Services
- [ ] Fault Management
- [ ] Documentation/CI
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [ ] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [ ] Documentation updated (if needed)
- [X] Ready for review
