### PR TITLE
[Feature]: Handle GPU falling even when there is no XID

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/templates/configmap.yaml
@@ -35,3 +35,10 @@ data:
       - name: "SysLogsSXIDError"
         journalPath: "/nvsentinel/var/log/journal/"
       {{- end }}
+
+      - name: "SysLogsGPUFallenOff"
+      {{- if .Values.global.kata.enabled }}
+        tags:
+          - "-u containerd.service"
+        {{- end }}
+        journalPath: "/nvsentinel/var/log/journal/"

--- a/health-monitors/syslog-health-monitor/pkg/common/common.go
+++ b/health-monitors/syslog-health-monitor/pkg/common/common.go
@@ -18,26 +18,20 @@ import (
 	_ "embed"
 	"fmt"
 	"log/slog"
-	"regexp"
 	"slices"
 	"strconv"
 	"strings"
 
 	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
+	"github.com/nvidia/nvsentinel/health-monitors/syslog-health-monitor/pkg/patterns"
 	"github.com/nvidia/nvsentinel/health-monitors/syslog-health-monitor/pkg/types"
 
 	"github.com/thedatashed/xlsxreader"
 )
 
-var (
-	// XIDPattern matches NVIDIA XID error messages in the format:
-	// "NVRM: Xid (PCI:0000:b3:00.0): 79, pid=1234, name=process, Ch 00000001"
-	// This pattern is used for detecting and filtering XID-related messages.
-	// Reuses the same pattern as the XID parser to ensure consistency.
-	XIDPattern = regexp.MustCompile(
-		`NVRM: Xid \(PCI:([0-9a-fA-F:.]+)\): (\d+)(?:, pid=(\d+))?(?:, name=([^,]+))?(?:, Ch ([0-9a-fA-F]+))?`,
-	)
-)
+// XIDPattern is the canonical pattern for detecting XID errors.
+// Re-exported from the patterns package for convenience.
+var XIDPattern = patterns.XIDPattern
 
 // NVIDIA XID Error Catalog - Embedded Excel File
 //

--- a/health-monitors/syslog-health-monitor/pkg/common/common.go
+++ b/health-monitors/syslog-health-monitor/pkg/common/common.go
@@ -18,6 +18,7 @@ import (
 	_ "embed"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -26,6 +27,13 @@ import (
 	"github.com/nvidia/nvsentinel/health-monitors/syslog-health-monitor/pkg/types"
 
 	"github.com/thedatashed/xlsxreader"
+)
+
+var (
+	// XIDPattern is a simple pattern to detect the presence of "Xid" in log messages.
+	// This is useful for filtering out XID-related messages that should be handled
+	// by the XID handler instead of other error handlers.
+	XIDPattern = regexp.MustCompile(`\bXid\b`)
 )
 
 // NVIDIA XID Error Catalog - Embedded Excel File

--- a/health-monitors/syslog-health-monitor/pkg/common/common.go
+++ b/health-monitors/syslog-health-monitor/pkg/common/common.go
@@ -30,10 +30,13 @@ import (
 )
 
 var (
-	// XIDPattern is a simple pattern to detect the presence of "Xid" in log messages.
-	// This is useful for filtering out XID-related messages that should be handled
-	// by the XID handler instead of other error handlers.
-	XIDPattern = regexp.MustCompile(`\bXid\b`)
+	// XIDPattern matches NVIDIA XID error messages in the format:
+	// "NVRM: Xid (PCI:0000:b3:00.0): 79, pid=1234, name=process, Ch 00000001"
+	// This pattern is used for detecting and filtering XID-related messages.
+	// Reuses the same pattern as the XID parser to ensure consistency.
+	XIDPattern = regexp.MustCompile(
+		`NVRM: Xid \(PCI:([0-9a-fA-F:.]+)\): (\d+)(?:, pid=(\d+))?(?:, name=([^,]+))?(?:, Ch ([0-9a-fA-F]+))?`,
+	)
 )
 
 // NVIDIA XID Error Catalog - Embedded Excel File

--- a/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler.go
+++ b/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler.go
@@ -15,6 +15,7 @@
 package gpufallen
 
 import (
+	"fmt"
 	"time"
 
 	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
@@ -31,11 +32,16 @@ func NewGPUFallenHandler(nodeName, defaultAgentName,
 		defaultAgentName:      defaultAgentName,
 		defaultComponentClass: defaultComponentClass,
 		checkName:             checkName,
+		recentXIDs:            make(map[string]xidRecord),
+		xidWindow:             5 * time.Minute, // Remember XIDs for 5 minutes
 	}, nil
 }
 
 // ProcessLine processes a single syslog line and returns any generated health events.
 func (h *GPUFallenHandler) ProcessLine(message string) (*pb.HealthEvents, error) {
+	// First check if this is an XID message and track it
+	h.trackXIDIfPresent(message)
+
 	// Check if this is a GPU falling off error
 	event := h.parseGPUFallenError(message)
 	if event == nil {
@@ -45,8 +51,45 @@ func (h *GPUFallenHandler) ProcessLine(message string) (*pb.HealthEvents, error)
 	return h.createHealthEventFromError(event), nil
 }
 
+// trackXIDIfPresent checks if the message contains an XID error and records it
+func (h *GPUFallenHandler) trackXIDIfPresent(message string) {
+	matches := common.XIDPattern.FindStringSubmatch(message)
+	if len(matches) < 3 {
+		return // Not an XID message
+	}
+
+	pciAddr := matches[1]
+	xidCode := 0
+	// Parse XID code (matches[2])
+	if _, err := fmt.Sscanf(matches[2], "%d", &xidCode); err != nil {
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.recentXIDs[pciAddr] = xidRecord{
+		timestamp: time.Now(),
+		xidCode:   xidCode,
+	}
+}
+
+// hasRecentXID checks if a PCI address has had an XID error within the time window
+func (h *GPUFallenHandler) hasRecentXID(pciAddr string) bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	record, exists := h.recentXIDs[pciAddr]
+	if !exists {
+		return false
+	}
+
+	// Check if the XID is still within the time window
+	return time.Since(record.timestamp) < h.xidWindow
+}
+
 func (h *GPUFallenHandler) parseGPUFallenError(message string) *gpuFallenErrorEvent {
-	// First check if this message contains "Xid"
+	// First check if this message itself contains "Xid" in same message
 	// If it has XID error it should be handled by XID handler
 	if common.XIDPattern.MatchString(message) {
 		return nil
@@ -58,6 +101,12 @@ func (h *GPUFallenHandler) parseGPUFallenError(message string) *gpuFallenErrorEv
 	}
 
 	pciAddr := m[1]
+
+	// Check if this PCI address has had a recent XID error
+	// If so, skip generating an event to avoid duplicates with XID handler
+	if h.hasRecentXID(pciAddr) {
+		return nil
+	}
 
 	// Try to extract PCI ID if present in the message
 	pciID := ""

--- a/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler.go
+++ b/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler.go
@@ -15,6 +15,7 @@
 package gpufallen
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"time"
@@ -28,6 +29,8 @@ import (
 // NewGPUFallenHandler creates a new GPUFallenHandler instance.
 func NewGPUFallenHandler(nodeName, defaultAgentName,
 	defaultComponentClass, checkName string) (*GPUFallenHandler, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+
 	h := &GPUFallenHandler{
 		nodeName:              nodeName,
 		defaultAgentName:      defaultAgentName,
@@ -35,12 +38,21 @@ func NewGPUFallenHandler(nodeName, defaultAgentName,
 		checkName:             checkName,
 		recentXIDs:            make(map[string]xidRecord),
 		xidWindow:             5 * time.Minute, // Remember XIDs for 5 minutes
+		cancelCleanup:         cancel,
 	}
 
 	// Start background cleanup goroutine to prevent unbounded memory growth
-	go h.cleanupExpiredXIDs()
+	go h.cleanupExpiredXIDs(ctx)
 
 	return h, nil
+}
+
+// Close stops the background cleanup goroutine and releases resources.
+// Should be called when the handler is no longer needed (e.g., in tests or shutdown).
+func (h *GPUFallenHandler) Close() {
+	if h.cancelCleanup != nil {
+		h.cancelCleanup()
+	}
 }
 
 // SetXIDWindow sets the time window for tracking XID errors.
@@ -120,24 +132,36 @@ func (h *GPUFallenHandler) hasRecentXID(pciAddr string) bool {
 	return isRecent
 }
 
-// cleanupExpiredXIDs runs periodically to remove expired XID entries
-// This prevents unbounded memory growth from XIDs on GPUs that never experience fallen-off errors
-func (h *GPUFallenHandler) cleanupExpiredXIDs() {
-	// Start with initial cleanup interval, but check dynamically for changes
-	ticker := time.NewTicker(1 * time.Minute) // Check every minute for production use
+// cleanupExpiredXIDs runs periodically to remove expired XID entries.
+// This prevents unbounded memory growth from XIDs on GPUs that never experience fallen-off errors.
+// The goroutine stops when the context is cancelled (via Close method).
+func (h *GPUFallenHandler) cleanupExpiredXIDs(ctx context.Context) {
+	// Calculate cleanup interval proportional to xidWindow (xidWindow / 5)
+	// This ensures tests with short windows don't wait too long for cleanup
+	h.mu.RLock()
+	cleanupInterval := h.xidWindow / 5
+	h.mu.RUnlock()
+
+	ticker := time.NewTicker(cleanupInterval)
 	defer ticker.Stop()
 
-	for range ticker.C {
-		h.mu.Lock()
-		now := time.Now()
-		window := h.xidWindow // Read current window value
+	for {
+		select {
+		case <-ctx.Done():
+			// Context cancelled, stop cleanup goroutine
+			return
+		case <-ticker.C:
+			h.mu.Lock()
+			now := time.Now()
+			window := h.xidWindow // Read current window value
 
-		for pciAddr, record := range h.recentXIDs {
-			if now.Sub(record.timestamp) >= window {
-				delete(h.recentXIDs, pciAddr)
+			for pciAddr, record := range h.recentXIDs {
+				if now.Sub(record.timestamp) >= window {
+					delete(h.recentXIDs, pciAddr)
+				}
 			}
+			h.mu.Unlock()
 		}
-		h.mu.Unlock()
 	}
 }
 

--- a/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler.go
+++ b/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler.go
@@ -1,0 +1,159 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gpufallen
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// NewGPUFallenHandler creates a new GPUFallenHandler instance.
+func NewGPUFallenHandler(nodeName, defaultAgentName,
+	defaultComponentClass, checkName string) (*GPUFallenHandler, error) {
+	return &GPUFallenHandler{
+		nodeName:              nodeName,
+		defaultAgentName:      defaultAgentName,
+		defaultComponentClass: defaultComponentClass,
+		checkName:             checkName,
+		pciToGPUUUID:          make(map[string]string),
+	}, nil
+}
+
+// ProcessLine processes a single syslog line and returns any generated health events.
+func (h *GPUFallenHandler) ProcessLine(message string) (*pb.HealthEvents, error) {
+	// First, check if this is a GPU UUID mapping line
+	if pciID, gpuUUID := h.parseNVRMGPUMapLine(message); pciID != "" && gpuUUID != "" {
+		normPCI := h.normalizePCI(pciID)
+		h.pciToGPUUUID[normPCI] = gpuUUID
+
+		slog.Info("Updated PCI->GPU UUID mapping", "pci", normPCI, "uuid", gpuUUID)
+
+		return nil, nil
+	}
+
+	// Check if this is a GPU falling off error
+	event := h.parseGPUFallenError(message)
+	if event == nil {
+		return nil, nil
+	}
+
+	return h.createHealthEventFromError(event), nil
+}
+
+func (h *GPUFallenHandler) parseNVRMGPUMapLine(message string) (string, string) {
+	m := reNvrmMap.FindStringSubmatch(message)
+	if len(m) >= 3 {
+		return m[1], m[2]
+	}
+
+	return "", ""
+}
+
+func (h *GPUFallenHandler) normalizePCI(pci string) string {
+	if idx := strings.Index(pci, "."); idx != -1 {
+		return pci[:idx]
+	}
+
+	return pci
+}
+
+func (h *GPUFallenHandler) parseGPUFallenError(message string) *gpuFallenErrorEvent {
+	// First check if this message contains "Xid"
+	// If has DIX error it should be handled by XID handler
+	if reXIDPattern.MatchString(message) {
+		return nil
+	}
+
+	m := reGPUFallenPattern.FindStringSubmatch(message)
+	if len(m) < 2 {
+		return nil
+	}
+
+	pciAddr := m[1]
+
+	// Try to extract PCI ID if present in the message
+	pciID := ""
+	pciIDMatch := rePCIIDPattern.FindStringSubmatch(message)
+	if len(pciIDMatch) >= 2 {
+		pciID = pciIDMatch[1]
+	}
+
+	return &gpuFallenErrorEvent{
+		pciAddr: pciAddr,
+		pciID:   pciID,
+		message: message,
+	}
+}
+
+func (h *GPUFallenHandler) createHealthEventFromError(event *gpuFallenErrorEvent) *pb.HealthEvents {
+	entitiesImpacted := []*pb.Entity{
+		{EntityType: "PCI", EntityValue: event.pciAddr},
+	}
+
+	// If PCI ID is there, add it as well
+	if event.pciID != "" {
+		entitiesImpacted = append(entitiesImpacted, &pb.Entity{
+			EntityType: "PCI_ID", EntityValue: event.pciID,
+		})
+	}
+
+	// Look up GPU UUID from PCI address
+	normPCI := h.normalizePCI(event.pciAddr)
+	if uuid, ok := h.pciToGPUUUID[normPCI]; ok && uuid != "" {
+		entitiesImpacted = append(entitiesImpacted, &pb.Entity{
+			EntityType: "GPU", EntityValue: uuid,
+		})
+	}
+
+	// Increment metrics
+	gpuFallenCounterMetric.WithLabelValues(h.nodeName, event.pciAddr).Inc()
+
+	healthEvent := &pb.HealthEvent{
+		Version:            1,
+		Agent:              h.defaultAgentName,
+		CheckName:          h.checkName,
+		ComponentClass:     h.defaultComponentClass,
+		GeneratedTimestamp: timestamppb.New(time.Now()),
+		EntitiesImpacted:   entitiesImpacted,
+		Message: fmt.Sprintf(
+			"GPU has fallen off the bus and is not responding to commands. PCI: %s",
+			event.pciAddr,
+		),
+		IsFatal:           true, // GPU falling off the bus is always fatal
+		IsHealthy:         false,
+		NodeName:          h.nodeName,
+		RecommendedAction: pb.RecommendedAction_RESTART_BM,
+		ErrorCode:         []string{"GPU_FALLEN_OFF_BUS"},
+		Metadata: map[string]string{
+			"JOURNAL_MESSAGE": event.message,
+			"PCI_ADDRESS":     event.pciAddr,
+		},
+	}
+
+	if event.pciID != "" {
+		healthEvent.Metadata["PCI_ID"] = event.pciID
+	}
+
+	return &pb.HealthEvents{
+		Version: 1,
+		Events:  []*pb.HealthEvent{healthEvent},
+	}
+}

--- a/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler.go
+++ b/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler.go
@@ -228,13 +228,6 @@ func (h *GPUFallenHandler) createHealthEventFromError(event *gpuFallenErrorEvent
 		NodeName:           h.nodeName,
 		RecommendedAction:  pb.RecommendedAction_RESTART_BM,
 		ErrorCode:          []string{"GPU_FALLEN_OFF_BUS"},
-		Metadata: map[string]string{
-			"PCI_ADDRESS": event.pciAddr,
-		},
-	}
-
-	if event.pciID != "" {
-		healthEvent.Metadata["PCI_ID"] = event.pciID
 	}
 
 	return &pb.HealthEvents{

--- a/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler.go
+++ b/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler.go
@@ -229,8 +229,7 @@ func (h *GPUFallenHandler) createHealthEventFromError(event *gpuFallenErrorEvent
 		RecommendedAction:  pb.RecommendedAction_RESTART_BM,
 		ErrorCode:          []string{"GPU_FALLEN_OFF_BUS"},
 		Metadata: map[string]string{
-			"JOURNAL_MESSAGE": event.message,
-			"PCI_ADDRESS":     event.pciAddr,
+			"PCI_ADDRESS": event.pciAddr,
 		},
 	}
 

--- a/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler.go
+++ b/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler.go
@@ -80,6 +80,7 @@ func (h *GPUFallenHandler) trackXIDIfPresent(message string) {
 			"pci_address", pciAddr,
 			"xid_string", matches[2],
 			"error", err)
+
 		return
 	}
 
@@ -130,6 +131,7 @@ func (h *GPUFallenHandler) cleanupExpiredXIDs() {
 		h.mu.Lock()
 		now := time.Now()
 		window := h.xidWindow // Read current window value
+
 		for pciAddr, record := range h.recentXIDs {
 			if now.Sub(record.timestamp) >= window {
 				delete(h.recentXIDs, pciAddr)

--- a/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler.go
+++ b/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler.go
@@ -16,6 +16,7 @@ package gpufallen
 
 import (
 	"fmt"
+	"log/slog"
 	"time"
 
 	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
@@ -27,14 +28,27 @@ import (
 // NewGPUFallenHandler creates a new GPUFallenHandler instance.
 func NewGPUFallenHandler(nodeName, defaultAgentName,
 	defaultComponentClass, checkName string) (*GPUFallenHandler, error) {
-	return &GPUFallenHandler{
+	h := &GPUFallenHandler{
 		nodeName:              nodeName,
 		defaultAgentName:      defaultAgentName,
 		defaultComponentClass: defaultComponentClass,
 		checkName:             checkName,
 		recentXIDs:            make(map[string]xidRecord),
 		xidWindow:             5 * time.Minute, // Remember XIDs for 5 minutes
-	}, nil
+	}
+
+	// Start background cleanup goroutine to prevent unbounded memory growth
+	go h.cleanupExpiredXIDs()
+
+	return h, nil
+}
+
+// SetXIDWindow sets the time window for tracking XID errors.
+// This is primarily used for testing with shorter time windows.
+func (h *GPUFallenHandler) SetXIDWindow(window time.Duration) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.xidWindow = window
 }
 
 // ProcessLine processes a single syslog line and returns any generated health events.
@@ -62,6 +76,10 @@ func (h *GPUFallenHandler) trackXIDIfPresent(message string) {
 	xidCode := 0
 	// Parse XID code (matches[2])
 	if _, err := fmt.Sscanf(matches[2], "%d", &xidCode); err != nil {
+		slog.Warn("Failed to parse XID code from message",
+			"pci_address", pciAddr,
+			"xid_string", matches[2],
+			"error", err)
 		return
 	}
 
@@ -75,17 +93,50 @@ func (h *GPUFallenHandler) trackXIDIfPresent(message string) {
 }
 
 // hasRecentXID checks if a PCI address has had an XID error within the time window
+// and opportunistically cleans up expired entries to prevent memory leaks
 func (h *GPUFallenHandler) hasRecentXID(pciAddr string) bool {
 	h.mu.RLock()
-	defer h.mu.RUnlock()
-
 	record, exists := h.recentXIDs[pciAddr]
+	h.mu.RUnlock()
+
 	if !exists {
 		return false
 	}
 
 	// Check if the XID is still within the time window
-	return time.Since(record.timestamp) < h.xidWindow
+	isRecent := time.Since(record.timestamp) < h.xidWindow
+
+	// If expired, remove it from the map to prevent memory leaks
+	if !isRecent {
+		h.mu.Lock()
+		// Double-check after acquiring write lock (entry might have been updated)
+		if record, exists := h.recentXIDs[pciAddr]; exists && time.Since(record.timestamp) >= h.xidWindow {
+			delete(h.recentXIDs, pciAddr)
+		}
+		h.mu.Unlock()
+	}
+
+	return isRecent
+}
+
+// cleanupExpiredXIDs runs periodically to remove expired XID entries
+// This prevents unbounded memory growth from XIDs on GPUs that never experience fallen-off errors
+func (h *GPUFallenHandler) cleanupExpiredXIDs() {
+	// Start with initial cleanup interval, but check dynamically for changes
+	ticker := time.NewTicker(1 * time.Minute) // Check every minute for production use
+	defer ticker.Stop()
+
+	for range ticker.C {
+		h.mu.Lock()
+		now := time.Now()
+		window := h.xidWindow // Read current window value
+		for pciAddr, record := range h.recentXIDs {
+			if now.Sub(record.timestamp) >= window {
+				delete(h.recentXIDs, pciAddr)
+			}
+		}
+		h.mu.Unlock()
+	}
 }
 
 func (h *GPUFallenHandler) parseGPUFallenError(message string) *gpuFallenErrorEvent {
@@ -135,8 +186,8 @@ func (h *GPUFallenHandler) createHealthEventFromError(event *gpuFallenErrorEvent
 		})
 	}
 
-	// Increment metrics
-	gpuFallenCounterMetric.WithLabelValues(h.nodeName, event.pciAddr).Inc()
+	// Increment metrics (node-level only to avoid cardinality explosion)
+	gpuFallenCounterMetric.WithLabelValues(h.nodeName).Inc()
 
 	healthEvent := &pb.HealthEvent{
 		Version:            1,

--- a/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler.go
+++ b/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler.go
@@ -92,6 +92,7 @@ func (h *GPUFallenHandler) parseGPUFallenError(message string) *gpuFallenErrorEv
 	// Try to extract PCI ID if present in the message
 	pciID := ""
 	pciIDMatch := rePCIIDPattern.FindStringSubmatch(message)
+
 	if len(pciIDMatch) >= 2 {
 		pciID = pciIDMatch[1]
 	}

--- a/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler.go
+++ b/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler.go
@@ -15,12 +15,10 @@
 package gpufallen
 
 import (
-	"fmt"
-	"log/slog"
-	"strings"
 	"time"
 
 	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
+	"github.com/nvidia/nvsentinel/health-monitors/syslog-health-monitor/pkg/common"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -33,22 +31,11 @@ func NewGPUFallenHandler(nodeName, defaultAgentName,
 		defaultAgentName:      defaultAgentName,
 		defaultComponentClass: defaultComponentClass,
 		checkName:             checkName,
-		pciToGPUUUID:          make(map[string]string),
 	}, nil
 }
 
 // ProcessLine processes a single syslog line and returns any generated health events.
 func (h *GPUFallenHandler) ProcessLine(message string) (*pb.HealthEvents, error) {
-	// First, check if this is a GPU UUID mapping line
-	if pciID, gpuUUID := h.parseNVRMGPUMapLine(message); pciID != "" && gpuUUID != "" {
-		normPCI := h.normalizePCI(pciID)
-		h.pciToGPUUUID[normPCI] = gpuUUID
-
-		slog.Info("Updated PCI->GPU UUID mapping", "pci", normPCI, "uuid", gpuUUID)
-
-		return nil, nil
-	}
-
 	// Check if this is a GPU falling off error
 	event := h.parseGPUFallenError(message)
 	if event == nil {
@@ -58,27 +45,10 @@ func (h *GPUFallenHandler) ProcessLine(message string) (*pb.HealthEvents, error)
 	return h.createHealthEventFromError(event), nil
 }
 
-func (h *GPUFallenHandler) parseNVRMGPUMapLine(message string) (string, string) {
-	m := reNvrmMap.FindStringSubmatch(message)
-	if len(m) >= 3 {
-		return m[1], m[2]
-	}
-
-	return "", ""
-}
-
-func (h *GPUFallenHandler) normalizePCI(pci string) string {
-	if idx := strings.Index(pci, "."); idx != -1 {
-		return pci[:idx]
-	}
-
-	return pci
-}
-
 func (h *GPUFallenHandler) parseGPUFallenError(message string) *gpuFallenErrorEvent {
 	// First check if this message contains "Xid"
-	// If has DIX error it should be handled by XID handler
-	if reXIDPattern.MatchString(message) {
+	// If it has XID error it should be handled by XID handler
+	if common.XIDPattern.MatchString(message) {
 		return nil
 	}
 
@@ -116,14 +86,6 @@ func (h *GPUFallenHandler) createHealthEventFromError(event *gpuFallenErrorEvent
 		})
 	}
 
-	// Look up GPU UUID from PCI address
-	normPCI := h.normalizePCI(event.pciAddr)
-	if uuid, ok := h.pciToGPUUUID[normPCI]; ok && uuid != "" {
-		entitiesImpacted = append(entitiesImpacted, &pb.Entity{
-			EntityType: "GPU", EntityValue: uuid,
-		})
-	}
-
 	// Increment metrics
 	gpuFallenCounterMetric.WithLabelValues(h.nodeName, event.pciAddr).Inc()
 
@@ -134,15 +96,12 @@ func (h *GPUFallenHandler) createHealthEventFromError(event *gpuFallenErrorEvent
 		ComponentClass:     h.defaultComponentClass,
 		GeneratedTimestamp: timestamppb.New(time.Now()),
 		EntitiesImpacted:   entitiesImpacted,
-		Message: fmt.Sprintf(
-			"GPU has fallen off the bus and is not responding to commands. PCI: %s",
-			event.pciAddr,
-		),
-		IsFatal:           true, // GPU falling off the bus is always fatal
-		IsHealthy:         false,
-		NodeName:          h.nodeName,
-		RecommendedAction: pb.RecommendedAction_RESTART_BM,
-		ErrorCode:         []string{"GPU_FALLEN_OFF_BUS"},
+		Message:            event.message,
+		IsFatal:            true, // GPU falling off the bus is always fatal
+		IsHealthy:          false,
+		NodeName:           h.nodeName,
+		RecommendedAction:  pb.RecommendedAction_RESTART_BM,
+		ErrorCode:          []string{"GPU_FALLEN_OFF_BUS"},
 		Metadata: map[string]string{
 			"JOURNAL_MESSAGE": event.message,
 			"PCI_ADDRESS":     event.pciAddr,

--- a/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler_test.go
@@ -184,15 +184,16 @@ func TestProcessLine(t *testing.T) {
 }
 
 func TestXIDTracking(t *testing.T) {
-	handler, err := NewGPUFallenHandler(
-		"test-node",
-		"test-agent",
-		"GPU",
-		"test-check",
-	)
-	require.NoError(t, err)
-
 	t.Run("XID then GPU fallen off - should suppress event", func(t *testing.T) {
+		// Create fresh handler for this test
+		handler, err := NewGPUFallenHandler(
+			"test-node",
+			"test-agent",
+			"GPU",
+			"test-check",
+		)
+		require.NoError(t, err)
+
 		// Process XID message first
 		xidMsg := "NVRM: Xid (PCI:0000:b3:00.0): 79, pid=1234, name=process"
 		events, err := handler.ProcessLine(xidMsg)
@@ -237,7 +238,7 @@ func TestXIDTracking(t *testing.T) {
 			"test-check",
 		)
 		require.NoError(t, err)
-		handler3.xidWindow = 100 * time.Millisecond // Very short window for testing
+		handler3.SetXIDWindow(100 * time.Millisecond) // Very short window for testing
 
 		// Process XID
 		xidMsg := "NVRM: Xid (PCI:0000:b3:00.0): 79, pid=1234"
@@ -295,5 +296,110 @@ func TestXIDTracking(t *testing.T) {
 		events, err := handler5.ProcessLine(combinedMsg)
 		require.NoError(t, err)
 		assert.Nil(t, events, "Should not generate event when XID is in same message - let XID handler process it")
+	})
+
+	t.Run("Malformed XID code should not crash and GPU fallen off should still generate event", func(t *testing.T) {
+		handler6, err := NewGPUFallenHandler(
+			"test-node",
+			"test-agent",
+			"GPU",
+			"test-check",
+		)
+		require.NoError(t, err)
+
+		// Process message with malformed XID code (not a number)
+		// This should log a warning but not panic or corrupt state
+		malformedXIDMsg := "NVRM: Xid (PCI:0000:b3:00.0): INVALID, pid=1234, name=process"
+		events, err := handler6.ProcessLine(malformedXIDMsg)
+		require.NoError(t, err)
+		assert.Nil(t, events, "Should not generate event for malformed XID")
+
+		// Now process GPU fallen off message - should generate event since malformed XID wasn't recorded
+		fallenMsg := "NVRM: The NVIDIA GPU 0000:b3:00.0 fallen off the bus and is not responding to commands."
+		events, err = handler6.ProcessLine(fallenMsg)
+		require.NoError(t, err)
+		require.NotNil(t, events, "Should generate event since malformed XID wasn't recorded")
+		assert.Len(t, events.Events, 1)
+	})
+
+	t.Run("Expired entries are cleaned up from map", func(t *testing.T) {
+		handler7, err := NewGPUFallenHandler(
+			"test-node",
+			"test-agent",
+			"GPU",
+			"test-check",
+		)
+		require.NoError(t, err)
+
+		// Set a very short duration for testing
+		handler7.SetXIDWindow(10 * time.Millisecond)
+
+		// Process XID message
+		xidMsg := "NVRM: Xid (PCI:0000:b3:00.0): 79, pid=1234, name=process"
+		events, err := handler7.ProcessLine(xidMsg)
+		require.NoError(t, err)
+		assert.Nil(t, events)
+
+		// Verify entry exists in map
+		handler7.mu.RLock()
+		_, exists := handler7.recentXIDs["0000:b3:00.0"]
+		handler7.mu.RUnlock()
+		assert.True(t, exists, "XID should be recorded in map")
+
+		// Wait for expiration
+		time.Sleep(15 * time.Millisecond)
+
+		// Check for recent XID - this should trigger cleanup
+		hasRecent := handler7.hasRecentXID("0000:b3:00.0")
+		assert.False(t, hasRecent, "XID should be expired")
+
+		// Verify entry was removed from map
+		handler7.mu.RLock()
+		_, exists = handler7.recentXIDs["0000:b3:00.0"]
+		handler7.mu.RUnlock()
+		assert.False(t, exists, "Expired XID should be cleaned up from map")
+	})
+
+	t.Run("Background cleanup removes expired entries", func(t *testing.T) {
+		handler8, err := NewGPUFallenHandler(
+			"test-node",
+			"test-agent",
+			"GPU",
+			"test-check",
+		)
+		require.NoError(t, err)
+
+		// Set very short window for testing
+		handler8.SetXIDWindow(50 * time.Millisecond)
+
+		// Process XID messages for multiple PCIs
+		xidMsg1 := "NVRM: Xid (PCI:0000:b3:00.0): 79"
+		xidMsg2 := "NVRM: Xid (PCI:0000:b4:00.0): 79"
+		xidMsg3 := "NVRM: Xid (PCI:0000:b5:00.0): 79"
+
+		handler8.ProcessLine(xidMsg1)
+		handler8.ProcessLine(xidMsg2)
+		handler8.ProcessLine(xidMsg3)
+
+		// Verify all entries exist
+		handler8.mu.RLock()
+		initialCount := len(handler8.recentXIDs)
+		handler8.mu.RUnlock()
+		assert.Equal(t, 3, initialCount, "Should have 3 XID entries")
+
+		// Wait for expiration + background cleanup to run (cleanup runs every 1 minute by default)
+		// For testing, we wait for expiration and rely on opportunistic cleanup via hasRecentXID
+		time.Sleep(100 * time.Millisecond)
+
+		// Trigger opportunistic cleanup by checking each PCI
+		handler8.hasRecentXID("0000:b3:00.0")
+		handler8.hasRecentXID("0000:b4:00.0")
+		handler8.hasRecentXID("0000:b5:00.0")
+
+		// Verify entries were cleaned up
+		handler8.mu.RLock()
+		finalCount := len(handler8.recentXIDs)
+		handler8.mu.RUnlock()
+		assert.Equal(t, 0, finalCount, "Expired entries should be cleaned up")
 	})
 }

--- a/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler_test.go
@@ -1,0 +1,287 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gpufallen
+
+import (
+	"testing"
+
+	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseNVRMGPUMapLine(t *testing.T) {
+	handler := &GPUFallenHandler{
+		pciToGPUUUID: make(map[string]string),
+	}
+
+	testCases := []struct {
+		name      string
+		line      string
+		expectPCI string
+		expectGPU string
+	}{
+		{
+			name:      "Valid GPU Map Line",
+			line:      "NVRM: GPU at PCI:0000:b3:00.0: GPU-12345678-1234-1234-1234-123456789012",
+			expectPCI: "0000:b3:00.0",
+			expectGPU: "GPU-12345678-1234-1234-1234-123456789012",
+		},
+		{
+			name:      "Invalid Line",
+			line:      "Some other log message",
+			expectPCI: "",
+			expectGPU: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pciID, gpuUUID := handler.parseNVRMGPUMapLine(tc.line)
+			assert.Equal(t, tc.expectPCI, pciID)
+			assert.Equal(t, tc.expectGPU, gpuUUID)
+		})
+	}
+}
+
+func TestNormalizePCI(t *testing.T) {
+	handler := &GPUFallenHandler{}
+
+	testCases := []struct {
+		name     string
+		pci      string
+		expected string
+	}{
+		{
+			name:     "PCI with function",
+			pci:      "0000:b3:00.0",
+			expected: "0000:b3:00",
+		},
+		{
+			name:     "PCI without function",
+			pci:      "0000:b3:00",
+			expected: "0000:b3:00",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := handler.normalizePCI(tc.pci)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestParseGPUFallenError(t *testing.T) {
+	handler := &GPUFallenHandler{}
+
+	testCases := []struct {
+		name        string
+		message     string
+		expectEvent bool
+		expectPCI   string
+		expectPCIID string
+	}{
+		{
+			name: "Complete GPU Fallen Error with PCI ID",
+			message: "[ 1843.308145] NVRM: The NVIDIA GPU 0000:b3:00.0\n" +
+				"               NVRM: (PCI ID: 10de:26b5) installed in this system has\n" +
+				"               NVRM: fallen off the bus and is not responding to commands.",
+			expectEvent: true,
+			expectPCI:   "0000:b3:00.0",
+			expectPCIID: "10de:26b5",
+		},
+		{
+			name: "GPU Fallen Error without PCI ID",
+			message: "[ 1843.308145] NVRM: The NVIDIA GPU 0000:b3:00.0\n" +
+				"               NVRM: installed in this system has\n" +
+				"               NVRM: fallen off the bus and is not responding to commands.",
+			expectEvent: true,
+			expectPCI:   "0000:b3:00.0",
+			expectPCIID: "",
+		},
+		{
+			name: "GPU Fallen Error with XID following - Should NOT match",
+			message: "[ 1843.308145] NVRM: The NVIDIA GPU 0000:b3:00.0\n" +
+				"               NVRM: (PCI ID: 10de:26b5) installed in this system has\n" +
+				"               NVRM: fallen off the bus and is not responding to commands.\n" +
+				"NVRM: Xid (PCI:0000:b3:00.0): 79, pid=12345, GPU has fallen off the bus.",
+			expectEvent: false,
+		},
+		{
+			name: "GPU Fallen Error with Xid in middle - Should NOT match",
+			message: "[ 1843.308145] NVRM: The NVIDIA GPU 0000:b3:00.0\n" +
+				"               NVRM: Xid (PCI:0000:b3:00.0): 79\n" +
+				"               NVRM: fallen off the bus and is not responding to commands.",
+			expectEvent: false,
+		},
+		{
+			name:        "Non-matching message",
+			message:     "Some other NVRM message",
+			expectEvent: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			event := handler.parseGPUFallenError(tc.message)
+			if tc.expectEvent {
+				require.NotNil(t, event, "Expected to parse an event")
+				assert.Equal(t, tc.expectPCI, event.pciAddr)
+				assert.Equal(t, tc.expectPCIID, event.pciID)
+				assert.Equal(t, tc.message, event.message)
+			} else {
+				assert.Nil(t, event, "Expected no event to be parsed")
+			}
+		})
+	}
+}
+
+func TestProcessLine(t *testing.T) {
+	testCases := []struct {
+		name          string
+		message       string
+		priorMapping  map[string]string
+		expectEvent   bool
+		validateEvent func(t *testing.T, events *pb.HealthEvents)
+	}{
+		{
+			name:        "GPU Map Line - Should not generate event",
+			message:     "NVRM: GPU at PCI:0000:b3:00.0: GPU-12345678-1234-1234-1234-123456789012",
+			expectEvent: false,
+		},
+		{
+			name: "GPU Fallen Error - Without GPU UUID",
+			message: "[ 1843.308145] NVRM: The NVIDIA GPU 0000:b3:00.0\n" +
+				"               NVRM: (PCI ID: 10de:26b5) installed in this system has\n" +
+				"               NVRM: fallen off the bus and is not responding to commands.",
+			expectEvent: true,
+			validateEvent: func(t *testing.T, events *pb.HealthEvents) {
+				require.NotNil(t, events)
+				require.Len(t, events.Events, 1)
+
+				event := events.Events[0]
+				assert.Equal(t, "test-agent", event.Agent)
+				assert.Equal(t, "test-check", event.CheckName)
+				assert.Equal(t, "GPU", event.ComponentClass)
+				assert.True(t, event.IsFatal)
+				assert.False(t, event.IsHealthy)
+				assert.Equal(t, pb.RecommendedAction_RESTART_BM, event.RecommendedAction)
+				assert.Contains(t, event.ErrorCode, "GPU_FALLEN_OFF_BUS")
+
+				// Should have PCI and PCI_ID entities, but no GPU UUID
+				assert.Len(t, event.EntitiesImpacted, 2)
+				assert.Equal(t, "PCI", event.EntitiesImpacted[0].EntityType)
+				assert.Equal(t, "0000:b3:00.0", event.EntitiesImpacted[0].EntityValue)
+				assert.Equal(t, "PCI_ID", event.EntitiesImpacted[1].EntityType)
+				assert.Equal(t, "10de:26b5", event.EntitiesImpacted[1].EntityValue)
+			},
+		},
+		{
+			name: "GPU Fallen Error - With GPU UUID from prior mapping",
+			message: "[ 1843.308145] NVRM: The NVIDIA GPU 0000:b3:00.0\n" +
+				"               NVRM: (PCI ID: 10de:26b5) installed in this system has\n" +
+				"               NVRM: fallen off the bus and is not responding to commands.",
+			priorMapping: map[string]string{
+				"0000:b3:00": "GPU-12345678-1234-1234-1234-123456789012",
+			},
+			expectEvent: true,
+			validateEvent: func(t *testing.T, events *pb.HealthEvents) {
+				require.NotNil(t, events)
+				require.Len(t, events.Events, 1)
+
+				event := events.Events[0]
+
+				// Should have PCI, PCI_ID, and GPU entities
+				assert.Len(t, event.EntitiesImpacted, 3)
+				assert.Equal(t, "PCI", event.EntitiesImpacted[0].EntityType)
+				assert.Equal(t, "PCI_ID", event.EntitiesImpacted[1].EntityType)
+				assert.Equal(t, "GPU", event.EntitiesImpacted[2].EntityType)
+				assert.Equal(t, "GPU-12345678-1234-1234-1234-123456789012", event.EntitiesImpacted[2].EntityValue)
+			},
+		},
+		{
+			name:        "Non-matching message",
+			message:     "Some other log message",
+			expectEvent: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler, err := NewGPUFallenHandler(
+				"test-node",
+				"test-agent",
+				"GPU",
+				"test-check",
+			)
+			require.NoError(t, err)
+
+			// Set up prior mappings if any
+			if tc.priorMapping != nil {
+				handler.pciToGPUUUID = tc.priorMapping
+			}
+
+			events, err := handler.ProcessLine(tc.message)
+			require.NoError(t, err)
+
+			if tc.expectEvent {
+				require.NotNil(t, events, "Expected an event to be generated")
+				if tc.validateEvent != nil {
+					tc.validateEvent(t, events)
+				}
+			} else {
+				assert.Nil(t, events, "Expected no event to be generated")
+			}
+		})
+	}
+}
+
+func TestProcessLine_BuildsGPUMapping(t *testing.T) {
+	handler, err := NewGPUFallenHandler(
+		"test-node",
+		"test-agent",
+		"GPU",
+		"test-check",
+	)
+	require.NoError(t, err)
+
+	// Process a GPU mapping line first
+	mapLine := "NVRM: GPU at PCI:0000:b3:00.0: GPU-12345678-1234-1234-1234-123456789012"
+	events, err := handler.ProcessLine(mapLine)
+	require.NoError(t, err)
+	assert.Nil(t, events)
+
+	// Verify the mapping was stored
+	assert.Equal(t, "GPU-12345678-1234-1234-1234-123456789012", handler.pciToGPUUUID["0000:b3:00"])
+
+	// Now process a GPU fallen error
+	fallenLine := "NVRM: The NVIDIA GPU 0000:b3:00.0 fallen off the bus and is not responding to commands."
+	events, err = handler.ProcessLine(fallenLine)
+	require.NoError(t, err)
+	require.NotNil(t, events)
+	require.Len(t, events.Events, 1)
+
+	// Verify the event includes the GPU UUID
+	event := events.Events[0]
+	hasGPUEntity := false
+	for _, entity := range event.EntitiesImpacted {
+		if entity.EntityType == "GPU" && entity.EntityValue == "GPU-12345678-1234-1234-1234-123456789012" {
+			hasGPUEntity = true
+			break
+		}
+	}
+	assert.True(t, hasGPUEntity, "Event should include GPU UUID entity")
+}

--- a/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler_test.go
@@ -22,68 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseNVRMGPUMapLine(t *testing.T) {
-	handler := &GPUFallenHandler{
-		pciToGPUUUID: make(map[string]string),
-	}
-
-	testCases := []struct {
-		name      string
-		line      string
-		expectPCI string
-		expectGPU string
-	}{
-		{
-			name:      "Valid GPU Map Line",
-			line:      "NVRM: GPU at PCI:0000:b3:00.0: GPU-12345678-1234-1234-1234-123456789012",
-			expectPCI: "0000:b3:00.0",
-			expectGPU: "GPU-12345678-1234-1234-1234-123456789012",
-		},
-		{
-			name:      "Invalid Line",
-			line:      "Some other log message",
-			expectPCI: "",
-			expectGPU: "",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			pciID, gpuUUID := handler.parseNVRMGPUMapLine(tc.line)
-			assert.Equal(t, tc.expectPCI, pciID)
-			assert.Equal(t, tc.expectGPU, gpuUUID)
-		})
-	}
-}
-
-func TestNormalizePCI(t *testing.T) {
-	handler := &GPUFallenHandler{}
-
-	testCases := []struct {
-		name     string
-		pci      string
-		expected string
-	}{
-		{
-			name:     "PCI with function",
-			pci:      "0000:b3:00.0",
-			expected: "0000:b3:00",
-		},
-		{
-			name:     "PCI without function",
-			pci:      "0000:b3:00",
-			expected: "0000:b3:00",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			result := handler.normalizePCI(tc.pci)
-			assert.Equal(t, tc.expected, result)
-		})
-	}
-}
-
 func TestParseGPUFallenError(t *testing.T) {
 	handler := &GPUFallenHandler{}
 
@@ -153,17 +91,11 @@ func TestProcessLine(t *testing.T) {
 	testCases := []struct {
 		name          string
 		message       string
-		priorMapping  map[string]string
 		expectEvent   bool
 		validateEvent func(t *testing.T, events *pb.HealthEvents)
 	}{
 		{
-			name:        "GPU Map Line - Should not generate event",
-			message:     "NVRM: GPU at PCI:0000:b3:00.0: GPU-12345678-1234-1234-1234-123456789012",
-			expectEvent: false,
-		},
-		{
-			name: "GPU Fallen Error - Without GPU UUID",
+			name: "GPU Fallen Error with PCI ID",
 			message: "[ 1843.308145] NVRM: The NVIDIA GPU 0000:b3:00.0\n" +
 				"               NVRM: (PCI ID: 10de:26b5) installed in this system has\n" +
 				"               NVRM: fallen off the bus and is not responding to commands.",
@@ -181,22 +113,30 @@ func TestProcessLine(t *testing.T) {
 				assert.Equal(t, pb.RecommendedAction_RESTART_BM, event.RecommendedAction)
 				assert.Contains(t, event.ErrorCode, "GPU_FALLEN_OFF_BUS")
 
-				// Should have PCI and PCI_ID entities, but no GPU UUID
+				// Should have PCI and PCI_ID entities only
 				assert.Len(t, event.EntitiesImpacted, 2)
-				assert.Equal(t, "PCI", event.EntitiesImpacted[0].EntityType)
-				assert.Equal(t, "0000:b3:00.0", event.EntitiesImpacted[0].EntityValue)
-				assert.Equal(t, "PCI_ID", event.EntitiesImpacted[1].EntityType)
-				assert.Equal(t, "10de:26b5", event.EntitiesImpacted[1].EntityValue)
+
+				// Find entities by type rather than assuming order
+				var hasPCI, hasPCIID bool
+				for _, entity := range event.EntitiesImpacted {
+					switch entity.EntityType {
+					case "PCI":
+						hasPCI = true
+						assert.Equal(t, "0000:b3:00.0", entity.EntityValue)
+					case "PCI_ID":
+						hasPCIID = true
+						assert.Equal(t, "10de:26b5", entity.EntityValue)
+					}
+				}
+				assert.True(t, hasPCI, "Should have PCI entity")
+				assert.True(t, hasPCIID, "Should have PCI_ID entity")
 			},
 		},
 		{
-			name: "GPU Fallen Error - With GPU UUID from prior mapping",
+			name: "GPU Fallen Error without PCI ID",
 			message: "[ 1843.308145] NVRM: The NVIDIA GPU 0000:b3:00.0\n" +
-				"               NVRM: (PCI ID: 10de:26b5) installed in this system has\n" +
+				"               NVRM: installed in this system has\n" +
 				"               NVRM: fallen off the bus and is not responding to commands.",
-			priorMapping: map[string]string{
-				"0000:b3:00": "GPU-12345678-1234-1234-1234-123456789012",
-			},
 			expectEvent: true,
 			validateEvent: func(t *testing.T, events *pb.HealthEvents) {
 				require.NotNil(t, events)
@@ -204,12 +144,10 @@ func TestProcessLine(t *testing.T) {
 
 				event := events.Events[0]
 
-				// Should have PCI, PCI_ID, and GPU entities
-				assert.Len(t, event.EntitiesImpacted, 3)
+				// Should have only PCI entity
+				assert.Len(t, event.EntitiesImpacted, 1)
 				assert.Equal(t, "PCI", event.EntitiesImpacted[0].EntityType)
-				assert.Equal(t, "PCI_ID", event.EntitiesImpacted[1].EntityType)
-				assert.Equal(t, "GPU", event.EntitiesImpacted[2].EntityType)
-				assert.Equal(t, "GPU-12345678-1234-1234-1234-123456789012", event.EntitiesImpacted[2].EntityValue)
+				assert.Equal(t, "0000:b3:00.0", event.EntitiesImpacted[0].EntityValue)
 			},
 		},
 		{
@@ -229,11 +167,6 @@ func TestProcessLine(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			// Set up prior mappings if any
-			if tc.priorMapping != nil {
-				handler.pciToGPUUUID = tc.priorMapping
-			}
-
 			events, err := handler.ProcessLine(tc.message)
 			require.NoError(t, err)
 
@@ -247,41 +180,4 @@ func TestProcessLine(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestProcessLine_BuildsGPUMapping(t *testing.T) {
-	handler, err := NewGPUFallenHandler(
-		"test-node",
-		"test-agent",
-		"GPU",
-		"test-check",
-	)
-	require.NoError(t, err)
-
-	// Process a GPU mapping line first
-	mapLine := "NVRM: GPU at PCI:0000:b3:00.0: GPU-12345678-1234-1234-1234-123456789012"
-	events, err := handler.ProcessLine(mapLine)
-	require.NoError(t, err)
-	assert.Nil(t, events)
-
-	// Verify the mapping was stored
-	assert.Equal(t, "GPU-12345678-1234-1234-1234-123456789012", handler.pciToGPUUUID["0000:b3:00"])
-
-	// Now process a GPU fallen error
-	fallenLine := "NVRM: The NVIDIA GPU 0000:b3:00.0 fallen off the bus and is not responding to commands."
-	events, err = handler.ProcessLine(fallenLine)
-	require.NoError(t, err)
-	require.NotNil(t, events)
-	require.Len(t, events.Events, 1)
-
-	// Verify the event includes the GPU UUID
-	event := events.Events[0]
-	hasGPUEntity := false
-	for _, entity := range event.EntitiesImpacted {
-		if entity.EntityType == "GPU" && entity.EntityValue == "GPU-12345678-1234-1234-1234-123456789012" {
-			hasGPUEntity = true
-			break
-		}
-	}
-	assert.True(t, hasGPUEntity, "Event should include GPU UUID entity")
 }

--- a/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler_test.go
@@ -167,6 +167,7 @@ func TestProcessLine(t *testing.T) {
 				"test-check",
 			)
 			require.NoError(t, err)
+			defer handler.Close()
 
 			events, err := handler.ProcessLine(tc.message)
 			require.NoError(t, err)
@@ -193,6 +194,8 @@ func TestXIDTracking(t *testing.T) {
 			"test-check",
 		)
 		require.NoError(t, err)
+		defer handler.Close()
+		defer handler.Close() // Cleanup goroutine to prevent leaks
 
 		// Process XID message first
 		xidMsg := "NVRM: Xid (PCI:0000:b3:00.0): 79, pid=1234, name=process"
@@ -218,6 +221,7 @@ func TestXIDTracking(t *testing.T) {
 			"test-check",
 		)
 		require.NoError(t, err)
+		defer handler2.Close()
 
 		// Process GPU fallen off without any prior XID
 		fallenMsg := "[ 1843.308145] NVRM: The NVIDIA GPU 0000:b3:00.0\n" +
@@ -238,6 +242,8 @@ func TestXIDTracking(t *testing.T) {
 			"test-check",
 		)
 		require.NoError(t, err)
+		defer handler3.Close()
+
 		handler3.SetXIDWindow(100 * time.Millisecond) // Very short window for testing
 
 		// Process XID
@@ -263,6 +269,7 @@ func TestXIDTracking(t *testing.T) {
 			"test-check",
 		)
 		require.NoError(t, err)
+		defer handler4.Close()
 
 		// Process XID for GPU 1
 		xidMsg1 := "NVRM: Xid (PCI:0000:b3:00.0): 79"
@@ -290,6 +297,7 @@ func TestXIDTracking(t *testing.T) {
 			"test-check",
 		)
 		require.NoError(t, err)
+		defer handler5.Close()
 
 		// Message contains both XID and "fallen off the bus"
 		combinedMsg := "NVRM: Xid (PCI:0000:b3:00.0): 79, GPU has fallen off the bus and is not responding to commands."
@@ -306,6 +314,7 @@ func TestXIDTracking(t *testing.T) {
 			"test-check",
 		)
 		require.NoError(t, err)
+		defer handler6.Close()
 
 		// Process message with malformed XID code (not a number)
 		// This should log a warning but not panic or corrupt state
@@ -330,6 +339,7 @@ func TestXIDTracking(t *testing.T) {
 			"test-check",
 		)
 		require.NoError(t, err)
+		defer handler7.Close()
 
 		// Set a very short duration for testing
 		handler7.SetXIDWindow(10 * time.Millisecond)
@@ -368,6 +378,7 @@ func TestXIDTracking(t *testing.T) {
 			"test-check",
 		)
 		require.NoError(t, err)
+		defer handler8.Close()
 
 		// Set very short window for testing
 		handler8.SetXIDWindow(50 * time.Millisecond)

--- a/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler_test.go
@@ -16,6 +16,7 @@ package gpufallen
 
 import (
 	"testing"
+	"time"
 
 	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	"github.com/stretchr/testify/assert"
@@ -180,4 +181,119 @@ func TestProcessLine(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestXIDTracking(t *testing.T) {
+	handler, err := NewGPUFallenHandler(
+		"test-node",
+		"test-agent",
+		"GPU",
+		"test-check",
+	)
+	require.NoError(t, err)
+
+	t.Run("XID then GPU fallen off - should suppress event", func(t *testing.T) {
+		// Process XID message first
+		xidMsg := "NVRM: Xid (PCI:0000:b3:00.0): 79, pid=1234, name=process"
+		events, err := handler.ProcessLine(xidMsg)
+		require.NoError(t, err)
+		assert.Nil(t, events, "XID handler should process XID, not gpufallen handler")
+
+		// Now process GPU fallen off message - should be suppressed
+		fallenMsg := "[ 1843.308145] NVRM: The NVIDIA GPU 0000:b3:00.0\n" +
+			"               NVRM: (PCI ID: 10de:26b5) installed in this system has\n" +
+			"               NVRM: fallen off the bus and is not responding to commands."
+		events, err = handler.ProcessLine(fallenMsg)
+		require.NoError(t, err)
+		assert.Nil(t, events, "Should suppress GPU fallen off when recent XID exists")
+	})
+
+	t.Run("GPU fallen off without prior XID - should generate event", func(t *testing.T) {
+		// Create fresh handler
+		handler2, err := NewGPUFallenHandler(
+			"test-node",
+			"test-agent",
+			"GPU",
+			"test-check",
+		)
+		require.NoError(t, err)
+
+		// Process GPU fallen off without any prior XID
+		fallenMsg := "[ 1843.308145] NVRM: The NVIDIA GPU 0000:b3:00.0\n" +
+			"               NVRM: (PCI ID: 10de:26b5) installed in this system has\n" +
+			"               NVRM: fallen off the bus and is not responding to commands."
+		events, err := handler2.ProcessLine(fallenMsg)
+		require.NoError(t, err)
+		require.NotNil(t, events, "Should generate event when no recent XID")
+		require.Len(t, events.Events, 1)
+	})
+
+	t.Run("XID expires after time window", func(t *testing.T) {
+		// Create handler with short window for testing
+		handler3, err := NewGPUFallenHandler(
+			"test-node",
+			"test-agent",
+			"GPU",
+			"test-check",
+		)
+		require.NoError(t, err)
+		handler3.xidWindow = 100 * time.Millisecond // Very short window for testing
+
+		// Process XID
+		xidMsg := "NVRM: Xid (PCI:0000:b3:00.0): 79, pid=1234"
+		_, err = handler3.ProcessLine(xidMsg)
+		require.NoError(t, err)
+
+		// Wait for XID to expire
+		time.Sleep(150 * time.Millisecond)
+
+		// Now GPU fallen off should generate event
+		fallenMsg := "NVRM: The NVIDIA GPU 0000:b3:00.0 fallen off the bus and is not responding to commands."
+		events, err := handler3.ProcessLine(fallenMsg)
+		require.NoError(t, err)
+		require.NotNil(t, events, "Should generate event after XID expires")
+	})
+
+	t.Run("Different PCI addresses tracked independently", func(t *testing.T) {
+		handler4, err := NewGPUFallenHandler(
+			"test-node",
+			"test-agent",
+			"GPU",
+			"test-check",
+		)
+		require.NoError(t, err)
+
+		// Process XID for GPU 1
+		xidMsg1 := "NVRM: Xid (PCI:0000:b3:00.0): 79"
+		_, err = handler4.ProcessLine(xidMsg1)
+		require.NoError(t, err)
+
+		// GPU fallen off for GPU 2 (different PCI) should still generate event
+		fallenMsg2 := "NVRM: The NVIDIA GPU 0000:b4:00.0 fallen off the bus and is not responding to commands."
+		events, err := handler4.ProcessLine(fallenMsg2)
+		require.NoError(t, err)
+		require.NotNil(t, events, "Should generate event for different PCI address")
+
+		// But GPU fallen off for GPU 1 should be suppressed
+		fallenMsg1 := "NVRM: The NVIDIA GPU 0000:b3:00.0 fallen off the bus and is not responding to commands."
+		events, err = handler4.ProcessLine(fallenMsg1)
+		require.NoError(t, err)
+		assert.Nil(t, events, "Should suppress for PCI with recent XID")
+	})
+
+	t.Run("Single message with both XID and GPU fallen off - should not generate event", func(t *testing.T) {
+		handler5, err := NewGPUFallenHandler(
+			"test-node",
+			"test-agent",
+			"GPU",
+			"test-check",
+		)
+		require.NoError(t, err)
+
+		// Message contains both XID and "fallen off the bus"
+		combinedMsg := "NVRM: Xid (PCI:0000:b3:00.0): 79, GPU has fallen off the bus and is not responding to commands."
+		events, err := handler5.ProcessLine(combinedMsg)
+		require.NoError(t, err)
+		assert.Nil(t, events, "Should not generate event when XID is in same message - let XID handler process it")
+	})
 }

--- a/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler_test.go
@@ -194,7 +194,6 @@ func TestXIDTracking(t *testing.T) {
 			"test-check",
 		)
 		require.NoError(t, err)
-		defer handler.Close()
 		defer handler.Close() // Cleanup goroutine to prevent leaks
 
 		// Process XID message first

--- a/health-monitors/syslog-health-monitor/pkg/gpufallen/metrics.go
+++ b/health-monitors/syslog-health-monitor/pkg/gpufallen/metrics.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gpufallen
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// Counter metric for GPU fallen off bus errors
+	gpuFallenCounterMetric = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "syslog_health_monitor_gpu_fallen_errors",
+			Help: "Total number of GPU fallen off bus errors detected",
+		},
+		[]string{"node", "pci_address"},
+	)
+)

--- a/health-monitors/syslog-health-monitor/pkg/gpufallen/types.go
+++ b/health-monitors/syslog-health-monitor/pkg/gpufallen/types.go
@@ -16,6 +16,8 @@ package gpufallen
 
 import (
 	"regexp"
+	"sync"
+	"time"
 )
 
 var (
@@ -32,12 +34,21 @@ var (
 	rePCIIDPattern = regexp.MustCompile(`PCI ID: ([0-9a-fA-F:]+)`)
 )
 
+// xidRecord tracks when an XID error was seen for a PCI address
+type xidRecord struct {
+	timestamp time.Time
+	xidCode   int
+}
+
 // GPUFallenHandler processes syslog lines related to GPU fallen off bus errors.
 type GPUFallenHandler struct {
 	nodeName              string
 	defaultAgentName      string
 	defaultComponentClass string
 	checkName             string
+	mu                    sync.RWMutex
+	recentXIDs            map[string]xidRecord // pciAddr -> XID record
+	xidWindow             time.Duration        // how long to remember XID errors
 }
 
 // gpuFallenErrorEvent represents a parsed GPU fallen off bus error event

--- a/health-monitors/syslog-health-monitor/pkg/gpufallen/types.go
+++ b/health-monitors/syslog-health-monitor/pkg/gpufallen/types.go
@@ -28,14 +28,8 @@ var (
 	reGPUFallenPattern = regexp.MustCompile(
 		`(?s)NVRM: The NVIDIA GPU ([0-9a-fA-F:.]+).*?fallen off the bus and is not responding to commands`)
 
-	// Pattern to detect XID errors in the message (to exclude messages that have XIDs)
-	reXIDPattern = regexp.MustCompile(`\bXid\b`)
-
 	// Pattern to extract PCI ID from the full error message
 	rePCIIDPattern = regexp.MustCompile(`PCI ID: ([0-9a-fA-F:]+)`)
-
-	// Pattern to match NVRM GPU mapping lines
-	reNvrmMap = regexp.MustCompile(`NVRM: GPU at PCI:([0-9a-fA-F:.]+): (GPU-[0-9a-fA-F-]+)`)
 )
 
 // GPUFallenHandler processes syslog lines related to GPU fallen off bus errors.
@@ -44,7 +38,6 @@ type GPUFallenHandler struct {
 	defaultAgentName      string
 	defaultComponentClass string
 	checkName             string
-	pciToGPUUUID          map[string]string
 }
 
 // gpuFallenErrorEvent represents a parsed GPU fallen off bus error event

--- a/health-monitors/syslog-health-monitor/pkg/gpufallen/types.go
+++ b/health-monitors/syslog-health-monitor/pkg/gpufallen/types.go
@@ -15,6 +15,7 @@
 package gpufallen
 
 import (
+	"context"
 	"regexp"
 	"sync"
 	"time"
@@ -49,6 +50,7 @@ type GPUFallenHandler struct {
 	mu                    sync.RWMutex
 	recentXIDs            map[string]xidRecord // pciAddr -> XID record
 	xidWindow             time.Duration        // how long to remember XID errors
+	cancelCleanup         context.CancelFunc   // stops the cleanup goroutine
 }
 
 // gpuFallenErrorEvent represents a parsed GPU fallen off bus error event

--- a/health-monitors/syslog-health-monitor/pkg/gpufallen/types.go
+++ b/health-monitors/syslog-health-monitor/pkg/gpufallen/types.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gpufallen
+
+import (
+	"regexp"
+)
+
+var (
+	// Pattern to match GPU falling off the bus errors
+	// This is most likely a single journal line that may contain newlines within it
+	// Example: "[ 1843.308145] NVRM: The NVIDIA GPU 0000:b3:00.0\n"
+	//          "               NVRM: (PCI ID: 10de:26b5) installed in this system has\n"
+	//          "               NVRM: fallen off the bus and is not responding to commands."
+	// The pattern uses (?s) flag to match across newlines within the single journal entry
+	reGPUFallenPattern = regexp.MustCompile(
+		`(?s)NVRM: The NVIDIA GPU ([0-9a-fA-F:.]+).*?fallen off the bus and is not responding to commands`)
+
+	// Pattern to detect XID errors in the message (to exclude messages that have XIDs)
+	reXIDPattern = regexp.MustCompile(`\bXid\b`)
+
+	// Pattern to extract PCI ID from the full error message
+	rePCIIDPattern = regexp.MustCompile(`PCI ID: ([0-9a-fA-F:]+)`)
+
+	// Pattern to match NVRM GPU mapping lines
+	reNvrmMap = regexp.MustCompile(`NVRM: GPU at PCI:([0-9a-fA-F:.]+): (GPU-[0-9a-fA-F-]+)`)
+)
+
+// GPUFallenHandler processes syslog lines related to GPU fallen off bus errors.
+type GPUFallenHandler struct {
+	nodeName              string
+	defaultAgentName      string
+	defaultComponentClass string
+	checkName             string
+	pciToGPUUUID          map[string]string
+}
+
+// gpuFallenErrorEvent represents a parsed GPU fallen off bus error event
+type gpuFallenErrorEvent struct {
+	pciAddr string
+	pciID   string
+	message string
+}

--- a/health-monitors/syslog-health-monitor/pkg/patterns/xid.go
+++ b/health-monitors/syslog-health-monitor/pkg/patterns/xid.go
@@ -12,20 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gpufallen
+package patterns
 
-import (
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
-)
+import "regexp"
 
-var (
-	// Counter metric for GPU fallen off bus errors
-	gpuFallenCounterMetric = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "syslog_health_monitor_gpu_fallen_errors",
-			Help: "Total number of GPU fallen off bus errors detected",
-		},
-		[]string{"node"},
-	)
+// XIDPattern matches standard NVIDIA XID error messages in the format:
+// "NVRM: Xid (PCI:0000:b3:00.0): 79, pid=1234, name=process, Ch 00000001"
+// This pattern is the canonical definition used across all handlers for
+// detecting and parsing XID errors. If the XID format changes, this is the
+// single source of truth that needs to be updated.
+var XIDPattern = regexp.MustCompile(
+	`NVRM: Xid \(PCI:([0-9a-fA-F:.]+)\): (\d+)(?:, pid=(\d+))?(?:, name=([^,]+))?(?:, Ch ([0-9a-fA-F]+))?`,
 )

--- a/health-monitors/syslog-health-monitor/pkg/syslog-monitor/syslogmonitor.go
+++ b/health-monitors/syslog-health-monitor/pkg/syslog-monitor/syslogmonitor.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
+	"github.com/nvidia/nvsentinel/health-monitors/syslog-health-monitor/pkg/gpufallen"
 	"github.com/nvidia/nvsentinel/health-monitors/syslog-health-monitor/pkg/sxid"
 	"github.com/nvidia/nvsentinel/health-monitors/syslog-health-monitor/pkg/types"
 	"github.com/nvidia/nvsentinel/health-monitors/syslog-health-monitor/pkg/xid"
@@ -102,6 +103,16 @@ func NewSyslogMonitorWithFactory(nodeName string, checks []CheckDefinition, pcCl
 			}
 
 			sm.checkToHandlerMap[check.Name] = sxidHandler
+
+		case GPUFallenOffCheck:
+			gpuFallenHandler, err := gpufallen.NewGPUFallenHandler(
+				nodeName, defaultAgentName, defaultComponentClass, check.Name)
+			if err != nil {
+				slog.Error("Error initializing GPU Fallen Off handler", "error", err.Error())
+				return nil, fmt.Errorf("failed to initialize GPU Fallen Off handler: %w", err)
+			}
+
+			sm.checkToHandlerMap[check.Name] = gpuFallenHandler
 
 		default:
 			slog.Error("Unsupported check", "check", check.Name)

--- a/health-monitors/syslog-health-monitor/pkg/syslog-monitor/syslogmonitor_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/syslog-monitor/syslogmonitor_test.go
@@ -630,3 +630,37 @@ func TestRunMultipleChecks(t *testing.T) {
 	assert.NotNil(t, sm.checkToHandlerMap[XIDErrorCheck], "XID handler should be initialized")
 	assert.NotNil(t, sm.checkToHandlerMap[SXIDErrorCheck], "SXID handler should be initialized")
 }
+
+// TestGPUFallenOffHandlerInitialization tests that the GPU Fallen Off handler is properly initialized
+func TestGPUFallenOffHandlerInitialization(t *testing.T) {
+	check := CheckDefinition{
+		Name:        GPUFallenOffCheck,
+		JournalPath: "/path",
+	}
+
+	mockJournal := &MockJournal{
+		Entries:         []MockJournalEntry{{Message: "test msg", Cursor: "c1", BootID: "b1"}},
+		CurrentPosition: -1,
+		TestBootID:      "b1",
+	}
+
+	mockFactory := NewMockJournalFactory()
+	mockFactory.JournalsByPath["/path"] = mockJournal
+
+	testStateFile := "/tmp/test-syslog-monitor-gpufallen.json"
+	defer os.Remove(testStateFile)
+
+	sm, err := NewSyslogMonitorWithFactory(
+		TEST_NODE,
+		[]CheckDefinition{check},
+		&mockPlatformConnectorClient{},
+		TEST_AGENT,
+		TEST_COMPONENT,
+		"60s",
+		testStateFile,
+		mockFactory,
+		"http://localhost:8080",
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, sm.checkToHandlerMap[GPUFallenOffCheck], "GPU Fallen Off handler should be initialized")
+}

--- a/health-monitors/syslog-health-monitor/pkg/syslog-monitor/types.go
+++ b/health-monitors/syslog-health-monitor/pkg/syslog-monitor/types.go
@@ -31,8 +31,9 @@ const (
 	FieldSyslogFacility = "SYSLOG_FACILITY"
 	FieldSystemdUnit    = "_SYSTEMD_UNIT"
 
-	XIDErrorCheck  = "SysLogsXIDError"
-	SXIDErrorCheck = "SysLogsSXIDError"
+	XIDErrorCheck     = "SysLogsXIDError"
+	SXIDErrorCheck    = "SysLogsSXIDError"
+	GPUFallenOffCheck = "SysLogsGPUFallenOff"
 )
 
 // syslogMonitorState represents the persistent state of the syslog monitor

--- a/health-monitors/syslog-health-monitor/pkg/xid/parser/csv.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/parser/csv.go
@@ -23,15 +23,16 @@ import (
 
 	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	"github.com/nvidia/nvsentinel/health-monitors/syslog-health-monitor/pkg/common"
+	"github.com/nvidia/nvsentinel/health-monitors/syslog-health-monitor/pkg/patterns"
 	"github.com/nvidia/nvsentinel/health-monitors/syslog-health-monitor/pkg/types"
 	"github.com/nvidia/nvsentinel/health-monitors/syslog-health-monitor/pkg/xid/metrics"
 )
 
 var (
-	reXidPattern = regexp.MustCompile(
-		`NVRM: Xid \(PCI:([0-9a-fA-F:.]+)\): (\d+)(?:, pid=(\d+))?(?:, name=([^,]+))?(?:, Ch ([0-9a-fA-F]+))?`,
-	)
+	// reXidPattern uses the canonical XID pattern from the patterns package
+	reXidPattern = patterns.XIDPattern
 
+	// reXidNVL5Pattern matches NVIDIA NVL5 XID messages with subcode and intrinfo
 	reXidNVL5Pattern = regexp.MustCompile(
 		`NVRM: Xid \(PCI:([^)]+)\): (\d+)(?:, pid=[^,]*)?(?:, name=[^,]*)?, ` +
 			`(\w+)\s+(\w+)\s+(\w+)\s+(\w+)\s+Link\s+(-?\d+)\s+\((0x[0-9a-fA-F]+)\s+(0x[0-9a-fA-F]+)`,

--- a/health-monitors/syslog-health-monitor/pkg/xid/parser/csv.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/parser/csv.go
@@ -29,9 +29,6 @@ import (
 )
 
 var (
-	// reXidPattern uses the canonical XID pattern from the patterns package
-	reXidPattern = patterns.XIDPattern
-
 	// reXidNVL5Pattern matches NVIDIA NVL5 XID messages with subcode and intrinfo
 	reXidNVL5Pattern = regexp.MustCompile(
 		`NVRM: Xid \(PCI:([^)]+)\): (\d+)(?:, pid=[^,]*)?(?:, name=[^,]*)?, ` +
@@ -136,7 +133,8 @@ func (p *CSVParser) parseNVL5XID(message string) (*Response, error) {
 
 // parseStandardXID parses standard XID messages
 func (p *CSVParser) parseStandardXID(message string) (*Response, error) {
-	m := reXidPattern.FindStringSubmatch(message)
+	// Use the canonical XID pattern from the patterns package directly
+	m := patterns.XIDPattern.FindStringSubmatch(message)
 	if len(m) < 3 {
 		return &Response{Success: false}, nil
 	}


### PR DESCRIPTION
## Summary

Adds support for detecting and reporting GPU failures where the GPU falls without an associated XID error (probably undetected previously by the syslog health monitor). This handled GPUs failures with the following dmesg logs that are **not linked to an XID**:

there are 4 cases now:

1) GPU fallen off only (no XID) - event generated
2) XID followed by GPU fallen off - duplicate suppressed via time buffer
3) Single message with both - let XID handler process
4) XID expires, GPU fallen off generates event after 5 min window

Here are the sequence diagrams for each: 


## 1: GPU Fallen Off Only (No XID)

```mermaid
sequenceDiagram
    participant J as Journal
    participant SM as SyslogMonitor
    participant GF as GPUFallenHandler
    participant PC as PlatformConnector

    J->>SM: Log: "GPU 0000:b3:00.0 fallen off the bus"
    SM->>GF: ProcessLine(message)
    GF->>GF: trackXIDIfPresent(message)
    Note over GF: No XID found, nothing tracked
    GF->>GF: parseGPUFallenError(message)
    GF->>GF: XIDPattern.MatchString(message)?
    Note over GF: No XID in message
    GF->>GF: hasRecentXID("0000:b3:00.0")?
    Note over GF: No recent XID
    GF->>GF: createHealthEventFromError()
    GF-->>SM: HealthEvent{IsFatal: true, Action: RESTART_BM}
    SM->>PC: SendHealthEvent()
```

## 2: XID 79 Followed by GPU Fallen Off (Duplicate Suppression)

```mermaid
sequenceDiagram
    participant J as Journal
    participant SM as SyslogMonitor
    participant XH as XIDHandler
    participant GF as GPUFallenHandler
    participant PC as PlatformConnector

    Note over J: T1: XID error occurs
    J->>SM: Log: "NVRM: Xid (PCI:0000:b3:00.0): 79"
    SM->>XH: ProcessLine(message)
    XH->>XH: parseXID()
    XH-->>SM: HealthEvent{XID: 79}
    SM->>PC: SendHealthEvent()
    
    SM->>GF: ProcessLine(message)
    GF->>GF: trackXIDIfPresent(message)
    Note over GF: Records XID 79 for 0000:b3:00.0<br/>timestamp: T1
    GF->>GF: parseGPUFallenError(message)
    GF->>GF: XIDPattern.MatchString(message)?
    Note over GF: XID found in message
    GF-->>SM: nil (no event)

    Note over J: T5: GPU fallen off (3 min later)
    J->>SM: Log: "GPU 0000:b3:00.0 fallen off the bus"
    SM->>GF: ProcessLine(message)
    GF->>GF: trackXIDIfPresent(message)
    Note over GF: No XID in this message
    GF->>GF: parseGPUFallenError(message)
    GF->>GF: XIDPattern.MatchString(message)?
    Note over GF: No XID in message
    GF->>GF: hasRecentXID("0000:b3:00.0")?
    Note over GF: Found XID at T1,<br/>T5-T1 < 5 min window
    GF-->>SM: nil (suppressed - duplicate)
    Note over SM: No duplicate event sent
```

## 3: Single Message with Both XID and GPU Fallen Off

```mermaid
sequenceDiagram
    participant J as Journal
    participant SM as SyslogMonitor
    participant XH as XIDHandler
    participant GF as GPUFallenHandler
    participant PC as PlatformConnector

    J->>SM: Log: "NVRM: Xid (PCI:0000:b3:00.0): 79<br/>GPU fallen off the bus"
    
    SM->>XH: ProcessLine(message)
    XH->>XH: parseXID()
    XH-->>SM: HealthEvent{XID: 79}
    SM->>PC: SendHealthEvent()
    
    SM->>GF: ProcessLine(message)
    GF->>GF: trackXIDIfPresent(message)
    Note over GF: Records XID 79
    GF->>GF: parseGPUFallenError(message)
    GF->>GF: XIDPattern.MatchString(message)?
    Note over GF: XID found in same message
    GF-->>SM: nil (let XID handler process)
    Note over SM: No duplicate event
```

## 4: XID Expires, GPU Fallen Off Generates Event

```mermaid
sequenceDiagram
    participant J as Journal
    participant SM as SyslogMonitor
    participant XH as XIDHandler
    participant GF as GPUFallenHandler
    participant PC as PlatformConnector

    Note over J: T1: XID error
    J->>SM: Log: "NVRM: Xid (PCI:0000:b3:00.0): 79"
    SM->>XH: ProcessLine(message)
    XH-->>SM: HealthEvent{XID: 79}
    SM->>PC: SendHealthEvent()
    
    SM->>GF: ProcessLine(message)
    GF->>GF: trackXIDIfPresent(message)
    Note over GF: Records XID 79, timestamp: T1

    Note over J: T10: GPU fallen off (6 min later)
    J->>SM: Log: "GPU 0000:b3:00.0 fallen off the bus"
    SM->>GF: ProcessLine(message)
    GF->>GF: parseGPUFallenError(message)
    GF->>GF: hasRecentXID("0000:b3:00.0")?
    Note over GF: XID at T1, T10-T1 > 5 min<br/>XID expired from buffer
    GF->>GF: createHealthEventFromError()
    GF-->>SM: HealthEvent{IsFatal: true}
    SM->>PC: SendHealthEvent()
```


## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] Health Monitors
- [ ] Core Services
- [ ] Fault Management
- [ ] Documentation/CI
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Detects NVIDIA GPU fallen-off-bus errors from system logs
  * Generates health events with recommended restart actions
  * Tracks XID errors to prevent duplicate alerts
  * Adds metrics for GPU error monitoring

<!-- end of auto-generated comment: release notes by coderabbit.ai -->