### PR TITLE
fix: pick cuda image from nvcr.io

### DIFF
--- a/metadata-collector/Dockerfile
+++ b/metadata-collector/Dockerfile
@@ -27,7 +27,7 @@ COPY metadata-collector/ .
 
 RUN CGO_ENABLED=1 GOOS=linux go build -a -ldflags="-s -w" -o metadata-collector main.go
 
-FROM nvidia/cuda:12.3.0-base-ubuntu22.04
+FROM nvcr.io/nvidia/cuda:12.3.0-base-ubuntu22.04
 
 RUN groupadd -r nvsentinel && useradd -r -g nvsentinel nvsentinel
 


### PR DESCRIPTION
## Summary

Pick up `nvidia/cuda:12.3.0-base-ubuntu22.04` from `nvcr.io`.
Context: https://github.com/NVIDIA/NVSentinel/actions/runs/19144054639/job/54717549001#step:6:441

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
