### PR TITLE
Ensure we have lint/lint-test in all go based modules

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -137,6 +137,7 @@ jobs:
           - platform-connectors
           - store-client
           - commons
+          - data-models
           - health-events-analyzer
           - fault-quarantine
           - labeler
@@ -144,6 +145,7 @@ jobs:
           - node-drainer
           - fault-remediation
           - janitor
+          - tests
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
@@ -162,11 +164,36 @@ jobs:
             ${{ matrix.component }}/coverage.txt
             ${{ matrix.component }}/report.xml
 
+  tilt-modules-lint-test:
+    runs-on: linux-amd64-cpu16
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        component:
+          - tilt/simple-health-client
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+
+      - name: Setup build environment
+        uses: ./.github/actions/setup-ci-env
+
+      - name: Run lint and test
+        run: make -C ${{ matrix.component }} lint-test
+
+      - name: Upload artifacts
+        uses: ./.github/actions/upload-test-artifacts
+        with:
+          component-name: simple-health-client
+          file-paths: |
+            ${{ matrix.component }}/coverage.xml
+            ${{ matrix.component }}/coverage.txt
+            ${{ matrix.component }}/report.xml
+
   consolidated-coverage-report:
     if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/pull-request/')
     runs-on: linux-amd64-cpu16
     timeout-minutes: 15
-    needs: [health-monitors-lint-test, modules-lint-test]
+    needs: [health-monitors-lint-test, modules-lint-test, tilt-modules-lint-test]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
@@ -363,7 +390,7 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: linux-amd64-cpu16
     timeout-minutes: 15
-    needs: [health-monitors-lint-test, modules-lint-test]
+    needs: [health-monitors-lint-test, modules-lint-test, tilt-modules-lint-test]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,12 +1,46 @@
 # Tests Makefile
 # End-to-end test targets
 
-# Go binary
-GO := go
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# =============================================================================
+# MODULE-SPECIFIC CONFIGURATION
+# =============================================================================
+
+# E2E Tests module configuration
+IS_GO_MODULE := 1
+TEST_EXTRA_FLAGS := -timeout 40m -count 1 -failfast
+
+# =============================================================================
+# INCLUDE COMMON DEFINITIONS
+# =============================================================================
+
+include ../make/common.mk
+include ../make/go.mk
+
+# =============================================================================
+# E2E-SPECIFIC TARGETS
+# =============================================================================
 
 # Default target
 .PHONY: all
 all: test
+
+.PHONY: lint-test
+lint-test: lint ## Run linting only (override go.mk comprehensive version)
+	@echo "Linting complete for $(MODULE_NAME)"
 
 # Run end-to-end tests in CI
 .PHONY: test-ci
@@ -21,18 +55,27 @@ test-ci:
 	kubectl rollout status deployment/fault-quarantine -n nvsentinel --timeout=10m
 	$(MAKE) test
 
-# Run end-to-end tests
+# Run end-to-end tests (override standard test to use gotestsum with custom format)
 .PHONY: test
-test:
-	gotestsum --format standard-verbose -- -timeout 40m -count 1 -failfast ./...
+test: ## Run end-to-end tests
+	@echo "Running end-to-end tests on $(MODULE_NAME)..."
+	$(GOTESTSUM) --format standard-verbose -- $(TEST_EXTRA_FLAGS) ./... -coverprofile=coverage.txt -covermode atomic -coverpkg=github.com/nvidia/nvsentinel/$(MODULE_NAME)/...
 
-# Help target
-.PHONY: help
-help:
-	@echo "Tests Makefile - Simple end-to-end test execution"
+# =============================================================================
+# MODULE HELP
+# =============================================================================
+
+help: ## Show help for available targets
+	@echo "Tests Makefile - E2E test execution with standard linting"
 	@echo ""
-	@echo "Targets:"
+	@echo "Standard targets from go.mk:"
+	@echo "  lint-test - Lint and test Go module (vet + golangci-lint + gotestsum)"
+	@echo "  lint      - Run golangci-lint"
+	@echo "  vet       - Run go vet"
+	@echo "  test      - Run end-to-end tests with coverage"
+	@echo "  clean     - Clean build artifacts"
+	@echo ""
+	@echo "E2E-specific targets:"
 	@echo "  all       - Run test (default)"
 	@echo "  test-ci   - Run end-to-end tests in CI environment"
-	@echo "  test      - Run end-to-end tests"
 	@echo "  help      - Show this help message"

--- a/tests/helpers/prometheus.go
+++ b/tests/helpers/prometheus.go
@@ -25,7 +25,8 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-// CheckPrometheusMetricEmpty executes the Prometheus `query` and verifies that it returns no results, using `description` for error reporting.
+// CheckPrometheusMetricEmpty executes the Prometheus `query` and verifies that it returns no results,
+// using `description` for error reporting.
 func CheckPrometheusMetricEmpty(ctx context.Context, t *testing.T, query string, description string) error {
 	result, err := queryPrometheus(ctx, query)
 	if err != nil {
@@ -33,6 +34,7 @@ func CheckPrometheusMetricEmpty(ctx context.Context, t *testing.T, query string,
 	}
 
 	var resultCount int
+
 	switch v := result.(type) {
 	case model.Vector:
 		resultCount = len(v)

--- a/tilt/simple-health-client/Makefile
+++ b/tilt/simple-health-client/Makefile
@@ -22,6 +22,9 @@
 # Simple-health-client specific settings
 CLEAN_EXTRA_FILES := simple-health-client
 
+# Go module configuration
+IS_GO_MODULE := 1
+
 # Docker configuration
 HAS_DOCKER := 1
 DOCKER_EXTRA_ARGS :=
@@ -31,6 +34,7 @@ DOCKER_EXTRA_ARGS :=
 # =============================================================================
 
 include ../../make/common.mk
+include ../../make/go.mk
 
 # =============================================================================
 # LEGACY COMPATIBILITY
@@ -44,6 +48,23 @@ publish: docker-publish
 # MODULE HELP
 # =============================================================================
 
-help:
-	@echo "Simple Health Client Makefile - Using nvsentinel common.mk standards"
+help: ## Show help for available targets
+	@echo "Simple Health Client Makefile - Using nvsentinel common.mk and go.mk standards"
+	@echo ""
+	@echo "Standard targets from go.mk:"
+	@echo "  lint-test - Lint and test Go module (vet + golangci-lint + gotestsum)"
+	@echo "  lint      - Run golangci-lint"
+	@echo "  vet       - Run go vet"
+	@echo "  test      - Run tests with coverage"
+	@echo "  build     - Build Go binary"
+	@echo "  clean     - Clean build artifacts"
+	@echo ""
+	@echo "Docker targets from common.mk:"
+	@echo "  docker         - Build and publish Docker image"
+	@echo "  docker-build   - Build Docker image"
+	@echo "  docker-publish - Publish Docker image"
+	@echo ""
+	@echo "Legacy compatibility:"
+	@echo "  image   - Alias for docker-build"
+	@echo "  publish - Alias for docker-publish"
 	@echo ""

--- a/tilt/simple-health-client/main.go
+++ b/tilt/simple-health-client/main.go
@@ -73,6 +73,7 @@ func main() {
 		defer cancel()
 
 		log.Printf("Sending health event for node: %s", healthEvent.NodeName)
+
 		_, err = client.HealthEventOccurredV1(ctx, healthEvents)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Failed to send health event: %v", err), http.StatusInternalServerError)
@@ -82,9 +83,14 @@ func main() {
 		log.Printf("SUCCESS: Health event sent for node %s", healthEvent.NodeName)
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"status": "success", "message": "Health event sent"})
+
+		response := map[string]string{"status": "success", "message": "Health event sent"}
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			log.Printf("Failed to encode JSON response: %v", err)
+		}
 	})
 
+	// #nosec G114 - test client, timeouts not critical
 	if err := http.ListenAndServe(":"+port, nil); err != nil {
 		slog.Error("Failed to start HTTP server", "error", err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary

- added missing lint/lint-test targets
- updates gitHub actions coverage (complete coverage matrix)

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [x] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a dedicated CI lint/test job for the simple-health-client, expanded the lint/test matrix and consolidated coverage workflows; increased baseline artifact retention and updated module-aware Make targets and help output.
* **Stability**
  * Hardened test helpers with better error wrapping, logging, guard checks, and safer rollout/config handling; improved teardown logging and robustness.
* **Behavior**
  * Improved HTTP request/response handling and JSON encoding with clearer error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->