### PR TITLE
fix: add missing s to daemonset name

### DIFF
--- a/scripts/validate-nvsentinel.sh
+++ b/scripts/validate-nvsentinel.sh
@@ -277,7 +277,7 @@ check_optional_deployment "simple-health-client" 1
 
 # Check daemonsets (system components that run on nodes)
 echo "=== DaemonSets ==="
-check_daemonset "platform-connector"
+check_daemonset "platform-connectors"
 check_daemonset "gpu-health-monitor-dcgm-3.x"
 check_daemonset "gpu-health-monitor-dcgm-4.x"
 check_daemonset "syslog-health-monitor-regular"


### PR DESCRIPTION
## Summary

add missing `s` in daemonset name

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Health Monitors
- [x] Core Services
- [ ] Fault Management
- [ ] Documentation/CI
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
