### PR TITLE
Correct coverage package scope in common.mk

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -277,6 +277,7 @@ jobs:
           output_dir: .github/outputs
 
       - name: Generate Coverage Report with Fixed PR Number
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           set -e  # Exit on error
 

--- a/make/go.mk
+++ b/make/go.mk
@@ -17,7 +17,7 @@ lint-test: ## Lint and test Go module (vet + golangci-lint + gotestsum)
 	$(TEST_SETUP_COMMANDS) \
 	$(GO) vet ./... && \
 	$(GOLANGCI_LINT) run --config $(GOLANGCI_CONFIG_PATH) $(LINT_EXTRA_FLAGS) && \
-	$(GOTESTSUM) --junitfile report.xml -- -race $(TEST_EXTRA_FLAGS) ./... -coverprofile=coverage.txt -covermode atomic -coverpkg=./... && \
+	$(GOTESTSUM) --junitfile report.xml -- -race $(TEST_EXTRA_FLAGS) ./... -coverprofile=coverage.txt -covermode atomic -coverpkg=github.com/nvidia/nvsentinel/$(MODULE_NAME)/... && \
 	$(GO) tool cover -func coverage.txt && \
 	$(GOCOVER_COBERTURA) < coverage.txt > coverage.xml
 
@@ -40,7 +40,7 @@ lint: ## Run golangci-lint
 test: ## Run tests with coverage
 	@echo "Running tests on $(MODULE_NAME)..."
 	$(TEST_SETUP_COMMANDS) \
-	$(GOTESTSUM) --junitfile report.xml -- -race $(TEST_EXTRA_FLAGS) ./... -coverprofile=coverage.txt -covermode atomic -coverpkg=./...
+	$(GOTESTSUM) --junitfile report.xml -- -race $(TEST_EXTRA_FLAGS) ./... -coverprofile=coverage.txt -covermode atomic -coverpkg=github.com/nvidia/nvsentinel/$(MODULE_NAME)/...
 
 .PHONY: coverage
 coverage: test ## Generate coverage reports


### PR DESCRIPTION
## Summary

Replace relative package paths with fully-qualified module paths in coverage collection to ensure Go's coverage tool tracks the actual tested code instead of only relative packages.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [x] 🔨 Build/CI

## Component(s) Affected
- [ ] Health Monitors
- [ ] Core Services
- [ ] Fault Management
- [ ] Documentation/CI
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
