### PR TITLE
pin version of grpcio-tools to v1.75.1

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -37,6 +37,9 @@ inputs:
   protoc-gen-go-grpc-version:
     description: 'protoc-gen-go-grpc version to install'
     required: true
+  grpcio-tools-version:
+    description: 'grpcio-tools version to install'
+    required: true
   shellcheck-version:
     description: 'shellcheck version to install'
     required: true
@@ -58,5 +61,6 @@ runs:
         protobuf-version: ${{ inputs.protobuf-version }}
         protoc-gen-go-version: ${{ inputs.protoc-gen-go-version }}
         protoc-gen-go-grpc-version: ${{ inputs.protoc-gen-go-grpc-version }}
+        grpcio-tools-version: ${{ inputs.grpcio-tools-version }}
         shellcheck-version: ${{ inputs.shellcheck-version }}
         install-dcgm: ${{ inputs.install-dcgm }}

--- a/.github/actions/setup-ci-tools/action.yml
+++ b/.github/actions/setup-ci-tools/action.yml
@@ -37,6 +37,9 @@ inputs:
   protoc-gen-go-grpc-version:
     description: 'protoc-gen-go-grpc version to install'
     required: true
+  grpcio-tools-version:
+    description: 'grpcio-tools version to install'
+    required: true
   shellcheck-version:
     description: 'shellcheck version to install'
     required: true
@@ -140,7 +143,7 @@ runs:
         fi
         go install google.golang.org/protobuf/cmd/protoc-gen-go@${{ inputs.protoc-gen-go-version }}
         go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@${{ inputs.protoc-gen-go-grpc-version }}
-        pip install grpcio==1.75.1 grpcio-tools==1.75.1
+        pip install grpcio==${{ inputs.grpcio-tools-version }} grpcio-tools==${{ inputs.grpcio-tools-version }}
 
     - name: Install DCGM (optional)
       if: inputs.install-dcgm == 'true'

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -56,6 +56,7 @@ jobs:
         protobuf-version: ${{ needs.prepare-environment.outputs.protobuf_version }}
         protoc-gen-go-version: ${{ needs.prepare-environment.outputs.protoc_gen_go_version }}
         protoc-gen-go-grpc-version: ${{ needs.prepare-environment.outputs.protoc_gen_go_grpc_version }}
+        grpcio-tools-version: ${{ needs.prepare-environment.outputs.grpcio_tools_version }}
         shellcheck-version: ${{ needs.prepare-environment.outputs.shellcheck_version }}
 
     - name: Initialize CodeQL
@@ -116,6 +117,7 @@ jobs:
         protobuf-version: ${{ needs.prepare-environment.outputs.protobuf_version }}
         protoc-gen-go-version: ${{ needs.prepare-environment.outputs.protoc_gen_go_version }}
         protoc-gen-go-grpc-version: ${{ needs.prepare-environment.outputs.protoc_gen_go_grpc_version }}
+        grpcio-tools-version: ${{ needs.prepare-environment.outputs.grpcio_tools_version }}
         shellcheck-version: ${{ needs.prepare-environment.outputs.shellcheck_version }}
 
     - name: Initialize CodeQL

--- a/.github/workflows/container-build-test.yml
+++ b/.github/workflows/container-build-test.yml
@@ -120,6 +120,7 @@ jobs:
           protobuf-version: ${{ needs.prepare-environment.outputs.protobuf_version }}
           protoc-gen-go-version: ${{ needs.prepare-environment.outputs.protoc_gen_go_version }}
           protoc-gen-go-grpc-version: ${{ needs.prepare-environment.outputs.protoc_gen_go_grpc_version }}
+          grpcio-tools-version: ${{ needs.prepare-environment.outputs.grpcio_tools_version }}
           shellcheck-version: ${{ needs.prepare-environment.outputs.shellcheck_version }}
 
       - name: Build container for ${{ matrix.component }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -87,6 +87,7 @@ jobs:
           protobuf-version: ${{ needs.prepare-environment.outputs.protobuf_version }}
           protoc-gen-go-version: ${{ needs.prepare-environment.outputs.protoc_gen_go_version }}
           protoc-gen-go-grpc-version: ${{ needs.prepare-environment.outputs.protoc_gen_go_grpc_version }}
+          grpcio-tools-version: ${{ needs.prepare-environment.outputs.grpcio_tools_version }}
           shellcheck-version: ${{ needs.prepare-environment.outputs.shellcheck_version }}
 
       - name: Set up Docker Buildx

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -81,6 +81,7 @@ jobs:
           protobuf-version: ${{ needs.prepare-environment.outputs.protobuf_version }}
           protoc-gen-go-version: ${{ needs.prepare-environment.outputs.protoc_gen_go_version }}
           protoc-gen-go-grpc-version: ${{ needs.prepare-environment.outputs.protoc_gen_go_grpc_version }}
+          grpcio-tools-version: ${{ needs.prepare-environment.outputs.grpcio_tools_version }}
           shellcheck-version: ${{ needs.prepare-environment.outputs.shellcheck_version }}
 
       - name: ${{ matrix.step_name }}
@@ -112,6 +113,7 @@ jobs:
           protobuf-version: ${{ needs.prepare-environment.outputs.protobuf_version }}
           protoc-gen-go-version: ${{ needs.prepare-environment.outputs.protoc_gen_go_version }}
           protoc-gen-go-grpc-version: ${{ needs.prepare-environment.outputs.protoc_gen_go_grpc_version }}
+          grpcio-tools-version: ${{ needs.prepare-environment.outputs.grpcio_tools_version }}
           shellcheck-version: ${{ needs.prepare-environment.outputs.shellcheck_version }}
           install-dcgm: ${{ matrix.install_dcgm || 'false' }}
 
@@ -156,6 +158,7 @@ jobs:
           protobuf-version: ${{ needs.prepare-environment.outputs.protobuf_version }}
           protoc-gen-go-version: ${{ needs.prepare-environment.outputs.protoc_gen_go_version }}
           protoc-gen-go-grpc-version: ${{ needs.prepare-environment.outputs.protoc_gen_go_grpc_version }}
+          grpcio-tools-version: ${{ needs.prepare-environment.outputs.grpcio_tools_version }}
           shellcheck-version: ${{ needs.prepare-environment.outputs.shellcheck_version }}
 
       - name: Run lint and test

--- a/.github/workflows/prepare-environment.yml
+++ b/.github/workflows/prepare-environment.yml
@@ -48,6 +48,9 @@ on:
       protoc_gen_go_grpc_version:
         description: 'protoc-gen-go-grpc version'
         value: ${{ jobs.prepare-vars.outputs.protoc_gen_go_grpc_version }}
+      grpcio_tools_version:
+        description: 'grpcio-tools version'
+        value: ${{ jobs.prepare-vars.outputs.grpcio_tools_version }}
       shellcheck_version:
         description: 'shellcheck version'
         value: ${{ jobs.prepare-vars.outputs.shellcheck_version }}
@@ -65,6 +68,7 @@ env:
   PROTOBUF_VERSION: 'v27.1'
   PROTOC_GEN_GO_VERSION: 'v1.36.6'
   PROTOC_GEN_GO_GRPC_VERSION: 'v1.3.0'
+  GRPCIO_TOOLS_VERSION: '1.75.1'
   SHELLCHECK_VERSION: 'v0.11.0'
 
 jobs:
@@ -83,6 +87,7 @@ jobs:
       protobuf_version: ${{ env.PROTOBUF_VERSION }}
       protoc_gen_go_version: ${{ env.PROTOC_GEN_GO_VERSION }}
       protoc_gen_go_grpc_version: ${{ env.PROTOC_GEN_GO_GRPC_VERSION }}
+      grpcio_tools_version: ${{ env.GRPCIO_TOOLS_VERSION }}
       shellcheck_version: ${{ env.SHELLCHECK_VERSION }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,7 @@ jobs:
           protobuf-version: ${{ needs.prepare-environment.outputs.protobuf_version }}
           protoc-gen-go-version: ${{ needs.prepare-environment.outputs.protoc_gen_go_version }}
           protoc-gen-go-grpc-version: ${{ needs.prepare-environment.outputs.protoc_gen_go_grpc_version }}
+          grpcio-tools-version: ${{ needs.prepare-environment.outputs.grpcio_tools_version }}
           shellcheck-version: ${{ needs.prepare-environment.outputs.shellcheck_version }}
 
       - name: Build image list
@@ -153,6 +154,7 @@ jobs:
           protobuf-version: ${{ needs.prepare-environment.outputs.protobuf_version }}
           protoc-gen-go-version: ${{ needs.prepare-environment.outputs.protoc_gen_go_version }}
           protoc-gen-go-grpc-version: ${{ needs.prepare-environment.outputs.protoc_gen_go_grpc_version }}
+          grpcio-tools-version: ${{ needs.prepare-environment.outputs.grpcio_tools_version }}
           shellcheck-version: ${{ needs.prepare-environment.outputs.shellcheck_version }}
 
       - name: Publish container for ${{ matrix.component }}

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ GOLANGCI_LINT_VERSION := v1.64.8
 GOTESTSUM_VERSION := latest
 GOCOVER_COBERTURA_VERSION := latest
 GO_VERSION := 1.24.8
+GRPCIO_TOOLS_VERSION := 1.75.1
 
 # Go modules with specific patterns from CI
 GO_MODULES := \


### PR DESCRIPTION
## Summary

Builds are breaking because there is newer version of grpcio-tools!

Example - https://github.com/NVIDIA/NVSentinel/actions/runs/18725881510/job/53410300162 

<!-- Brief description of your changes -->

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [x] 🔨 Build/CI

## Component(s) Affected
- [ ] Health Monitors
- [ ] Core Services
- [ ] Fault Management
- [ ] Documentation/CI
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
