### PR TITLE
feat: repeated xid failures in burst

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
@@ -32,15 +32,254 @@ resources:
 logLevel: info
 
 config: |
-  [[rules]]
-  # The node condition for this rule needs to be removed manually because health-events-analyzer does not publish healthy events to clear it.
+  # The node condition for these rules needs to be removed manually because health-events-analyzer does not publish healthy events to clear it.
   # Please run the command below to remove the node condition:
-  # kubectl get node <NODE_NAME> -o json | jq '.status.conditions |= map(select(.type != "MultipleRemediations"))' | kubectl replace -f - --subresource=status
+  # kubectl get node <NODE_NAME> -o json | jq '.status.conditions |= map(select(.type != "<NAME_OF_APPLIED_RULE>"))' | kubectl replace -f - --subresource=status
+  [[rules]]
   name = "MultipleRemediations"
   description = "Detect if multiple remediations are performed within 7 days on a node"
-  time_window = "168h"
   recommended_action = "CONTACT_SUPPORT"
+  stage = [
+    '''
+    {
+      "$match": {
+        "$expr": {
+          "$gte": [
+            "$healthevent.generatedtimestamp.seconds",
+            {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 604800]}
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$match": {
+        "healtheventstatus.faultremediated": true,
+        "healthevent.nodename": "this.healthevent.nodename",
+        "healthevent.isfatal": "this.healthevent.isfatal"
+      }
+    }
+    ''',
+    '{"$count": "count"}',
+    '{"$match": {"count": {"$gte": 5}}}'
+  ]
 
-  [[rules.sequence]]
-  criteria = {"healtheventstatus.faultremediated" = true, "healthevent.nodename" = "this.healthevent.nodename", "healthevent.isfatal" = "this.healthevent.isfatal"}
-  errorCount = 5
+  [[rules]]
+  name = "RepeatedXidError"
+  description = "Detect occurrence of fatal XIDs 5 times within 24 hours"
+  recommended_action = "CONTACT_SUPPORT"
+  stage = [
+    '''
+    {
+      "$match": {
+        "$expr": {
+          "$gte": [
+            "$healthevent.generatedtimestamp.seconds",
+            {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$match": {
+        "healthevent.ishealthy": false,
+        "healthevent.nodename": "this.healthevent.nodename",
+        "$expr": {
+          "$gt": [
+            {
+              "$size": {
+                "$setIntersection": [
+                  {
+                    "$map": {
+                      "input": {
+                        "$filter": {
+                          "input": "$healthevent.entitiesimpacted",
+                          "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                        }
+                      },
+                      "in": "$$this.entityvalue"
+                    }
+                  },
+                  {
+                    "$map": {
+                      "input": {
+                        "$filter": {
+                          "input": "this.healthevent.entitiesimpacted",
+                          "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                        }
+                      },
+                      "in": "$$this.entityvalue"
+                    }
+                  }
+                ]
+              }
+            },
+            0
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$setWindowFields": {
+        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+        "output": {
+          "prevTimestamp": {
+            "$shift": {
+              "output": "$healthevent.generatedtimestamp.seconds",
+              "by": -1
+            }
+          }
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$addFields": {
+        "isStickyXid": {
+          "$in": [
+            {"$arrayElemAt": ["$healthevent.errorcode", 0]},
+            ["74", "79", "95", "109", "119"]
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$setWindowFields": {
+        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+        "output": {
+          "allPreviousEvents": {
+            "$push": "$$ROOT",
+            "window": {"documents": ["unbounded", -1]}
+          }
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$addFields": {
+        "stickyXidWithin3Hours": {
+          "$cond": {
+            "if": "$isStickyXid",
+            "then": {
+              "$anyElementTrue": {
+                "$map": {
+                  "input": "$allPreviousEvents",
+                  "as": "prevEvent",
+                  "in": {
+                    "$and": [
+                      {
+                        "$in": [
+                          {"$arrayElemAt": ["$$prevEvent.healthevent.errorcode", 0]},
+                          ["74", "79", "95", "109", "119"]
+                        ]
+                      },
+                      {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 10800]}
+                    ]
+                  }
+                }
+              }
+            },
+            "else": false
+          }
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$setWindowFields": {
+        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+        "output": {
+          "burstId": {
+            "$sum": {
+              "$cond": {
+                "if": {"$eq": ["$prevTimestamp", null]},
+                "then": 1,
+                "else": {
+                  "$cond": {
+                    "if": {
+                      "$and": [
+                        "$isStickyXid",
+                        "$stickyXidWithin3Hours"
+                      ]
+                    },
+                    "then": 0,
+                    "else": {
+                      "$cond": {
+                        "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 180]},
+                        "then": 1,
+                        "else": 0
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "window": {"documents": ["unbounded", "current"]}
+          }
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$group": {
+        "_id": {"burstId": "$burstId"},
+        "uniqueXidsInBurst": {"$addToSet": {"$arrayElemAt": ["$healthevent.errorcode", 0]}},
+        "targetXidCount": {
+          "$sum": {
+            "$cond": [
+              {"$eq": [{"$arrayElemAt": ["$healthevent.errorcode", 0]}, "this.healthevent.errorcode.0"]},
+              1,
+              0
+            ]
+          }
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$setWindowFields": {
+        "sortBy": {"_id.burstId": 1},
+        "output": {"maxBurstId": {"$max": "$_id.burstId"}}
+      }
+    }
+    ''',
+    '''
+    {
+      "$match": {
+        "$expr": {
+          "$and": [
+            {"$in": ["this.healthevent.errorcode.0", "$uniqueXidsInBurst"]},
+            {
+              "$or": [
+                {"$ne": ["$_id.burstId", "$maxBurstId"]},
+                {"$eq": ["$targetXidCount", 1]}
+              ]
+            }
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$group": {
+        "_id": null,
+        "count": {"$sum": 1},
+        "bursts": {"$push": {"burstId": "$_id.burstId", "uniqueXids": "$uniqueXidsInBurst"}}
+      }
+    }
+    ''',
+    '{"$match": {"count": {"$gte": 5}}}'
+  ]

--- a/distros/kubernetes/nvsentinel/charts/mongodb-store/templates/jobs.yaml
+++ b/distros/kubernetes/nvsentinel/charts/mongodb-store/templates/jobs.yaml
@@ -139,6 +139,12 @@ spec:
                   db.$MONGODB_MAINTENANCE_EVENT_COLLECTION_NAME.createIndex(
                     { 'cspStatus': 1 },
                   );
+                  db.$MONGODB_COLLECTION_NAME.createIndex({
+                    'healthevent.nodename': 1,
+                    'healthevent.entitiesimpacted.entitytype': 1,
+                    'healthevent.entitiesimpacted.entityvalue': 1,
+                    'healthevent.generatedtimestamp.seconds': 1
+                  });
                 // Check if user exists before creating
                 var userExists = db.getSiblingDB('\$external').getUser('$MONGODB_APPLICATION_USER_DN');
                 if (userExists) {

--- a/health-events-analyzer/pkg/config/rules.go
+++ b/health-events-analyzer/pkg/config/rules.go
@@ -20,17 +20,11 @@ import (
 	"github.com/nvidia/nvsentinel/commons/pkg/configmanager"
 )
 
-type SequenceStep struct {
-	Criteria   map[string]interface{} `toml:"criteria"`
-	ErrorCount int                    `toml:"errorCount"`
-}
-
 type HealthEventsAnalyzerRule struct {
-	Name              string         `toml:"name"`
-	Description       string         `toml:"description"`
-	TimeWindow        string         `toml:"time_window"`
-	Sequence          []SequenceStep `toml:"sequence"`
-	RecommendedAction string         `toml:"recommended_action"`
+	Name              string   `toml:"name"`
+	Description       string   `toml:"description"`
+	RecommendedAction string   `toml:"recommended_action"`
+	Stage             []string `toml:"stage"`
 }
 
 type TomlConfig struct {

--- a/tests/data/health-events-analyzer-config.yaml
+++ b/tests/data/health-events-analyzer-config.yaml
@@ -8,10 +8,249 @@ data:
     [[rules]]
     name = "MultipleRemediations"
     description = "Detect if multiple remediations are performed within 3 minutes on a node"
-    time_window = "3m"
     recommended_action = "CONTACT_SUPPORT"
 
-    [[rules.sequence]]
-    criteria = {"healtheventstatus.faultremediated" = true, "healthevent.nodename" = "this.healthevent.nodename", "healthevent.isfatal" = "this.healthevent.isfatal"}
-    errorCount = 5
+    stage = [
+      '''
+      {
+        "$match": {
+          "$expr": {
+            "$gte": [
+              "$healthevent.generatedtimestamp.seconds",
+              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 180]}
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$match": {
+          "healtheventstatus.faultremediated": true,
+          "healthevent.nodename": "this.healthevent.nodename",
+          "healthevent.isfatal": "this.healthevent.isfatal"
+        }
+      }
+      ''',
+      '{"$count": "count"}',
+      '{"$match": {"count": {"$gte": 5}}}'
+    ]
 
+    [[rules]]
+    name = "RepeatedXidError"
+    description = "Detect occurrence of fatal XIDs 2 times within 3 minutes where the burst window is 10 seconds and sticky XIDs window is 20seconds"
+    recommended_action = "CONTACT_SUPPORT"
+    stage = [
+      '''
+      {
+        "$match": {
+          "$expr": {
+            "$gte": [
+              "$healthevent.generatedtimestamp.seconds",
+              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 180]}
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$match": {
+          "healthevent.ishealthy": false,
+          "healthevent.nodename": "this.healthevent.nodename",
+          "$expr": {
+            "$gt": [
+              {
+                "$size": {
+                  "$setIntersection": [
+                    {
+                      "$map": {
+                        "input": {
+                          "$filter": {
+                            "input": "$healthevent.entitiesimpacted",
+                            "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                          }
+                        },
+                        "in": "$$this.entityvalue"
+                      }
+                    },
+                    {
+                      "$map": {
+                        "input": {
+                          "$filter": {
+                            "input": "this.healthevent.entitiesimpacted",
+                            "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                          }
+                        },
+                        "in": "$$this.entityvalue"
+                      }
+                    }
+                  ]
+                }
+              },
+              0
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$setWindowFields": {
+          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+          "output": {
+            "prevTimestamp": {
+              "$shift": {
+                "output": "$healthevent.generatedtimestamp.seconds",
+                "by": -1
+              }
+            }
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$addFields": {
+          "isStickyXid": {
+            "$in": [
+              {"$arrayElemAt": ["$healthevent.errorcode", 0]},
+              ["74", "79", "95", "109", "119"]
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$setWindowFields": {
+          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+          "output": {
+            "allPreviousEvents": {
+              "$push": "$$ROOT",
+              "window": {"documents": ["unbounded", -1]}
+            }
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$addFields": {
+          "stickyXidWithin3Hours": {
+            "$cond": {
+              "if": "$isStickyXid",
+              "then": {
+                "$anyElementTrue": {
+                  "$map": {
+                    "input": "$allPreviousEvents",
+                    "as": "prevEvent",
+                    "in": {
+                      "$and": [
+                        {
+                          "$in": [
+                            {"$arrayElemAt": ["$$prevEvent.healthevent.errorcode", 0]},
+                            ["74", "79", "95", "109", "119"]
+                          ]
+                        },
+                        {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 20]}
+                      ]
+                    }
+                  }
+                }
+              },
+              "else": false
+            }
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$setWindowFields": {
+          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+          "output": {
+            "burstId": {
+              "$sum": {
+                "$cond": {
+                  "if": {"$eq": ["$prevTimestamp", null]},
+                  "then": 1,
+                  "else": {
+                    "$cond": {
+                      "if": {
+                        "$and": [
+                          "$isStickyXid",
+                          "$stickyXidWithin3Hours"
+                        ]
+                      },
+                      "then": 0,
+                      "else": {
+                        "$cond": {
+                          "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 10]},
+                          "then": 1,
+                          "else": 0
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "window": {"documents": ["unbounded", "current"]}
+            }
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$group": {
+          "_id": {"burstId": "$burstId"},
+          "uniqueXidsInBurst": {"$addToSet": {"$arrayElemAt": ["$healthevent.errorcode", 0]}},
+          "targetXidCount": {
+            "$sum": {
+              "$cond": [
+                {"$eq": [{"$arrayElemAt": ["$healthevent.errorcode", 0]}, "this.healthevent.errorcode.0"]},
+                1,
+                0
+              ]
+            }
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$setWindowFields": {
+          "sortBy": {"_id.burstId": 1},
+          "output": {"maxBurstId": {"$max": "$_id.burstId"}}
+        }
+      }
+      ''',
+      '''
+      {
+        "$match": {
+          "$expr": {
+            "$and": [
+              {"$in": ["this.healthevent.errorcode.0", "$uniqueXidsInBurst"]},
+              {
+                "$or": [
+                  {"$ne": ["$_id.burstId", "$maxBurstId"]},
+                  {"$eq": ["$targetXidCount", 1]}
+                ]
+              }
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$group": {
+          "_id": null,
+          "count": {"$sum": 1},
+          "bursts": {"$push": {"burstId": "$_id.burstId", "uniqueXids": "$uniqueXidsInBurst"}}
+        }
+      }
+      ''',
+      '{"$match": {"count": {"$gte": 2}}}'
+    ]

--- a/tests/helpers/kube.go
+++ b/tests/helpers/kube.go
@@ -1411,11 +1411,15 @@ func WaitForNodeConditionWithCheckName(
 
 		for _, condition := range node.Status.Conditions {
 			if condition.Status == v1.ConditionTrue &&
-				condition.Reason == checkName+"IsNotHealthy" && message == condition.Message {
-				t.Logf("Found node condition: Type=%s, Reason=%s, Status=%s, Message=%s",
-					condition.Type, condition.Reason, condition.Status, condition.Message)
+				condition.Reason == checkName+"IsNotHealthy" {
+				t.Logf("Checking if message matches: expected message=%s, actual message=%s", message, condition.Message)
 
-				return true
+				if message == condition.Message {
+					t.Logf("Found node condition: Type=%s, Reason=%s, Status=%s, Message=%s",
+						condition.Type, condition.Reason, condition.Status, condition.Message)
+
+					return true
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary

<!-- Brief description of your changes -->

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] Health Monitors
- [ ] Core Services
- [ ] Fault Management
- [ ] Documentation/CI
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review

## Summary
This PR is handling the changes in health events analyzer to detect multiple XID occurrences. It also takes care of handling the XID events occurred in burst. XIDs can occur in burst thats why are considering XIDs burst while counting the XID occurrences. We have defined 3min burst gap that means if no XIDs occur for 3min then all previous XIDs will be part of same burst group. 
Added burst_gap_seconds field in events-analyzer config to define the burst time window.

## Testing
1. Written tilt test TestRepeatedXIDRule which is handling all the scenarios possible for RepeatedXIDRule.
2. Did manual testing on cluster by injecting multiple XIDs and checking if rule met the criteria or not and also if its considering the burst time correctly or not.
3. Covered following scenarios in tilt test and during manual testing
    a. If no XIDs count met then no node condition will be applied
    b. if XID say 13 occurred multiple times in same burst then it will be counted 1 and only one time health-events-analyzer will publish new fatal event not for every occurrences of same XID in same burst. 
    c. event published by health-events-analyzer are not considered while running mongo pipeline
    d. time window and burst window both were considered correctly to group the XIDs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect repeated fatal XID errors within 24‑hour windows.
  * Rules now support multi‑stage, JSON-style pipeline definitions for richer stage‑based detection.
  * Node‑condition removal guidance generalized to reference applied rule names.

* **Performance**
  * Added a compound index to speed up health‑event queries and aggregations.

* **Tests**
  * Test suite and helpers updated with stage‑based scenarios, new error codes, teardown signature change, and an end‑to‑end XID rule test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->