### PR TITLE
fix: health events are not sent for dcgm connectivity failures

### DIFF
--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_platform_connector/test_platform_connector.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_platform_connector/test_platform_connector.py
@@ -595,16 +595,20 @@ class TestPlatformConnectors(unittest.TestCase):
             # Test 1: DCGM Connectivity Failure (system-level event, no entities)
             # This tests the cache cleanup path: if checkName == "GpuDcgmConnectivityFailure"
             platform_connector_processor.dcgm_connectivity_failed()
-            dcgm_failure_cache_key = platform_connector_processor._build_cache_key("GpuDcgmConnectivityFailure", "DCGM", "ALL")
-            assert dcgm_failure_cache_key not in platform_connector_processor.entity_cache, \
-                "DCGM failure cache entry should be removed after send failure"
+            dcgm_failure_cache_key = platform_connector_processor._build_cache_key(
+                "GpuDcgmConnectivityFailure", "DCGM", "ALL"
+            )
+            assert (
+                dcgm_failure_cache_key not in platform_connector_processor.entity_cache
+            ), "DCGM failure cache entry should be removed after send failure"
 
             # Test 2: DCGM Connectivity Restored
             timestamp = Timestamp()
             timestamp.GetCurrentTime()
             platform_connector_processor.clear_dcgm_connectivity_failure(timestamp)
-            assert dcgm_failure_cache_key not in platform_connector_processor.entity_cache, \
-                "DCGM restored cache entry should be removed after send failure"
+            assert (
+                dcgm_failure_cache_key not in platform_connector_processor.entity_cache
+            ), "DCGM restored cache entry should be removed after send failure"
 
             # Test 3: GPU Health Event (entity-specific event)
             # This tests the cache cleanup path: elif len(entitiesImpacted) > 0
@@ -621,8 +625,9 @@ class TestPlatformConnectors(unittest.TestCase):
             gpu_ids = [0]
             platform_connector_processor.health_event_occurred(dcgm_health_events, gpu_ids, gpu_serials)
             gpu_health_cache_key = platform_connector_processor._build_cache_key("GpuInforomWatch", "GPU", "0")
-            assert gpu_health_cache_key not in platform_connector_processor.entity_cache, \
-                "GPU health cache entry should be removed after send failure"
+            assert (
+                gpu_health_cache_key not in platform_connector_processor.entity_cache
+            ), "GPU health cache entry should be removed after send failure"
 
             # Platform connector comes UP - Start server
             healthEventProcessor = PlatformConnectorServicer()
@@ -630,12 +635,13 @@ class TestPlatformConnectors(unittest.TestCase):
             platformconnector_pb2_grpc.add_PlatformConnectorServicer_to_server(healthEventProcessor, server)
             server.add_insecure_port(f"unix://{socket_path}")
             server.start()
-            
+
             # Retry DCGM Connectivity Failure
             platform_connector_processor.dcgm_connectivity_failed()
             time.sleep(1)
-            assert dcgm_failure_cache_key in platform_connector_processor.entity_cache, \
-                "DCGM failure cache entry should be present after successful send"
+            assert (
+                dcgm_failure_cache_key in platform_connector_processor.entity_cache
+            ), "DCGM failure cache entry should be present after successful send"
             assert platform_connector_processor.entity_cache[dcgm_failure_cache_key].isFatal == True
             assert platform_connector_processor.entity_cache[dcgm_failure_cache_key].isHealthy == False
 
@@ -656,8 +662,9 @@ class TestPlatformConnectors(unittest.TestCase):
             timestamp.GetCurrentTime()
             platform_connector_processor.clear_dcgm_connectivity_failure(timestamp)
             time.sleep(1)
-            assert platform_connector_processor.entity_cache[dcgm_failure_cache_key].isHealthy == True, \
-                "DCGM failure cache entry should be updated to healthy"
+            assert (
+                platform_connector_processor.entity_cache[dcgm_failure_cache_key].isHealthy == True
+            ), "DCGM failure cache entry should be updated to healthy"
 
             # Verify DCGM restored event was sent
             health_events = healthEventProcessor.health_events
@@ -673,8 +680,9 @@ class TestPlatformConnectors(unittest.TestCase):
             # Retry GPU Health Event
             platform_connector_processor.health_event_occurred(dcgm_health_events, gpu_ids, gpu_serials)
             time.sleep(1)
-            assert gpu_health_cache_key in platform_connector_processor.entity_cache, \
-                "GPU health cache entry should be present after successful send"
+            assert (
+                gpu_health_cache_key in platform_connector_processor.entity_cache
+            ), "GPU health cache entry should be present after successful send"
             assert platform_connector_processor.entity_cache[gpu_health_cache_key].isFatal == True
             assert platform_connector_processor.entity_cache[gpu_health_cache_key].isHealthy == False
 

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_platform_connector/test_platform_connector.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_platform_connector/test_platform_connector.py
@@ -537,3 +537,161 @@ class TestPlatformConnectors(unittest.TestCase):
         assert restored_event.recommendedAction == platformconnector_pb2.NONE
 
         server.stop(0)
+
+    def test_event_retry_and_cache_cleanup_when_platform_connector_down(self):
+        """Test when platform connector goes down and comes back up."""
+        import tempfile
+        import os
+
+        original_max_retries = platform_connector.MAX_RETRIES
+        original_initial_delay = platform_connector.INITIAL_DELAY
+        platform_connector.MAX_RETRIES = 3
+        platform_connector.INITIAL_DELAY = 1
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix="_test_state") as f:
+            f.write("test_boot_id")
+            state_file_path = f.name
+
+        try:
+            watcher = dcgm.DCGMWatcher(
+                addr="localhost:5555",
+                poll_interval_seconds=10,
+                callbacks=[],
+                dcgm_k8s_service_enabled=False,
+            )
+            gpu_serials = {0: "1650924060039"}
+            exit = Event()
+
+            dcgm_errors_info_dict = {"DCGM_FR_CORRUPT_INFOROM": "COMPONENT_RESET"}
+            dcgm_health_conditions_categorization_mapping_config = {
+                "DCGM_HEALTH_WATCH_INFOROM": "Fatal",
+                "DCGM_HEALTH_WATCH_THERMAL": "NonFatal",
+                "DCGM_HEALTH_WATCH_POWER": "NonFatal",
+                "DCGM_HEALTH_WATCH_NVLINK": "Fatal",
+                "DCGM_HEALTH_WATCH_SM": "Fatal",
+                "DCGM_HEALTH_WATCH_MEM": "Fatal",
+                "DCGM_HEALTH_WATCH_MCU": "Fatal",
+                "DCGM_HEALTH_WATCH_DRIVER": "Fatal",
+                "DCGM_HEALTH_WATCH_NVSWITCH_FATAL": "Fatal",
+                "DCGM_HEALTH_WATCH_NVSWITCH_NONFATAL": "NonFatal",
+                "DCGM_HEALTH_WATCH_PCIE": "Fatal",
+                "DCGM_HEALTH_WATCH_PMU": "Fatal",
+                "DCGM_HEALTH_WATCH_CPUSET": "NonFatal",
+                "DCGM_HEALTH_WATCH_NVSWITCH": "Fatal",
+            }
+
+            platform_connector_processor = platform_connector.PlatformConnectorEventProcessor(
+                socket_path=socket_path,
+                node_name=node_name,
+                exit=exit,
+                dcgm_errors_info_dict=dcgm_errors_info_dict,
+                state_file_path=state_file_path,
+                dcgm_health_conditions_categorization_mapping_config=dcgm_health_conditions_categorization_mapping_config,
+            )
+
+            # Verify cache is empty initially
+            assert len(platform_connector_processor.entity_cache) == 0
+
+            # Test 1: DCGM Connectivity Failure (system-level event, no entities)
+            # This tests the cache cleanup path: if checkName == "GpuDcgmConnectivityFailure"
+            platform_connector_processor.dcgm_connectivity_failed()
+            dcgm_failure_cache_key = platform_connector_processor._build_cache_key("GpuDcgmConnectivityFailure", "DCGM", "ALL")
+            assert dcgm_failure_cache_key not in platform_connector_processor.entity_cache, \
+                "DCGM failure cache entry should be removed after send failure"
+
+            # Test 2: DCGM Connectivity Restored
+            timestamp = Timestamp()
+            timestamp.GetCurrentTime()
+            platform_connector_processor.clear_dcgm_connectivity_failure(timestamp)
+            assert dcgm_failure_cache_key not in platform_connector_processor.entity_cache, \
+                "DCGM restored cache entry should be removed after send failure"
+
+            # Test 3: GPU Health Event (entity-specific event)
+            # This tests the cache cleanup path: elif len(entitiesImpacted) > 0
+            dcgm_health_events = watcher._get_health_status_dict()
+            dcgm_health_events["DCGM_HEALTH_WATCH_INFOROM"] = dcgmtypes.HealthDetails(
+                status=dcgmtypes.HealthStatus.FAIL,
+                entity_failures={
+                    0: dcgm.types.ErrorDetails(
+                        code="DCGM_FR_CORRUPT_INFOROM",
+                        message="A corrupt InfoROM has been detected in GPU 0.",
+                    )
+                },
+            )
+            gpu_ids = [0]
+            platform_connector_processor.health_event_occurred(dcgm_health_events, gpu_ids, gpu_serials)
+            gpu_health_cache_key = platform_connector_processor._build_cache_key("GpuInforomWatch", "GPU", "0")
+            assert gpu_health_cache_key not in platform_connector_processor.entity_cache, \
+                "GPU health cache entry should be removed after send failure"
+
+            # Platform connector comes UP - Start server
+            healthEventProcessor = PlatformConnectorServicer()
+            server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+            platformconnector_pb2_grpc.add_PlatformConnectorServicer_to_server(healthEventProcessor, server)
+            server.add_insecure_port(f"unix://{socket_path}")
+            server.start()
+            
+            # Retry DCGM Connectivity Failure
+            platform_connector_processor.dcgm_connectivity_failed()
+            time.sleep(1)
+            assert dcgm_failure_cache_key in platform_connector_processor.entity_cache, \
+                "DCGM failure cache entry should be present after successful send"
+            assert platform_connector_processor.entity_cache[dcgm_failure_cache_key].isFatal == True
+            assert platform_connector_processor.entity_cache[dcgm_failure_cache_key].isHealthy == False
+
+            # Verify DCGM failure event was sent
+            health_events = healthEventProcessor.health_events
+            dcgm_failure_event = None
+            for event in health_events:
+                if event.checkName == "GpuDcgmConnectivityFailure" and not event.isHealthy:
+                    dcgm_failure_event = event
+                    break
+            assert dcgm_failure_event is not None, "DCGM failure event should be sent"
+            assert dcgm_failure_event.isFatal == True
+            assert dcgm_failure_event.errorCode == ["DCGM_CONNECTIVITY_ERROR"]
+            assert dcgm_failure_event.entitiesImpacted == []
+
+            # Retry DCGM Connectivity Restored
+            timestamp = Timestamp()
+            timestamp.GetCurrentTime()
+            platform_connector_processor.clear_dcgm_connectivity_failure(timestamp)
+            time.sleep(1)
+            assert platform_connector_processor.entity_cache[dcgm_failure_cache_key].isHealthy == True, \
+                "DCGM failure cache entry should be updated to healthy"
+
+            # Verify DCGM restored event was sent
+            health_events = healthEventProcessor.health_events
+            dcgm_restored_event = None
+            for event in health_events:
+                if event.checkName == "GpuDcgmConnectivityFailure" and event.isHealthy:
+                    dcgm_restored_event = event
+                    break
+            assert dcgm_restored_event is not None, "DCGM restored event should be sent"
+            assert dcgm_restored_event.isFatal == False
+            assert dcgm_restored_event.isHealthy == True
+
+            # Retry GPU Health Event
+            platform_connector_processor.health_event_occurred(dcgm_health_events, gpu_ids, gpu_serials)
+            time.sleep(1)
+            assert gpu_health_cache_key in platform_connector_processor.entity_cache, \
+                "GPU health cache entry should be present after successful send"
+            assert platform_connector_processor.entity_cache[gpu_health_cache_key].isFatal == True
+            assert platform_connector_processor.entity_cache[gpu_health_cache_key].isHealthy == False
+
+            # Verify GPU health event was sent
+            health_events = healthEventProcessor.health_events
+            gpu_health_event = None
+            for event in health_events:
+                if event.checkName == "GpuInforomWatch" and not event.isHealthy:
+                    gpu_health_event = event
+                    break
+            assert gpu_health_event is not None, "GPU health event should be sent"
+            assert gpu_health_event.errorCode[0] == "DCGM_FR_CORRUPT_INFOROM"
+            assert gpu_health_event.entitiesImpacted[0].entityValue == "0"
+
+            server.stop(0)
+        finally:
+            platform_connector.MAX_RETRIES = original_max_retries
+            platform_connector.INITIAL_DELAY = original_initial_delay
+            if os.path.exists(state_file_path):
+                os.unlink(state_file_path)


### PR DESCRIPTION
## Summary

GPU health monitor events were not being sent to the platform connector when dcgm connectivity issues occurred.
This is happening because cache is blocking event retries.
when the platform connector was temporarily unavailable:
- GPU health monitor detected DCGM connectivity failure
- Created GpuDcgmConnectivityFailure event and added to cache
- Attempted to send event to platform connector and all retires failed
- Event remained in cache permanently
- On subsequent poll cycles, cache hit prevented event creation
- When platform connector came back up, no event was sent

Solution: Cache cleanup done after all retry attempts gets exhausted.

 ## Testing
 
- Simulate the dcgm connection failure by pointing fake endpoint from gpu health monitor
   --dcgm-addr nvidia-dcgm-fake.gpu-operator.svc:5555  # Fake service  

- Simulate the platform connector down by adding nodeSelector label which was not available
   nvsentinel-test-down: "true"  # Only run on nodes with this label
   
- Now GPU health monitor detects dcgm connection failure and try to send health event to platform connector but not able to send since platform connector is down. Here is screenshot

<img width="1580" height="1293" alt="Screenshot 2025-11-03 at 11 13 38 AM" src="https://github.com/user-attachments/assets/4f371ca0-57d2-446e-8acd-99c08b671992" />

In the above screenshot it's visible that dcgm connection failure event removed from cache after all retries exhausted.
  "Removed DCGM connectivity event from cache after send failure: GpuDcgmConnectivityFailure|DCGM|ALL"

- When platform connector came up at around 05:15:16, it receives a fatal event regarding dcgm connection error.

<img width="3402" height="272" alt="Screenshot 2025-11-03 at 11 28 50 AM" src="https://github.com/user-attachments/assets/b2af71b6-4802-4457-a84c-708954a18aa7" />

- When dcgm came up at around 05:20:44, GPU health monitor sends healthy event successfully

<img width="3402" height="65" alt="Screenshot 2025-11-03 at 11 37 24 AM" src="https://github.com/user-attachments/assets/e05bd788-8bee-4b8b-bdb7-d9ebb76801bb" />


 ## Unit Test
 
 
<img width="1360" height="279" alt="Screenshot 2025-11-03 at 6 01 51 PM" src="https://github.com/user-attachments/assets/41d5b3e4-1a3d-49b2-9eb2-e318df48d14d" />


## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [x] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced handling of GPU DCGM connectivity failures with improved cache management and diagnostic logging.

* **Tests**
  * Added comprehensive test coverage for DCGM connectivity scenarios and cache cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->