### PR TITLE
fix: FQ should not propagate unnecessary events to ND and FR

### DIFF
--- a/fault-quarantine/pkg/reconciler/reconciler.go
+++ b/fault-quarantine/pkg/reconciler/reconciler.go
@@ -423,6 +423,8 @@ func (r *Reconciler) handleAlreadyQuarantinedNode(
 		}
 
 		metrics.ProcessingErrors.WithLabelValues("get_node_annotations_error").Inc()
+		// Cannot proceed without valid annotation data
+		return nil
 	case event.IsHealthy:
 		_, hasExistingCheck := healthEventsAnnotationMap.GetEvent(event)
 		if !hasExistingCheck {

--- a/fault-quarantine/pkg/reconciler/reconciler.go
+++ b/fault-quarantine/pkg/reconciler/reconciler.go
@@ -412,6 +412,27 @@ func (r *Reconciler) handleAlreadyQuarantinedNode(
 	event *protos.HealthEvent,
 	ruleSetEvals []evaluator.RuleSetEvaluatorIface,
 ) *model.Status {
+	healthEventsAnnotationMap, _, err := r.getHealthEventsFromAnnotation(event)
+
+	// Only propagate events to ND/FR if they will modify node annotations
+	// Returning nil prevents unnecessary MongoDB writes and downstream processing
+	switch {
+	case err != nil:
+		if errors.Is(err, errNoQuarantineAnnotation) {
+			return nil
+		}
+
+		metrics.ProcessingErrors.WithLabelValues("get_node_annotations_error").Inc()
+	case event.IsHealthy:
+		_, hasExistingCheck := healthEventsAnnotationMap.GetEvent(event)
+		if !hasExistingCheck {
+			return nil
+		}
+	case !r.eventMatchesAnyRule(event, ruleSetEvals):
+		return nil
+	}
+
+	// Event will modify annotations, proceed with quarantine handling and propagate to ND/FR
 	var status model.Status
 
 	if r.handleQuarantinedNode(ctx, event, ruleSetEvals) {


### PR DESCRIPTION
## Summary

<!-- Brief description of your changes -->

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of health events for quarantined nodes: added pre-checks to avoid propagating events that are missing, healthy, or do not match configured rules.
  * Ensured quarantine annotation and node unschedulable state are preserved when non-matching events are received.

* **Tests**
  * Added end-to-end tests validating non-propagation of untracked/ non-matching events and quarantine state preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->