### PR TITLE
fix: add cache and fix go mod

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -112,7 +112,6 @@ jobs:
 
       - name: Configure ctlptl registry authentication
         run: |
-          chmod +x scripts/configure-ctlptl-registry.sh
           ./scripts/configure-ctlptl-registry.sh
 
       - name: Compute ref name with short SHA

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -248,6 +248,10 @@ jobs:
       - name: Install E2E testing tools
         uses: ./.github/actions/install-e2e-tools
 
+      - name: Configure ctlptl registry authentication
+        run: |
+          ./scripts/configure-ctlptl-registry.sh
+
       - name: Compute ref name with short SHA
         id: ref-name
         run: |
@@ -284,6 +288,7 @@ jobs:
       - name: Create Kind cluster using make
         env:
           CLUSTER_NAME: ${{ env.CLUSTER_NAME }}
+          CTLPTL_YAML: ctlptl-config.yaml
         run: |
           make cluster-create
 

--- a/commons/Makefile
+++ b/commons/Makefile
@@ -19,7 +19,7 @@
 # MODULE-SPECIFIC CONFIGURATION
 # =============================================================================
 
-# Logger-sdk specific settings (library module - no Docker or binary)
+# commons specific settings (library module - no Docker or binary)
 IS_GO_MODULE := 1
 HAS_DOCKER := 0
 

--- a/commons/go.mod
+++ b/commons/go.mod
@@ -1,4 +1,4 @@
-module github.com/nvidia/nvsentinel/logger-sdk
+module github.com/nvidia/nvsentinel/commons
 
 go 1.25
 


### PR DESCRIPTION
## Summary

the docker rate limit was causing e2e to fail, make use of the same mirror as the rest of the jobs and fix use of an incorrect name

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Health Monitors
- [x] Core Services
- [ ] Fault Management
- [ ] Documentation/CI
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
