### PR TITLE
fix more test flakes

### DIFF
--- a/dev/Makefile
+++ b/dev/Makefile
@@ -37,17 +37,17 @@ tilt-ci:
 	@echo "Waiting for all deployments to be ready..."
 	@kubectl get deployments --all-namespaces --no-headers -o custom-columns=":metadata.namespace,:metadata.name" | while read ns name; do \
 		echo "Waiting for deployment $$name in namespace $$ns..."; \
-		kubectl rollout status deployment/$$name -n $$ns --timeout=300s; \
+		kubectl rollout status deployment/$$name -n $$ns --timeout=300s || exit 1; \
 	done
 	@echo "Waiting for all daemonsets to be ready..."
 	@kubectl get daemonsets --all-namespaces --no-headers -o custom-columns=":metadata.namespace,:metadata.name" | while read ns name; do \
 		echo "Waiting for daemonset $$name in namespace $$ns..."; \
-		kubectl rollout status daemonset/$$name -n $$ns --timeout=300s; \
+		kubectl rollout status daemonset/$$name -n $$ns --timeout=300s || exit 1; \
 	done
 	@echo "Waiting for all statefulsets to be ready..."
 	@kubectl get statefulsets --all-namespaces --no-headers -o custom-columns=":metadata.namespace,:metadata.name" | while read ns name; do \
 		echo "Waiting for statefulset $$name in namespace $$ns..."; \
-		kubectl rollout status statefulset/$$name -n $$ns --timeout=300s; \
+		kubectl rollout status statefulset/$$name -n $$ns --timeout=300s || exit 1; \
 	done
 	@echo "All workloads are ready!"
 

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -34,6 +34,22 @@ tilt-ci:
 		exit 1; \
 	fi
 	cd .. && tilt ci
+	@echo "Waiting for all deployments to be ready..."
+	@kubectl get deployments --all-namespaces --no-headers -o custom-columns=":metadata.namespace,:metadata.name" | while read ns name; do \
+		echo "Waiting for deployment $$name in namespace $$ns..."; \
+		kubectl rollout status deployment/$$name -n $$ns --timeout=300s; \
+	done
+	@echo "Waiting for all daemonsets to be ready..."
+	@kubectl get daemonsets --all-namespaces --no-headers -o custom-columns=":metadata.namespace,:metadata.name" | while read ns name; do \
+		echo "Waiting for daemonset $$name in namespace $$ns..."; \
+		kubectl rollout status daemonset/$$name -n $$ns --timeout=300s; \
+	done
+	@echo "Waiting for all statefulsets to be ready..."
+	@kubectl get statefulsets --all-namespaces --no-headers -o custom-columns=":metadata.namespace,:metadata.name" | while read ns name; do \
+		echo "Waiting for statefulset $$name in namespace $$ns..."; \
+		kubectl rollout status statefulset/$$name -n $$ns --timeout=300s; \
+	done
+	@echo "All workloads are ready!"
 
 # ctlptl cluster configuration
 .PHONY: cluster-create
@@ -60,6 +76,8 @@ cluster-create:
 		exit 1; \
 	fi
 	ctlptl apply -f $(CTLPTL_CONFIG_FILE)
+	@echo "Waiting for all nodes to be ready..."
+	@kubectl wait --for=condition=ready nodes --all --timeout=300s
 	@echo "Cluster created successfully!"
 	@echo "Registry available at localhost:$(REGISTRY_PORT)"
 

--- a/health-monitors/syslog-health-monitor/Dockerfile
+++ b/health-monitors/syslog-health-monitor/Dockerfile
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 ARG CUDA_VERSION="12.1.1-base-ubuntu22.04"
+ARG BUILD_TAGS="systemd"
+
 FROM public.ecr.aws/docker/library/golang:1.24-bullseye AS builder
 
 WORKDIR /go/src/nvsentinel
@@ -38,7 +40,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && rm -rf /var/lib/apt/lists/*
 
 RUN cd health-monitors/syslog-health-monitor && \
-    CGO_ENABLED=1 go build -tags "systemd" -ldflags="-s -w" -o syslog-health-monitor main.go
+    CGO_ENABLED=1 go build -tags "${BUILD_TAGS}" -ldflags="-s -w" -o syslog-health-monitor main.go
 
 FROM nvcr.io/nvidia/cuda:${CUDA_VERSION} AS runtime
 

--- a/health-monitors/syslog-health-monitor/Tiltfile
+++ b/health-monitors/syslog-health-monitor/Tiltfile
@@ -15,5 +15,6 @@
 docker_build(
     "ghcr.io/nvidia/nvsentinel-syslog-health-monitor",
     context="../..",
-    dockerfile="./Dockerfile"
+    dockerfile="./Dockerfile",
+    build_args={"BUILD_TAGS": ""}
 )


### PR DESCRIPTION
## Summary

Fix a few more test flakes:
* Sometimes it takes time for the kind cluster nodes to be in a ready state and in such cases if tilt starts to deploy applications before the nodes are ready some applications do not go to a ready state before the timeout is reached
* Tilt doesn't realisably wait for all replicas to be ready, in some cases one or more replicas of mongodb are not rolled out before the tests started to run
* The syslog health monitor was spewing error logs as journal isn't available in kind, we should make use of the journal stub in kind.

## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [X] Health Monitors
- [ ] Core Services
- [ ] Fault Management
- [ ] Documentation/CI
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [ ] Documentation updated (if needed)
- [X] Ready for review
