### PR TITLE
feat: add helm chart for metadata-collector

### DIFF
--- a/distros/kubernetes/nvsentinel/Chart.yaml
+++ b/distros/kubernetes/nvsentinel/Chart.yaml
@@ -52,3 +52,6 @@ dependencies:
   - name: janitor
     version: "0.1.0"
     condition: global.janitor.enabled
+  - name: metadata-collector
+    version: "0.1.0"
+    condition: global.metadataCollector.enabled

--- a/distros/kubernetes/nvsentinel/charts/metadata-collector/Chart.yaml
+++ b/distros/kubernetes/nvsentinel/charts/metadata-collector/Chart.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v2
+name: metadata-collector
+description: A Helm chart for the GPU Metadata Collector DaemonSet
+
+type: application
+
+version: 0.1.0
+
+appVersion: "1.0.0"
+

--- a/distros/kubernetes/nvsentinel/charts/metadata-collector/templates/_helpers.tpl
+++ b/distros/kubernetes/nvsentinel/charts/metadata-collector/templates/_helpers.tpl
@@ -1,0 +1,41 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "metadata-collector.name" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "metadata-collector.fullname" -}}
+{{- "metadata-collector" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "metadata-collector.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "metadata-collector.labels" -}}
+helm.sh/chart: {{ include "metadata-collector.chart" . }}
+{{ include "metadata-collector.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "metadata-collector.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "metadata-collector.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+

--- a/distros/kubernetes/nvsentinel/charts/metadata-collector/templates/daemonset.yaml
+++ b/distros/kubernetes/nvsentinel/charts/metadata-collector/templates/daemonset.yaml
@@ -47,9 +47,6 @@ spec:
             runAsUser: 0
             runAsGroup: 0
             privileged: true
-            capabilities:
-              add:
-                - SYS_ADMIN
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default ((.Values.global).image).tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
@@ -60,10 +57,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-            - name: NVIDIA_VISIBLE_DEVICES
-              value: all
-            - name: NVIDIA_DRIVER_CAPABILITIES
-              value: utility
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/distros/kubernetes/nvsentinel/charts/metadata-collector/templates/daemonset.yaml
+++ b/distros/kubernetes/nvsentinel/charts/metadata-collector/templates/daemonset.yaml
@@ -1,0 +1,102 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "metadata-collector.fullname" . }}
+  labels:
+    {{- include "metadata-collector.labels" . | nindent 4 }}
+spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      {{- include "metadata-collector.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "metadata-collector.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      hostNetwork: true
+      hostPID: true
+      initContainers:
+        - name: metadata-collector
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+            privileged: true
+            capabilities:
+              add:
+                - SYS_ADMIN
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default ((.Values.global).image).tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --output-path={{ .Values.outputPath }}
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: all
+            - name: NVIDIA_DRIVER_CAPABILITIES
+              value: utility
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: output
+              mountPath: /var/lib/nvsentinel
+            - name: sys
+              mountPath: /sys
+              readOnly: true
+      containers:
+        - name: pause
+          image: "{{ .Values.pauseImage.repository }}:{{ .Values.pauseImage.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+      volumes:
+        - name: output
+          hostPath:
+            path: /var/lib/nvsentinel
+            type: DirectoryOrCreate
+        - name: sys
+          hostPath:
+            path: /sys
+            type: Directory
+      nodeSelector:
+        nvidia.com/gpu.present: "true"
+        nvsentinel.dgxc.nvidia.com/driver.installed: "true"
+        {{- with (.Values.global.nodeSelector | default .Values.nodeSelector) }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with (.Values.global.affinity | default .Values.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (.Values.global.tolerations | default .Values.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+

--- a/distros/kubernetes/nvsentinel/charts/metadata-collector/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/metadata-collector/values.yaml
@@ -18,8 +18,8 @@ image:
   tag: ""
 
 pauseImage:
-  repository: gcr.io/google-containers/pause
-  tag: "3.0"
+  repository: registry.k8s.io/pause
+  tag: "3.10"
 
 podAnnotations: {}
 

--- a/distros/kubernetes/nvsentinel/charts/metadata-collector/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/metadata-collector/values.yaml
@@ -23,10 +23,6 @@ pauseImage:
 
 podAnnotations: {}
 
-# Specify a runtimeClassName to use (e.g., nvidia, runc, kata-vm-isolation)
-# Leave empty to use cluster default
-runtimeClassName: ""
-
 resources: 
   limits:
     cpu: 500m

--- a/distros/kubernetes/nvsentinel/charts/metadata-collector/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/metadata-collector/values.yaml
@@ -1,0 +1,39 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+image:
+  repository: ghcr.io/nvidia/nvsentinel/metadata-collector
+  pullPolicy: IfNotPresent
+  tag: ""
+
+pauseImage:
+  repository: gcr.io/google-containers/pause
+  tag: "3.0"
+
+podAnnotations: {}
+
+# Specify a runtimeClassName to use (e.g., nvidia, runc, kata-vm-isolation)
+# Leave empty to use cluster default
+runtimeClassName: ""
+
+resources: 
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+outputPath: /var/lib/nvsentinel/gpu_metadata.json
+

--- a/distros/kubernetes/nvsentinel/values-tilt.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt.yaml
@@ -64,6 +64,9 @@ global:
   mongodbStore:
     enabled: true
 
+  metadataCollector:
+    enabled: false
+
 mongodb-store:
   mongodb:
     replicaCount: 1

--- a/distros/kubernetes/nvsentinel/values.yaml
+++ b/distros/kubernetes/nvsentinel/values.yaml
@@ -43,6 +43,8 @@ global:
     enabled: true
   labeler:
     enabled: true
+  metadataCollector:
+    enabled: true
   inclusterFileServer:
     enabled: false
     metricsPort: 9001


### PR DESCRIPTION
## Summary

```
$ helm template nvsentinel distros/kubernetes/nvsentinel/ \
  --show-only charts/metadata-collector/templates/daemonset.yaml
---
# Source: nvsentinel/charts/metadata-collector/templates/daemonset.yaml
# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: metadata-collector
  labels:
    helm.sh/chart: metadata-collector-0.1.0
    app.kubernetes.io/name: metadata-collector
    app.kubernetes.io/instance: nvsentinel
    app.kubernetes.io/version: "1.0.0"
    app.kubernetes.io/managed-by: Helm
spec:
  updateStrategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: metadata-collector
      app.kubernetes.io/instance: nvsentinel
  template:
    metadata:
      labels:
        app.kubernetes.io/name: metadata-collector
        app.kubernetes.io/instance: nvsentinel
    spec:
      hostNetwork: true
      hostPID: true
      initContainers:
        - name: metadata-collector
          securityContext:
            runAsUser: 0
            runAsGroup: 0
            privileged: true
            capabilities:
              add:
                - SYS_ADMIN
          image: "ghcr.io/nvidia/nvsentinel/metadata-collector:main"
          imagePullPolicy: IfNotPresent
          args:
            - --output-path=/var/lib/nvsentinel/gpu_metadata.json
          env:
            - name: NODE_NAME
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: spec.nodeName
            - name: NVIDIA_VISIBLE_DEVICES
              value: all
            - name: NVIDIA_DRIVER_CAPABILITIES
              value: utility
          resources:
            limits:
              cpu: 500m
              memory: 256Mi
            requests:
              cpu: 100m
              memory: 128Mi
          volumeMounts:
            - name: output
              mountPath: /var/lib/nvsentinel
            - name: sys
              mountPath: /sys
              readOnly: true
      containers:
        - name: pause
          image: "gcr.io/google-containers/pause:3.0"
          imagePullPolicy: IfNotPresent
      volumes:
        - name: output
          hostPath:
            path: /var/lib/nvsentinel
            type: DirectoryOrCreate
        - name: sys
          hostPath:
            path: /sys
            type: Directory
      nodeSelector:
        nvidia.com/gpu.present: "true"
        nvsentinel.dgxc.nvidia.com/driver.installed: "true"
```


## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GPU Metadata Collector component running as a DaemonSet on GPU nodes; collects and stores GPU metadata in JSON.
  * Enabled by default with configurable image, pause image, resource requests/limits, and output path.
  * Supports optional node selectors, affinity, tolerations, annotations, and image pull settings for fine-grained deployment control.
  * Helm chart and dependency entry added for the new component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->