### PR TITLE
fix: fail fast in some cases when the health event can't be published

### DIFF
--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/platform_connector/platform_connector.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/platform_connector/platform_connector.py
@@ -118,6 +118,7 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
                 self.send_health_event_with_retries(health_events)
             except Exception as e:
                 log.error(f"Exception while sending DCGM connectivity restored events: {e}")
+                raise
 
     def health_event_occurred(
         self, health_details: dict[str, dcgmtypes.HealthDetails], gpu_ids: list, serials: dict[int, str]
@@ -248,8 +249,8 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
                 try:
                     self.send_health_event_with_retries(health_events)
                 except Exception as e:
-                    log.error(f"Exception while sending health events: {e}. Events will be retried in next cycle.")
-                    # Don't crash - continue monitoring
+                    log.error(f"Exception while sending health events: {e}")
+                    self.entity_cache = {}
 
     def get_recommended_action_from_dcgm_error_map(self, error_code):
         if error_code in self.dcgm_errors_info_dict:
@@ -322,4 +323,4 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
                     self.send_health_event_with_retries(health_events)
                 except Exception as e:
                     log.error(f"Exception while sending DCGM connectivity failure events: {e}")
-                    # Don't crash - continue monitoring
+                    raise

--- a/health-monitors/syslog-health-monitor/pkg/syslog-monitor/syslogmonitor.go
+++ b/health-monitors/syslog-health-monitor/pkg/syslog-monitor/syslogmonitor.go
@@ -282,10 +282,12 @@ func (sm *SyslogMonitor) handleBootIDChange(oldBootID, newBootID string) error {
 			errRes := types.ErrorResolution{
 				RecommendedAction: pb.RecommendedAction_NONE,
 			}
+
 			healthEvents := sm.prepareHealthEventWithAction(check, message, true, errRes)
 			if err := sm.sendHealthEventWithRetry(healthEvents, 5, 2*time.Second); err != nil {
 				return fmt.Errorf("failed to send health event: %w", err)
 			}
+
 			slog.Info("Published healthy event after system reboot", "check", check.Name)
 		}
 	}

--- a/health-monitors/syslog-health-monitor/pkg/syslog-monitor/syslogmonitor.go
+++ b/health-monitors/syslog-health-monitor/pkg/syslog-monitor/syslogmonitor.go
@@ -277,19 +277,16 @@ func (sm *SyslogMonitor) handleBootIDChange(oldBootID, newBootID string) error {
 
 		slog.Info("Cleared all cursors due to system reboot")
 
-		// Publish healthy events for all checks after a reboot
-		if sm.pcClient != nil {
-			for _, check := range sm.checks {
-				message := "No Health Failures"
-				errRes := types.ErrorResolution{
-					RecommendedAction: pb.RecommendedAction_NONE,
-				}
-				healthEvents := sm.prepareHealthEventWithAction(check, message, true, errRes)
-				sm.sendHealthEventWithRetry(healthEvents, 5, 2*time.Second)
-				slog.Info("Published healthy event after system reboot", "check", check.Name)
+		for _, check := range sm.checks {
+			message := "No Health Failures"
+			errRes := types.ErrorResolution{
+				RecommendedAction: pb.RecommendedAction_NONE,
 			}
-		} else {
-			slog.Warn("Platform connector client is nil, cannot send healthy events after reboot")
+			healthEvents := sm.prepareHealthEventWithAction(check, message, true, errRes)
+			if err := sm.sendHealthEventWithRetry(healthEvents, 5, 2*time.Second); err != nil {
+				return fmt.Errorf("failed to send health event: %w", err)
+			}
+			slog.Info("Published healthy event after system reboot", "check", check.Name)
 		}
 	}
 
@@ -782,12 +779,7 @@ func (sm *SyslogMonitor) prepareHealthEventWithAction(
 
 // sendHealthEventWithRetry sends health events to platform connector with retry logic
 func (sm *SyslogMonitor) sendHealthEventWithRetry(healthEvents *pb.HealthEvents,
-	maxRetries int, retryDelay time.Duration) {
-	if sm.pcClient == nil {
-		slog.Error("PlatformConnectorClient is nil, cannot send health event")
-		return
-	}
-
+	maxRetries int, retryDelay time.Duration) error {
 	slog.Info("Attempting to send health event", "events", healthEvents)
 
 	backoff := wait.Backoff{
@@ -816,15 +808,14 @@ func (sm *SyslogMonitor) sendHealthEventWithRetry(healthEvents *pb.HealthEvents,
 
 	if err != nil {
 		slog.Error("All retry attempts to send health event failed", "error", err)
+		return fmt.Errorf("failed all attempts to send health events: %w", err)
 	}
+
+	return nil
 }
 
 // isRetryableError determines if an error is retryable
 func isRetryableError(err error) bool {
-	if err == nil {
-		return false
-	}
-
 	if s, ok := status.FromError(err); ok {
 		if s.Code() == codes.Unavailable || s.Code() == codes.DeadlineExceeded {
 			return true
@@ -851,7 +842,9 @@ func (sm *SyslogMonitor) handleSingleLine(check CheckDefinition, lineToEvaluate 
 		}
 
 		if healthEvents != nil {
-			sm.sendHealthEventWithRetry(healthEvents, 5, 2*time.Second)
+			if err := sm.sendHealthEventWithRetry(healthEvents, 5, 2*time.Second); err != nil {
+				return fmt.Errorf("failed to send health event: %w", err)
+			}
 		}
 	}
 

--- a/node-drainer-module/pkg/mongodb/event_watcher.go
+++ b/node-drainer-module/pkg/mongodb/event_watcher.go
@@ -55,7 +55,6 @@ func NewEventWatcher(
 func (w *EventWatcher) Start(ctx context.Context) error {
 	slog.Info("Starting MongoDB event watcher")
 
-	// Cold start failure shouldn't prevent normal operation
 	if err := w.handleColdStart(ctx); err != nil {
 		slog.Error("Failed to handle cold start", "error", err)
 		return fmt.Errorf("failed to cold start: %w", err)

--- a/node-drainer-module/pkg/mongodb/event_watcher.go
+++ b/node-drainer-module/pkg/mongodb/event_watcher.go
@@ -58,6 +58,7 @@ func (w *EventWatcher) Start(ctx context.Context) error {
 	// Cold start failure shouldn't prevent normal operation
 	if err := w.handleColdStart(ctx); err != nil {
 		slog.Error("Failed to handle cold start", "error", err)
+		return fmt.Errorf("failed to cold start: %w", err)
 	}
 
 	watcher, err := storewatcher.NewChangeStreamWatcher(ctx, w.mongoConfig, w.tokenConfig, w.mongoPipeline)
@@ -77,11 +78,12 @@ func (w *EventWatcher) Start(ctx context.Context) error {
 		case event := <-watcher.Events():
 			if err := w.preprocessAndEnqueueEvent(ctx, event); err != nil {
 				slog.Error("Failed to preprocess and enqueue event", "error", err)
-				continue
+				return fmt.Errorf("failed to preprocess and enqueue event: %w", err)
 			}
 
 			if err := watcher.MarkProcessed(ctx); err != nil {
 				slog.Error("Error updating resume token", "error", err)
+				return fmt.Errorf("failed to update resume token: %w", err)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

fixes https://github.com/NVIDIA/NVSentinel/issues/196

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] Health Monitors
- [ ] Core Services
- [ ] Fault Management
- [ ] Documentation/CI
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Enhanced error handling across health monitoring operations with stricter failure propagation
* Fixed instances where operation failures were silently ignored; errors now surface to calling functions for improved visibility and diagnostics
* Improved event publishing reliability by ensuring consistent error propagation throughout the system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->