### PR TITLE
chore: remove paths-ignore in GH actions as it doesn't seem to work with copy pr bot

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -19,14 +19,6 @@ on:
     branches:
       - main
       - "pull-request/[0-9]+"
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/*.yaml'
-      - '.github/*.yml'
-      - '.github/headers/**'
     tags:
       - 'v*'
   workflow_call: {}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -27,14 +27,6 @@ on:
     branches:
       - main
       - "pull-request/[0-9]+"
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/*.yaml'
-      - '.github/*.yml'
-      - '.github/headers/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -19,14 +19,6 @@ on:
     branches:
       - main
       - "pull-request/[0-9]+"
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/*.yaml'
-      - '.github/*.yml'
-      - '.github/headers/**'
     tags:
       - 'v*'
   workflow_dispatch:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,14 +20,6 @@ on:
       - 'v*'
     branches:
       - main
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/*.yaml'
-      - '.github/*.yml'
-      - '.github/headers/**'
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,14 +18,6 @@ on:
   push:
     tags:
       - 'v*'
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/*.yaml'
-      - '.github/*.yml'
-      - '.github/headers/**'
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## Summary

remove paths-ignore in GH actions as it doesn't seem to work with copy pr bot

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [x] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated trigger configurations across multiple CI/CD workflows (CodeQL scanning, e2e testing, linting, publishing, and release automation) to activate on all push events instead of selectively ignoring changes to documentation files, Markdown, and GitHub workflow configurations. This ensures more comprehensive repository scanning and testing coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->