### PR TITLE
Fix: platform-connector component-specific tolerations support

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/values.yaml
@@ -49,3 +49,8 @@ xidSideCar:
     repository: ""
     tag: ""
     pullPolicy: IfNotPresent
+
+# Scheduling configuration
+nodeSelector: {}
+affinity: {}
+tolerations: []

--- a/distros/kubernetes/nvsentinel/templates/daemonset.yaml
+++ b/distros/kubernetes/nvsentinel/templates/daemonset.yaml
@@ -106,7 +106,7 @@ spec:
           secret:
             secretName: mongo-app-client-cert-secret
             optional: true
-      {{- with .Values.global.tolerations }}
+      {{- with (.Values.global.tolerations | default .Values.platformConnector.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/distros/kubernetes/nvsentinel/values-full.yaml
+++ b/distros/kubernetes/nvsentinel/values-full.yaml
@@ -247,6 +247,10 @@ platformConnector:
   #   sidecar.istio.io/inject: "false"
   podAnnotations: {}
 
+  # Tolerations for platform-connector pods
+  # Used when global.tolerations is not specified
+  tolerations: []
+
   # Kubernetes connector configuration
   # Handles updating Kubernetes node status and conditions
   k8sConnector:

--- a/distros/kubernetes/nvsentinel/values.yaml
+++ b/distros/kubernetes/nvsentinel/values.yaml
@@ -71,6 +71,8 @@ platformConnector:
 
   podAnnotations: {}
 
+  tolerations: []
+
   k8sConnector:
     enabled: true
     qps: 5.0


### PR DESCRIPTION
## Summary

## Issue #334 

Platform connector doesn't apply component-specific tolerations from values file. 

## Main Cause

The daemonset template was only checking `global.tolerations` without any fallback:

```yaml
{{- with .Values.global.tolerations }}
```

So if global tolerations aren't set, nothing gets applied even if you define platformConnector.tolerations.

## Changes Done

1. **Fixed the template** - Added fallback pattern to check component-specific tolerations:
   ```yaml
   {{- with (.Values.global.tolerations | default .Values.platformConnector.tolerations) }}
   ```
   Now it uses global if set, otherwise falls back to component-specific.

2. **Added tolerations field** to `values.yaml` and `values-full.yaml` so users know they can set it.

3. **Added tolerations to syslog-health-monitor values** for consistency. Syslog was actually working because the template already had the fallback pattern, but the values file didn't have the field defined. I think its better to define it empty so its discoverable.

----------------------------------------------------------------------------------------------------------------------------

## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [X] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pod scheduling configuration options (node selector, affinity, and tolerations) for Kubernetes deployments
  * Enhanced tolerance configuration with automatic fallback mechanism for platform connector pod scheduling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->