### PR TITLE
bug: fix new line handling on linux

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -72,6 +72,11 @@ This will:
 - Install development and Go tools
 - Configure Python gRPC tools
 
+**Automated installation**: To skip interactive prompts and auto-install all dependencies:
+```bash
+make dev-env-setup AUTO_MODE=true
+```
+
 ### Build System
 
 **Unified build system** features:

--- a/Makefile
+++ b/Makefile
@@ -118,9 +118,9 @@ endif
 
 # Setup development environment
 .PHONY: dev-env-setup
-dev-env-setup: ## Setup complete development environment (installs all required tools)
+dev-env-setup: ## Setup complete development environment (installs all required tools). Use AUTO_MODE=true to skip prompts
 	@echo "Setting up NVSentinel development environment..."
-	@bash scripts/setup-dev-env.sh
+	@AUTO_MODE=$(AUTO_MODE) bash scripts/setup-dev-env.sh
 
 # Install lint tools
 .PHONY: install-lint-tools

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -81,9 +81,10 @@ prompt_continue() {
         return 0
     fi
     
-    read -p "Continue? [Y/n] " -n 1 -r
-    echo
-    if [[ ! $REPLY =~ ^[Yy]$ ]] && [[ -n $REPLY ]]; then
+    read -p "Continue? [Y/n] " -r
+    # Default to Y if empty (just pressed Enter)
+    REPLY=${REPLY:-Y}
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
         log_warning "Skipped"
         return 1
     fi


### PR DESCRIPTION
## Summary

Fixed the Linux `make dev-env-setup` interactive prompt issue:

Root Cause
The `prompt_continue()` function used `read -n 1` which reads exactly one character. On Linux systems, when users pressed Enter (newline), this sometimes wasn't counted as input, causing the script to hang or exit with error code `8`.

Updated `prompt_continue()` function:
* Removed `-n 1 flag` to read full line instead of single character
* Added `REPLY=${REPLY:-Y}` to default to "Y" when Enter is pressed (empty input)
* Simplified the logic: now rejects only explicit `n` or `N`, accepts everything else (including empty/Enter)
* Added `AUTO_MODE=$(AUTO_MODE)` to pass environment variable to script
* Documented the `AUTO_MODE=true` option for non-interactive installation

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development environment setup instructions with new installation method

* **New Features**
  * Non-interactive automated installation mode now available for faster setup

* **Bug Fixes**
  * Corrected development environment setup configuration

* **Improvements**
  * Enhanced interactive prompts with Enter-to-continue defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->