### PR TITLE
fix: error out when change stream returns an error

### DIFF
--- a/store-client-sdk/pkg/storewatcher/watchStore.go
+++ b/store-client-sdk/pkg/storewatcher/watchStore.go
@@ -295,7 +295,7 @@ func (w *ChangeStreamWatcher) Start(ctx context.Context) {
 			default:
 				w.mu.Lock()
 				hasNext := w.changeStream.Next(ctx)
-				cErr := w.changeStream.Err()
+				csErr := w.changeStream.Err()
 				w.mu.Unlock()
 
 				if hasNext {
@@ -310,8 +310,8 @@ func (w *ChangeStreamWatcher) Start(ctx context.Context) {
 						continue
 					}
 					w.eventChannel <- event
-				} else if cErr != nil {
-					klog.Fatalf("failed to watch change stream: %v", w.changeStream.Err())
+				} else if csErr != nil {
+					klog.Fatalf("failed to watch change stream: %v", csErr)
 				}
 			}
 		}

--- a/store-client-sdk/pkg/storewatcher/watchStore.go
+++ b/store-client-sdk/pkg/storewatcher/watchStore.go
@@ -309,10 +309,8 @@ func (w *ChangeStreamWatcher) Start(ctx context.Context) {
 						continue
 					}
 					w.eventChannel <- event
-				} else {
-					if w.changeStream.Err() != nil {
-						klog.Fatalf("failed to watch change stream: %v", w.changeStream.Err())
-					}
+				} else if w.changeStream.Err() != nil {
+					klog.Fatalf("failed to watch change stream: %v", w.changeStream.Err())
 				}
 			}
 		}

--- a/store-client-sdk/pkg/storewatcher/watchStore.go
+++ b/store-client-sdk/pkg/storewatcher/watchStore.go
@@ -309,6 +309,10 @@ func (w *ChangeStreamWatcher) Start(ctx context.Context) {
 						continue
 					}
 					w.eventChannel <- event
+				} else {
+					if w.changeStream.Err() != nil {
+						klog.Fatalf("failed to watch change stream: %v", w.changeStream.Err())
+					}
 				}
 			}
 		}

--- a/store-client-sdk/pkg/storewatcher/watchStore.go
+++ b/store-client-sdk/pkg/storewatcher/watchStore.go
@@ -295,6 +295,7 @@ func (w *ChangeStreamWatcher) Start(ctx context.Context) {
 			default:
 				w.mu.Lock()
 				hasNext := w.changeStream.Next(ctx)
+				cErr := w.changeStream.Err()
 				w.mu.Unlock()
 
 				if hasNext {
@@ -309,7 +310,7 @@ func (w *ChangeStreamWatcher) Start(ctx context.Context) {
 						continue
 					}
 					w.eventChannel <- event
-				} else if w.changeStream.Err() != nil {
+				} else if cErr != nil {
 					klog.Fatalf("failed to watch change stream: %v", w.changeStream.Err())
 				}
 			}


### PR DESCRIPTION
## Summary

A busy wait loop can be caused if the mongodb change stream returns false continuously due to an error. This PR introduces error checking for the change stream errors and forces a fatal error to prevent a busy wait loop

## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Health Monitors
- [ ] Core Services
- [X] Fault Management
- [ ] Documentation/CI
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [ ] Documentation updated (if needed)
- [X] Ready for review
