### PR TITLE
feat: build/publish images using ko and attest their provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,15 +77,6 @@ jobs:
           ./build_image_list.sh
           cat versions.txt
 
-      # Temp dual image build for ko logging investigation
-      - name: Build image using ko
-        id: build-ko
-        env:
-          KO_DOCKER_REPO: ghcr.io/${{ github.repository }}  # Includes both owner and repo name
-          VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
-          GIT_COMMIT: ${{ github.sha }}
-        run: scripts/buildko
-
       - name: Upload versions.txt
         uses: actions/upload-artifact@v4
         with:
@@ -165,3 +156,57 @@ jobs:
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           container_name: ${{ matrix.container_name }}
           tag_suffix: ${{ matrix.tag_suffix }}
+
+
+  # Build images using ko and attest provenance
+  # Once validated, this will replace the container-publish job above
+  build-images:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    env:
+      KO_DOCKER_REPO: ghcr.io/${{ github.repository }}
+      VERSION: ${{ github.ref_name }}
+      GIT_COMMIT: ${{ github.sha }}
+    outputs:
+      images: ${{ steps.ko-build.outputs.images }}
+    steps:
+      - name: Install Ko
+        uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d  # v0.9
+
+      - name: Authenticate to GHCR
+        shell: bash
+        run: echo ${{ secrets.GITHUB_TOKEN }} | ko login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build Using Ko
+        id: ko-build
+        run: scripts/buildko
+
+  attest:
+    needs: build-images
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      id-token: write
+      attestations: write
+    strategy:
+      matrix:
+        image: ${{ fromJson(needs.build-images.outputs.images) }}
+    steps:
+      - name: Authenticate to GHCR
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attest build provenance
+        id: attest
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a  # v3.0.0
+        with:
+          subject-name: ${{ matrix.image.name }}
+          subject-digest: ${{ matrix.image.digest }}
+          push-to-registry: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -162,6 +162,8 @@ jobs:
   # Once validated, this will replace the container-publish job above
   build-images:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: prepare-environment
     permissions:
       contents: read
       packages: write
@@ -174,6 +176,21 @@ jobs:
     outputs:
       images: ${{ steps.ko-build.outputs.images }}
     steps:
+      - name: Checkout Code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+
+      - name: Setup build environment
+        uses: ./.github/actions/setup-build-env
+        with:
+          go-version: ${{ needs.prepare-environment.outputs.go_version }}
+          python-version: ${{ needs.prepare-environment.outputs.python_version }}
+          poetry-version: ${{ needs.prepare-environment.outputs.poetry_version }}
+          golangci-lint-version: ${{ needs.prepare-environment.outputs.golangci_lint_version }}
+          protobuf-version: ${{ needs.prepare-environment.outputs.protobuf_version }}
+          protoc-gen-go-version: ${{ needs.prepare-environment.outputs.protoc_gen_go_version }}
+          protoc-gen-go-grpc-version: ${{ needs.prepare-environment.outputs.protoc_gen_go_grpc_version }}
+          shellcheck-version: ${{ needs.prepare-environment.outputs.shellcheck_version }}
+
       - name: Install Ko
         uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d  # v0.9
 

--- a/.gitignore
+++ b/.gitignore
@@ -510,3 +510,5 @@ override.tf.json
 .terraformrc
 terraform.rc
 .DS_Store
+digests.txt
+images.json

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# .ko.yaml (repo root)
+# .ko.yaml in the root of the repository
 defaultBaseImage: cgr.dev/chainguard/static:latest
 platforms: [linux/amd64, linux/arm64]
 
@@ -38,11 +38,11 @@ builds:
     
   - id: csp-health-monitor
     dir: health-monitors/csp-health-monitor
-    main: cmd/csp-health-monitor
+    main: ./cmd/csp-health-monitor
 
   - id: maintenance-notifier
     dir: health-monitors/csp-health-monitor
-    main: cmd/maintenance-notifier
+    main: ./cmd/maintenance-notifier
 
   - id: labeler-module
     dir: labeler-module
@@ -56,3 +56,7 @@ labels:
   org.opencontainers.image.source: "https://github.com/nvidia/nvsentinel"
   org.opencontainers.image.licenses: "Apache-2.0"
   org.opencontainers.image.title: "NVSentinel"
+  org.opencontainers.image.description: "NVSentinel is an AI-powered monitoring and fault remediation solution for Kubernetes clusters."
+  org.opencontainers.image.version: "{{.Env.VERSION}}"
+  org.opencontainers.image.revision: "{{.Env.GIT_COMMIT}}"
+  org.opencontainers.image.created: "{{.Env.BUILD_DATE}}"

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -56,7 +56,7 @@ labels:
   org.opencontainers.image.source: "https://github.com/nvidia/nvsentinel"
   org.opencontainers.image.licenses: "Apache-2.0"
   org.opencontainers.image.title: "NVSentinel"
-  org.opencontainers.image.description: "NVSentinel is an AI-powered monitoring and fault remediation solution for Kubernetes clusters."
+  org.opencontainers.image.description: "Fault remediation service to help with rapidly node-level issues resolution in GPU-accelerated computing environments"
   org.opencontainers.image.version: "{{.Env.VERSION}}"
   org.opencontainers.image.revision: "{{.Env.GIT_COMMIT}}"
   org.opencontainers.image.created: "{{.Env.BUILD_DATE}}"

--- a/scripts/buildko
+++ b/scripts/buildko
@@ -14,14 +14,13 @@ if [ ! -f go.work ]; then
     ./fault-quarantine-module \
     ./fault-remediation-module \
     ./health-events-analyzer \
-    ./health-monitors/csp-health-monitor/cmd/csp-health-monitor \
-    ./health-monitors/csp-health-monitor/cmd/maintenance-notifier \
+    ./health-monitors/csp-health-monitor \
     ./labeler-module \
     ./node-drainer-module \
-    ./platform-connectors 
+    ./platform-connectors
 fi
 
-ko build -B --sbom=cyclonedx --tags="${VERSION}-slim" \
+ko build -B --image-refs=digests.txt --sbom=cyclonedx --tags="${VERSION}-slim" \
   ./fault-quarantine-module \
   ./fault-remediation-module \
   ./health-events-analyzer \
@@ -30,3 +29,20 @@ ko build -B --sbom=cyclonedx --tags="${VERSION}-slim" \
   ./labeler-module \
   ./node-drainer-module \
   ./platform-connectors 
+
+echo "built refs:"
+cat digests.txt
+
+# digests.txt has: ghcr.io/mchmarny/fault-quarantine-module:v0.1.0-slim@sha256:9168...
+# for attestation matrix we need subject-name WITHOUT tag, and the digest.
+jq -R -s '
+  split("\n")
+  | map(select(length>0))
+  | map({
+      name: (   split("@")[0] | sub(":[^@]+$"; "") ),
+      digest: ( split("@")[1] )
+    })
+' digests.txt | tee images.json
+
+# Export images.json content to GitHub Actions output
+echo "images=$(jq -c . images.json)" >> "$GITHUB_OUTPUT"

--- a/scripts/buildko
+++ b/scripts/buildko
@@ -33,7 +33,7 @@ ko build -B --image-refs=digests.txt --sbom=cyclonedx --tags="${VERSION}-slim" \
 echo "built refs:"
 cat digests.txt
 
-# digests.txt has: ghcr.io/mchmarny/fault-quarantine-module:v0.1.0-slim@sha256:9168...
+# digests.txt has: ghcr.io/nvidia/nvsentinel-fault-quarantine-module:v0.1.0-slim@sha256:9168...
 # for attestation matrix we need subject-name WITHOUT tag, and the digest.
 jq -R -s '
   split("\n")


### PR DESCRIPTION
## Summary

This addresses both #88 (declarative Go image builds with SBOM)  and #89 (SLSA provenance on published images). 

Once implemented, users will be able to navigate to https://github.com/mchmarny/NVSentinel/attestations and pick the image/version to verify. The subject digest at the bottom should match the digest of the image you are deploying.

Alternatively, users can also do attestation validation via CLI: 


```shell
export IMAGE=ghcr.io/nvidia/fault-quarantine-module:v0.1.0-slim

gh attestation verify "oci://$IMAGE" \
  --repo nvidia/nvsentinel \
  --predicate-type https://slsa.dev/provenance/v1 \
  --limit 1
```


## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [x] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Health Monitors
- [ ] Core Services
- [ ] Fault Management
- [ ] Documentation/CI
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
