### PR TITLE
fix: Taints should not be applied by fault quarantine module in dryRun mode

### DIFF
--- a/fault-quarantine/pkg/informer/k8s_client.go
+++ b/fault-quarantine/pkg/informer/k8s_client.go
@@ -231,6 +231,11 @@ func (c *FaultQuarantineClient) QuarantineNodeAndSetAnnotations(
 }
 
 func (c *FaultQuarantineClient) applyTaints(node *v1.Node, taints []config.Taint, nodename string) error {
+	if c.DryRunMode {
+		slog.Info("DryRun mode enabled, skipping taint application", "node", nodename)
+		return nil
+	}
+
 	existingTaints := make(map[config.Taint]v1.Taint)
 	for _, taint := range node.Spec.Taints {
 		existingTaints[config.Taint{Key: taint.Key, Value: taint.Value, Effect: string(taint.Effect)}] = taint
@@ -339,6 +344,11 @@ func (c *FaultQuarantineClient) UnQuarantineNodeAndRemoveAnnotations(
 }
 
 func (c *FaultQuarantineClient) removeTaints(node *v1.Node, taints []config.Taint, nodename string) bool {
+	if c.DryRunMode {
+		slog.Info("DryRun mode enabled, skipping taint removal", "node", nodename)
+		return false
+	}
+
 	taintsAlreadyPresentOnNodeMap := map[config.Taint]bool{}
 	for _, taint := range node.Spec.Taints {
 		taintsAlreadyPresentOnNodeMap[config.Taint{Key: taint.Key, Value: taint.Value, Effect: string(taint.Effect)}] = true
@@ -428,6 +438,11 @@ func (c *FaultQuarantineClient) HandleManualUncordonCleanup(
 }
 
 func (c *FaultQuarantineClient) removeNodeTaints(node *v1.Node, taintsToRemove []config.Taint) {
+	if c.DryRunMode {
+		slog.Info("DryRun mode enabled, skipping node taint removal")
+		return
+	}
+
 	taintsToRemoveMap := make(map[config.Taint]bool, len(taintsToRemove))
 	for _, taint := range taintsToRemove {
 		taintsToRemoveMap[taint] = true

--- a/fault-quarantine/pkg/reconciler/reconciler_e2e_test.go
+++ b/fault-quarantine/pkg/reconciler/reconciler_e2e_test.go
@@ -3528,6 +3528,15 @@ func TestE2E_DryRunMode(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, node.Spec.Unschedulable, "Node should NOT be cordoned in dry run mode")
 
+	t.Log("Verify taints are NOT applied in dry run mode")
+	fqTaintCount := 0
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == "nvidia.com/gpu-xid-error" {
+			fqTaintCount++
+		}
+	}
+	assert.Equal(t, 0, fqTaintCount, "Node should NOT have taints applied in dry run mode")
+
 	// Annotations ARE added in dry run (only spec changes are skipped)
 	assert.NotEmpty(t, node.Annotations[common.QuarantineHealthEventAnnotationKey], "Annotations are still added in dry run")
 }

--- a/tests/fault_management_test.go
+++ b/tests/fault_management_test.go
@@ -61,9 +61,7 @@ func TestDryRunMode(t *testing.T) {
 		return newCtx
 	})
 
-	// Taints should not be applied in dry-run mode
-	// TODO: Verify the same after https://github.com/NVIDIA/NVSentinel/issues/193 is fixed
-	feature.Assess("taints applied in dry-run", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+	feature.Assess("taints not applied in dry-run", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		client, err := c.NewClient()
 		require.NoError(t, err)
 
@@ -72,7 +70,7 @@ func TestDryRunMode(t *testing.T) {
 			WithMessage("XID error occurred")
 		helpers.SendHealthEvent(ctx, t, event)
 
-		require.Eventually(t, func() bool {
+		assert.Never(t, func() bool {
 			node, err := helpers.GetNodeByName(ctx, client, testCtx.NodeName)
 			if err != nil {
 				return false
@@ -86,7 +84,7 @@ func TestDryRunMode(t *testing.T) {
 				}
 			}
 			return false
-		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval)
+		}, 10*time.Second, helpers.WaitInterval, "Taint should NOT be applied in dry-run mode")
 
 		return ctx
 	})


### PR DESCRIPTION

## Summary

<!-- Brief description of your changes -->

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dry-run mode for taint operations: taint/label/annotation changes are logged but not applied, enabling safe previews.

* **Tests**
  * Explicit test coverage confirming taints are not applied in dry-run mode.
  * Assertions updated to assert absence of taints (negative checks) and polling simplified.
  * Teardown enhanced to remove dry-run annotations left on nodes to ensure clean test state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->