### PR TITLE
fix flaky test

### DIFF
--- a/node-drainer-module/pkg/reconciler/reconciler.go
+++ b/node-drainer-module/pkg/reconciler/reconciler.go
@@ -233,15 +233,15 @@ func (r *Reconciler) executeUpdateStatus(ctx context.Context,
 	podsEvictionStatus := &healthEvent.HealthEventStatus.UserPodsEvictionStatus
 	podsEvictionStatus.Status = storeconnector.StatusSucceeded
 
-	err := r.updateNodeUserPodsEvictedStatus(ctx, collection, event, podsEvictionStatus)
-	if err != nil {
-		return err
-	}
-
 	if _, err := r.Config.StateManager.UpdateNVSentinelStateNodeLabel(ctx,
 		nodeName, statemanager.DrainSucceededLabelValue, false); err != nil {
 		klog.Errorf("Failed to update node label to drain-succeeded for %s: %v", nodeName, err)
 		metrics.TotalEventProcessingError.WithLabelValues("label_update_error").Inc()
+	}
+
+	err := r.updateNodeUserPodsEvictedStatus(ctx, collection, event, podsEvictionStatus)
+	if err != nil {
+		return fmt.Errorf("failed to update user pod eviction status: %w", err)
 	}
 
 	metrics.NodeDrainStatus.WithLabelValues(nodeName).Set(0)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -16,9 +16,6 @@ test-ci:
 	kubectl get po -Ao wide
 	kubectl get no -o wide
 	$(MAKE) test
-	kubectl logs -l app.kubernetes.io/name=fault-remediation -n nvsentinel
-	kubectl logs -l app.kubernetes.io/name=node-drainer -n nvsentinel
-	kubectl logs -l app.kubernetes.io/name=fault-quarantine -n nvsentinel
 
 # Run end-to-end tests
 .PHONY: test

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -16,6 +16,9 @@ test-ci:
 	kubectl get po -Ao wide
 	kubectl get no -o wide
 	$(MAKE) test
+	kubectl logs -l app.kubernetes.io/name=fault-remediation -n nvsentinel
+	kubectl logs -l app.kubernetes.io/name=node-drainer -n nvsentinel
+	kubectl logs -l app.kubernetes.io/name=fault-quarantine -n nvsentinel
 
 # Run end-to-end tests
 .PHONY: test


### PR DESCRIPTION
## Summary

State labels should always be updated before updating mongodb to prevent the "previous" module from undoing label changes 

## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Health Monitors
- [X] Core Services
- [ ] Fault Management
- [ ] Documentation/CI
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [ ] Documentation updated (if needed)
- [X] Ready for review
