### PR TITLE
Fix duplicate node-drainer events by sorting pod lists

### DIFF
--- a/node-drainer/pkg/informers/informers.go
+++ b/node-drainer/pkg/informers/informers.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"sync"
 	"time"
 
@@ -521,6 +522,8 @@ func (i *Informers) DeletePodsAfterTimeout(ctx context.Context, nodeName string,
 	for _, pod := range remainingPods {
 		podNames = append(podNames, pod.Name)
 	}
+
+	sort.Strings(podNames)
 
 	message := fmt.Sprintf(
 		"Waiting for following pods to finish: %v in namespace: %v or they will be force deleted on: %s",

--- a/node-drainer/pkg/reconciler/reconciler.go
+++ b/node-drainer/pkg/reconciler/reconciler.go
@@ -19,11 +19,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-<<<<<<< HEAD
 	"strings"
-=======
 	"sort"
->>>>>>> b503038 (fix: ensure deterministic pod event messages)
 	"sync"
 	"time"
 

--- a/node-drainer/pkg/reconciler/reconciler.go
+++ b/node-drainer/pkg/reconciler/reconciler.go
@@ -19,8 +19,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"strings"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 

--- a/node-drainer/pkg/reconciler/reconciler.go
+++ b/node-drainer/pkg/reconciler/reconciler.go
@@ -19,7 +19,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+<<<<<<< HEAD
 	"strings"
+=======
+	"sort"
+>>>>>>> b503038 (fix: ensure deterministic pod event messages)
 	"sync"
 	"time"
 
@@ -391,6 +395,8 @@ func (r *Reconciler) executeCheckCompletion(ctx context.Context,
 	}
 
 	if !allPodsComplete {
+		sort.Strings(remainingPods)
+
 		message := fmt.Sprintf("Waiting for following pods to finish: %v", remainingPods)
 		reason := "AwaitingPodCompletion"
 

--- a/node-drainer/pkg/reconciler/reconciler_integration_test.go
+++ b/node-drainer/pkg/reconciler/reconciler_integration_test.go
@@ -1195,5 +1195,136 @@ func TestReconciler_MultipleEventsOnNodeCancelledByUnQuarantine(t *testing.T) {
 
 	pod2, err := setup.client.CoreV1().Pods("timeout-test").Get(setup.ctx, "pod-2", metav1.GetOptions{})
 	require.NoError(t, err)
-	assert.Nil(t, pod2.DeletionTimestamp, "pod-2 should not be deleted")
+	return metric.Counter.GetValue()
+}
+
+func getCounterVecValue(t *testing.T, counterVec *prometheus.CounterVec, labelValues ...string) float64 {
+	t.Helper()
+	counter, err := counterVec.GetMetricWithLabelValues(labelValues...)
+	require.NoError(t, err)
+	metric := &dto.Metric{}
+	err = counter.Write(metric)
+	require.NoError(t, err)
+	return metric.Counter.GetValue()
+}
+
+func getGaugeValue(t *testing.T, gauge prometheus.Gauge) float64 {
+	t.Helper()
+	metric := &dto.Metric{}
+	err := gauge.Write(metric)
+	require.NoError(t, err)
+	return metric.Gauge.GetValue()
+}
+
+func getGaugeVecValue(t *testing.T, gaugeVec *prometheus.GaugeVec, labelValues ...string) float64 {
+	t.Helper()
+	gauge, err := gaugeVec.GetMetricWithLabelValues(labelValues...)
+	require.NoError(t, err)
+	metric := &dto.Metric{}
+	err = gauge.Write(metric)
+	require.NoError(t, err)
+	return metric.Gauge.GetValue()
+}
+
+func getHistogramCount(t *testing.T, histogram prometheus.Histogram) uint64 {
+	t.Helper()
+	metric := &dto.Metric{}
+	err := histogram.Write(metric)
+	require.NoError(t, err)
+	return metric.Histogram.GetSampleCount()
+}
+
+// TestReconciler_PodListSortingConsistentEvents verifies that pod list sorting prevents duplicate Kubernetes events by ensuring consistent event messages across multiple reconciliation calls.
+func TestReconciler_PodListSortingConsistentEvents(t *testing.T) {
+	setup := setupDirectTest(t, []config.UserNamespace{
+		{Name: "test-*", Mode: config.ModeAllowCompletion},
+	}, false)
+
+	nodeName := "test-node-sorting"
+	createNode(setup.ctx, t, setup.client, nodeName)
+	createNamespace(setup.ctx, t, setup.client, "test-sorting")
+
+	for _, podName := range []string{"ubuntu-gpu-deployment-64c54f5b4c-2c4c5", "alloy-metrics-55d6fbdbd-vrp2h", "alloy-gateway-0"} {
+		createPod(setup.ctx, t, setup.client, "test-sorting", podName, nodeName, v1.PodRunning)
+	}
+
+	// Wait for all pods to be visible in the informer cache
+	require.Eventually(t, func() bool {
+		pods, err := setup.informersInstance.FindEvictablePodsInNamespaceAndNode("test-sorting", nodeName)
+		if err != nil {
+			return false
+		}
+		return len(pods) == 3
+	}, 30*time.Second, 100*time.Millisecond, "All 3 pods should be visible in informer cache before test starts")
+
+	const numIterations = 5
+	var referenceMessage string
+	var mismatchFound bool
+	var mismatchIteration int
+	var mismatchMessage string
+
+	for i := 0; i < numIterations; i++ {
+		setup.client.CoreV1().Events(metav1.NamespaceDefault).DeleteCollection(
+			setup.ctx, metav1.DeleteOptions{}, metav1.ListOptions{})
+
+		// Wait for events to be deleted
+		require.Eventually(t, func() bool {
+			events, _ := setup.client.CoreV1().Events(metav1.NamespaceDefault).List(
+				setup.ctx,
+				metav1.ListOptions{
+					FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Node", nodeName),
+				},
+			)
+			return len(events.Items) == 0
+		}, 5*time.Second, 50*time.Millisecond, "Events should be deleted before next iteration")
+
+		err := processHealthEvent(setup.ctx, t, setup.reconciler, setup.mockCollection, healthEventOptions{
+			nodeName:        nodeName,
+			nodeQuarantined: model.Quarantined,
+		})
+
+		assert.Error(t, err)
+
+		// Wait for new event to be created with the pod list
+		var currentMessage string
+		require.Eventually(t, func() bool {
+			events, err := setup.client.CoreV1().Events(metav1.NamespaceDefault).List(
+				setup.ctx,
+				metav1.ListOptions{
+					FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Node", nodeName),
+				},
+			)
+			if err != nil || len(events.Items) == 0 {
+				return false
+			}
+			msg := events.Items[len(events.Items)-1].Message
+			if len(msg) > 0 && msg != "" {
+				currentMessage = msg
+				return true
+			}
+			return false
+		}, 5*time.Second, 50*time.Millisecond, "Event with pod list should be created")
+
+		if i == 0 {
+			referenceMessage = currentMessage
+			continue
+		}
+
+		if currentMessage != referenceMessage {
+			mismatchFound = true
+			mismatchIteration = i
+			mismatchMessage = currentMessage
+			break
+		}
+	}
+
+	require.NotEmpty(t, referenceMessage, "No event messages were generated")
+
+	if mismatchFound {
+		assert.Fail(t, fmt.Sprintf("FAIL: Iteration %d produced different message. sort.Strings() missing from reconciler.go:252\nExpected: %s\nGot: %s",
+			mismatchIteration, referenceMessage, mismatchMessage))
+	}
+
+	expectedMessage := "Waiting for following pods to finish: [test-sorting/alloy-gateway-0 test-sorting/alloy-metrics-55d6fbdbd-vrp2h test-sorting/ubuntu-gpu-deployment-64c54f5b4c-2c4c5]"
+	assert.Equal(t, expectedMessage, referenceMessage, "FAIL: Pods not in same order")
 }

--- a/node-drainer/pkg/reconciler/reconciler_integration_test.go
+++ b/node-drainer/pkg/reconciler/reconciler_integration_test.go
@@ -1038,7 +1038,6 @@ func getHistogramCount(t *testing.T, histogram prometheus.Histogram) uint64 {
 	return metric.Histogram.GetSampleCount()
 }
 
-<<<<<<< HEAD
 // TestReconciler_CancelledEventWithOngoingDrain validates that Cancelled events stop ongoing drain operations
 func TestReconciler_CancelledEventWithOngoingDrain(t *testing.T) {
 	setup := setupRequeueTest(t, []config.UserNamespace{
@@ -1197,63 +1196,4 @@ func TestReconciler_MultipleEventsOnNodeCancelledByUnQuarantine(t *testing.T) {
 	pod2, err := setup.client.CoreV1().Pods("timeout-test").Get(setup.ctx, "pod-2", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Nil(t, pod2.DeletionTimestamp, "pod-2 should not be deleted")
-}
-
-// TestReconciler_PodListSortingConsistentEvents verifies that pod list sorting prevents duplicate Kubernetes events by ensuring consistent event messages across multiple reconciliation calls.
-func TestReconciler_PodListSortingConsistentEvents(t *testing.T) {
-	setup := setupDirectTest(t, []config.UserNamespace{
-		{Name: "test-*", Mode: config.ModeAllowCompletion},
-	}, false)
-
-	nodeName := "test-node-sorting"
-	createNode(setup.ctx, t, setup.client, nodeName)
-	createNamespace(setup.ctx, t, setup.client, "test-sorting")
-
-	for _, podName := range []string{"ubuntu-gpu-deployment-64c54f5b4c-2c4c5", "alloy-metrics-55d6fbdbd-vrp2h", "alloy-gateway-0"} {
-		createPod(setup.ctx, t, setup.client, "test-sorting", podName, nodeName, v1.PodRunning)
-	}
-
-	time.Sleep(2 * time.Second)
-
-	const numIterations = 10
-	eventMessages := make([]string, 0, numIterations)
-
-	for i := 0; i < numIterations; i++ {
-		setup.client.CoreV1().Events(metav1.NamespaceDefault).DeleteCollection(
-			setup.ctx, metav1.DeleteOptions{}, metav1.ListOptions{})
-
-		time.Sleep(100 * time.Millisecond)
-
-		err := processHealthEvent(setup.ctx, t, setup.reconciler, setup.mockCollection, healthEventOptions{
-			nodeName:        nodeName,
-			nodeQuarantined: model.Quarantined,
-		})
-
-		assert.Error(t, err)
-		time.Sleep(200 * time.Millisecond)
-
-		events, err := setup.client.CoreV1().Events(metav1.NamespaceDefault).List(
-			setup.ctx,
-			metav1.ListOptions{
-				FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Node", nodeName),
-			},
-		)
-		require.NoError(t, err)
-
-		if len(events.Items) > 0 {
-			eventMessages = append(eventMessages, events.Items[len(events.Items)-1].Message)
-		}
-	}
-
-	require.Greater(t, len(eventMessages), 0)
-
-	referenceMessage := eventMessages[0]
-	for i, msg := range eventMessages {
-		assert.Equal(t, referenceMessage, msg,
-			"FAIL: Iteration %d different message. sort.Strings() missing from reconciler.go:252", i)
-	}
-
-	expectedMessage := "Waiting for following pods to finish: [test-sorting/alloy-gateway-0 test-sorting/alloy-metrics-55d6fbdbd-vrp2h test-sorting/ubuntu-gpu-deployment-64c54f5b4c-2c4c5]"
-	assert.Equal(t, expectedMessage, referenceMessage, "FAIL: Pods not in sorted order")
->>>>>>> eca3677 (Add integration test for pod list sorting consistency)
 }


### PR DESCRIPTION
## Summary

**Issue:**  
Issue #339 – The node-drainer emitted multiple Kubernetes events for the same set of pods because the pod list in the event message wasn’t ordered. As a result, Kubernetes treated each permutation of the pod list as a separate event instead of aggregating them.

**Reason:**  
Go’s iteration over maps/slices is non-deterministic. Without sorting the pod names, identical pod sets produced different event message strings, which caused Kubernetes to record duplicate events rather than incrementing counts.

**Solution:**  
Sort the pod names before constructing event messages in both `AllowCompletion` (reconciler.go) and `DeleteAfterTimeout` (informers.go). This ensures the same pod set always generates a consistent event string, allowing Kubernetes to aggregate events correctly.

## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pod lists in status messages and node events are now deterministically and alphabetically sorted for consistent, clearer logging and to prevent spurious or duplicate events.

* **Tests**
  * Integration tests updated to run multiple reconciliation steps, validate sorted pod lists, and cover multi-pod scenarios. A per-test reconciliation count was added so tests can simulate repeated processing and verify stable event messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->