### PR TITLE
feat: add scaffolding for kubernetes object monitor

### DIFF
--- a/.github/workflows/container-build-test.yml
+++ b/.github/workflows/container-build-test.yml
@@ -59,6 +59,8 @@ jobs:
             make_command: 'make -C health-monitors/gpu-health-monitor docker-build-dcgm4'
           - component: syslog-health-monitor
             make_command: 'make -C health-monitors/syslog-health-monitor docker-build'
+          - component: kubernetes-object-monitor
+            make_command: 'make -C health-monitors/kubernetes-object-monitor docker-build'
           # Log Collection (Docker-based)
           - component: log-collector
             make_command: 'make -C log-collector docker-build-log-collector'

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -97,6 +97,7 @@ jobs:
         include:
           - component: syslog-health-monitor
           - component: csp-health-monitor
+          - component: kubernetes-object-monitor
           - component: gpu-health-monitor
             install_dcgm: 'true'
             python_required: 'true'

--- a/health-monitors/Makefile
+++ b/health-monitors/Makefile
@@ -10,7 +10,8 @@ GOCOVER_COBERTURA := gocover-cobertura
 # Health monitor modules
 GO_HEALTH_MONITORS := \
 	syslog-health-monitor \
-	csp-health-monitor
+	csp-health-monitor \
+	kubernetes-object-monitor
 
 PYTHON_HEALTH_MONITORS := \
 	gpu-health-monitor
@@ -54,6 +55,10 @@ lint-test-csp-health-monitor:
 lint-test-gpu-health-monitor:
 	$(MAKE) -C gpu-health-monitor lint-test
 
+.PHONY: lint-test-kubernetes-object-monitor
+lint-test-kubernetes-object-monitor:
+	$(MAKE) -C kubernetes-object-monitor lint-test
+
 # Build targets for health monitors (delegate to module Makefiles)
 .PHONY: build-all
 build-all:
@@ -78,6 +83,10 @@ build-csp-health-monitor:
 build-gpu-health-monitor:
 	$(MAKE) -C gpu-health-monitor setup
 
+.PHONY: build-kubernetes-object-monitor
+build-kubernetes-object-monitor:
+	$(MAKE) -C kubernetes-object-monitor build
+
 # Clean targets (delegate to module Makefiles)
 .PHONY: clean-all
 clean-all:
@@ -101,6 +110,10 @@ clean-csp-health-monitor:
 .PHONY: clean-gpu-health-monitor
 clean-gpu-health-monitor:
 	$(MAKE) -C gpu-health-monitor clean
+
+.PHONY: clean-kubernetes-object-monitor
+clean-kubernetes-object-monitor:
+	$(MAKE) -C kubernetes-object-monitor clean
 
 # Help target
 .PHONY: help

--- a/health-monitors/kubernetes-object-monitor/Dockerfile
+++ b/health-monitors/kubernetes-object-monitor/Dockerfile
@@ -32,10 +32,6 @@ RUN cd health-monitors/kubernetes-object-monitor && \
 
 FROM public.ecr.aws/docker/library/debian:bookworm-slim AS runtime
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
 COPY --from=builder /go/src/nvsentinel/health-monitors/kubernetes-object-monitor/kubernetes-object-monitor /app/kubernetes-object-monitor
 
 ENTRYPOINT ["/app/kubernetes-object-monitor"]

--- a/health-monitors/kubernetes-object-monitor/Dockerfile
+++ b/health-monitors/kubernetes-object-monitor/Dockerfile
@@ -1,0 +1,42 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM public.ecr.aws/docker/library/golang:1.25-trixie AS builder
+
+WORKDIR /go/src/nvsentinel
+
+COPY health-monitors/kubernetes-object-monitor/go.mod health-monitors/kubernetes-object-monitor/go.sum health-monitors/kubernetes-object-monitor/
+COPY data-models/go.mod data-models/go.sum ./data-models/
+COPY commons/go.mod commons/go.sum ./commons/
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    cd health-monitors/kubernetes-object-monitor && go mod download
+
+COPY health-monitors/kubernetes-object-monitor/ health-monitors/kubernetes-object-monitor/
+COPY data-models/ data-models/
+COPY commons/ commons/
+
+RUN cd health-monitors/kubernetes-object-monitor && \
+    CGO_ENABLED=0 go build -ldflags="-s -w" -o kubernetes-object-monitor main.go
+
+FROM public.ecr.aws/docker/library/debian:bookworm-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /go/src/nvsentinel/health-monitors/kubernetes-object-monitor/kubernetes-object-monitor /app/kubernetes-object-monitor
+
+ENTRYPOINT ["/app/kubernetes-object-monitor"]
+

--- a/health-monitors/kubernetes-object-monitor/Makefile
+++ b/health-monitors/kubernetes-object-monitor/Makefile
@@ -1,0 +1,21 @@
+# kubernetes-object-monitor Makefile
+
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+IS_GO_MODULE := 1
+HAS_DOCKER := 1
+
+include ../../make/common.mk
+include ../../make/go.mk
+include ../../make/docker.mk
+
+.PHONY: all
+all: lint-test
+
+.PHONY: help
+help:
+	@echo "kubernetes-object-monitor Makefile - Using nvsentinel make/*.mk standards"
+	@echo ""
+	@echo "Main targets: all, lint-test, ci-test, build, test, lint, clean"
+	@echo "Docker targets: docker, docker-build, docker-publish"
+

--- a/health-monitors/kubernetes-object-monitor/go.mod
+++ b/health-monitors/kubernetes-object-monitor/go.mod
@@ -2,4 +2,6 @@ module github.com/nvidia/nvsentinel/health-monitors/kubernetes-object-monitor
 
 go 1.25.4
 
-require github.com/nvidia/nvsentinel/commons v0.0.0-20251111085135-849ea8d68052
+require github.com/nvidia/nvsentinel/commons v0.0.0
+
+replace github.com/nvidia/nvsentinel/commons => ../../commons

--- a/health-monitors/kubernetes-object-monitor/go.mod
+++ b/health-monitors/kubernetes-object-monitor/go.mod
@@ -1,0 +1,5 @@
+module github.com/nvidia/nvsentinel/health-monitors/kubernetes-object-monitor
+
+go 1.25.4
+
+require github.com/nvidia/nvsentinel/commons v0.0.0-20251111085135-849ea8d68052

--- a/health-monitors/kubernetes-object-monitor/go.sum
+++ b/health-monitors/kubernetes-object-monitor/go.sum
@@ -1,2 +1,0 @@
-github.com/nvidia/nvsentinel/commons v0.0.0-20251111085135-849ea8d68052 h1:UIJb7W2qRtJuEdlEYnAONV3uXd67iKLe6cj0h5Uivlw=
-github.com/nvidia/nvsentinel/commons v0.0.0-20251111085135-849ea8d68052/go.mod h1:6/uBapOlb1xuokKr8Isawm+VRwIHmCa+fymSuf0gXpM=

--- a/health-monitors/kubernetes-object-monitor/go.sum
+++ b/health-monitors/kubernetes-object-monitor/go.sum
@@ -1,0 +1,2 @@
+github.com/nvidia/nvsentinel/commons v0.0.0-20251111085135-849ea8d68052 h1:UIJb7W2qRtJuEdlEYnAONV3uXd67iKLe6cj0h5Uivlw=
+github.com/nvidia/nvsentinel/commons v0.0.0-20251111085135-849ea8d68052/go.mod h1:6/uBapOlb1xuokKr8Isawm+VRwIHmCa+fymSuf0gXpM=

--- a/health-monitors/kubernetes-object-monitor/main.go
+++ b/health-monitors/kubernetes-object-monitor/main.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/nvidia/nvsentinel/commons/pkg/logger"
+)
+
+const (
+	defaultAgentName = "kubernetes-object-monitor"
+)
+
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+func main() {
+	logLevel := os.Getenv("LOG_LEVEL")
+	if logLevel == "" {
+		logLevel = "info"
+	}
+
+	logger.SetDefaultStructuredLogger(defaultAgentName, version)
+	slog.Info("Starting kubernetes-object-monitor", "version", version, "commit", commit, "date", date, "log_level", logLevel)
+
+	if err := run(); err != nil {
+		slog.Error("Fatal error", "error", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	slog.Info("Kubernetes Object Monitor started successfully")
+	slog.Info("TODO: Implement controller-runtime based monitor with CEL policy evaluation")
+
+	<-ctx.Done()
+
+	slog.Info("Shutdown signal received, exiting gracefully")
+	return nil
+}

--- a/health-monitors/kubernetes-object-monitor/main.go
+++ b/health-monitors/kubernetes-object-monitor/main.go
@@ -40,7 +40,8 @@ func main() {
 	}
 
 	logger.SetDefaultStructuredLogger(defaultAgentName, version)
-	slog.Info("Starting kubernetes-object-monitor", "version", version, "commit", commit, "date", date, "log_level", logLevel)
+	slog.Info("Starting kubernetes-object-monitor", "version",
+		version, "commit", commit, "date", date, "log_level", logLevel)
 
 	if err := run(); err != nil {
 		slog.Error("Fatal error", "error", err)
@@ -58,5 +59,6 @@ func run() error {
 	<-ctx.Done()
 
 	slog.Info("Shutdown signal received, exiting gracefully")
+
 	return nil
 }


### PR DESCRIPTION
## Summary

<!-- Brief description of your changes -->

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [x] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Kubernetes object monitor: runnable binary image, initial runtime scaffold, and basic startup/shutdown logging.

* **Chores**
  * Integrated the new monitor into CI lint/build/test workflows and extended the health-monitor build orchestration.
  * Added module-level build/test/clean targets and a module manifest to enable independent builds and packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->