### PR TITLE
Add missing param for grpcio tools

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -191,6 +191,7 @@ jobs:
           protobuf-version: ${{ needs.prepare-environment.outputs.protobuf_version }}
           protoc-gen-go-version: ${{ needs.prepare-environment.outputs.protoc_gen_go_version }}
           protoc-gen-go-grpc-version: ${{ needs.prepare-environment.outputs.protoc_gen_go_grpc_version }}
+          grpcio-tools-version: ${{ needs.prepare-environment.outputs.grpcio_tools_version }}
           shellcheck-version: ${{ needs.prepare-environment.outputs.shellcheck_version }}
 
       # ko is already installed in the setup-ci-tools action


### PR DESCRIPTION
## Summary

Whoops! sorry @lalitadithya 

fix for https://github.com/NVIDIA/NVSentinel/actions/runs/18748936135/job/53483112596#step:3:567

```
ERROR: Invalid requirement: 'grpcio==': Expected end or semicolon (after name and no valid version specifier)
    grpcio==
          ^
Error: Process completed with exit code 1
```

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [x] 🔨 Build/CI

## Component(s) Affected
- [ ] Health Monitors
- [ ] Core Services
- [ ] Fault Management
- [ ] Documentation/CI
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review
