### PR TITLE
LOG_COLLECTOR_MANIFEST_PATH to point to correct config mount

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
           - name: LOG_LEVEL
             value: "{{ .Values.logLevel }}"
           - name: LOG_COLLECTOR_MANIFEST_PATH
-            value: /etc/fault-remediation/templates/log-collector-job.yaml
+            value: /etc/config/log-collector-job.yaml
           - name: ENABLE_GCP_SOS_COLLECTION
             value: "{{ .Values.logCollector.enableGcpSosCollection }}"
           - name: ENABLE_AWS_SOS_COLLECTION


### PR DESCRIPTION
## Summary
Fixed the log collector manifest path in the fault-remediation deployment configuration.
**Problem**
The LOG_COLLECTOR_MANIFEST_PATH environment variable was pointing to an incorrect location (/etc/fault-remediation/templates/log-collector-job.yaml), while the actual ConfigMap mounts the file at /etc/config/log-collector-job.yaml. This mismatch caused log collector jobs to fail with the error:

`failed to read log collector manifest: open /etc/fault-remediation/templates/log-collector-job.yaml: no such file or directory`
Solution
Updated the LOG_COLLECTOR_MANIFEST_PATH environment variable in distros/kubernetes/nvsentinel/charts/fault-remediation/templates/deployment.yaml to point to the correct mounted path: /etc/config/log-collector-job.yaml.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [x] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to reference the correct manifest path location for the fault-remediation service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->