### PR TITLE
chore: pin version of helm to avoid pulling latest release 

### DIFF
--- a/.github/actions/setup-ci-env/action.yml
+++ b/.github/actions/setup-ci-env/action.yml
@@ -78,7 +78,7 @@ runs:
     - name: Install Helm
       uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4.3.1
       with:
-        version: 'latest'
+        version: 'v3.14.4'
 
     - name: Cache Helm plugins
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Install helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4.3.1
         with:
-          version: 'latest'
+          version: 'v3.14.4'
 
       - name: Configure Helm for GitHub Packages
         run: |

--- a/Makefile
+++ b/Makefile
@@ -674,7 +674,7 @@ tilt-ci: ## Run Tilt in CI mode (no UI, waits for all resources)
 	@echo "Starting Tilt with SKIP_KWOK_NODES_IN_TILT=1 (with retry logic)..."
 	@for i in 1 2 3; do \
 		echo "Attempt $$i of 3..."; \
-		if SKIP_KWOK_NODES_IN_TILT=1 tilt ci -f tilt/Tiltfile --timeout=10m; then \
+		if SKIP_KWOK_NODES_IN_TILT=1 tilt ci -f tilt/Tiltfile --timeout=10m --debug; then \
 			echo "Tilt CI succeeded on attempt $$i"; \
 			break; \
 		else \

--- a/Makefile
+++ b/Makefile
@@ -674,7 +674,7 @@ tilt-ci: ## Run Tilt in CI mode (no UI, waits for all resources)
 	@echo "Starting Tilt with SKIP_KWOK_NODES_IN_TILT=1 (with retry logic)..."
 	@for i in 1 2 3; do \
 		echo "Attempt $$i of 3..."; \
-		if SKIP_KWOK_NODES_IN_TILT=1 tilt ci -f tilt/Tiltfile --timeout=10m --debug --klog 9; then \
+		if SKIP_KWOK_NODES_IN_TILT=1 tilt ci -f tilt/Tiltfile --timeout=10m; then \
 			echo "Tilt CI succeeded on attempt $$i"; \
 			break; \
 		else \

--- a/Makefile
+++ b/Makefile
@@ -674,7 +674,7 @@ tilt-ci: ## Run Tilt in CI mode (no UI, waits for all resources)
 	@echo "Starting Tilt with SKIP_KWOK_NODES_IN_TILT=1 (with retry logic)..."
 	@for i in 1 2 3; do \
 		echo "Attempt $$i of 3..."; \
-		if SKIP_KWOK_NODES_IN_TILT=1 tilt ci -f tilt/Tiltfile --timeout=10m --debug; then \
+		if SKIP_KWOK_NODES_IN_TILT=1 tilt ci -f tilt/Tiltfile --timeout=10m --debug --klog 9; then \
 			echo "Tilt CI succeeded on attempt $$i"; \
 			break; \
 		else \


### PR DESCRIPTION
## Summary

pin the version of helm to avoid pulling latest releases which can have breaking changes

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [x] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased CI debug output for automated runs to provide more detailed logs during retry attempts.
  * Pinned Helm installer in CI to a specific version (v3.14.4) to ensure consistent tooling across releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->