### PR TITLE
feat: add helm chart for kubernetes object monitor

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,6 +106,9 @@ jobs:
           - component: syslog-health-monitor
             make_command: 'make -C health-monitors/syslog-health-monitor docker-publish'
             container_name: 'nvsentinel/syslog-health-monitor'
+          - component: kubernetes-object-monitor
+            make_command: 'make -C health-monitors/kubernetes-object-monitor docker-publish'
+            container_name: 'nvsentinel/kubernetes-object-monitor'
           - component: metadata-collector
             make_command: 'make -C metadata-collector docker-publish'
             container_name: 'nvsentinel/metadata-collector'

--- a/distros/kubernetes/nvsentinel/Chart.yaml
+++ b/distros/kubernetes/nvsentinel/Chart.yaml
@@ -55,3 +55,6 @@ dependencies:
   - name: metadata-collector
     version: "0.1.0"
     condition: global.metadataCollector.enabled
+  - name: kubernetes-object-monitor
+    version: "0.1.0"
+    condition: global.kubernetesObjectMonitor.enabled

--- a/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/Chart.yaml
+++ b/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/Chart.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: kubernetes-object-monitor
+description: Monitors Kubernetes objects and publishes health events based on CEL policy predicates
+
+# Application chart for deployment
+type: application
+
+# Chart version - increment for chart changes
+version: 0.1.0
+
+# Application version
+appVersion: "1.16.0"
+

--- a/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/Chart.yaml
+++ b/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/Chart.yaml
@@ -15,13 +15,7 @@
 apiVersion: v2
 name: kubernetes-object-monitor
 description: Monitors Kubernetes objects and publishes health events based on CEL policy predicates
-
-# Application chart for deployment
 type: application
-
-# Chart version - increment for chart changes
 version: 0.1.0
-
-# Application version
 appVersion: "1.16.0"
 

--- a/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/_helpers.tpl
+++ b/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/_helpers.tpl
@@ -1,0 +1,41 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kubernetes-object-monitor.name" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "kubernetes-object-monitor.fullname" -}}
+{{- "kubernetes-object-monitor" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kubernetes-object-monitor.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kubernetes-object-monitor.labels" -}}
+helm.sh/chart: {{ include "kubernetes-object-monitor.chart" . }}
+{{ include "kubernetes-object-monitor.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kubernetes-object-monitor.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubernetes-object-monitor.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+

--- a/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/clusterrole.yaml
+++ b/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/clusterrole.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kubernetes-object-monitor.fullname" . }}
+  labels:
+    {{- include "kubernetes-object-monitor.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update

--- a/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/clusterrole.yaml
+++ b/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/clusterrole.yaml
@@ -12,6 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- $resourcesByGroup := dict -}}
+{{- range .Values.policies -}}
+  {{- $group := .resource.group | default "" -}}
+  {{- $kind := .resource.kind | lower -}}
+  {{- $resource := printf "%ss" $kind -}}
+  {{- $existing := index $resourcesByGroup $group | default list -}}
+  {{- if not (has $resource $existing) -}}
+    {{- $updated := append $existing $resource -}}
+    {{- $_ := set $resourcesByGroup $group $updated -}}
+  {{- end -}}
+{{- end -}}
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -29,3 +41,18 @@ rules:
       - watch
       - patch
       - update
+
+  {{- range $group, $resources := $resourcesByGroup }}
+  {{- if ne $group "" }}
+  - apiGroups:
+      - {{ $group | quote }}
+    resources:
+      {{- range $resources }}
+      - {{ . }}
+      {{- end }}
+    verbs:
+      - get
+      - list
+      - watch
+  {{- end }}
+  {{- end }}

--- a/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/clusterrole.yaml
+++ b/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/clusterrole.yaml
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- $resourcesByGroup := dict -}}
-{{- range .Values.policies -}}
-  {{- $group := .resource.group | default "" -}}
-  {{- $kind := .resource.kind | lower -}}
-  {{- $resource := printf "%ss" $kind -}}
-  {{- $existing := index $resourcesByGroup $group | default list -}}
-  {{- if not (has $resource $existing) -}}
-    {{- $updated := append $existing $resource -}}
-    {{- $_ := set $resourcesByGroup $group $updated -}}
-  {{- end -}}
-{{- end -}}
-
+{{- $resourcesByGroup := dict }}
+{{- range .Values.policies }}
+  {{- $group := .resource.group | default "" }}
+  {{- $kind := .resource.kind | lower }}
+  {{- $resource := printf "%ss" $kind }}
+  {{- $existing := index $resourcesByGroup $group | default list }}
+  {{- if not (has $resource $existing) }}
+    {{- $updated := append $existing $resource }}
+    {{- $_ := set $resourcesByGroup $group $updated }}
+  {{- end }}
+{{- end }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -41,7 +41,6 @@ rules:
       - watch
       - patch
       - update
-
   {{- range $group, $resources := $resourcesByGroup }}
   {{- if ne $group "" }}
   - apiGroups:

--- a/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/clusterrolebinding.yaml
+++ b/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/clusterrolebinding.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kubernetes-object-monitor.fullname" . }}
+  labels:
+    {{- include "kubernetes-object-monitor.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kubernetes-object-monitor.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "kubernetes-object-monitor.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+

--- a/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/configmap.yaml
@@ -1,0 +1,53 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kubernetes-object-monitor.fullname" . }}
+  labels:
+    {{- include "kubernetes-object-monitor.labels" . | nindent 4 }}
+data:
+  config.toml: |
+    {{- range .Values.policies }}
+    [[policies]]
+      name = {{ .name | quote }}
+      enabled = {{ .enabled }}
+      
+      [policies.resource]
+        group = {{ .resource.group | quote }}
+        version = {{ .resource.version | quote }}
+        kind = {{ .resource.kind | quote }}
+      
+      [policies.predicate]
+        expression = {{ if contains "\n" .predicate.expression }}'''
+{{ .predicate.expression | trim | nindent 10 }}
+        '''{{ else }}{{ .predicate.expression | quote }}{{ end }}
+      
+      {{- if .nodeAssociation }}
+      [policies.nodeAssociation]
+        expression = {{ .nodeAssociation.expression | quote }}
+      {{- end }}
+      
+      [policies.healthEvent]
+        componentClass = {{ .healthEvent.componentClass | quote }}
+        isFatal = {{ .healthEvent.isFatal }}
+        message = {{ .healthEvent.message | quote }}
+        recommendedAction = {{ .healthEvent.recommendedAction | quote }}
+        {{- if .healthEvent.errorCode }}
+        errorCode = [{{- range $index, $code := .healthEvent.errorCode }}{{- if $index }}, {{ end }}{{ $code | quote }}{{- end }}]
+        {{- end }}
+    
+    {{- end }}
+

--- a/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/deployment.yaml
@@ -48,31 +48,31 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default ((.Values.global).image).tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - "--config"
-            - "/config/config.toml"
-            - "--platform-connector-socket"
-            - "{{ .Values.platformConnector.socket }}"
-            - "--metrics-port"
-            - "{{ (.Values.global).metricsPort | default 8080 }}"
-            - "--max-concurrent-reconciles"
-            - "{{ .Values.maxConcurrentReconciles }}"
+            - "--policy-config-path=/config/config.toml"
+            - "--platform-connector-socket=unix://{{ ((.Values.global).socketPath) | default "/var/run/nvsentinel.sock" }}"
+            - "--metrics-bind-address=:{{ ((.Values.global).metricsPort) | default 2112 }}"
+            - "--health-probe-bind-address=:8081"
+            - "--max-concurrent-reconciles={{ .Values.maxConcurrentReconciles }}"
+            - "--resync-period={{ .Values.resyncPeriod }}"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           ports:
             - name: metrics
-              containerPort: {{ (.Values.global).metricsPort | default 8080 }}
+              containerPort: {{ ((.Values.global).metricsPort) | default 2112 }}
+            - name: health
+              containerPort: 8081
           livenessProbe:
             httpGet:
               path: /healthz
-              port: metrics
+              port: health
             initialDelaySeconds: 15
             periodSeconds: 20
             timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /healthz
-              port: metrics
+              path: /readyz
+              port: health
             initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 3
@@ -84,8 +84,8 @@ spec:
             - name: config
               mountPath: /config
               readOnly: true
-            - name: platform-connector-socket
-              mountPath: /var/run/platform-connector
+            - name: socket
+              mountPath: /var/run
       volumes:
         - name: config
           configMap:

--- a/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/deployment.yaml
@@ -1,0 +1,108 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kubernetes-object-monitor.fullname" . }}
+  labels:
+    {{- include "kubernetes-object-monitor.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "kubernetes-object-monitor.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "kubernetes-object-monitor.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.global }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+      serviceAccountName: {{ include "kubernetes-object-monitor.fullname" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default ((.Values.global).image).tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--config"
+            - "/config/config.toml"
+            - "--platform-connector-socket"
+            - "{{ .Values.platformConnector.socket }}"
+            - "--metrics-port"
+            - "{{ (.Values.global).metricsPort | default 8080 }}"
+            - "--max-concurrent-reconciles"
+            - "{{ .Values.maxConcurrentReconciles }}"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          ports:
+            - name: metrics
+              containerPort: {{ (.Values.global).metricsPort | default 8080 }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          env:
+            - name: LOG_LEVEL
+              value: "{{ .Values.logLevel }}"
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+            - name: platform-connector-socket
+              mountPath: /var/run/platform-connector
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "kubernetes-object-monitor.fullname" . }}
+        {{- range .Values.volumes }}
+        - {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with ((.Values.global).systemNodeSelector | default .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with ((.Values.global).affinity | default .Values.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with ((.Values.global).systemNodeTolerations | default .Values.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+

--- a/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/serviceaccount.yaml
+++ b/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/serviceaccount.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kubernetes-object-monitor.fullname" . }}
+  labels:
+    {{- include "kubernetes-object-monitor.labels" . | nindent 4 }}
+

--- a/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/values.yaml
@@ -30,6 +30,9 @@ podAnnotations: {}
 maxConcurrentReconciles: 1
 resyncPeriod: 5m
 
+# RBAC permissions are automatically generated based on the resources defined in policies.
+# Nodes always get write permissions (patch/update) for annotations.
+# All other resources get read-only permissions (get/list/watch).
 policies:
   - name: node-not-ready
     enabled: true
@@ -47,6 +50,45 @@ policies:
       recommendedAction: CONTACT_SUPPORT
       errorCode:
         - NODE_NOT_READY
+
+  # Example: Monitor a custom resource (e.g., a GPU Job)
+  # Uncomment and modify to monitor your own custom resources
+  #
+  # - name: gpu-job-failed
+  #   enabled: true
+  #   resource:
+  #     group: batch.example.com
+  #     version: v1alpha1
+  #     kind: GPUJob
+  #   predicate:
+  #     # CEL expression to detect unhealthy state
+  #     # Access the resource via 'resource' variable
+  #     expression: |
+  #       has(resource.status.state) && resource.status.state == "Failed"
+  #   nodeAssociation:
+  #     # Optional: CEL expression to map this resource to a specific node
+  #     # This is useful for resources that run on specific nodes
+  #     
+  #     # Example 1: Direct node reference
+  #     expression: resource.spec.nodeName
+  #     
+  #     # Example 2: Use lookup() to find the node from a related Pod
+  #     # Useful when monitoring resources that reference other resources
+  #     # expression: |
+  #     #   lookup('v1', 'Pod', resource.metadata.namespace, resource.spec.podName).spec.nodeName
+  #     
+  #     # Example 3: Chain lookup() calls to traverse multiple resources
+  #     # expression: |
+  #     #   lookup('v1', 'Node', '', 
+  #     #     lookup('v1', 'Pod', resource.metadata.namespace, resource.status.podName).spec.nodeName
+  #     #   ).metadata.name
+  #   healthEvent:
+  #     componentClass: GPU
+  #     isFatal: false
+  #     message: "GPU job failed on node"
+  #     recommendedAction: CONTACT_SUPPORT
+  #     errorCode:
+  #       - GPU_JOB_FAILED
 
 resources:
   requests:

--- a/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/values.yaml
@@ -1,0 +1,66 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default values for kubernetes-object-monitor.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+logLevel: info
+
+image:
+  repository: ghcr.io/nvidia/nvsentinel/kubernetes-object-monitor
+  pullPolicy: IfNotPresent
+  tag: ""
+
+podAnnotations: {}
+
+maxConcurrentReconciles: 1
+
+platformConnector:
+  socket: "unix:///var/run/platform-connector/platform-connector.sock"
+
+policies:
+  - name: node-not-ready
+    enabled: true
+    resource:
+      group: ""
+      version: v1
+      kind: Node
+    predicate:
+      expression: |
+        resource.status.conditions.filter(c, c.type == "Ready" && c.status == "False").size() > 0
+    healthEvent:
+      componentClass: Node
+      isFatal: true
+      message: "Node is not ready"
+      recommendedAction: CONTACT_SUPPORT
+      errorCode:
+        - NODE_NOT_READY
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+volumes:
+  - name: platform-connector-socket
+    hostPath:
+      path: /var/run/platform-connector
+      type: DirectoryOrCreate
+

--- a/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/values.yaml
@@ -28,9 +28,7 @@ image:
 podAnnotations: {}
 
 maxConcurrentReconciles: 1
-
-platformConnector:
-  socket: "unix:///var/run/platform-connector/platform-connector.sock"
+resyncPeriod: 5m
 
 policies:
   - name: node-not-ready
@@ -59,8 +57,8 @@ resources:
     memory: 256Mi
 
 volumes:
-  - name: platform-connector-socket
+  - name: socket
     hostPath:
-      path: /var/run/platform-connector
+      path: /var/run/nvsentinel
       type: DirectoryOrCreate
 

--- a/distros/kubernetes/nvsentinel/values-tilt.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt.yaml
@@ -184,6 +184,24 @@ platformConnector:
 kubernetes-object-monitor:
   logLevel: debug
 
+  policies:
+    - name: node-test-condition
+      enabled: true
+      resource:
+        group: ""
+        version: v1
+        kind: Node
+      predicate:
+        expression: |
+          resource.status.conditions.filter(c, c.type == "TestCondition" && c.status == "False").size() > 0
+      healthEvent:
+        componentClass: Node
+        isFatal: false
+        message: "Node test condition is not ready"
+        recommendedAction: CONTACT_SUPPORT
+        errorCode:
+          - NODE_TEST_CONDITION_NOT_READY
+
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/distros/kubernetes/nvsentinel/values-tilt.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt.yaml
@@ -67,6 +67,9 @@ global:
   metadataCollector:
     enabled: false
 
+  kubernetesObjectMonitor:
+    enabled: true
+
 mongodb-store:
   mongodb:
     replicaCount: 1
@@ -177,3 +180,17 @@ csp-health-monitor:
 platformConnector:
   nodeMetadata:
     enabled: true
+
+kubernetes-object-monitor:
+  logLevel: debug
+
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: kwok
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: kube-system
+        topologyKey: kubernetes.io/hostname

--- a/distros/kubernetes/nvsentinel/values.yaml
+++ b/distros/kubernetes/nvsentinel/values.yaml
@@ -54,6 +54,8 @@ global:
     cleanupMetricsPort: 9002
   mongodbStore:
     enabled: false
+  kubernetesObjectMonitor:
+    enabled: false
 
 platformConnector:
   image:

--- a/health-monitors/kubernetes-object-monitor/Tiltfile
+++ b/health-monitors/kubernetes-object-monitor/Tiltfile
@@ -1,0 +1,20 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+docker_build(
+    "ghcr.io/nvidia/nvsentinel/kubernetes-object-monitor",
+    context="../..",
+    dockerfile="./Dockerfile"
+)
+

--- a/health-monitors/kubernetes-object-monitor/go.mod
+++ b/health-monitors/kubernetes-object-monitor/go.mod
@@ -3,6 +3,7 @@ module github.com/nvidia/nvsentinel/health-monitors/kubernetes-object-monitor
 go 1.25.4
 
 require (
+	github.com/go-logr/logr v1.4.3
 	github.com/google/cel-go v0.26.1
 	github.com/nvidia/nvsentinel/commons v0.0.0
 	github.com/nvidia/nvsentinel/data-models v0.0.0
@@ -30,7 +31,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-openapi/jsonpointer v0.22.1 // indirect
 	github.com/go-openapi/jsonreference v0.21.3 // indirect
 	github.com/go-openapi/swag v0.25.1 // indirect

--- a/health-monitors/kubernetes-object-monitor/pkg/initializer/initializer.go
+++ b/health-monitors/kubernetes-object-monitor/pkg/initializer/initializer.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	"github.com/nvidia/nvsentinel/health-monitors/kubernetes-object-monitor/pkg/annotations"
 	celenv "github.com/nvidia/nvsentinel/health-monitors/kubernetes-object-monitor/pkg/cel"
@@ -38,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
 
@@ -59,6 +61,10 @@ type Components struct {
 }
 
 func InitializeAll(ctx context.Context, params Params) (*Components, error) {
+	slogHandler := slog.Default().Handler()
+	logrLogger := logr.FromSlogHandler(slogHandler)
+	ctrllog.SetLogger(logrLogger)
+
 	cfg, err := config.Load(params.PolicyConfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load policy config: %w", err)

--- a/tests/helpers/kube.go
+++ b/tests/helpers/kube.go
@@ -1594,10 +1594,13 @@ func SetNodeConditionStatus(
 				return err
 			}
 
+			found := false
 			modified := false
 
 			for i := range node.Status.Conditions {
 				if node.Status.Conditions[i].Type == conditionType {
+					found = true
+
 					if node.Status.Conditions[i].Status != status {
 						node.Status.Conditions[i].Status = status
 						node.Status.Conditions[i].LastTransitionTime = metav1.Now()
@@ -1607,6 +1610,19 @@ func SetNodeConditionStatus(
 
 					break
 				}
+			}
+
+			if !found {
+				now := metav1.Now()
+				node.Status.Conditions = append(node.Status.Conditions, v1.NodeCondition{
+					Type:               conditionType,
+					Status:             status,
+					LastTransitionTime: now,
+					LastHeartbeatTime:  now,
+					Reason:             "TestCondition",
+					Message:            "Set by test",
+				})
+				modified = true
 			}
 
 			if !modified {

--- a/tests/helpers/kube.go
+++ b/tests/helpers/kube.go
@@ -1576,3 +1576,50 @@ func VerifyEventsMatchPatterns(t *testing.T, ctx context.Context,
 
 	return true
 }
+
+func SetNodeConditionStatus(
+	ctx context.Context,
+	t *testing.T,
+	client klient.Client,
+	nodeName string,
+	conditionType v1.NodeConditionType,
+	status v1.ConditionStatus,
+) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			node, err := GetNodeByName(ctx, client, nodeName)
+			if err != nil {
+				return err
+			}
+
+			modified := false
+
+			for i := range node.Status.Conditions {
+				if node.Status.Conditions[i].Type == conditionType {
+					if node.Status.Conditions[i].Status != status {
+						node.Status.Conditions[i].Status = status
+						node.Status.Conditions[i].LastTransitionTime = metav1.Now()
+						node.Status.Conditions[i].LastHeartbeatTime = metav1.Now()
+						modified = true
+					}
+
+					break
+				}
+			}
+
+			if !modified {
+				return nil
+			}
+
+			return client.Resources().UpdateStatus(ctx, node)
+		})
+		if err != nil {
+			t.Logf("Failed to update node status: %v", err)
+			return false
+		}
+
+		return true
+	}, EventuallyWaitTimeout, WaitInterval)
+}

--- a/tests/kubernetes_object_monitor_test.go
+++ b/tests/kubernetes_object_monitor_test.go
@@ -30,6 +30,9 @@ type k8sObjectMonitorContextKey int
 
 const (
 	k8sMonitorKeyNodeName k8sObjectMonitorContextKey = iota
+
+	annotationKey     = "nvsentinel.nvidia.com/k8s-object-monitor-policy-matches"
+	testConditionType = "TestCondition"
 )
 
 func TestKubernetesObjectMonitor(t *testing.T) {
@@ -41,12 +44,19 @@ func TestKubernetesObjectMonitor(t *testing.T) {
 		client, err := c.NewClient()
 		require.NoError(t, err)
 
-		pod, err := helpers.GetPodOnWorkerNode(ctx, t, client, helpers.NVSentinelNamespace, "kubernetes-object-monitor")
+		nodeList := &v1.NodeList{}
+		err = client.Resources().List(ctx, nodeList)
 		require.NoError(t, err)
-		require.NotNil(t, pod)
 
-		testNodeName := pod.Spec.NodeName
-		t.Logf("Using kubernetes-object-monitor pod: %s on node: %s", pod.Name, testNodeName)
+		var testNodeName string
+		for _, node := range nodeList.Items {
+			if node.Labels["type"] != "kwok" {
+				testNodeName = node.Name
+				break
+			}
+		}
+		require.NotEmpty(t, testNodeName, "no real (non-KWOK) nodes found in cluster")
+		t.Logf("Using test node: %s", testNodeName)
 
 		return context.WithValue(ctx, k8sMonitorKeyNodeName, testNodeName)
 	})
@@ -56,9 +66,9 @@ func TestKubernetesObjectMonitor(t *testing.T) {
 		require.NoError(t, err)
 
 		nodeName := ctx.Value(k8sMonitorKeyNodeName).(string)
-		t.Logf("Marking node %s as NotReady", nodeName)
+		t.Logf("Setting TestCondition to False on node %s", nodeName)
 
-		helpers.SetNodeConditionStatus(ctx, t, client, nodeName, v1.NodeReady, v1.ConditionFalse)
+		helpers.SetNodeConditionStatus(ctx, t, client, nodeName, v1.NodeConditionType(testConditionType), v1.ConditionFalse)
 
 		t.Log("Waiting for policy match annotation on node")
 		require.Eventually(t, func() bool {
@@ -68,7 +78,7 @@ func TestKubernetesObjectMonitor(t *testing.T) {
 				return false
 			}
 
-			annotation, exists := node.Annotations["nvsentinel.nvidia.com/k8s-object-monitor-policy-matches"]
+			annotation, exists := node.Annotations[annotationKey]
 			if !exists {
 				return false
 			}
@@ -85,9 +95,9 @@ func TestKubernetesObjectMonitor(t *testing.T) {
 		require.NoError(t, err)
 
 		nodeName := ctx.Value(k8sMonitorKeyNodeName).(string)
-		t.Logf("Marking node %s as Ready", nodeName)
+		t.Logf("Setting TestCondition to True on node %s", nodeName)
 
-		helpers.SetNodeConditionStatus(ctx, t, client, nodeName, v1.NodeReady, v1.ConditionTrue)
+		helpers.SetNodeConditionStatus(ctx, t, client, nodeName, v1.NodeConditionType(testConditionType), v1.ConditionTrue)
 
 		t.Log("Waiting for policy match annotation to be cleared")
 		require.Eventually(t, func() bool {
@@ -97,7 +107,7 @@ func TestKubernetesObjectMonitor(t *testing.T) {
 				return false
 			}
 
-			annotation, exists := node.Annotations["nvsentinel.nvidia.com/k8s-object-monitor-policy-matches"]
+			annotation, exists := node.Annotations[annotationKey]
 			if exists && annotation != "" {
 				t.Logf("Annotation still exists: %s", annotation)
 				return false

--- a/tests/kubernetes_object_monitor_test.go
+++ b/tests/kubernetes_object_monitor_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"tests/helpers"
+)
+
+type k8sObjectMonitorContextKey int
+
+const (
+	k8sMonitorKeyNodeName k8sObjectMonitorContextKey = iota
+)
+
+func TestKubernetesObjectMonitor(t *testing.T) {
+	feature := features.New("Kubernetes Object Monitor - Node Not Ready Detection").
+		WithLabel("suite", "kubernetes-object-monitor").
+		WithLabel("component", "node-monitoring")
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err)
+
+		pod, err := helpers.GetPodOnWorkerNode(ctx, t, client, helpers.NVSentinelNamespace, "kubernetes-object-monitor")
+		require.NoError(t, err)
+		require.NotNil(t, pod)
+
+		testNodeName := pod.Spec.NodeName
+		t.Logf("Using kubernetes-object-monitor pod: %s on node: %s", pod.Name, testNodeName)
+
+		return context.WithValue(ctx, k8sMonitorKeyNodeName, testNodeName)
+	})
+
+	feature.Assess("Node NotReady triggers health event", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err)
+
+		nodeName := ctx.Value(k8sMonitorKeyNodeName).(string)
+		t.Logf("Marking node %s as NotReady", nodeName)
+
+		helpers.SetNodeConditionStatus(ctx, t, client, nodeName, v1.NodeReady, v1.ConditionFalse)
+
+		t.Log("Waiting for policy match annotation on node")
+		require.Eventually(t, func() bool {
+			node, err := helpers.GetNodeByName(ctx, client, nodeName)
+			if err != nil {
+				t.Logf("Failed to get node: %v", err)
+				return false
+			}
+
+			annotation, exists := node.Annotations["nvsentinel.nvidia.com/k8s-object-monitor-policy-matches"]
+			if !exists {
+				return false
+			}
+
+			t.Logf("Found policy match annotation: %s", annotation)
+			return true
+		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval)
+
+		return ctx
+	})
+
+	feature.Assess("Node Ready recovery clears annotation", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err)
+
+		nodeName := ctx.Value(k8sMonitorKeyNodeName).(string)
+		t.Logf("Marking node %s as Ready", nodeName)
+
+		helpers.SetNodeConditionStatus(ctx, t, client, nodeName, v1.NodeReady, v1.ConditionTrue)
+
+		t.Log("Waiting for policy match annotation to be cleared")
+		require.Eventually(t, func() bool {
+			node, err := helpers.GetNodeByName(ctx, client, nodeName)
+			if err != nil {
+				t.Logf("Failed to get node: %v", err)
+				return false
+			}
+
+			annotation, exists := node.Annotations["nvsentinel.nvidia.com/k8s-object-monitor-policy-matches"]
+			if exists && annotation != "" {
+				t.Logf("Annotation still exists: %s", annotation)
+				return false
+			}
+
+			return true
+		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval)
+
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}

--- a/tilt/Tiltfile
+++ b/tilt/Tiltfile
@@ -96,6 +96,7 @@ include('../platform-connectors/Tiltfile')
 include('./simple-health-client/Tiltfile')
 include('../health-events-analyzer/Tiltfile')
 include('../health-monitors/gpu-health-monitor/Tiltfile')
+include('../health-monitors/kubernetes-object-monitor/Tiltfile')
 include('../health-monitors/syslog-health-monitor/Tiltfile')
 include('../labeler/Tiltfile')
 
@@ -157,6 +158,11 @@ if not skip_kwok_nodes:
 
 k8s_resource(
     'gpu-health-monitor-dcgm-4.x',
+    resource_deps=['platform-connectors']
+)
+
+k8s_resource(
+    'kubernetes-object-monitor',
     resource_deps=['platform-connectors']
 )
 


### PR DESCRIPTION
## Summary

```
cat > /tmp/test-values.yaml << 'EOF'
policies:
  - name: node-not-ready
    enabled: true
    resource:
      group: ""
      version: v1
      kind: Node
    predicate:
      expression: "true"
    healthEvent:
      componentClass: Node
      isFatal: true
      message: Test
      recommendedAction: CONTACT_SUPPORT
      errorCode: [TEST]
  - name: gpu-job-failed
    enabled: true
    resource:
      group: batch.nvidia.com
      version: v1alpha1
      kind: GPUJob
    predicate:
      expression: "true"
    healthEvent:
      componentClass: GPU
      isFatal: false
      message: Test
      recommendedAction: CONTACT_SUPPORT
      errorCode: [TEST]
  - name: deployment-check
    enabled: true
    resource:
      group: apps
      version: v1
      kind: Deployment
    predicate:
      expression: "true"
    healthEvent:
      componentClass: Apps
      isFatal: false
      message: Test
      recommendedAction: CONTACT_SUPPORT
      errorCode: [TEST]
EOF
helm template test . -f /tmp/test-values.yaml --show-only templates/clusterrole.yaml
---
# Source: kubernetes-object-monitor/templates/clusterrole.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: kubernetes-object-monitor
  labels:
    helm.sh/chart: kubernetes-object-monitor-0.1.0
    app.kubernetes.io/name: kubernetes-object-monitor
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "1.16.0"
    app.kubernetes.io/managed-by: Helm
rules:
  - apiGroups:
      - ""
    resources:
      - nodes
    verbs:
      - get
      - list
      - watch
      - patch
      - update
  - apiGroups:
      - "apps"
    resources:
      - deployments
    verbs:
      - get
      - list
      - watch
  - apiGroups:
      - "batch.nvidia.com"
    resources:
      - gpujobs
    verbs:
      - get
      - list
      - watch
 ```

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [x] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Kubernetes Object Monitor that watches Kubernetes objects (nodes) and emits health events based on configurable policy predicates; includes default policies and enable/disable config.
* **Chores**
  * Added Helm chart, deployment manifests, local dev config, Tilt integration, and CI build/publish entry to support deploying and iterating the monitor.
* **Tests**
  * Added end-to-end tests validating NotReady/Ready detection and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->