### PR TITLE
feat: implement Workflow XID 13 and XID 31

### DIFF
--- a/data-models/pkg/protos/health_event.pb.go
+++ b/data-models/pkg/protos/health_event.pb.go
@@ -47,8 +47,7 @@ const (
 	RecommendedAction_RESTART_VM      RecommendedAction = 15
 	RecommendedAction_RESTART_BM      RecommendedAction = 24
 	RecommendedAction_REPLACE_VM      RecommendedAction = 25
-	RecommendedAction_CHECK_APP_CUDA  RecommendedAction = 26
-	RecommendedAction_RUN_DCGMEUD     RecommendedAction = 27
+	RecommendedAction_RUN_DCGMEUD     RecommendedAction = 26
 	RecommendedAction_UNKNOWN         RecommendedAction = 99
 )
 
@@ -62,8 +61,7 @@ var (
 		15: "RESTART_VM",
 		24: "RESTART_BM",
 		25: "REPLACE_VM",
-		26: "CHECK_APP_CUDA",
-		27: "RUN_DCGMEUD",
+		26: "RUN_DCGMEUD",
 		99: "UNKNOWN",
 	}
 	RecommendedAction_value = map[string]int32{
@@ -74,8 +72,7 @@ var (
 		"RESTART_VM":      15,
 		"RESTART_BM":      24,
 		"REPLACE_VM":      25,
-		"CHECK_APP_CUDA":  26,
-		"RUN_DCGMEUD":     27,
+		"RUN_DCGMEUD":     26,
 		"UNKNOWN":         99,
 	}
 )
@@ -455,7 +452,7 @@ const file_health_event_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\">\n" +
 	"\x12BehaviourOverrides\x12\x14\n" +
 	"\x05force\x18\x01 \x01(\bR\x05force\x12\x12\n" +
-	"\x04skip\x18\x02 \x01(\bR\x04skip*\xbc\x01\n" +
+	"\x04skip\x18\x02 \x01(\bR\x04skip*\xa8\x01\n" +
 	"\x11RecommendedAction\x12\b\n" +
 	"\x04NONE\x10\x00\x12\x13\n" +
 	"\x0fCOMPONENT_RESET\x10\x02\x12\x13\n" +
@@ -466,9 +463,8 @@ const file_health_event_proto_rawDesc = "" +
 	"\n" +
 	"RESTART_BM\x10\x18\x12\x0e\n" +
 	"\n" +
-	"REPLACE_VM\x10\x19\x12\x12\n" +
-	"\x0eCHECK_APP_CUDA\x10\x1a\x12\x0f\n" +
-	"\vRUN_DCGMEUD\x10\x1b\x12\v\n" +
+	"REPLACE_VM\x10\x19\x12\x0f\n" +
+	"\vRUN_DCGMEUD\x10\x1a\x12\v\n" +
 	"\aUNKNOWN\x10c2`\n" +
 	"\x11PlatformConnector\x12K\n" +
 	"\x15HealthEventOccurredV1\x12\x18.datamodels.HealthEvents\x1a\x16.google.protobuf.Empty\"\x00B5Z3github.com/nvidia/nvsentinel/data-models/pkg/protosb\x06proto3"

--- a/data-models/pkg/protos/health_event.pb.go
+++ b/data-models/pkg/protos/health_event.pb.go
@@ -43,9 +43,12 @@ const (
 	RecommendedAction_NONE            RecommendedAction = 0
 	RecommendedAction_COMPONENT_RESET RecommendedAction = 2
 	RecommendedAction_CONTACT_SUPPORT RecommendedAction = 5
+	RecommendedAction_RUN_FIELDDIAG   RecommendedAction = 6
 	RecommendedAction_RESTART_VM      RecommendedAction = 15
 	RecommendedAction_RESTART_BM      RecommendedAction = 24
 	RecommendedAction_REPLACE_VM      RecommendedAction = 25
+	RecommendedAction_CHECK_APP_CUDA  RecommendedAction = 26
+	RecommendedAction_RUN_DCGMEUD     RecommendedAction = 27
 	RecommendedAction_UNKNOWN         RecommendedAction = 99
 )
 
@@ -55,18 +58,24 @@ var (
 		0:  "NONE",
 		2:  "COMPONENT_RESET",
 		5:  "CONTACT_SUPPORT",
+		6:  "RUN_FIELDDIAG",
 		15: "RESTART_VM",
 		24: "RESTART_BM",
 		25: "REPLACE_VM",
+		26: "CHECK_APP_CUDA",
+		27: "RUN_DCGMEUD",
 		99: "UNKNOWN",
 	}
 	RecommendedAction_value = map[string]int32{
 		"NONE":            0,
 		"COMPONENT_RESET": 2,
 		"CONTACT_SUPPORT": 5,
+		"RUN_FIELDDIAG":   6,
 		"RESTART_VM":      15,
 		"RESTART_BM":      24,
 		"REPLACE_VM":      25,
+		"CHECK_APP_CUDA":  26,
+		"RUN_DCGMEUD":     27,
 		"UNKNOWN":         99,
 	}
 )
@@ -446,17 +455,20 @@ const file_health_event_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\">\n" +
 	"\x12BehaviourOverrides\x12\x14\n" +
 	"\x05force\x18\x01 \x01(\bR\x05force\x12\x12\n" +
-	"\x04skip\x18\x02 \x01(\bR\x04skip*\x84\x01\n" +
+	"\x04skip\x18\x02 \x01(\bR\x04skip*\xbc\x01\n" +
 	"\x11RecommendedAction\x12\b\n" +
 	"\x04NONE\x10\x00\x12\x13\n" +
 	"\x0fCOMPONENT_RESET\x10\x02\x12\x13\n" +
-	"\x0fCONTACT_SUPPORT\x10\x05\x12\x0e\n" +
+	"\x0fCONTACT_SUPPORT\x10\x05\x12\x11\n" +
+	"\rRUN_FIELDDIAG\x10\x06\x12\x0e\n" +
 	"\n" +
 	"RESTART_VM\x10\x0f\x12\x0e\n" +
 	"\n" +
 	"RESTART_BM\x10\x18\x12\x0e\n" +
 	"\n" +
-	"REPLACE_VM\x10\x19\x12\v\n" +
+	"REPLACE_VM\x10\x19\x12\x12\n" +
+	"\x0eCHECK_APP_CUDA\x10\x1a\x12\x0f\n" +
+	"\vRUN_DCGMEUD\x10\x1b\x12\v\n" +
 	"\aUNKNOWN\x10c2`\n" +
 	"\x11PlatformConnector\x12K\n" +
 	"\x15HealthEventOccurredV1\x12\x18.datamodels.HealthEvents\x1a\x16.google.protobuf.Empty\"\x00B5Z3github.com/nvidia/nvsentinel/data-models/pkg/protosb\x06proto3"

--- a/data-models/protobufs/health_event.proto
+++ b/data-models/protobufs/health_event.proto
@@ -33,9 +33,12 @@ enum RecommendedAction {
   NONE = 0;
   COMPONENT_RESET = 2;
   CONTACT_SUPPORT = 5;
+  RUN_FIELDDIAG = 6;
   RESTART_VM = 15;
   RESTART_BM = 24;
   REPLACE_VM = 25;
+  CHECK_APP_CUDA = 26;
+  RUN_DCGMEUD = 27;
 
   UNKNOWN = 99;
 }

--- a/data-models/protobufs/health_event.proto
+++ b/data-models/protobufs/health_event.proto
@@ -37,8 +37,7 @@ enum RecommendedAction {
   RESTART_VM = 15;
   RESTART_BM = 24;
   REPLACE_VM = 25;
-  CHECK_APP_CUDA = 26;
-  RUN_DCGMEUD = 27;
+  RUN_DCGMEUD = 26;
 
   UNKNOWN = 99;
 }

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
@@ -70,892 +70,898 @@ config: |
 
   [[rules]]
   name = "RepeatedXidErrorOnSameGPU"
-  description = "Detect occurrence of fatal XIDs 5 times within 24 hours (production: 86400s for real workloads)"
+  description = "Detect occurrence of fatal XIDs 2 times within 2 minutes where the burst window is 10 seconds and sticky XIDs window is 20seconds"
   recommended_action = "CONTACT_SUPPORT"
+  recommended_action_mappings = { "31" = { recommended_action = "RUN_DCGMEUD", message = "if pass: RUN_FIELDDIAGS" } }
+
   stage = [
-    '''
-    {
+      '''
+      {
       "$match": {
-        "$expr": {
+          "$expr": {
           "$gte": [
-            "$healthevent.generatedtimestamp.seconds",
-            {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
+              "$healthevent.generatedtimestamp.seconds",
+              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 120]}
           ]
-        }
+          }
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
       "$match": {
-        "healthevent.ishealthy": false,
-        "healthevent.nodename": "this.healthevent.nodename",
-        "$expr": {
+          "healthevent.ishealthy": false,
+          "healthevent.nodename": "this.healthevent.nodename",
+          "$expr": {
           "$gt": [
-            {
+              {
               "$size": {
-                "$setIntersection": [
+                  "$setIntersection": [
                   {
-                    "$map": {
+                      "$map": {
                       "input": {
-                        "$filter": {
+                          "$filter": {
                           "input": {"$ifNull": ["$healthevent.entitiesimpacted", []]},
                           "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
-                        }
+                          }
                       },
                       "in": "$$this.entityvalue"
-                    }
+                      }
                   },
                   {
-                    "$map": {
+                      "$map": {
                       "input": {
-                        "$filter": {
+                          "$filter": {
                           "input": "this.healthevent.entitiesimpacted",
                           "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
-                        }
+                          }
                       },
                       "in": "$$this.entityvalue"
-                    }
+                      }
                   }
-                ]
+                  ]
               }
-            },
-            0
+              },
+              0
           ]
-        }
+          }
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
       "$setWindowFields": {
-        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
-        "output": {
+          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+          "output": {
           "prevTimestamp": {
-            "$shift": {
+              "$shift": {
               "output": "$healthevent.generatedtimestamp.seconds",
               "by": -1
-            }
+              }
           }
-        }
+          }
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
       "$addFields": {
-        "isStickyXid": {
+          "isStickyXid": {
           "$in": [
-            {"$arrayElemAt": ["$healthevent.errorcode", 0]},
-            ["74", "79", "95", "109", "119"]
+              {"$arrayElemAt": ["$healthevent.errorcode", 0]},
+              ["74", "79", "95", "109", "119"]
           ]
-        }
-      }
-    }
-    ''',
-    '''
-    {
-      "$setWindowFields": {
-        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
-        "output": {
-          "allPreviousEvents": {
-            "$push": "$$ROOT",
-            "window": {"documents": ["unbounded", -1]}
           }
-        }
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
+      "$setWindowFields": {
+          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+          "output": {
+          "allPreviousEvents": {
+              "$push": "$$ROOT",
+              "window": {"documents": ["unbounded", -1]}
+          }
+          }
+      }
+      }
+      ''',
+      '''
+      {
       "$addFields": {
-        "stickyXidWithin3Hours": {
+          "stickyXidWithin3Hours": {
           "$cond": {
-            "if": "$isStickyXid",
-            "then": {
+              "if": "$isStickyXid",
+              "then": {
               "$anyElementTrue": {
-                "$map": {
+                  "$map": {
                   "input": "$allPreviousEvents",
                   "as": "prevEvent",
                   "in": {
-                    "$and": [
+                      "$and": [
                       {
-                        "$in": [
+                          "$in": [
                           {"$arrayElemAt": ["$$prevEvent.healthevent.errorcode", 0]},
                           ["74", "79", "95", "109", "119"]
-                        ]
+                          ]
                       },
-                      {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 10800]}
-                    ]
-                  }
-                }
-              }
-            },
-            "else": false
-          }
-        }
-      }
-    }
-    ''',
-    '''
-    {
-      "$setWindowFields": {
-        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
-        "output": {
-          "burstId": {
-            "$sum": {
-              "$cond": {
-                "if": {"$eq": ["$prevTimestamp", null]},
-                "then": 1,
-                "else": {
-                  "$cond": {
-                    "if": {
-                      "$and": [
-                        "$isStickyXid",
-                        "$stickyXidWithin3Hours"
+                      {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 20]}
                       ]
-                    },
-                    "then": 0,
-                    "else": {
-                      "$cond": {
-                        "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 180]},
-                        "then": 1,
-                        "else": 0
-                      }
-                    }
                   }
-                }
+                  }
               }
-            },
-            "window": {"documents": ["unbounded", "current"]}
+              },
+              "else": false
           }
-        }
+          }
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
+      "$setWindowFields": {
+          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+          "output": {
+          "burstId": {
+              "$sum": {
+              "$cond": {
+                  "if": {"$eq": ["$prevTimestamp", null]},
+                  "then": 1,
+                  "else": {
+                  "$cond": {
+                      "if": {
+                      "$and": [
+                          "$isStickyXid",
+                          "$stickyXidWithin3Hours"
+                      ]
+                      },
+                      "then": 0,
+                      "else": {
+                      "$cond": {
+                          "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 10]},
+                          "then": 1,
+                          "else": 0
+                      }
+                      }
+                  }
+                  }
+              }
+              },
+              "window": {"documents": ["unbounded", "current"]}
+          }
+          }
+      }
+      }
+      ''',
+      '''
+      {
       "$group": {
-        "_id": {"burstId": "$burstId"},
-        "uniqueXidsInBurst": {"$addToSet": {"$arrayElemAt": ["$healthevent.errorcode", 0]}},
-        "targetXidCount": {
+          "_id": {"burstId": "$burstId"},
+          "uniqueXidsInBurst": {"$addToSet": {"$arrayElemAt": ["$healthevent.errorcode", 0]}},
+          "targetXidCount": {
           "$sum": {
-            "$cond": [
+              "$cond": [
               {"$eq": [{"$arrayElemAt": ["$healthevent.errorcode", 0]}, "this.healthevent.errorcode.0"]},
               1,
               0
-            ]
-          }
-        }
-      }
-    }
-    ''',
-    '''
-    {
-      "$setWindowFields": {
-        "sortBy": {"_id.burstId": 1},
-        "output": {"maxBurstId": {"$max": "$_id.burstId"}}
-      }
-    }
-    ''',
-    '''
-    {
-      "$match": {
-        "$expr": {
-          "$and": [
-            {"$in": ["this.healthevent.errorcode.0", "$uniqueXidsInBurst"]},
-            {
-              "$or": [
-                {"$ne": ["$_id.burstId", "$maxBurstId"]},
-                {"$eq": ["$targetXidCount", 1]}
               ]
-            }
+          }
+          }
+      }
+      }
+      ''',
+      '''
+      {
+      "$setWindowFields": {
+          "sortBy": {"_id.burstId": 1},
+          "output": {"maxBurstId": {"$max": "$_id.burstId"}}
+      }
+      }
+      ''',
+      '''
+      {
+      "$match": {
+          "$expr": {
+          "$and": [
+              {"$in": ["this.healthevent.errorcode.0", "$uniqueXidsInBurst"]},
+              {
+              "$or": [
+                  {"$ne": ["$_id.burstId", "$maxBurstId"]},
+                  {"$eq": ["$targetXidCount", 1]}
+              ]
+              }
           ]
-        }
+          }
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
       "$group": {
-        "_id": null,
-        "count": {"$sum": 1},
-        "bursts": {"$push": {"burstId": "$_id.burstId", "uniqueXids": "$uniqueXidsInBurst"}}
+          "_id": null,
+          "count": {"$sum": 1},
+          "bursts": {"$push": {"burstId": "$_id.burstId", "uniqueXids": "$uniqueXidsInBurst"}}
       }
-    }
-    ''',
-    '{"$match": {"count": {"$gte": 5}}}'
+      }
+      ''',
+      '{"$match": {"count": {"$gte": 2}}}'
   ]
 
   [[rules]]
   name = "RepeatedXidErrorOnDifferentGPU"
-  description = "Detect occurrence of XIDs on 5+ different GPUs within 24 hours"
-  recommended_action = "CHECK_APP_CUDA"
+  description = "Detect occurrence of XIDs on 2+ different GPUs within 1 minutes"
+  message = "run CHECK_APP_CUDA"
+  recommended_action = "NONE"
   stage = [
-    '''
-    {
+      '''
+      {
       "$match": {
-        "$expr": {
+          "$expr": {
           "$gte": [
-            "$healthevent.generatedtimestamp.seconds",
-            {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
+              "$healthevent.generatedtimestamp.seconds",
+              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 60]}
           ]
-        }
+          }
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
       "$match": {
-        "healthevent.ishealthy": false,
-        "healthevent.nodename": "this.healthevent.nodename",
-        "healthevent.errorcode": "this.healthevent.errorcode.0"
+          "healthevent.ishealthy": false,
+          "healthevent.nodename": "this.healthevent.nodename",
+          "healthevent.errorcode": "this.healthevent.errorcode.0"
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
       "$addFields": {
-        "gpuUuid": {
+          "gpuUuid": {
           "$let": {
-            "vars": {
+              "vars": {
               "uuid": {
-                "$arrayElemAt": [
+                  "$arrayElemAt": [
                   {
-                    "$map": {
+                      "$map": {
                       "input": {"$filter": {"input": {"$ifNull": ["$healthevent.entitiesimpacted", []]}, "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}}},
                       "in": "$$this.entityvalue"
-                    }
+                      }
                   },
                   0
-                ]
+                  ]
               }
-            },
-            "in": {
+              },
+              "in": {
               "$cond": [
-                {"$ne": ["$$uuid", null]},
-                "$$uuid",
-                null
+                  {"$ne": ["$$uuid", null]},
+                  "$$uuid",
+                  null
               ]
-            }
+              }
           }
-        }
+          }
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
       "$group": {
-        "_id": null,
-        "uniqueGPUs": {"$addToSet": "$gpuUuid"}
+          "_id": null,
+          "uniqueGPUs": {"$addToSet": "$gpuUuid"}
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
       "$match": {
-        "$expr": {
-          "$gte": [{"$size": "$uniqueGPUs"}, 5]
-        }
+          "$expr": {
+          "$gte": [{"$size": "$uniqueGPUs"}, 2]
+          }
       }
-    }
-    '''
+      }
+      '''
   ]
 
   [[rules]]
-  name = "XID13OnSameGPCAndTPC"
-  description = "Detect if XID 13 occurred 5 times on the same GPC and TPC within 24 hours"
-  recommended_action = "RUN_FIELDDIAG"
+  name = "XIDErrorOnSameGPCAndTPC"
+  description = "Detect if XID error occurred 2 times on the same GPC and TPC within 2 minutes"
+  message = "if pass run RUN_FIELDDIAGS" 
+  recommended_action = "RUN_DCGMEUD"
   stage = [
-    '''
-    {
+      '''
+      {
       "$match": {
-        "$expr": {
+          "$expr": {
           "$gte": [
-            "$healthevent.generatedtimestamp.seconds",
-            {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
+              "$healthevent.generatedtimestamp.seconds",
+              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 120]}
           ]
-        }
+          }
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
       "$match": {
-        "healthevent.ishealthy": false,
-        "healthevent.nodename": "this.healthevent.nodename",
-        "$expr": {
+          "healthevent.ishealthy": false,
+          "healthevent.nodename": "this.healthevent.nodename",
+          "$expr": {
           "$gt": [
-            {
+              {
               "$size": {
-                "$setIntersection": [
+                  "$setIntersection": [
                   {
-                    "$map": {
+                      "$map": {
                       "input": {
-                        "$filter": {
+                          "$filter": {
                           "input": "$healthevent.entitiesimpacted",
-                          "cond": {"$eq": ["$$this.entitytype", "GPU"]}
-                        }
+                          "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
+                          }
                       },
                       "in": "$$this.entityvalue"
-                    }
+                      }
                   },
                   {
-                    "$map": {
+                      "$map": {
                       "input": {
-                        "$filter": {
+                          "$filter": {
                           "input": "this.healthevent.entitiesimpacted",
-                          "cond": {"$eq": ["$$this.entitytype", "GPU"]}
-                        }
+                          "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
+                          }
                       },
                       "in": "$$this.entityvalue"
-                    }
+                      }
                   }
-                ]
+                  ]
               }
-            },
-            0
+              },
+              0
           ]
-        },
+          }
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
       "$setWindowFields": {
-        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
-        "output": {
+          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+          "output": {
           "prevTimestamp": {
-            "$shift": {
+              "$shift": {
               "output": "$healthevent.generatedtimestamp.seconds",
               "by": -1
-            }
+              }
           }
-        }
+          }
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
       "$addFields": {
-        "isStickyXid": {
+          "isStickyXid": {
           "$in": [
-            {"$arrayElemAt": ["$healthevent.errorcode", 0]},
-            ["74", "79", "95", "109", "119"]
+              {"$arrayElemAt": ["$healthevent.errorcode", 0]},
+              ["74", "79", "95", "109", "119"]
           ]
-        }
-      }
-    }
-    ''',
-    '''
-    {
-      "$setWindowFields": {
-        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
-        "output": {
-          "allPreviousEvents": {
-            "$push": "$$ROOT",
-            "window": {"documents": ["unbounded", -1]}
           }
-        }
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
+      "$setWindowFields": {
+          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+          "output": {
+          "allPreviousEvents": {
+              "$push": "$$ROOT",
+              "window": {"documents": ["unbounded", -1]}
+          }
+          }
+      }
+      }
+      ''',
+      '''
+      {
       "$addFields": {
-        "stickyXidWithin3Hours": {
+          "stickyXidWithin3Hours": {
           "$cond": {
-            "if": "$isStickyXid",
-            "then": {
+              "if": "$isStickyXid",
+              "then": {
               "$anyElementTrue": {
-                "$map": {
+                  "$map": {
                   "input": "$allPreviousEvents",
                   "as": "prevEvent",
                   "in": {
-                    "$and": [
+                      "$and": [
                       {
-                        "$in": [
+                          "$in": [
                           {"$arrayElemAt": ["$$prevEvent.healthevent.errorcode", 0]},
                           ["74", "79", "95", "109", "119"]
-                        ]
+                          ]
                       },
-                      {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 10800]}
-                    ]
-                  }
-                }
-              }
-            },
-            "else": false
-          }
-        }
-      }
-    }
-    ''',
-    '''
-    {
-      "$setWindowFields": {
-        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
-        "output": {
-          "burstId": {
-            "$sum": {
-              "$cond": {
-                "if": {"$eq": ["$prevTimestamp", null]},
-                "then": 1,
-                "else": {
-                  "$cond": {
-                    "if": {
-                      "$and": [
-                        "$isStickyXid",
-                        "$stickyXidWithin3Hours"
+                      {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 20]}
                       ]
-                    },
-                    "then": 0,
-                    "else": {
-                      "$cond": {
-                        "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 180]},
-                        "then": 1,
-                        "else": 0
-                      }
-                    }
                   }
-                }
+                  }
               }
-            },
-            "window": {"documents": ["unbounded", "current"]}
+              },
+              "else": false
           }
-        }
+          }
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
+      "$setWindowFields": {
+          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+          "output": {
+          "burstId": {
+              "$sum": {
+              "$cond": {
+                  "if": {"$eq": ["$prevTimestamp", null]},
+                  "then": 1,
+                  "else": {
+                  "$cond": {
+                      "if": {
+                      "$and": [
+                          "$isStickyXid",
+                          "$stickyXidWithin3Hours"
+                      ]
+                      },
+                      "then": 0,
+                      "else": {
+                      "$cond": {
+                          "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 4]},
+                          "then": 1,
+                          "else": 0
+                      }
+                      }
+                  }
+                  }
+              }
+              },
+              "window": {"documents": ["unbounded", "current"]}
+          }
+          }
+      }
+      }
+      ''',
+      '''
+      {
       "$group": {
-        "_id": {"burstId": "$burstId"},
-        "uniqueXidsInBurst": {"$addToSet": {"$arrayElemAt": ["$healthevent.errorcode", 0]}},
-        "targetXidCount": {
+          "_id": {"burstId": "$burstId"},
+          "uniqueXidsInBurst": {"$addToSet": {"$arrayElemAt": ["$healthevent.errorcode", 0]}},
+          "targetXidCount": {
           "$sum": {
-            "$cond": [
+              "$cond": [
               {
-                "$and": [
+                  "$and": [
                   {"$eq": [{"$arrayElemAt": ["$healthevent.errorcode", 0]}, "this.healthevent.errorcode.0"]},
                   {
-                    "$eq": [
+                      "$eq": [
                       {
-                        "$arrayElemAt": [
+                          "$arrayElemAt": [
                           {
-                            "$map": {
+                              "$map": {
                               "input": {"$filter": {"input": "$healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "GPC"]}}},
                               "in": "$$this.entityvalue"
-                            }
+                              }
                           },
                           0
-                        ]
+                          ]
                       },
                       {
-                        "$arrayElemAt": [
+                          "$arrayElemAt": [
                           {
-                            "$map": {
+                              "$map": {
                               "input": {"$filter": {"input": "this.healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "GPC"]}}},
                               "in": "$$this.entityvalue"
-                            }
+                              }
                           },
                           0
-                        ]
+                          ]
                       }
-                    ]
+                      ]
                   },
                   {
-                    "$eq": [
+                      "$eq": [
                       {
-                        "$arrayElemAt": [
+                          "$arrayElemAt": [
                           {
-                            "$map": {
+                              "$map": {
                               "input": {"$filter": {"input": "$healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "TPC"]}}},
                               "in": "$$this.entityvalue"
-                            }
+                              }
                           },
                           0
-                        ]
+                          ]
                       },
                       {
-                        "$arrayElemAt": [
+                          "$arrayElemAt": [
                           {
-                            "$map": {
+                              "$map": {
                               "input": {"$filter": {"input": "this.healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "TPC"]}}},
                               "in": "$$this.entityvalue"
-                            }
+                              }
                           },
                           0
-                        ]
+                          ]
                       }
-                    ]
+                      ]
                   }
-                ]
+                  ]
               },
               1,
               0
-            ]
-          }
-        }
-      }
-    }
-    ''',
-    '''
-    {
-      "$setWindowFields": {
-        "sortBy": {"_id.burstId": 1},
-        "output": {"maxBurstId": {"$max": "$_id.burstId"}}
-      }
-    }
-    ''',
-    '''
-    {
-      "$match": {
-        "$expr": {
-          "$and": [
-            {"$in": ["this.healthevent.errorcode.0", "$uniqueXidsInBurst"]},
-            {
-              "$or": [
-                {"$ne": ["$_id.burstId", "$maxBurstId"]},
-                {"$eq": ["$targetXidCount", 1]}
               ]
-            }
+          }
+          }
+      }
+      }
+      ''',
+      '''
+      {
+      "$setWindowFields": {
+          "sortBy": {"_id.burstId": 1},
+          "output": {"maxBurstId": {"$max": "$_id.burstId"}}
+      }
+      }
+      ''',
+      '''
+      {
+      "$match": {
+          "$expr": {
+          "$and": [
+              {"$in": ["this.healthevent.errorcode.0", "$uniqueXidsInBurst"]},
+              {"$gt": ["$targetXidCount", 0]},
+              {
+              "$or": [
+                  {"$ne": ["$_id.burstId", "$maxBurstId"]},
+                  {"$gte": ["$targetXidCount", 1]}
+              ]
+              }
           ]
-        }
+          }
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
       "$group": {
-        "_id": null,
-        "count": {"$sum": 1},
-        "bursts": {"$push": {"burstId": "$_id.burstId", "uniqueXids": "$uniqueXidsInBurst"}}
+          "_id": null,
+          "count": {"$sum": 1},
+          "bursts": {"$push": {"burstId": "$_id.burstId", "uniqueXids": "$uniqueXidsInBurst"}}
       }
-    }
-    ''',
-    '{"$match": {"count": {"$gte": 5}}}'
+      }
+      ''',
+      '{"$match": {"count": {"$gte": 2}}}'
   ]
 
   [[rules]]
-  name = "XID13OnDifferentGPCAndTPC"
-  description = "Detect if XID 13 occurred 5 times on different GPC and TPC within 24 hours"
-  recommended_action = "RUN_FIELDDIAG"
+  name = "XIDErrorOnDifferentGPCAndTPC"
+  description = "Detect if XID error occurred on 2 different GPC and TPC combinations within 1.5 minutes"
+  message = "run CHECK_APP_CUDA"
+  recommended_action = "NONE"
   stage = [
-    '''
-    {
+      '''
+      {
       "$match": {
-        "$expr": {
+          "$expr": {
           "$gte": [
-            "$healthevent.generatedtimestamp.seconds",
-            {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
+              "$healthevent.generatedtimestamp.seconds",
+              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 90]}
           ]
-        }
+          }
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
       "$match": {
-        "healthevent.ishealthy": false,
-        "healthevent.nodename": "this.healthevent.nodename",
-        "healthevent.errorcode": "13",
-        "$expr": {
+          "healthevent.ishealthy": false,
+          "healthevent.nodename": "this.healthevent.nodename",
+          "healthevent.errorcode": "this.healthevent.errorcode.0",
+          "$expr": {
           "$gt": [
-            {
+              {
               "$size": {
-                "$setIntersection": [
+                  "$setIntersection": [
                   {
-                    "$map": {
+                      "$map": {
                       "input": {
-                        "$filter": {
+                          "$filter": {
                           "input": "$healthevent.entitiesimpacted",
                           "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
-                        }
+                          }
                       },
                       "in": "$$this.entityvalue"
-                    }
+                      }
                   },
                   {
-                    "$map": {
+                      "$map": {
                       "input": {
-                        "$filter": {
+                          "$filter": {
                           "input": "this.healthevent.entitiesimpacted",
                           "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
-                        }
+                          }
                       },
                       "in": "$$this.entityvalue"
-                    }
+                      }
                   }
-                ]
+                  ]
               }
-            },
-            0
+              },
+              0
           ]
-        },
+          }
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
       "$addFields": {
-        "gpcTpcCombination": {
+          "gpcTpcCombination": {
           "$let": {
-            "vars": {
+              "vars": {
               "gpc": {
-                "$arrayElemAt": [
+                  "$arrayElemAt": [
                   {
-                    "$map": {
+                      "$map": {
                       "input": {"$filter": {"input": "$healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "GPC"]}}},
                       "in": "$$this.entityvalue"
-                    }
+                      }
                   },
                   0
-                ]
+                  ]
               },
               "tpc": {
-                "$arrayElemAt": [
+                  "$arrayElemAt": [
                   {
-                    "$map": {
+                      "$map": {
                       "input": {"$filter": {"input": "$healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "TPC"]}}},
                       "in": "$$this.entityvalue"
-                    }
+                      }
                   },
                   0
-                ]
+                  ]
               }
-            },
-            "in": {
+              },
+              "in": {
               "$cond": [
-                {"$and": [{"$ne": ["$$gpc", null]}, {"$ne": ["$$tpc", null]}]},
-                {"$concat": ["GPC:", "$$gpc", "-TPC:", "$$tpc"]},
-                null
+                  {"$and": [{"$ne": ["$$gpc", null]}, {"$ne": ["$$tpc", null]}]},
+                  {"$concat": ["GPC:", "$$gpc", "-TPC:", "$$tpc"]},
+                  null
               ]
-            }
+              }
           }
-        }
+          }
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
       "$group": {
-        "_id": null,
-        "uniqueGPCAndTPCCombinations": {"$addToSet": "$gpcTpcCombination"}
+          "_id": null,
+          "uniqueGPCAndTPCCombinations": {"$addToSet": "$gpcTpcCombination"}
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
       "$match": {
-        "$expr": {
-          "$gte": [{"$size": "$uniqueGPCAndTPCCombinations"}, 5]
-        }
+          "$expr": {
+          "$gte": [{"$size": "$uniqueGPCAndTPCCombinations"}, 2]
+          }
       }
-    }
-    '''
+      }
+      '''
   ]
 
   [[rules]]
   name = "XIDErrorSoloNoBurst"
-  description = "Detect if XID error occurred only once in the latest burst within 24 hours"
-  recommended_action = "CHECK_APP_CUDA"
+  description = "Detect if XID error occurred only once in the last burst within 1 minutes time window"
+  message = "run CHECK_APP_CUDA"
+  recommended_action = "NONE"
   stage = [
-    '''
-    {
+      '''
+      {
       "$match": {
-        "$expr": {
+          "$expr": {
           "$gte": [
-            "$healthevent.generatedtimestamp.seconds",
-            {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
+              "$healthevent.generatedtimestamp.seconds",
+              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 60]}
           ]
-        }
+          }
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
       "$match": {
-        "healthevent.ishealthy": false,
-        "healthevent.nodename": "this.healthevent.nodename",
-        "$expr": {
+          "healthevent.ishealthy": false,
+          "healthevent.nodename": "this.healthevent.nodename",
+          "$expr": {
           "$gt": [
-            {
+              {
               "$size": {
-                "$setIntersection": [
+                  "$setIntersection": [
                   {
-                    "$map": {
+                      "$map": {
                       "input": {
-                        "$filter": {
+                          "$filter": {
                           "input": "$healthevent.entitiesimpacted",
-                          "cond": {"$eq": ["$$this.entitytype", "GPU"]}
-                        }
+                          "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
+                          }
                       },
                       "in": "$$this.entityvalue"
-                    }
+                      }
                   },
                   {
-                    "$map": {
+                      "$map": {
                       "input": {
-                        "$filter": {
+                          "$filter": {
                           "input": "this.healthevent.entitiesimpacted",
-                          "cond": {"$eq": ["$$this.entitytype", "GPU"]}
-                        }
+                          "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
+                          }
                       },
                       "in": "$$this.entityvalue"
-                    }
+                      }
                   }
-                ]
+                  ]
               }
-            },
-            0
+              },
+              0
           ]
-        },
+          }
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
       "$setWindowFields": {
-        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
-        "output": {
+          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+          "output": {
           "prevTimestamp": {
-            "$shift": {
+              "$shift": {
               "output": "$healthevent.generatedtimestamp.seconds",
               "by": -1
-            }
+              }
           }
-        }
+          }
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
       "$addFields": {
-        "isStickyXid": {
+          "isStickyXid": {
           "$in": [
-            {"$arrayElemAt": ["$healthevent.errorcode", 0]},
-            ["74", "79", "95", "109", "119"]
+              {"$arrayElemAt": ["$healthevent.errorcode", 0]},
+              ["74", "79", "95", "109", "119"]
           ]
-        }
-      }
-    }
-    ''',
-    '''
-    {
-      "$setWindowFields": {
-        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
-        "output": {
-          "allPreviousEvents": {
-            "$push": "$$ROOT",
-            "window": {"documents": ["unbounded", -1]}
           }
-        }
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
+      "$setWindowFields": {
+          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+          "output": {
+          "allPreviousEvents": {
+              "$push": "$$ROOT",
+              "window": {"documents": ["unbounded", -1]}
+          }
+          }
+      }
+      }
+      ''',
+      '''
+      {
       "$addFields": {
-        "stickyXidWithin3Hours": {
+          "stickyXidWithin3Hours": {
           "$cond": {
-            "if": "$isStickyXid",
-            "then": {
+              "if": "$isStickyXid",
+              "then": {
               "$anyElementTrue": {
-                "$map": {
+                  "$map": {
                   "input": "$allPreviousEvents",
                   "as": "prevEvent",
                   "in": {
-                    "$and": [
+                      "$and": [
                       {
-                        "$in": [
+                          "$in": [
                           {"$arrayElemAt": ["$$prevEvent.healthevent.errorcode", 0]},
                           ["74", "79", "95", "109", "119"]
-                        ]
+                          ]
                       },
-                      {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 10800]}
-                    ]
-                  }
-                }
-              }
-            },
-            "else": false
-          }
-        }
-      }
-    }
-    ''',
-    '''
-    {
-      "$setWindowFields": {
-        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
-        "output": {
-          "burstId": {
-            "$sum": {
-              "$cond": {
-                "if": {"$eq": ["$prevTimestamp", null]},
-                "then": 1,
-                "else": {
-                  "$cond": {
-                    "if": {
-                      "$and": [
-                        "$isStickyXid",
-                        "$stickyXidWithin3Hours"
+                      {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 20]}
                       ]
-                    },
-                    "then": 0,
-                    "else": {
-                      "$cond": {
-                        "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 180]},
-                        "then": 1,
-                        "else": 0
-                      }
-                    }
                   }
-                }
+                  }
               }
-            },
-            "window": {"documents": ["unbounded", "current"]}
+              },
+              "else": false
           }
-        }
+          }
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
+      "$setWindowFields": {
+          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+          "output": {
+          "burstId": {
+              "$sum": {
+              "$cond": {
+                  "if": {"$eq": ["$prevTimestamp", null]},
+                  "then": 1,
+                  "else": {
+                  "$cond": {
+                      "if": {
+                      "$and": [
+                          "$isStickyXid",
+                          "$stickyXidWithin3Hours"
+                      ]
+                      },
+                      "then": 0,
+                      "else": {
+                      "$cond": {
+                          "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 4]},
+                          "then": 1,
+                          "else": 0
+                      }
+                      }
+                  }
+                  }
+              }
+              },
+              "window": {"documents": ["unbounded", "current"]}
+          }
+          }
+      }
+      }
+      ''',
+      '''
+      {
       "$group": {
-        "_id": {"burstId": "$burstId"},
-        "targetXidCount": {
+          "_id": {"burstId": "$burstId"},
+          "targetXidCount": {
           "$sum": {
-            "$cond": [
+              "$cond": [
               {"$eq": [{"$arrayElemAt": ["$healthevent.errorcode", 0]}, "this.healthevent.errorcode.0"]},
               1,
               0
-            ]
+              ]
           }
-        }
+          }
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
       "$setWindowFields": {
-        "sortBy": {"_id.burstId": 1},
-        "output": {"maxBurstId": {"$max": "$_id.burstId"}}
+          "sortBy": {"_id.burstId": 1},
+          "output": {"maxBurstId": {"$max": "$_id.burstId"}}
       }
-    }
-    ''',
-    '''
-    {
+      }
+      ''',
+      '''
+      {
       "$match": {
-        "$expr": {
+          "$expr": {
           "$and": [
-            {"$eq": ["$_id.burstId", "$maxBurstId"]},
-            {"$eq": ["$targetXidCount", 1]}
+              {"$eq": ["$_id.burstId", "$maxBurstId"]},
+              {"$eq": ["$targetXidCount", 1]}
           ]
-        }
+          }
       }
-    }
-    '''
+      }
+      '''
   ]
-

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
@@ -313,7 +313,7 @@ config: |
   name = "RepeatedXID31OnSameGPU"
   description = "Detect if XID 31 occurred 2 or more times on the same GPU within 24 hours where the burst window is 3 minutes and sticky XIDs window is 3 hours"
   recommended_action = "RUN_DCGMEUD"
-  message = "if pass: RUN_FIELDDIAGS"
+  message = "if DCGM EUD tests passes, run field diagnostics"
   stage = [
     '''
     {
@@ -554,7 +554,7 @@ config: |
   [[rules]]
   name = "RepeatedXID31OnDifferentGPU"
   description = "Detect if XID 31 occurred 2 or more times on different GPUs within 24 hours"
-  message = "run CHECK_APP_CUDA"
+  message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, report if driver issue"
   recommended_action = "NONE"
   stage = [
     '''
@@ -642,7 +642,7 @@ config: |
   [[rules]]
   name = "RepeatedXID13OnSameGPCAndTPC"
   description = "Detect if XID 13 occurred 2 or more times on the same GPC and TPC within 24 hours"
-  message = "if pass run RUN_FIELDDIAGS" 
+  message = "if DCGM EUD tests passes, run field diagnostics"
   recommended_action = "RUN_DCGMEUD"
   stage = [
     '''
@@ -939,7 +939,7 @@ config: |
   [[rules]]
   name = "RepeatedXID13OnDifferentGPCAndTPC"
   description = "Detect if XID 13 occurred 2 or more times on different GPC and TPC combinations within 24 hours"
-  message = "run CHECK_APP_CUDA"
+  message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, report if driver issue"
   recommended_action = "NONE"
   stage = [
     '''
@@ -1078,7 +1078,7 @@ config: |
   [[rules]]
   name = "XIDErrorSoloNoBurst"
   description = "Detect if XID error occurred only once in the last burst within 24 hours time window"
-  message = "run CHECK_APP_CUDA"
+  message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, report if driver issue"
   recommended_action = "NONE"
   stage = [
     '''

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
@@ -313,7 +313,7 @@ config: |
   name = "RepeatedXID31OnSameGPU"
   description = "Detect if XID 31 occurred 2 or more times on the same GPU within 24 hours where the burst window is 3 minutes and sticky XIDs window is 3 hours"
   recommended_action = "RUN_DCGMEUD"
-  message = "if DCGM EUD tests passes, run field diagnostics"
+  message = "if DCGM EUD tests pass, run field diagnostics"
   stage = [
     '''
     {
@@ -642,7 +642,7 @@ config: |
   [[rules]]
   name = "RepeatedXID13OnSameGPCAndTPC"
   description = "Detect if XID 13 occurred 2 or more times on the same GPC and TPC within 24 hours"
-  message = "if DCGM EUD tests passes, run field diagnostics"
+  message = "if DCGM EUD tests pass, run field diagnostics"
   recommended_action = "RUN_DCGMEUD"
   stage = [
     '''

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
@@ -69,917 +69,1224 @@ config: |
   ]
 
   [[rules]]
-  name = "RepeatedXidErrorOnSameGPU"
-  description = "Detect occurrence of fatal XIDs within 24 hours where the burst window is 3 minutes and sticky XIDs window is 3 hours. Count threshold: 2 for XID-31, 5 for others"
+  name = "RepeatedXIDErrorOnSameGPU"
+  description = "Detect occurrence of fatal XIDs 5 times within 24 hours where the burst window is 3 minutes and sticky XIDs window is 3 hours"
   recommended_action = "CONTACT_SUPPORT"
-  recommended_action_mappings = { "31" = { recommended_action = "RUN_DCGMEUD", message = "if pass: RUN_FIELDDIAGS" } }
-
   stage = [
-      '''
-      {
+    '''
+    {
       "$match": {
-          "$expr": {
+        "$expr": {
           "$gte": [
-              "$healthevent.generatedtimestamp.seconds",
-              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
+            "$healthevent.generatedtimestamp.seconds",
+            {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
           ]
-          }
+        }
       }
-      }
-      ''',
+    }
+    ''',
       '''
-      {
+    {
       "$match": {
-          "healthevent.ishealthy": false,
-          "healthevent.nodename": "this.healthevent.nodename",
-          "$expr": {
+      "$expr": {
+          "$ne": [
+            "this.healthevent.errorcode.0",
+            "31"
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$match": {
+        "healthevent.ishealthy": false,
+        "healthevent.nodename": "this.healthevent.nodename",
+        "$expr": {
           "$gt": [
-              {
+            {
               "$size": {
-                  "$setIntersection": [
+                "$setIntersection": [
                   {
-                      "$map": {
+                    "$map": {
                       "input": {
-                          "$filter": {
+                        "$filter": {
                           "input": {"$ifNull": ["$healthevent.entitiesimpacted", []]},
                           "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
-                          }
+                        }
                       },
                       "in": "$$this.entityvalue"
-                      }
+                    }
                   },
                   {
-                      "$map": {
+                    "$map": {
                       "input": {
-                          "$filter": {
+                        "$filter": {
                           "input": "this.healthevent.entitiesimpacted",
                           "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
-                          }
+                        }
                       },
                       "in": "$$this.entityvalue"
-                      }
+                    }
                   }
-                  ]
+                ]
               }
-              },
-              0
+            },
+            0
           ]
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$setWindowFields": {
-          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
-          "output": {
+        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+        "output": {
           "prevTimestamp": {
-              "$shift": {
+            "$shift": {
               "output": "$healthevent.generatedtimestamp.seconds",
               "by": -1
-              }
+            }
           }
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$addFields": {
-          "isStickyXid": {
+        "isStickyXid": {
           "$in": [
-              {"$arrayElemAt": ["$healthevent.errorcode", 0]},
-              ["74", "79", "95", "109", "119"]
+            {"$arrayElemAt": ["$healthevent.errorcode", 0]},
+            ["74", "79", "95", "109", "119"]
           ]
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$setWindowFields": {
-          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
-          "output": {
+        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+        "output": {
           "allPreviousEvents": {
-              "$push": "$$ROOT",
-              "window": {"documents": ["unbounded", -1]}
+            "$push": "$$ROOT",
+            "window": {"documents": ["unbounded", -1]}
           }
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$addFields": {
-          "stickyXidWithin3Hours": {
+        "stickyXidWithin3Hours": {
           "$cond": {
-              "if": "$isStickyXid",
-              "then": {
+            "if": "$isStickyXid",
+            "then": {
               "$anyElementTrue": {
-                  "$map": {
+                "$map": {
                   "input": "$allPreviousEvents",
                   "as": "prevEvent",
                   "in": {
-                      "$and": [
+                    "$and": [
                       {
-                          "$in": [
+                        "$in": [
                           {"$arrayElemAt": ["$$prevEvent.healthevent.errorcode", 0]},
                           ["74", "79", "95", "109", "119"]
-                          ]
+                        ]
                       },
                       {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 10800]}
-                      ]
+                    ]
                   }
-                  }
+                }
               }
-              },
-              "else": false
+            },
+            "else": false
           }
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$setWindowFields": {
-          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
-          "output": {
+        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+        "output": {
           "burstId": {
-              "$sum": {
+            "$sum": {
               "$cond": {
-                  "if": {"$eq": ["$prevTimestamp", null]},
-                  "then": 1,
-                  "else": {
+                "if": {"$eq": ["$prevTimestamp", null]},
+                "then": 1,
+                "else": {
                   "$cond": {
-                      "if": {
+                    "if": {
                       "$and": [
-                          "$isStickyXid",
-                          "$stickyXidWithin3Hours"
+                        "$isStickyXid",
+                        "$stickyXidWithin3Hours"
                       ]
-                      },
-                      "then": 0,
-                      "else": {
+                    },
+                    "then": 0,
+                    "else": {
                       "$cond": {
-                          "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 180]},
-                          "then": 1,
-                          "else": 0
+                        "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 180]},
+                        "then": 1,
+                        "else": 0
                       }
-                      }
+                    }
                   }
-                  }
+                }
               }
-              },
-              "window": {"documents": ["unbounded", "current"]}
+            },
+            "window": {"documents": ["unbounded", "current"]}
           }
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$group": {
-          "_id": {"burstId": "$burstId"},
-          "uniqueXidsInBurst": {"$addToSet": {"$arrayElemAt": ["$healthevent.errorcode", 0]}},
-          "targetXidCount": {
+        "_id": {"burstId": "$burstId"},
+        "uniqueXidsInBurst": {"$addToSet": {"$arrayElemAt": ["$healthevent.errorcode", 0]}},
+        "targetXidCount": {
           "$sum": {
-              "$cond": [
+            "$cond": [
               {"$eq": [{"$arrayElemAt": ["$healthevent.errorcode", 0]}, "this.healthevent.errorcode.0"]},
               1,
               0
-              ]
+            ]
           }
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$setWindowFields": {
-          "sortBy": {"_id.burstId": 1},
-          "output": {"maxBurstId": {"$max": "$_id.burstId"}}
+        "sortBy": {"_id.burstId": 1},
+        "output": {"maxBurstId": {"$max": "$_id.burstId"}}
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$match": {
-          "$expr": {
+        "$expr": {
           "$and": [
-              {"$in": ["this.healthevent.errorcode.0", "$uniqueXidsInBurst"]},
-              {
+            {"$in": ["this.healthevent.errorcode.0", "$uniqueXidsInBurst"]},
+            {
               "$or": [
-                  {"$ne": ["$_id.burstId", "$maxBurstId"]},
-                  {"$eq": ["$targetXidCount", 1]}
+                {"$ne": ["$_id.burstId", "$maxBurstId"]},
+                {"$eq": ["$targetXidCount", 1]}
               ]
-              }
+            }
           ]
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$group": {
-          "_id": null,
-          "count": {"$sum": 1},
-          "bursts": {"$push": {"burstId": "$_id.burstId", "uniqueXids": "$uniqueXidsInBurst"}}
+        "_id": null,
+        "count": {"$sum": 1},
+        "bursts": {"$push": {"burstId": "$_id.burstId", "uniqueXids": "$uniqueXidsInBurst"}}
       }
-      }
-      ''',
-      '''
-      {
-      "$match": {
-          "$expr": {
-          "$gte": [
-              "$count",
-              {
-              "$switch": {
-                  "branches": [
-                  { "case": { "$eq": ["this.healthevent.errorcode.0", "31"] }, "then": 2 }
-                  ],
-                  "default": 5
-              }
-              }
+    }
+    ''',
+    '''
+    {
+    "$match": {
+        "$expr": {
+        "$gte": [
+            "$count", 5
           ]
-          }
-      }
-      }
-      '''
+        }
+    }
+    }
+    '''
   ]
 
   [[rules]]
-  name = "RepeatedXidErrorOnDifferentGPU"
-  description = "Detect occurrence of XIDs on 2 or more different GPUs within 24 hours"
-  message = "run CHECK_APP_CUDA"
-  recommended_action = "NONE"
-  stage = [
-      '''
-      {
-      "$match": {
-          "$expr": {
-          "$gte": [
-              "$healthevent.generatedtimestamp.seconds",
-              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
-          ]
-          }
-      }
-      }
-      ''',
-      '''
-      {
-      "$match": {
-          "healthevent.ishealthy": false,
-          "healthevent.nodename": "this.healthevent.nodename",
-          "healthevent.errorcode": "this.healthevent.errorcode.0"
-      }
-      }
-      ''',
-      '''
-      {
-      "$addFields": {
-          "gpuUuid": {
-          "$let": {
-              "vars": {
-              "uuid": {
-                  "$arrayElemAt": [
-                  {
-                      "$map": {
-                      "input": {"$filter": {"input": {"$ifNull": ["$healthevent.entitiesimpacted", []]}, "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}}},
-                      "in": "$$this.entityvalue"
-                      }
-                  },
-                  0
-                  ]
-              }
-              },
-              "in": {
-              "$cond": [
-                  {"$ne": ["$$uuid", null]},
-                  "$$uuid",
-                  null
-              ]
-              }
-          }
-          }
-      }
-      }
-      ''',
-      '''
-      {
-      "$group": {
-          "_id": null,
-          "uniqueGPUs": {"$addToSet": "$gpuUuid"}
-      }
-      }
-      ''',
-      '''
-      {
-      "$match": {
-          "$expr": {
-          "$gte": [{"$size": "$uniqueGPUs"}, 2]
-          }
-      }
-      }
-      '''
-  ]
-
-  [[rules]]
-  name = "XIDErrorOnSameGPCAndTPC"
-  description = "Detect if XID error occurred 2 or more times on the same GPC and TPC within 24 hours"
-  message = "if pass run RUN_FIELDDIAGS" 
+  name = "RepeatedXID31OnSameGPU"
+  description = "Detect if XID 31 occurred 2 or more times on the same GPU within 24 hours where the burst window is 3 minutes and sticky XIDs window is 3 hours"
   recommended_action = "RUN_DCGMEUD"
+  message = "if pass: RUN_FIELDDIAGS"
   stage = [
-      '''
-      {
+    '''
+    {
       "$match": {
-          "$expr": {
+        "$expr": {
           "$gte": [
-              "$healthevent.generatedtimestamp.seconds",
-              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
+            "$healthevent.generatedtimestamp.seconds",
+            {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
           ]
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$match": {
-          "healthevent.ishealthy": false,
-          "healthevent.nodename": "this.healthevent.nodename",
-          "$expr": {
+      "$expr": {
+          "$eq": [
+            "this.healthevent.errorcode.0",
+            "31"
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$match": {
+        "healthevent.ishealthy": false,
+        "healthevent.nodename": "this.healthevent.nodename",
+        "$expr": {
           "$gt": [
-              {
+            {
               "$size": {
-                  "$setIntersection": [
+                "$setIntersection": [
                   {
-                      "$map": {
+                    "$map": {
                       "input": {
-                          "$filter": {
-                          "input": "$healthevent.entitiesimpacted",
+                        "$filter": {
+                          "input": {"$ifNull": ["$healthevent.entitiesimpacted", []]},
                           "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
-                          }
+                        }
                       },
                       "in": "$$this.entityvalue"
-                      }
+                    }
                   },
                   {
-                      "$map": {
+                    "$map": {
                       "input": {
-                          "$filter": {
+                        "$filter": {
                           "input": "this.healthevent.entitiesimpacted",
                           "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
-                          }
+                        }
                       },
                       "in": "$$this.entityvalue"
-                      }
+                    }
                   }
-                  ]
+                ]
               }
-              },
-              0
+            },
+            0
           ]
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$setWindowFields": {
-          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
-          "output": {
+        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+        "output": {
           "prevTimestamp": {
-              "$shift": {
+            "$shift": {
               "output": "$healthevent.generatedtimestamp.seconds",
               "by": -1
-              }
+            }
           }
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$addFields": {
-          "isStickyXid": {
+        "isStickyXid": {
           "$in": [
-              {"$arrayElemAt": ["$healthevent.errorcode", 0]},
-              ["74", "79", "95", "109", "119"]
+            {"$arrayElemAt": ["$healthevent.errorcode", 0]},
+            ["74", "79", "95", "109", "119"]
           ]
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$setWindowFields": {
-          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
-          "output": {
+        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+        "output": {
           "allPreviousEvents": {
-              "$push": "$$ROOT",
-              "window": {"documents": ["unbounded", -1]}
+            "$push": "$$ROOT",
+            "window": {"documents": ["unbounded", -1]}
           }
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$addFields": {
-          "stickyXidWithin3Hours": {
+        "stickyXidWithin3Hours": {
           "$cond": {
-              "if": "$isStickyXid",
-              "then": {
+            "if": "$isStickyXid",
+            "then": {
               "$anyElementTrue": {
-                  "$map": {
+                "$map": {
                   "input": "$allPreviousEvents",
                   "as": "prevEvent",
                   "in": {
-                      "$and": [
+                    "$and": [
                       {
-                          "$in": [
+                        "$in": [
                           {"$arrayElemAt": ["$$prevEvent.healthevent.errorcode", 0]},
                           ["74", "79", "95", "109", "119"]
-                          ]
+                        ]
                       },
                       {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 10800]}
-                      ]
+                    ]
                   }
-                  }
+                }
               }
-              },
-              "else": false
+            },
+            "else": false
           }
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$setWindowFields": {
-          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
-          "output": {
+        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+        "output": {
           "burstId": {
-              "$sum": {
+            "$sum": {
               "$cond": {
-                  "if": {"$eq": ["$prevTimestamp", null]},
-                  "then": 1,
-                  "else": {
+                "if": {"$eq": ["$prevTimestamp", null]},
+                "then": 1,
+                "else": {
                   "$cond": {
-                      "if": {
+                    "if": {
                       "$and": [
-                          "$isStickyXid",
-                          "$stickyXidWithin3Hours"
+                        "$isStickyXid",
+                        "$stickyXidWithin3Hours"
                       ]
-                      },
-                      "then": 0,
-                      "else": {
+                    },
+                    "then": 0,
+                    "else": {
                       "$cond": {
-                          "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 180]},
-                          "then": 1,
-                          "else": 0
+                        "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 180]},
+                        "then": 1,
+                        "else": 0
                       }
-                      }
+                    }
                   }
-                  }
+                }
               }
-              },
-              "window": {"documents": ["unbounded", "current"]}
+            },
+            "window": {"documents": ["unbounded", "current"]}
           }
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$group": {
-          "_id": {"burstId": "$burstId"},
-          "uniqueXidsInBurst": {"$addToSet": {"$arrayElemAt": ["$healthevent.errorcode", 0]}},
-          "targetXidCount": {
+        "_id": {"burstId": "$burstId"},
+        "uniqueXidsInBurst": {"$addToSet": {"$arrayElemAt": ["$healthevent.errorcode", 0]}},
+        "targetXidCount": {
           "$sum": {
-              "$cond": [
-              {
-                  "$and": [
-                  {"$eq": [{"$arrayElemAt": ["$healthevent.errorcode", 0]}, "this.healthevent.errorcode.0"]},
-                  {
-                      "$eq": [
-                      {
-                          "$arrayElemAt": [
-                          {
-                              "$map": {
-                              "input": {"$filter": {"input": "$healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "GPC"]}}},
-                              "in": "$$this.entityvalue"
-                              }
-                          },
-                          0
-                          ]
-                      },
-                      {
-                          "$arrayElemAt": [
-                          {
-                              "$map": {
-                              "input": {"$filter": {"input": "this.healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "GPC"]}}},
-                              "in": "$$this.entityvalue"
-                              }
-                          },
-                          0
-                          ]
-                      }
-                      ]
-                  },
-                  {
-                      "$eq": [
-                      {
-                          "$arrayElemAt": [
-                          {
-                              "$map": {
-                              "input": {"$filter": {"input": "$healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "TPC"]}}},
-                              "in": "$$this.entityvalue"
-                              }
-                          },
-                          0
-                          ]
-                      },
-                      {
-                          "$arrayElemAt": [
-                          {
-                              "$map": {
-                              "input": {"$filter": {"input": "this.healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "TPC"]}}},
-                              "in": "$$this.entityvalue"
-                              }
-                          },
-                          0
-                          ]
-                      }
-                      ]
-                  }
-                  ]
-              },
+            "$cond": [
+              {"$eq": [{"$arrayElemAt": ["$healthevent.errorcode", 0]}, "this.healthevent.errorcode.0"]},
               1,
               0
-              ]
+            ]
           }
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$setWindowFields": {
-          "sortBy": {"_id.burstId": 1},
-          "output": {"maxBurstId": {"$max": "$_id.burstId"}}
+        "sortBy": {"_id.burstId": 1},
+        "output": {"maxBurstId": {"$max": "$_id.burstId"}}
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$match": {
-          "$expr": {
+        "$expr": {
           "$and": [
-              {"$in": ["this.healthevent.errorcode.0", "$uniqueXidsInBurst"]},
-              {"$gt": ["$targetXidCount", 0]},
-              {
+            {"$in": ["this.healthevent.errorcode.0", "$uniqueXidsInBurst"]},
+            {
               "$or": [
-                  {"$ne": ["$_id.burstId", "$maxBurstId"]},
-                  {"$gte": ["$targetXidCount", 1]}
+                {"$ne": ["$_id.burstId", "$maxBurstId"]},
+                {"$eq": ["$targetXidCount", 1]}
               ]
-              }
+            }
           ]
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$group": {
-          "_id": null,
-          "count": {"$sum": 1},
-          "bursts": {"$push": {"burstId": "$_id.burstId", "uniqueXids": "$uniqueXidsInBurst"}}
+        "_id": null,
+        "count": {"$sum": 1},
+        "bursts": {"$push": {"burstId": "$_id.burstId", "uniqueXids": "$uniqueXidsInBurst"}}
       }
-      }
-      ''',
-      '{"$match": {"count": {"$gte": 2}}}'
+    }
+    ''',
+    '''
+    {
+    "$match": {
+        "$expr": {
+        "$gte": [
+            "$count", 2
+        ]
+        }
+    }
+    }
+    '''
   ]
 
   [[rules]]
-  name = "XIDErrorOnDifferentGPCAndTPC"
-  description = "Detect if XID error occurred on 2 or more different GPC and TPC combinations within 24 hours"
+  name = "RepeatedXID31OnDifferentGPU"
+  description = "Detect if XID 31 occurred 2 or more times on different GPUs within 24 hours"
   message = "run CHECK_APP_CUDA"
   recommended_action = "NONE"
   stage = [
-      '''
-      {
+    '''
+    {
       "$match": {
-          "$expr": {
+        "$expr": {
           "$gte": [
-              "$healthevent.generatedtimestamp.seconds",
-              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
+            "$healthevent.generatedtimestamp.seconds",
+            {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
           ]
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$match": {
-          "healthevent.ishealthy": false,
-          "healthevent.nodename": "this.healthevent.nodename",
-          "healthevent.errorcode": "this.healthevent.errorcode.0",
-          "$expr": {
-          "$gt": [
-              {
-              "$size": {
-                  "$setIntersection": [
+      "$expr": {
+          "$eq": [
+            "this.healthevent.errorcode.0",
+            "31"
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$match": {
+        "healthevent.ishealthy": false,
+        "healthevent.nodename": "this.healthevent.nodename",
+        "healthevent.errorcode": "this.healthevent.errorcode.0"
+      }
+    }
+    ''',
+    '''
+    {
+      "$addFields": {
+        "gpuUuid": {
+          "$let": {
+            "vars": {
+              "uuid": {
+                "$arrayElemAt": [
                   {
-                      "$map": {
+                    "$map": {
+                      "input": {"$filter": {"input": {"$ifNull": ["$healthevent.entitiesimpacted", []]}, "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}}},
+                      "in": "$$this.entityvalue"
+                    }
+                  },
+                  0
+                ]
+              }
+            },
+            "in": {
+              "$cond": [
+                {"$ne": ["$$uuid", null]},
+                "$$uuid",
+                null
+              ]
+            }
+          }
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$group": {
+        "_id": null,
+        "uniqueGPUs": {"$addToSet": "$gpuUuid"}
+      }
+    }
+    ''',
+    '''
+    {
+      "$match": {
+        "$expr": {
+          "$gte": [{"$size": "$uniqueGPUs"}, 2]
+        }
+      }
+    }
+    '''
+  ]
+  
+  [[rules]]
+  name = "RepeatedXID13OnSameGPCAndTPC"
+  description = "Detect if XID 13 occurred 2 or more times on the same GPC and TPC within 24 hours"
+  message = "if pass run RUN_FIELDDIAGS" 
+  recommended_action = "RUN_DCGMEUD"
+  stage = [
+    '''
+    {
+      "$match": {
+        "$expr": {
+          "$gte": [
+            "$healthevent.generatedtimestamp.seconds",
+            {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$match": {
+      "$expr": {
+          "$eq": [
+            "this.healthevent.errorcode.0",
+            "13"
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$match": {
+        "healthevent.ishealthy": false,
+        "healthevent.nodename": "this.healthevent.nodename",
+        "$expr": {
+          "$gt": [
+            {
+              "$size": {
+                "$setIntersection": [
+                  {
+                    "$map": {
                       "input": {
-                          "$filter": {
-                          "input": "$healthevent.entitiesimpacted",
+                        "$filter": {
+                          "input": {"$ifNull": ["$healthevent.entitiesimpacted", []]},
                           "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
-                          }
+                        }
                       },
                       "in": "$$this.entityvalue"
-                      }
+                    }
                   },
                   {
-                      "$map": {
+                    "$map": {
                       "input": {
-                          "$filter": {
+                        "$filter": {
                           "input": "this.healthevent.entitiesimpacted",
                           "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
-                          }
+                        }
                       },
                       "in": "$$this.entityvalue"
-                      }
+                    }
                   }
-                  ]
+                ]
               }
-              },
-              0
+            },
+            0
           ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$setWindowFields": {
+        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+        "output": {
+          "prevTimestamp": {
+            "$shift": {
+              "output": "$healthevent.generatedtimestamp.seconds",
+              "by": -1
+            }
           }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$addFields": {
-          "gpcTpcCombination": {
-          "$let": {
-              "vars": {
-              "gpc": {
-                  "$arrayElemAt": [
-                  {
-                      "$map": {
-                      "input": {"$filter": {"input": "$healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "GPC"]}}},
-                      "in": "$$this.entityvalue"
+        "isStickyXid": {
+          "$in": [
+            {"$arrayElemAt": ["$healthevent.errorcode", 0]},
+            ["74", "79", "95", "109", "119"]
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$setWindowFields": {
+        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+        "output": {
+          "allPreviousEvents": {
+            "$push": "$$ROOT",
+            "window": {"documents": ["unbounded", -1]}
+          }
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$addFields": {
+        "stickyXidWithin3Hours": {
+          "$cond": {
+            "if": "$isStickyXid",
+            "then": {
+              "$anyElementTrue": {
+                "$map": {
+                  "input": "$allPreviousEvents",
+                  "as": "prevEvent",
+                  "in": {
+                    "$and": [
+                      {
+                        "$in": [
+                          {"$arrayElemAt": ["$$prevEvent.healthevent.errorcode", 0]},
+                          ["74", "79", "95", "109", "119"]
+                        ]
+                      },
+                      {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 10800]}
+                    ]
+                  }
+                }
+              }
+            },
+            "else": false
+          }
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$setWindowFields": {
+        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+        "output": {
+          "burstId": {
+            "$sum": {
+              "$cond": {
+                "if": {"$eq": ["$prevTimestamp", null]},
+                "then": 1,
+                "else": {
+                  "$cond": {
+                    "if": {
+                      "$and": [
+                        "$isStickyXid",
+                        "$stickyXidWithin3Hours"
+                      ]
+                    },
+                    "then": 0,
+                    "else": {
+                      "$cond": {
+                        "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 180]},
+                        "then": 1,
+                        "else": 0
                       }
+                    }
+                  }
+                }
+              }
+            },
+            "window": {"documents": ["unbounded", "current"]}
+          }
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$addFields": {
+        "gpcValue": {
+          "$arrayElemAt": [
+            {
+              "$map": {
+                "input": {"$filter": {"input": {"$ifNull": ["$healthevent.entitiesimpacted", []]}, "cond": {"$eq": ["$$this.entitytype", "GPC"]}}},
+                "in": "$$this.entityvalue"
+              }
+            },
+            0
+          ]
+        },
+        "tpcValue": {
+          "$arrayElemAt": [
+            {
+              "$map": {
+                "input": {"$filter": {"input": {"$ifNull": ["$healthevent.entitiesimpacted", []]}, "cond": {"$eq": ["$$this.entitytype", "TPC"]}}},
+                "in": "$$this.entityvalue"
+              }
+            },
+            0
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$match": {
+        "$and": [
+          {"gpcValue": {"$ne": null}},
+          {"tpcValue": {"$ne": null}}
+        ]
+      }
+    }
+    ''',
+    '''
+    {
+      "$group": {
+        "_id": {"burstId": "$burstId"},
+        "uniqueXidsInBurst": {"$addToSet": {"$arrayElemAt": ["$healthevent.errorcode", 0]}},
+        "targetXidCount": {
+          "$sum": {
+            "$cond": [
+              {
+                "$and": [
+                  {"$eq": [{"$arrayElemAt": ["$healthevent.errorcode", 0]}, "this.healthevent.errorcode.0"]},
+                  {"$eq": ["$gpcValue", {
+                    "$arrayElemAt": [
+                      {
+                        "$map": {
+                          "input": {"$filter": {"input": "this.healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "GPC"]}}},
+                          "in": "$$this.entityvalue"
+                        }
+                      },
+                      0
+                    ]
+                  }]},
+                  {"$eq": ["$tpcValue", {
+                    "$arrayElemAt": [
+                      {
+                        "$map": {
+                          "input": {"$filter": {"input": "this.healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "TPC"]}}},
+                          "in": "$$this.entityvalue"
+                        }
+                      },
+                      0
+                    ]
+                  }]}
+                ]
+              },
+              1,
+              0
+            ]
+          }
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$setWindowFields": {
+        "sortBy": {"_id.burstId": 1},
+        "output": {"maxBurstId": {"$max": "$_id.burstId"}}
+      }
+    }
+    ''',
+    '''
+    {
+      "$match": {
+        "$expr": {
+          "$and": [
+            {"$in": ["this.healthevent.errorcode.0", "$uniqueXidsInBurst"]},
+            {"$gt": ["$targetXidCount", 0]},
+            {
+              "$or": [
+                {"$ne": ["$_id.burstId", "$maxBurstId"]},
+                {"$gte": ["$targetXidCount", 1]}
+              ]
+            }
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$group": {
+        "_id": null,
+        "count": {"$sum": 1},
+        "bursts": {"$push": {"burstId": "$_id.burstId", "uniqueXids": "$uniqueXidsInBurst"}}
+      }
+    }
+    ''',
+    '{"$match": {"count": {"$gte": 2}}}'
+  ]
+  
+  [[rules]]
+  name = "RepeatedXID13OnDifferentGPCAndTPC"
+  description = "Detect if XID 13 occurred 2 or more times on different GPC and TPC combinations within 24 hours"
+  message = "run CHECK_APP_CUDA"
+  recommended_action = "NONE"
+  stage = [
+    '''
+    {
+      "$match": {
+        "$expr": {
+          "$gte": [
+            "$healthevent.generatedtimestamp.seconds",
+            {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$match": {
+      "$expr": {
+          "$eq": [
+            "this.healthevent.errorcode.0",
+            "13"
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$match": {
+        "healthevent.ishealthy": false,
+        "healthevent.nodename": "this.healthevent.nodename",
+        "healthevent.errorcode": "this.healthevent.errorcode.0",
+        "$expr": {
+          "$gt": [
+            {
+              "$size": {
+                "$setIntersection": [
+                  {
+                    "$map": {
+                      "input": {
+                        "$filter": {
+                          "input": {"$ifNull": ["$healthevent.entitiesimpacted", []]},
+                          "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
+                        }
+                      },
+                      "in": "$$this.entityvalue"
+                    }
+                  },
+                  {
+                    "$map": {
+                      "input": {
+                        "$filter": {
+                          "input": "this.healthevent.entitiesimpacted",
+                          "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
+                        }
+                      },
+                      "in": "$$this.entityvalue"
+                    }
+                  }
+                ]
+              }
+            },
+            0
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$addFields": {
+        "gpcTpcCombination": {
+          "$let": {
+            "vars": {
+              "gpc": {
+                "$arrayElemAt": [
+                  {
+                    "$map": {
+                      "input": {"$filter": {"input": {"$ifNull": ["$healthevent.entitiesimpacted", []]}, "cond": {"$eq": ["$$this.entitytype", "GPC"]}}},
+                      "in": "$$this.entityvalue"
+                    }
                   },
                   0
-                  ]
+                ]
               },
               "tpc": {
-                  "$arrayElemAt": [
+                "$arrayElemAt": [
                   {
-                      "$map": {
-                      "input": {"$filter": {"input": "$healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "TPC"]}}},
+                    "$map": {
+                      "input": {"$filter": {"input": {"$ifNull": ["$healthevent.entitiesimpacted", []]}, "cond": {"$eq": ["$$this.entitytype", "TPC"]}}},
                       "in": "$$this.entityvalue"
-                      }
+                    }
                   },
                   0
-                  ]
+                ]
               }
-              },
-              "in": {
+            },
+            "in": {
               "$cond": [
-                  {"$and": [{"$ne": ["$$gpc", null]}, {"$ne": ["$$tpc", null]}]},
-                  {"$concat": ["GPC:", "$$gpc", "-TPC:", "$$tpc"]},
-                  null
+                {"$and": [{"$ne": ["$$gpc", null]}, {"$ne": ["$$tpc", null]}]},
+                {"$concat": ["GPC:", "$$gpc", "-TPC:", "$$tpc"]},
+                null
               ]
-              }
+            }
           }
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
-      "$group": {
-          "_id": null,
-          "uniqueGPCAndTPCCombinations": {"$addToSet": "$gpcTpcCombination"}
-      }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$match": {
-          "$expr": {
+        "gpcTpcCombination": {"$ne": null}
+      }
+    }
+    ''',
+    '''
+    {
+      "$group": {
+        "_id": null,
+        "uniqueGPCAndTPCCombinations": {"$addToSet": "$gpcTpcCombination"}
+      }
+    }
+    ''',
+    '''
+    {
+      "$match": {
+        "$expr": {
           "$gte": [{"$size": "$uniqueGPCAndTPCCombinations"}, 2]
-          }
+        }
       }
-      }
-      '''
+    }
+    '''
   ]
-
+  
   [[rules]]
   name = "XIDErrorSoloNoBurst"
   description = "Detect if XID error occurred only once in the last burst within 24 hours time window"
   message = "run CHECK_APP_CUDA"
   recommended_action = "NONE"
   stage = [
-      '''
-      {
+    '''
+    {
       "$match": {
-          "$expr": {
+        "$expr": {
           "$gte": [
-              "$healthevent.generatedtimestamp.seconds",
-              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
+            "$healthevent.generatedtimestamp.seconds",
+            {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
           ]
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$match": {
-          "healthevent.ishealthy": false,
-          "healthevent.nodename": "this.healthevent.nodename",
-          "$expr": {
+        "$expr": {
+          "$in": [
+            "this.healthevent.errorcode.0",
+            ["13", "31"]
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$match": {
+        "healthevent.ishealthy": false,
+        "healthevent.nodename": "this.healthevent.nodename",
+        "$expr": {
           "$gt": [
-              {
+            {
               "$size": {
-                  "$setIntersection": [
+                "$setIntersection": [
                   {
-                      "$map": {
+                    "$map": {
                       "input": {
-                          "$filter": {
-                          "input": "$healthevent.entitiesimpacted",
+                        "$filter": {
+                          "input": {"$ifNull": ["$healthevent.entitiesimpacted", []]},
                           "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
-                          }
+                        }
                       },
                       "in": "$$this.entityvalue"
-                      }
+                    }
                   },
                   {
-                      "$map": {
+                    "$map": {
                       "input": {
-                          "$filter": {
+                        "$filter": {
                           "input": "this.healthevent.entitiesimpacted",
                           "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
-                          }
+                        }
                       },
                       "in": "$$this.entityvalue"
-                      }
+                    }
                   }
-                  ]
+                ]
               }
-              },
-              0
+            },
+            0
           ]
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$setWindowFields": {
-          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
-          "output": {
+        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+        "output": {
           "prevTimestamp": {
-              "$shift": {
+            "$shift": {
               "output": "$healthevent.generatedtimestamp.seconds",
               "by": -1
-              }
+            }
           }
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$addFields": {
-          "isStickyXid": {
+        "isStickyXid": {
           "$in": [
-              {"$arrayElemAt": ["$healthevent.errorcode", 0]},
-              ["74", "79", "95", "109", "119"]
+            {"$arrayElemAt": ["$healthevent.errorcode", 0]},
+            ["74", "79", "95", "109", "119"]
           ]
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$setWindowFields": {
-          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
-          "output": {
+        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+        "output": {
           "allPreviousEvents": {
-              "$push": "$$ROOT",
-              "window": {"documents": ["unbounded", -1]}
+            "$push": "$$ROOT",
+            "window": {"documents": ["unbounded", -1]}
           }
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$addFields": {
-          "stickyXidWithin3Hours": {
+        "stickyXidWithin3Hours": {
           "$cond": {
-              "if": "$isStickyXid",
-              "then": {
+            "if": "$isStickyXid",
+            "then": {
               "$anyElementTrue": {
-                  "$map": {
+                "$map": {
                   "input": "$allPreviousEvents",
                   "as": "prevEvent",
                   "in": {
-                      "$and": [
+                    "$and": [
                       {
-                          "$in": [
+                        "$in": [
                           {"$arrayElemAt": ["$$prevEvent.healthevent.errorcode", 0]},
                           ["74", "79", "95", "109", "119"]
-                          ]
+                        ]
                       },
                       {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 10800]}
-                      ]
+                    ]
                   }
-                  }
+                }
               }
-              },
-              "else": false
+            },
+            "else": false
           }
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$setWindowFields": {
-          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
-          "output": {
+        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+        "output": {
           "burstId": {
-              "$sum": {
+            "$sum": {
               "$cond": {
-                  "if": {"$eq": ["$prevTimestamp", null]},
-                  "then": 1,
-                  "else": {
+                "if": {"$eq": ["$prevTimestamp", null]},
+                "then": 1,
+                "else": {
                   "$cond": {
-                      "if": {
+                    "if": {
                       "$and": [
-                          "$isStickyXid",
-                          "$stickyXidWithin3Hours"
+                        "$isStickyXid",
+                        "$stickyXidWithin3Hours"
                       ]
-                      },
-                      "then": 0,
-                      "else": {
+                    },
+                    "then": 0,
+                    "else": {
                       "$cond": {
-                          "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 180]},
-                          "then": 1,
-                          "else": 0
+                        "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 180]},
+                        "then": 1,
+                        "else": 0
                       }
-                      }
+                    }
                   }
-                  }
+                }
               }
-              },
-              "window": {"documents": ["unbounded", "current"]}
+            },
+            "window": {"documents": ["unbounded", "current"]}
           }
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$group": {
-          "_id": {"burstId": "$burstId"},
-          "targetXidCount": {
+        "_id": {"burstId": "$burstId"},
+        "targetXidCount": {
           "$sum": {
-              "$cond": [
+            "$cond": [
               {"$eq": [{"$arrayElemAt": ["$healthevent.errorcode", 0]}, "this.healthevent.errorcode.0"]},
               1,
               0
-              ]
+            ]
           }
-          }
+        }
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$setWindowFields": {
-          "sortBy": {"_id.burstId": 1},
-          "output": {"maxBurstId": {"$max": "$_id.burstId"}}
+        "sortBy": {"_id.burstId": 1},
+        "output": {"maxBurstId": {"$max": "$_id.burstId"}}
       }
-      }
-      ''',
-      '''
-      {
+    }
+    ''',
+    '''
+    {
       "$match": {
-          "$expr": {
+        "$expr": {
           "$and": [
-              {"$eq": ["$_id.burstId", "$maxBurstId"]},
-              {"$eq": ["$targetXidCount", 1]}
+            {"$eq": ["$_id.burstId", "$maxBurstId"]},
+            {"$eq": ["$targetXidCount", 1]}
           ]
-          }
+        }
       }
-      }
-      '''
+    }
+    '''
   ]

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
@@ -70,7 +70,7 @@ config: |
 
   [[rules]]
   name = "RepeatedXidErrorOnSameGPU"
-  description = "Detect occurrence of fatal XIDs 2 times within 2 minutes where the burst window is 10 seconds and sticky XIDs window is 20seconds"
+  description = "Detect occurrence of fatal XIDs within 24 hours where the burst window is 3 minutes and sticky XIDs window is 3 hours. Count threshold: 2 for XID-31, 5 for others"
   recommended_action = "CONTACT_SUPPORT"
   recommended_action_mappings = { "31" = { recommended_action = "RUN_DCGMEUD", message = "if pass: RUN_FIELDDIAGS" } }
 
@@ -81,7 +81,7 @@ config: |
           "$expr": {
           "$gte": [
               "$healthevent.generatedtimestamp.seconds",
-              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 120]}
+              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
           ]
           }
       }
@@ -187,7 +187,7 @@ config: |
                           ["74", "79", "95", "109", "119"]
                           ]
                       },
-                      {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 20]}
+                      {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 10800]}
                       ]
                   }
                   }
@@ -220,7 +220,7 @@ config: |
                       "then": 0,
                       "else": {
                       "$cond": {
-                          "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 10]},
+                          "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 180]},
                           "then": 1,
                           "else": 0
                       }
@@ -286,12 +286,30 @@ config: |
       }
       }
       ''',
-      '{"$match": {"count": {"$gte": 2}}}'
+      '''
+      {
+      "$match": {
+          "$expr": {
+          "$gte": [
+              "$count",
+              {
+              "$switch": {
+                  "branches": [
+                  { "case": { "$eq": ["this.healthevent.errorcode.0", "31"] }, "then": 2 }
+                  ],
+                  "default": 5
+              }
+              }
+          ]
+          }
+      }
+      }
+      '''
   ]
 
   [[rules]]
   name = "RepeatedXidErrorOnDifferentGPU"
-  description = "Detect occurrence of XIDs on 2+ different GPUs within 1 minutes"
+  description = "Detect occurrence of XIDs on 2 or more different GPUs within 24 hours"
   message = "run CHECK_APP_CUDA"
   recommended_action = "NONE"
   stage = [
@@ -301,7 +319,7 @@ config: |
           "$expr": {
           "$gte": [
               "$healthevent.generatedtimestamp.seconds",
-              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 60]}
+              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
           ]
           }
       }
@@ -367,7 +385,7 @@ config: |
 
   [[rules]]
   name = "XIDErrorOnSameGPCAndTPC"
-  description = "Detect if XID error occurred 2 times on the same GPC and TPC within 2 minutes"
+  description = "Detect if XID error occurred 2 or more times on the same GPC and TPC within 24 hours"
   message = "if pass run RUN_FIELDDIAGS" 
   recommended_action = "RUN_DCGMEUD"
   stage = [
@@ -377,7 +395,7 @@ config: |
           "$expr": {
           "$gte": [
               "$healthevent.generatedtimestamp.seconds",
-              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 120]}
+              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
           ]
           }
       }
@@ -483,7 +501,7 @@ config: |
                           ["74", "79", "95", "109", "119"]
                           ]
                       },
-                      {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 20]}
+                      {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 10800]}
                       ]
                   }
                   }
@@ -516,7 +534,7 @@ config: |
                       "then": 0,
                       "else": {
                       "$cond": {
-                          "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 4]},
+                          "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 180]},
                           "then": 1,
                           "else": 0
                       }
@@ -644,7 +662,7 @@ config: |
 
   [[rules]]
   name = "XIDErrorOnDifferentGPCAndTPC"
-  description = "Detect if XID error occurred on 2 different GPC and TPC combinations within 1.5 minutes"
+  description = "Detect if XID error occurred on 2 or more different GPC and TPC combinations within 24 hours"
   message = "run CHECK_APP_CUDA"
   recommended_action = "NONE"
   stage = [
@@ -654,7 +672,7 @@ config: |
           "$expr": {
           "$gte": [
               "$healthevent.generatedtimestamp.seconds",
-              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 90]}
+              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
           ]
           }
       }
@@ -764,7 +782,7 @@ config: |
 
   [[rules]]
   name = "XIDErrorSoloNoBurst"
-  description = "Detect if XID error occurred only once in the last burst within 1 minutes time window"
+  description = "Detect if XID error occurred only once in the last burst within 24 hours time window"
   message = "run CHECK_APP_CUDA"
   recommended_action = "NONE"
   stage = [
@@ -774,7 +792,7 @@ config: |
           "$expr": {
           "$gte": [
               "$healthevent.generatedtimestamp.seconds",
-              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 60]}
+              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
           ]
           }
       }
@@ -880,7 +898,7 @@ config: |
                           ["74", "79", "95", "109", "119"]
                           ]
                       },
-                      {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 20]}
+                      {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 10800]}
                       ]
                   }
                   }
@@ -913,7 +931,7 @@ config: |
                       "then": 0,
                       "else": {
                       "$cond": {
-                          "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 4]},
+                          "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 180]},
                           "then": 1,
                           "else": 0
                       }

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
@@ -69,7 +69,7 @@ config: |
   ]
 
   [[rules]]
-  name = "RepeatedXidError"
+  name = "RepeatedXidErrorOnSameGPU"
   description = "Detect occurrence of fatal XIDs 5 times within 24 hours (production: 86400s for real workloads)"
   recommended_action = "CONTACT_SUPPORT"
   stage = [
@@ -100,7 +100,7 @@ config: |
                       "input": {
                         "$filter": {
                           "input": {"$ifNull": ["$healthevent.entitiesimpacted", []]},
-                          "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                          "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
                         }
                       },
                       "in": "$$this.entityvalue"
@@ -111,7 +111,7 @@ config: |
                       "input": {
                         "$filter": {
                           "input": "this.healthevent.entitiesimpacted",
-                          "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                          "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
                         }
                       },
                       "in": "$$this.entityvalue"
@@ -285,6 +285,81 @@ config: |
     }
     ''',
     '{"$match": {"count": {"$gte": 5}}}'
+  ]
+
+  [[rules]]
+  name = "RepeatedXidErrorOnDifferentGPU"
+  description = "Detect occurrence of XIDs on 5+ different GPUs within 24 hours"
+  recommended_action = "CHECK_APP_CUDA"
+  stage = [
+    '''
+    {
+      "$match": {
+        "$expr": {
+          "$gte": [
+            "$healthevent.generatedtimestamp.seconds",
+            {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$match": {
+        "healthevent.ishealthy": false,
+        "healthevent.nodename": "this.healthevent.nodename",
+        "healthevent.errorcode": "this.healthevent.errorcode.0"
+      }
+    }
+    ''',
+    '''
+    {
+      "$addFields": {
+        "gpuUuid": {
+          "$let": {
+            "vars": {
+              "uuid": {
+                "$arrayElemAt": [
+                  {
+                    "$map": {
+                      "input": {"$filter": {"input": {"$ifNull": ["$healthevent.entitiesimpacted", []]}, "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}}},
+                      "in": "$$this.entityvalue"
+                    }
+                  },
+                  0
+                ]
+              }
+            },
+            "in": {
+              "$cond": [
+                {"$ne": ["$$uuid", null]},
+                "$$uuid",
+                null
+              ]
+            }
+          }
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$group": {
+        "_id": null,
+        "uniqueGPUs": {"$addToSet": "$gpuUuid"}
+      }
+    }
+    ''',
+    '''
+    {
+      "$match": {
+        "$expr": {
+          "$gte": [{"$size": "$uniqueGPUs"}, 5]
+        }
+      }
+    }
+    '''
   ]
 
   [[rules]]

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
@@ -286,3 +286,601 @@ config: |
     ''',
     '{"$match": {"count": {"$gte": 5}}}'
   ]
+
+  [[rules]]
+  name = "XID13OnSameGPCAndTPC"
+  description = "Detect if XID 13 occurred 5 times on the same GPC and TPC within 24 hours"
+  recommended_action = "RUN_FIELDDIAG"
+  stage = [
+    '''
+    {
+      "$match": {
+        "$expr": {
+          "$gte": [
+            "$healthevent.generatedtimestamp.seconds",
+            {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$match": {
+        "healthevent.ishealthy": false,
+        "healthevent.nodename": "this.healthevent.nodename",
+        "$expr": {
+          "$gt": [
+            {
+              "$size": {
+                "$setIntersection": [
+                  {
+                    "$map": {
+                      "input": {
+                        "$filter": {
+                          "input": "$healthevent.entitiesimpacted",
+                          "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                        }
+                      },
+                      "in": "$$this.entityvalue"
+                    }
+                  },
+                  {
+                    "$map": {
+                      "input": {
+                        "$filter": {
+                          "input": "this.healthevent.entitiesimpacted",
+                          "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                        }
+                      },
+                      "in": "$$this.entityvalue"
+                    }
+                  }
+                ]
+              }
+            },
+            0
+          ]
+        },
+      }
+    }
+    ''',
+    '''
+    {
+      "$setWindowFields": {
+        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+        "output": {
+          "prevTimestamp": {
+            "$shift": {
+              "output": "$healthevent.generatedtimestamp.seconds",
+              "by": -1
+            }
+          }
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$addFields": {
+        "isStickyXid": {
+          "$in": [
+            {"$arrayElemAt": ["$healthevent.errorcode", 0]},
+            ["74", "79", "95", "109", "119"]
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$setWindowFields": {
+        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+        "output": {
+          "allPreviousEvents": {
+            "$push": "$$ROOT",
+            "window": {"documents": ["unbounded", -1]}
+          }
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$addFields": {
+        "stickyXidWithin3Hours": {
+          "$cond": {
+            "if": "$isStickyXid",
+            "then": {
+              "$anyElementTrue": {
+                "$map": {
+                  "input": "$allPreviousEvents",
+                  "as": "prevEvent",
+                  "in": {
+                    "$and": [
+                      {
+                        "$in": [
+                          {"$arrayElemAt": ["$$prevEvent.healthevent.errorcode", 0]},
+                          ["74", "79", "95", "109", "119"]
+                        ]
+                      },
+                      {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 10800]}
+                    ]
+                  }
+                }
+              }
+            },
+            "else": false
+          }
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$setWindowFields": {
+        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+        "output": {
+          "burstId": {
+            "$sum": {
+              "$cond": {
+                "if": {"$eq": ["$prevTimestamp", null]},
+                "then": 1,
+                "else": {
+                  "$cond": {
+                    "if": {
+                      "$and": [
+                        "$isStickyXid",
+                        "$stickyXidWithin3Hours"
+                      ]
+                    },
+                    "then": 0,
+                    "else": {
+                      "$cond": {
+                        "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 180]},
+                        "then": 1,
+                        "else": 0
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "window": {"documents": ["unbounded", "current"]}
+          }
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$group": {
+        "_id": {"burstId": "$burstId"},
+        "uniqueXidsInBurst": {"$addToSet": {"$arrayElemAt": ["$healthevent.errorcode", 0]}},
+        "targetXidCount": {
+          "$sum": {
+            "$cond": [
+              {
+                "$and": [
+                  {"$eq": [{"$arrayElemAt": ["$healthevent.errorcode", 0]}, "this.healthevent.errorcode.0"]},
+                  {
+                    "$eq": [
+                      {
+                        "$arrayElemAt": [
+                          {
+                            "$map": {
+                              "input": {"$filter": {"input": "$healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "GPC"]}}},
+                              "in": "$$this.entityvalue"
+                            }
+                          },
+                          0
+                        ]
+                      },
+                      {
+                        "$arrayElemAt": [
+                          {
+                            "$map": {
+                              "input": {"$filter": {"input": "this.healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "GPC"]}}},
+                              "in": "$$this.entityvalue"
+                            }
+                          },
+                          0
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "$eq": [
+                      {
+                        "$arrayElemAt": [
+                          {
+                            "$map": {
+                              "input": {"$filter": {"input": "$healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "TPC"]}}},
+                              "in": "$$this.entityvalue"
+                            }
+                          },
+                          0
+                        ]
+                      },
+                      {
+                        "$arrayElemAt": [
+                          {
+                            "$map": {
+                              "input": {"$filter": {"input": "this.healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "TPC"]}}},
+                              "in": "$$this.entityvalue"
+                            }
+                          },
+                          0
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              1,
+              0
+            ]
+          }
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$setWindowFields": {
+        "sortBy": {"_id.burstId": 1},
+        "output": {"maxBurstId": {"$max": "$_id.burstId"}}
+      }
+    }
+    ''',
+    '''
+    {
+      "$match": {
+        "$expr": {
+          "$and": [
+            {"$in": ["this.healthevent.errorcode.0", "$uniqueXidsInBurst"]},
+            {
+              "$or": [
+                {"$ne": ["$_id.burstId", "$maxBurstId"]},
+                {"$eq": ["$targetXidCount", 1]}
+              ]
+            }
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$group": {
+        "_id": null,
+        "count": {"$sum": 1},
+        "bursts": {"$push": {"burstId": "$_id.burstId", "uniqueXids": "$uniqueXidsInBurst"}}
+      }
+    }
+    ''',
+    '{"$match": {"count": {"$gte": 5}}}'
+  ]
+
+  [[rules]]
+  name = "XID13OnDifferentGPCAndTPC"
+  description = "Detect if XID 13 occurred 5 times on different GPC and TPC within 24 hours"
+  recommended_action = "RUN_FIELDDIAG"
+  stage = [
+    '''
+    {
+      "$match": {
+        "$expr": {
+          "$gte": [
+            "$healthevent.generatedtimestamp.seconds",
+            {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$match": {
+        "healthevent.ishealthy": false,
+        "healthevent.nodename": "this.healthevent.nodename",
+        "healthevent.errorcode": "13",
+        "$expr": {
+          "$gt": [
+            {
+              "$size": {
+                "$setIntersection": [
+                  {
+                    "$map": {
+                      "input": {
+                        "$filter": {
+                          "input": "$healthevent.entitiesimpacted",
+                          "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
+                        }
+                      },
+                      "in": "$$this.entityvalue"
+                    }
+                  },
+                  {
+                    "$map": {
+                      "input": {
+                        "$filter": {
+                          "input": "this.healthevent.entitiesimpacted",
+                          "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
+                        }
+                      },
+                      "in": "$$this.entityvalue"
+                    }
+                  }
+                ]
+              }
+            },
+            0
+          ]
+        },
+      }
+    }
+    ''',
+    '''
+    {
+      "$addFields": {
+        "gpcTpcCombination": {
+          "$let": {
+            "vars": {
+              "gpc": {
+                "$arrayElemAt": [
+                  {
+                    "$map": {
+                      "input": {"$filter": {"input": "$healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "GPC"]}}},
+                      "in": "$$this.entityvalue"
+                    }
+                  },
+                  0
+                ]
+              },
+              "tpc": {
+                "$arrayElemAt": [
+                  {
+                    "$map": {
+                      "input": {"$filter": {"input": "$healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "TPC"]}}},
+                      "in": "$$this.entityvalue"
+                    }
+                  },
+                  0
+                ]
+              }
+            },
+            "in": {
+              "$cond": [
+                {"$and": [{"$ne": ["$$gpc", null]}, {"$ne": ["$$tpc", null]}]},
+                {"$concat": ["GPC:", "$$gpc", "-TPC:", "$$tpc"]},
+                null
+              ]
+            }
+          }
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$group": {
+        "_id": null,
+        "uniqueGPCAndTPCCombinations": {"$addToSet": "$gpcTpcCombination"}
+      }
+    }
+    ''',
+    '''
+    {
+      "$match": {
+        "$expr": {
+          "$gte": [{"$size": "$uniqueGPCAndTPCCombinations"}, 5]
+        }
+      }
+    }
+    '''
+  ]
+
+  [[rules]]
+  name = "XIDErrorSoloNoBurst"
+  description = "Detect if XID error occurred only once in the latest burst within 24 hours"
+  recommended_action = "CHECK_APP_CUDA"
+  stage = [
+    '''
+    {
+      "$match": {
+        "$expr": {
+          "$gte": [
+            "$healthevent.generatedtimestamp.seconds",
+            {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 86400]}
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$match": {
+        "healthevent.ishealthy": false,
+        "healthevent.nodename": "this.healthevent.nodename",
+        "$expr": {
+          "$gt": [
+            {
+              "$size": {
+                "$setIntersection": [
+                  {
+                    "$map": {
+                      "input": {
+                        "$filter": {
+                          "input": "$healthevent.entitiesimpacted",
+                          "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                        }
+                      },
+                      "in": "$$this.entityvalue"
+                    }
+                  },
+                  {
+                    "$map": {
+                      "input": {
+                        "$filter": {
+                          "input": "this.healthevent.entitiesimpacted",
+                          "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                        }
+                      },
+                      "in": "$$this.entityvalue"
+                    }
+                  }
+                ]
+              }
+            },
+            0
+          ]
+        },
+      }
+    }
+    ''',
+    '''
+    {
+      "$setWindowFields": {
+        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+        "output": {
+          "prevTimestamp": {
+            "$shift": {
+              "output": "$healthevent.generatedtimestamp.seconds",
+              "by": -1
+            }
+          }
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$addFields": {
+        "isStickyXid": {
+          "$in": [
+            {"$arrayElemAt": ["$healthevent.errorcode", 0]},
+            ["74", "79", "95", "109", "119"]
+          ]
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$setWindowFields": {
+        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+        "output": {
+          "allPreviousEvents": {
+            "$push": "$$ROOT",
+            "window": {"documents": ["unbounded", -1]}
+          }
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$addFields": {
+        "stickyXidWithin3Hours": {
+          "$cond": {
+            "if": "$isStickyXid",
+            "then": {
+              "$anyElementTrue": {
+                "$map": {
+                  "input": "$allPreviousEvents",
+                  "as": "prevEvent",
+                  "in": {
+                    "$and": [
+                      {
+                        "$in": [
+                          {"$arrayElemAt": ["$$prevEvent.healthevent.errorcode", 0]},
+                          ["74", "79", "95", "109", "119"]
+                        ]
+                      },
+                      {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 10800]}
+                    ]
+                  }
+                }
+              }
+            },
+            "else": false
+          }
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$setWindowFields": {
+        "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+        "output": {
+          "burstId": {
+            "$sum": {
+              "$cond": {
+                "if": {"$eq": ["$prevTimestamp", null]},
+                "then": 1,
+                "else": {
+                  "$cond": {
+                    "if": {
+                      "$and": [
+                        "$isStickyXid",
+                        "$stickyXidWithin3Hours"
+                      ]
+                    },
+                    "then": 0,
+                    "else": {
+                      "$cond": {
+                        "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 180]},
+                        "then": 1,
+                        "else": 0
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "window": {"documents": ["unbounded", "current"]}
+          }
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$group": {
+        "_id": {"burstId": "$burstId"},
+        "targetXidCount": {
+          "$sum": {
+            "$cond": [
+              {"$eq": [{"$arrayElemAt": ["$healthevent.errorcode", 0]}, "this.healthevent.errorcode.0"]},
+              1,
+              0
+            ]
+          }
+        }
+      }
+    }
+    ''',
+    '''
+    {
+      "$setWindowFields": {
+        "sortBy": {"_id.burstId": 1},
+        "output": {"maxBurstId": {"$max": "$_id.burstId"}}
+      }
+    }
+    ''',
+    '''
+    {
+      "$match": {
+        "$expr": {
+          "$and": [
+            {"$eq": ["$_id.burstId", "$maxBurstId"]},
+            {"$eq": ["$targetXidCount", 1]}
+          ]
+        }
+      }
+    }
+    '''
+  ]
+

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
@@ -554,7 +554,7 @@ config: |
   [[rules]]
   name = "RepeatedXID31OnDifferentGPU"
   description = "Detect if XID 31 occurred 2 or more times on different GPUs within 24 hours"
-  message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, report if driver issue"
+  message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support"
   recommended_action = "NONE"
   stage = [
     '''
@@ -939,7 +939,7 @@ config: |
   [[rules]]
   name = "RepeatedXID13OnDifferentGPCAndTPC"
   description = "Detect if XID 13 occurred 2 or more times on different GPC and TPC combinations within 24 hours"
-  message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, report if driver issue"
+  message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support"
   recommended_action = "NONE"
   stage = [
     '''
@@ -1078,7 +1078,7 @@ config: |
   [[rules]]
   name = "XIDErrorSoloNoBurst"
   description = "Detect if XID error occurred only once in the last burst within 24 hours time window"
-  message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, report if driver issue"
+  message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support"
   recommended_action = "NONE"
   stage = [
     '''

--- a/health-events-analyzer/pkg/config/rules.go
+++ b/health-events-analyzer/pkg/config/rules.go
@@ -25,6 +25,7 @@ type HealthEventsAnalyzerRule struct {
 	Description       string   `toml:"description"`
 	Stage             []string `toml:"stage"`
 	RecommendedAction string   `toml:"recommended_action"`
+	Message           string   `toml:"message"`
 }
 
 type TomlConfig struct {

--- a/health-events-analyzer/pkg/config/rules.go
+++ b/health-events-analyzer/pkg/config/rules.go
@@ -21,11 +21,12 @@ import (
 )
 
 type HealthEventsAnalyzerRule struct {
-	Name              string   `toml:"name"`
-	Description       string   `toml:"description"`
-	Stage             []string `toml:"stage"`
-	RecommendedAction string   `toml:"recommended_action"`
-	Message           string   `toml:"message"`
+	Name                      string                       `toml:"name"`
+	Description               string                       `toml:"description"`
+	Stage                     []string                     `toml:"stage"`
+	RecommendedAction         string                       `toml:"recommended_action"`
+	Message                   string                       `toml:"message"`
+	RecommendedActionMappings map[string]map[string]string `toml:"recommended_action_mappings"`
 }
 
 type TomlConfig struct {

--- a/health-events-analyzer/pkg/config/rules.go
+++ b/health-events-analyzer/pkg/config/rules.go
@@ -21,12 +21,11 @@ import (
 )
 
 type HealthEventsAnalyzerRule struct {
-	Name                      string                       `toml:"name"`
-	Description               string                       `toml:"description"`
-	Stage                     []string                     `toml:"stage"`
-	RecommendedAction         string                       `toml:"recommended_action"`
-	Message                   string                       `toml:"message"`
-	RecommendedActionMappings map[string]map[string]string `toml:"recommended_action_mappings"`
+	Name              string   `toml:"name"`
+	Description       string   `toml:"description"`
+	Stage             []string `toml:"stage"`
+	RecommendedAction string   `toml:"recommended_action"`
+	Message           string   `toml:"message"`
 }
 
 type TomlConfig struct {

--- a/health-events-analyzer/pkg/publisher/publisher.go
+++ b/health-events-analyzer/pkg/publisher/publisher.go
@@ -101,8 +101,13 @@ func (p *PublisherConfig) Publish(ctx context.Context, event *protos.HealthEvent
 	newEvent.CheckName = ruleName
 	newEvent.RecommendedAction = recommendedAction
 	newEvent.IsHealthy = false
-	newEvent.IsFatal = true
 	newEvent.Message = message
+
+	if recommendedAction == protos.RecommendedAction_NONE {
+		newEvent.IsFatal = false
+	} else {
+		newEvent.IsFatal = true
+	}
 
 	req := &protos.HealthEvents{
 		Version: 1,

--- a/health-events-analyzer/pkg/publisher/publisher.go
+++ b/health-events-analyzer/pkg/publisher/publisher.go
@@ -94,7 +94,7 @@ func NewPublisher(platformConnectorClient protos.PlatformConnectorClient) *Publi
 }
 
 func (p *PublisherConfig) Publish(ctx context.Context, event *protos.HealthEvent,
-	recommendedAction protos.RecommendedAction, ruleName string) error {
+	recommendedAction protos.RecommendedAction, ruleName string, message string) error {
 	newEvent := proto.Clone(event).(*protos.HealthEvent)
 
 	newEvent.Agent = "health-events-analyzer"
@@ -102,6 +102,7 @@ func (p *PublisherConfig) Publish(ctx context.Context, event *protos.HealthEvent
 	newEvent.RecommendedAction = recommendedAction
 	newEvent.IsHealthy = false
 	newEvent.IsFatal = true
+	newEvent.Message = message
 
 	req := &protos.HealthEvents{
 		Version: 1,

--- a/health-events-analyzer/pkg/publisher/publisher.go
+++ b/health-events-analyzer/pkg/publisher/publisher.go
@@ -104,10 +104,6 @@ func (p *PublisherConfig) Publish(ctx context.Context, event *protos.HealthEvent
 	newEvent.IsFatal = true
 	newEvent.Message = message
 
-	slog.Info("new event entities impacted", "entities", newEvent.EntitiesImpacted)
-
-	slog.Info("old event entities impacted", "entities", event.EntitiesImpacted)
-
 	req := &protos.HealthEvents{
 		Version: 1,
 		Events:  []*protos.HealthEvent{newEvent},

--- a/health-events-analyzer/pkg/publisher/publisher.go
+++ b/health-events-analyzer/pkg/publisher/publisher.go
@@ -104,6 +104,10 @@ func (p *PublisherConfig) Publish(ctx context.Context, event *protos.HealthEvent
 	newEvent.IsFatal = true
 	newEvent.Message = message
 
+	slog.Info("new event entities impacted", "entities", newEvent.EntitiesImpacted)
+
+	slog.Info("old event entities impacted", "entities", event.EntitiesImpacted)
+
 	req := &protos.HealthEvents{
 		Version: 1,
 		Events:  []*protos.HealthEvent{newEvent},

--- a/health-events-analyzer/pkg/reconciler/reconciler.go
+++ b/health-events-analyzer/pkg/reconciler/reconciler.go
@@ -283,7 +283,7 @@ func (r *Reconciler) publishMatchedEvent(ctx context.Context,
 
 	// No need to clone here - Publisher.Publish already clones the event
 	// The EventProcessor creates a fresh stack variable for each event, so no mutation risk
-	err := r.config.Publisher.Publish(ctx, event.HealthEvent, protos.RecommendedAction(actionVal), rule.Name)
+	err := r.config.Publisher.Publish(ctx, event.HealthEvent, protos.RecommendedAction(actionVal), rule.Name, rule.Message)
 	if err != nil {
 		slog.Error("Error in publishing the new fatal event", "error", err)
 		return fmt.Errorf("error in publishing the new fatal event: %w", err)
@@ -356,14 +356,14 @@ func (r *Reconciler) validateAllSequenceCriteria(ctx context.Context, rule confi
 		// Check for explicit ruleMatched field (used in tests and by SequenceFacet pipelines)
 		if matched, ok := result[0]["ruleMatched"].(bool); ok {
 			if matched {
-				slog.Info("✓ Rule matched via ruleMatched field",
+				slog.Info("Rule matched via ruleMatched field",
 					"rule_name", rule.Name,
 					"node", healthEventWithStatus.HealthEvent.NodeName)
 
 				return true, nil
 			}
 
-			slog.Info("✗ Rule did not match (ruleMatched=false)",
+			slog.Info("Rule did not match (ruleMatched=false)",
 				"rule_name", rule.Name,
 				"node", healthEventWithStatus.HealthEvent.NodeName,
 				"result", result[0])
@@ -371,16 +371,10 @@ func (r *Reconciler) validateAllSequenceCriteria(ctx context.Context, rule confi
 			return false, nil
 		}
 
-		// For Stage-based pipelines, presence of results indicates a match
-		slog.Info("✓ Rule matched via results existence",
-			"rule_name", rule.Name,
-			"node", healthEventWithStatus.HealthEvent.NodeName,
-			"result_count", len(result))
-
 		return true, nil
 	}
 
-	slog.Info("✗ Rule did not match (no results)",
+	slog.Info("Rule did not match (no results)",
 		"rule_name", rule.Name,
 		"node", healthEventWithStatus.HealthEvent.NodeName)
 

--- a/health-events-analyzer/pkg/reconciler/reconciler.go
+++ b/health-events-analyzer/pkg/reconciler/reconciler.go
@@ -279,17 +279,11 @@ func (r *Reconciler) publishMatchedEvent(ctx context.Context,
 	slog.Info("Rule matched for event", "rule_name", rule.Name, "event", event)
 	ruleMatchedTotal.WithLabelValues(rule.Name, event.HealthEvent.NodeName).Inc()
 
-	// Get error code, default to empty string if not available
-	errorCode := ""
-	if len(event.HealthEvent.ErrorCode) > 0 {
-		errorCode = event.HealthEvent.ErrorCode[0]
-	}
-
-	actionVal, message := r.getRecommendedActionForEvent(rule, rule.Name, errorCode)
+	actionVal := r.getRecommendedActionValue(rule.RecommendedAction, rule.Name)
 
 	// No need to clone here - Publisher.Publish already clones the event
 	// The EventProcessor creates a fresh stack variable for each event, so no mutation risk
-	err := r.config.Publisher.Publish(ctx, event.HealthEvent, protos.RecommendedAction(actionVal), rule.Name, message)
+	err := r.config.Publisher.Publish(ctx, event.HealthEvent, protos.RecommendedAction(actionVal), rule.Name, rule.Message)
 	if err != nil {
 		slog.Error("Error in publishing the new fatal event", "error", err)
 		return fmt.Errorf("error in publishing the new fatal event: %w", err)
@@ -298,43 +292,6 @@ func (r *Reconciler) publishMatchedEvent(ctx context.Context,
 	slog.Info("New event successfully published for matching rule", "rule_name", rule.Name)
 
 	return nil
-}
-
-// getRecommendedActionForEvent determines the recommended action for an event
-// It first checks if there's a specific action mapping for the event's error code,
-// then falls back to the rule's default recommended action
-func (r *Reconciler) getRecommendedActionForEvent(rule config.HealthEventsAnalyzerRule, ruleName string,
-	errorCode string) (int32, string) {
-	// If no mappings defined, use defaults
-	if rule.RecommendedActionMappings == nil {
-		return r.getRecommendedActionValue(rule.RecommendedAction, ruleName), rule.Message
-	}
-
-	// Check if there's a mapping for this specific error code
-	if actionDetails, ok := rule.RecommendedActionMappings[errorCode]; ok && actionDetails["recommended_action"] != "" {
-		// Use mapped action
-		actionVal := r.getRecommendedActionValue(actionDetails["recommended_action"], ruleName)
-
-		// Use mapped message if provided, otherwise fall back to rule's default message
-		message := actionDetails["message"]
-		if message == "" {
-			message = rule.Message
-		}
-
-		slog.Info("Using error code specific action mapping",
-			"rule_name", ruleName,
-			"error_code", errorCode,
-			"recommended_action", actionDetails["recommended_action"],
-			"message", message)
-
-		return actionVal, message
-	}
-
-	slog.Debug("No action mapping found for error code, using default recommended action",
-		"error_code", errorCode,
-		"rule_name", ruleName)
-
-	return r.getRecommendedActionValue(rule.RecommendedAction, ruleName), rule.Message
 }
 
 // getRecommendedActionValue returns the action value, with fallback to RecommendedAction_CONTACT_SUPPORT if invalid

--- a/health-events-analyzer/pkg/reconciler/reconciler.go
+++ b/health-events-analyzer/pkg/reconciler/reconciler.go
@@ -458,7 +458,8 @@ func (r *Reconciler) processXidBurstDetection(ctx context.Context, event *protos
 
 	// Use the publisher to create and publish the RepeatedXidError event
 	// The publisher will set agent, checkName, isHealthy, isFatal, and recommendedAction
-	err := r.config.Publisher.Publish(ctx, event, protos.RecommendedAction_CONTACT_SUPPORT, "RepeatedXidError")
+	err := r.config.Publisher.Publish(ctx, event, protos.RecommendedAction_CONTACT_SUPPORT, "RepeatedXidError",
+		event.Message)
 	if err != nil {
 		slog.Error("Failed to publish RepeatedXidError event",
 			"error", err,

--- a/health-events-analyzer/pkg/reconciler/reconciler_test.go
+++ b/health-events-analyzer/pkg/reconciler/reconciler_test.go
@@ -174,6 +174,7 @@ var (
 				`{"$match": {"count": {"$gte": 3}}}`,
 			},
 			RecommendedAction: "CONTACT_SUPPORT",
+			Message:           "XID error occurred",
 		},
 		{
 			Name:        "rule3",
@@ -198,32 +199,6 @@ var (
 			IsHealthy:      false,
 			Message:        "XID error occurred",
 			ErrorCode:      []string{"13"},
-			EntitiesImpacted: []*protos.Entity{{
-				EntityType:  "GPU",
-				EntityValue: "1",
-			}},
-			Metadata: map[string]string{
-				"SerialNumber": "1655322004581",
-			},
-			GeneratedTimestamp: &timestamppb.Timestamp{
-				Seconds: time.Now().Unix(),
-				Nanos:   0,
-			},
-			NodeName: "node1",
-		},
-		HealthEventStatus: datamodels.HealthEventStatus{},
-	}
-	healthEvent_48 = datamodels.HealthEventWithStatus{
-		CreatedAt: time.Now(),
-		HealthEvent: &protos.HealthEvent{
-			Version:        1,
-			Agent:          "gpu-health-monitor",
-			ComponentClass: "GPU",
-			CheckName:      "GpuXidError",
-			IsFatal:        true,
-			IsHealthy:      false,
-			Message:        "XID error occurred",
-			ErrorCode:      []string{"48"},
 			EntitiesImpacted: []*protos.Entity{{
 				EntityType:  "GPU",
 				EntityValue: "1",
@@ -312,7 +287,7 @@ func TestHandleEvent(t *testing.T) {
 			Agent:              "health-events-analyzer", // Publisher sets this
 			CheckName:          "rule2",                  // Publisher sets this to ruleName
 			ComponentClass:     healthEvent_13.HealthEvent.ComponentClass,
-			Message:            healthEvent_13.HealthEvent.Message,
+			Message:            "XID error occurred",                     // From rule2.Message
 			RecommendedAction:  protos.RecommendedAction_CONTACT_SUPPORT, // From rule2
 			ErrorCode:          healthEvent_13.HealthEvent.ErrorCode,
 			IsHealthy:          false, // Publisher sets this
@@ -686,11 +661,11 @@ func TestGetPipelineStages_ReturnTypeCompatibility(t *testing.T) {
 	// by checking it matches the signature that store-client expects
 	mockDB := &mockDatabaseClient{}
 	mockCursor := &mockCursor{}
-	
+
 	// The Aggregate method expects interface{} but should work with []map[string]interface{}
 	// This ensures backward compatibility with MongoDB driver
 	mockDB.On("Aggregate", mock.Anything, pipeline).Return(mockCursor, nil)
-	
+
 	cursor, err := mockDB.Aggregate(context.Background(), pipeline)
 	assert.NoError(t, err)
 	assert.NotNil(t, cursor)

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/protos/health_event_pb2.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/protos/health_event_pb2.py
@@ -21,7 +21,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x12health_event.proto\x12\ndatamodels\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1bgoogle/protobuf/empty.proto"H\n\x0cHealthEvents\x12\x0f\n\x07version\x18\x01 \x01(\r\x12\'\n\x06\x65vents\x18\x02 \x03(\x0b\x32\x17.datamodels.HealthEvent"1\n\x06\x45ntity\x12\x12\n\nentityType\x18\x01 \x01(\t\x12\x13\n\x0b\x65ntityValue\x18\x02 \x01(\t"\xb1\x04\n\x0bHealthEvent\x12\x0f\n\x07version\x18\x01 \x01(\r\x12\r\n\x05\x61gent\x18\x02 \x01(\t\x12\x16\n\x0e\x63omponentClass\x18\x03 \x01(\t\x12\x11\n\tcheckName\x18\x04 \x01(\t\x12\x0f\n\x07isFatal\x18\x05 \x01(\x08\x12\x11\n\tisHealthy\x18\x06 \x01(\x08\x12\x0f\n\x07message\x18\x07 \x01(\t\x12\x38\n\x11recommendedAction\x18\x08 \x01(\x0e\x32\x1d.datamodels.RecommendedAction\x12\x11\n\terrorCode\x18\t \x03(\t\x12,\n\x10\x65ntitiesImpacted\x18\n \x03(\x0b\x32\x12.datamodels.Entity\x12\x37\n\x08metadata\x18\x0b \x03(\x0b\x32%.datamodels.HealthEvent.MetadataEntry\x12\x36\n\x12generatedTimestamp\x18\x0c \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x10\n\x08nodeName\x18\r \x01(\t\x12;\n\x13quarantineOverrides\x18\x0e \x01(\x0b\x32\x1e.datamodels.BehaviourOverrides\x12\x36\n\x0e\x64rainOverrides\x18\x0f \x01(\x0b\x32\x1e.datamodels.BehaviourOverrides\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"1\n\x12\x42\x65haviourOverrides\x12\r\n\x05\x66orce\x18\x01 \x01(\x08\x12\x0c\n\x04skip\x18\x02 \x01(\x08*\x84\x01\n\x11RecommendedAction\x12\x08\n\x04NONE\x10\x00\x12\x13\n\x0f\x43OMPONENT_RESET\x10\x02\x12\x13\n\x0f\x43ONTACT_SUPPORT\x10\x05\x12\x0e\n\nRESTART_VM\x10\x0f\x12\x0e\n\nRESTART_BM\x10\x18\x12\x0e\n\nREPLACE_VM\x10\x19\x12\x0b\n\x07UNKNOWN\x10\x63\x32`\n\x11PlatformConnector\x12K\n\x15HealthEventOccurredV1\x12\x18.datamodels.HealthEvents\x1a\x16.google.protobuf.Empty"\x00\x42\x35Z3github.com/nvidia/nvsentinel/data-models/pkg/protosb\x06proto3'
+    b'\n\x12health_event.proto\x12\ndatamodels\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1bgoogle/protobuf/empty.proto"H\n\x0cHealthEvents\x12\x0f\n\x07version\x18\x01 \x01(\r\x12\'\n\x06\x65vents\x18\x02 \x03(\x0b\x32\x17.datamodels.HealthEvent"1\n\x06\x45ntity\x12\x12\n\nentityType\x18\x01 \x01(\t\x12\x13\n\x0b\x65ntityValue\x18\x02 \x01(\t"\xb1\x04\n\x0bHealthEvent\x12\x0f\n\x07version\x18\x01 \x01(\r\x12\r\n\x05\x61gent\x18\x02 \x01(\t\x12\x16\n\x0e\x63omponentClass\x18\x03 \x01(\t\x12\x11\n\tcheckName\x18\x04 \x01(\t\x12\x0f\n\x07isFatal\x18\x05 \x01(\x08\x12\x11\n\tisHealthy\x18\x06 \x01(\x08\x12\x0f\n\x07message\x18\x07 \x01(\t\x12\x38\n\x11recommendedAction\x18\x08 \x01(\x0e\x32\x1d.datamodels.RecommendedAction\x12\x11\n\terrorCode\x18\t \x03(\t\x12,\n\x10\x65ntitiesImpacted\x18\n \x03(\x0b\x32\x12.datamodels.Entity\x12\x37\n\x08metadata\x18\x0b \x03(\x0b\x32%.datamodels.HealthEvent.MetadataEntry\x12\x36\n\x12generatedTimestamp\x18\x0c \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x10\n\x08nodeName\x18\r \x01(\t\x12;\n\x13quarantineOverrides\x18\x0e \x01(\x0b\x32\x1e.datamodels.BehaviourOverrides\x12\x36\n\x0e\x64rainOverrides\x18\x0f \x01(\x0b\x32\x1e.datamodels.BehaviourOverrides\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"1\n\x12\x42\x65haviourOverrides\x12\r\n\x05\x66orce\x18\x01 \x01(\x08\x12\x0c\n\x04skip\x18\x02 \x01(\x08*\xa8\x01\n\x11RecommendedAction\x12\x08\n\x04NONE\x10\x00\x12\x13\n\x0f\x43OMPONENT_RESET\x10\x02\x12\x13\n\x0f\x43ONTACT_SUPPORT\x10\x05\x12\x11\n\rRUN_FIELDDIAG\x10\x06\x12\x0e\n\nRESTART_VM\x10\x0f\x12\x0e\n\nRESTART_BM\x10\x18\x12\x0e\n\nREPLACE_VM\x10\x19\x12\x0f\n\x0bRUN_DCGMEUD\x10\x1a\x12\x0b\n\x07UNKNOWN\x10\x63\x32`\n\x11PlatformConnector\x12K\n\x15HealthEventOccurredV1\x12\x18.datamodels.HealthEvents\x1a\x16.google.protobuf.Empty"\x00\x42\x35Z3github.com/nvidia/nvsentinel/data-models/pkg/protosb\x06proto3'
 )
 
 _globals = globals()
@@ -33,7 +33,7 @@ if not _descriptor._USE_C_DESCRIPTORS:
     _globals["_HEALTHEVENT_METADATAENTRY"]._loaded_options = None
     _globals["_HEALTHEVENT_METADATAENTRY"]._serialized_options = b"8\001"
     _globals["_RECOMMENDEDACTION"]._serialized_start = 837
-    _globals["_RECOMMENDEDACTION"]._serialized_end = 969
+    _globals["_RECOMMENDEDACTION"]._serialized_end = 1005
     _globals["_HEALTHEVENTS"]._serialized_start = 96
     _globals["_HEALTHEVENTS"]._serialized_end = 168
     _globals["_ENTITY"]._serialized_start = 170
@@ -44,6 +44,6 @@ if not _descriptor._USE_C_DESCRIPTORS:
     _globals["_HEALTHEVENT_METADATAENTRY"]._serialized_end = 783
     _globals["_BEHAVIOUROVERRIDES"]._serialized_start = 785
     _globals["_BEHAVIOUROVERRIDES"]._serialized_end = 834
-    _globals["_PLATFORMCONNECTOR"]._serialized_start = 971
-    _globals["_PLATFORMCONNECTOR"]._serialized_end = 1067
+    _globals["_PLATFORMCONNECTOR"]._serialized_start = 1007
+    _globals["_PLATFORMCONNECTOR"]._serialized_end = 1103
 # @@protoc_insertion_point(module_scope)

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/protos/health_event_pb2.pyi
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/protos/health_event_pb2.pyi
@@ -16,17 +16,21 @@ class RecommendedAction(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
     NONE: _ClassVar[RecommendedAction]
     COMPONENT_RESET: _ClassVar[RecommendedAction]
     CONTACT_SUPPORT: _ClassVar[RecommendedAction]
+    RUN_FIELDDIAG: _ClassVar[RecommendedAction]
     RESTART_VM: _ClassVar[RecommendedAction]
     RESTART_BM: _ClassVar[RecommendedAction]
     REPLACE_VM: _ClassVar[RecommendedAction]
+    RUN_DCGMEUD: _ClassVar[RecommendedAction]
     UNKNOWN: _ClassVar[RecommendedAction]
 
 NONE: RecommendedAction
 COMPONENT_RESET: RecommendedAction
 CONTACT_SUPPORT: RecommendedAction
+RUN_FIELDDIAG: RecommendedAction
 RESTART_VM: RecommendedAction
 RESTART_BM: RecommendedAction
 REPLACE_VM: RecommendedAction
+RUN_DCGMEUD: RecommendedAction
 UNKNOWN: RecommendedAction
 
 class HealthEvents(_message.Message):

--- a/health-monitors/syslog-health-monitor/pkg/xid/parser/csv.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/parser/csv.go
@@ -161,6 +161,7 @@ func (p *CSVParser) parseStandardXID(message string) (*Response, error) {
 			}
 		}
 	}
+
 	xidDetails := XIDDetails{
 		DecodedXIDStr: fmt.Sprintf("%d", xidCode),
 		Driver:        "",

--- a/health-monitors/syslog-health-monitor/pkg/xid/parser/csv.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/parser/csv.go
@@ -149,6 +149,18 @@ func (p *CSVParser) parseStandardXID(message string) (*Response, error) {
 
 	recommendedAction := p.getRecommendedActionForXid(xidCode, message)
 
+	metadata := make(map[string]string)
+
+	if xidCode == 13 {
+		gpc, tpc, sm := fetchXID13MetadataFromMessage(message)
+		if gpc != "" && tpc != "" && sm != "" {
+			metadata = map[string]string{
+				"GPC": gpc,
+				"TPC": tpc,
+				"SM":  sm,
+			}
+		}
+	}
 	xidDetails := XIDDetails{
 		DecodedXIDStr: fmt.Sprintf("%d", xidCode),
 		Driver:        "",
@@ -157,6 +169,7 @@ func (p *CSVParser) parseStandardXID(message string) (*Response, error) {
 		Number:        xidCode,
 		PCIE:          pciAddr,
 		Resolution:    recommendedAction.String(),
+		Metadata:      metadata,
 	}
 
 	return &Response{
@@ -255,4 +268,15 @@ func (p *CSVParser) doesXIDIntrInfoMatchRule(intrinfoBinaryPattern string, intrI
 	}
 
 	return true
+}
+
+func fetchXID13MetadataFromMessage(message string) (string, string, string) {
+	re := regexp.MustCompile(`\(GPC\s+(\d+),\s*TPC\s+(\d+),\s*SM\s+(\d+)\)`)
+	matches := re.FindStringSubmatch(message)
+
+	if len(matches) != 4 {
+		return "", "", ""
+	}
+
+	return matches[1], matches[2], matches[3]
 }

--- a/health-monitors/syslog-health-monitor/pkg/xid/parser/csv_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/parser/csv_test.go
@@ -170,6 +170,7 @@ func TestCSVParser_Parse(t *testing.T) {
 			expectedAction:    pb.RecommendedAction_COMPONENT_RESET,
 			expectedMnemonic:  "XID 154",
 			expectedErrorCode: "154",
+			expectedMetadata:  map[string]string{},
 		},
 	}
 

--- a/health-monitors/syslog-health-monitor/pkg/xid/parser/csv_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/parser/csv_test.go
@@ -60,6 +60,17 @@ func TestCSVParser_Parse(t *testing.T) {
 			expectedErrorCode: "149.NETIR_LINK_EVT",
 		},
 		{
+			name:              "Parse metadata from XID-13",
+			message:           "NVRM: Xid (PCI:0000:b5:00): 13, pid='<unknown>', name=<unknown>, Graphics SM Warp Exception on (GPC 1, TPC 3, SM 0): Out Of Range Address",
+			expectedSuccess:   true,
+			expectedXIDCode:   13,
+			expectedPCIAddr:   "0000:b5:00",
+			expectedAction:    pb.RecommendedAction_RESTART_VM,
+			expectedMnemonic:  "XID 13",
+			expectedErrorCode: "13",
+			expectedMetadata:  map[string]string{"GPC": "1", "TPC": "3", "SM": "0"},
+		},
+		{
 			name:              "Complex XID format with all fields",
 			message:           "NVRM: Xid (PCI:0000:66:00): 32, pid=2280636, name=train.3, Channel ID 0000000d intr0 00040000",
 			expectedSuccess:   true,
@@ -68,6 +79,7 @@ func TestCSVParser_Parse(t *testing.T) {
 			expectedAction:    pb.RecommendedAction_NONE,
 			expectedMnemonic:  "XID 32",
 			expectedErrorCode: "32",
+			expectedMetadata:  map[string]string{},
 		},
 		{
 			name:              "Minimal XID format",
@@ -78,6 +90,7 @@ func TestCSVParser_Parse(t *testing.T) {
 			expectedAction:    pb.RecommendedAction_COMPONENT_RESET,
 			expectedMnemonic:  "XID 46",
 			expectedErrorCode: "46",
+			expectedMetadata:  map[string]string{},
 		},
 		{
 			name:              "Different PCI address format",
@@ -88,6 +101,7 @@ func TestCSVParser_Parse(t *testing.T) {
 			expectedAction:    pb.RecommendedAction_NONE,
 			expectedMnemonic:  "XID 69",
 			expectedErrorCode: "69",
+			expectedMetadata:  map[string]string{},
 		},
 		{
 			name:              "Different XID code",
@@ -98,6 +112,7 @@ func TestCSVParser_Parse(t *testing.T) {
 			expectedAction:    pb.RecommendedAction_NONE,
 			expectedMnemonic:  "XID 8",
 			expectedErrorCode: "8",
+			expectedMetadata:  map[string]string{},
 		},
 		{
 			name:              "Unknown XID defaults to CONTACT_SUPPORT",
@@ -108,6 +123,7 @@ func TestCSVParser_Parse(t *testing.T) {
 			expectedAction:    pb.RecommendedAction_CONTACT_SUPPORT,
 			expectedMnemonic:  "XID 999",
 			expectedErrorCode: "999",
+			expectedMetadata:  map[string]string{},
 		},
 		{
 			name:            "Non-XID NVRM message",
@@ -164,6 +180,7 @@ func TestCSVParser_Parse(t *testing.T) {
 			assert.Equal(t, tc.expectedMnemonic, result.Result.Mnemonic, "Mnemonic should match")
 			assert.Equal(t, tc.expectedErrorCode, result.Result.DecodedXIDStr, "Decoded XID string should match")
 			assert.Equal(t, tc.expectedErrorCode, result.Result.Name, "Name should match")
+			assert.Equal(t, tc.expectedMetadata, result.Result.Metadata, "Metadata should match")
 
 			if tc.expectedXIDCode != 999 {
 				assert.NotEqual(t, pb.RecommendedAction_CONTACT_SUPPORT.String(), result.Result.Resolution,

--- a/health-monitors/syslog-health-monitor/pkg/xid/parser/csv_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/parser/csv_test.go
@@ -71,6 +71,17 @@ func TestCSVParser_Parse(t *testing.T) {
 			expectedMetadata:  map[string]string{"GPC": "1", "TPC": "3", "SM": "0"},
 		},
 		{
+			name:              "XID 13 with no GPC, TPC, or SM values",
+			message:           "NVRM: Xid (PCI:0000:b5:00): 13, pid='<unknown>', name=<unknown>, Graphics Exception: ESR 0x50df30=0x107000e 0x50df34=0x20 0x50df28=0xf81eb60 0x50df2c=0x1174",
+			expectedSuccess:   true,
+			expectedXIDCode:   13,
+			expectedPCIAddr:   "0000:b5:00",
+			expectedAction:    pb.RecommendedAction_RESTART_VM,
+			expectedMnemonic:  "XID 13",
+			expectedErrorCode: "13",
+			expectedMetadata:  map[string]string{},
+		},
+		{
 			name:              "Complex XID format with all fields",
 			message:           "NVRM: Xid (PCI:0000:66:00): 32, pid=2280636, name=train.3, Channel ID 0000000d intr0 00040000",
 			expectedSuccess:   true,

--- a/health-monitors/syslog-health-monitor/pkg/xid/parser/csv_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/parser/csv_test.go
@@ -47,6 +47,7 @@ func TestCSVParser_Parse(t *testing.T) {
 		expectedAction    pb.RecommendedAction
 		expectedMnemonic  string
 		expectedErrorCode string
+		expectedMetadata  map[string]string
 	}{
 		{
 			name:              "NL5 XID",

--- a/health-monitors/syslog-health-monitor/pkg/xid/parser/parser.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/parser/parser.go
@@ -34,14 +34,15 @@ type Response struct {
 
 // XIDDetails contains the parsed XID information
 type XIDDetails struct {
-	Context             string `json:"context"`
-	DecodedXIDStr       string `json:"decoded_xid_string"`
-	Driver              string `json:"driver"`
-	InvestigatoryAction string `json:"investigatory_action"`
-	Machine             string `json:"machine"`
-	Mnemonic            string `json:"mnemonic"`
-	Name                string `json:"name"`
-	Number              int    `json:"number"`
-	PCIE                string `json:"pcie_bdf"`
-	Resolution          string `json:"resolution"`
+	Context             string            `json:"context"`
+	DecodedXIDStr       string            `json:"decoded_xid_string"`
+	Driver              string            `json:"driver"`
+	InvestigatoryAction string            `json:"investigatory_action"`
+	Machine             string            `json:"machine"`
+	Mnemonic            string            `json:"mnemonic"`
+	Name                string            `json:"name"`
+	Number              int               `json:"number"`
+	PCIE                string            `json:"pcie_bdf"`
+	Resolution          string            `json:"resolution"`
+	Metadata            map[string]string `json:"metadata"`
 }

--- a/health-monitors/syslog-health-monitor/pkg/xid/xid_handler.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/xid_handler.go
@@ -145,6 +145,24 @@ func (xidHandler *XIDHandler) createHealthEventFromResponse(
 		})
 	}
 
+	if xidResp.Result.Metadata != nil {
+		if gpc, ok := xidResp.Result.Metadata["GPC"]; ok {
+			entities = append(entities, &pb.Entity{
+				EntityType: "GPC", EntityValue: gpc,
+			})
+		}
+		if tpc, ok := xidResp.Result.Metadata["TPC"]; ok {
+			entities = append(entities, &pb.Entity{
+				EntityType: "TPC", EntityValue: tpc,
+			})
+		}
+		if sm, ok := xidResp.Result.Metadata["SM"]; ok {
+			entities = append(entities, &pb.Entity{
+				EntityType: "SM", EntityValue: sm,
+			})
+		}
+	}
+
 	metadata := make(map[string]string)
 	if chassisSerial := xidHandler.metadataReader.GetChassisSerial(); chassisSerial != nil {
 		metadata["chassis_serial"] = *chassisSerial

--- a/health-monitors/syslog-health-monitor/pkg/xid/xid_handler.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/xid_handler.go
@@ -151,11 +151,13 @@ func (xidHandler *XIDHandler) createHealthEventFromResponse(
 				EntityType: "GPC", EntityValue: gpc,
 			})
 		}
+
 		if tpc, ok := xidResp.Result.Metadata["TPC"]; ok {
 			entities = append(entities, &pb.Entity{
 				EntityType: "TPC", EntityValue: tpc,
 			})
 		}
+
 		if sm, ok := xidResp.Result.Metadata["SM"]; ok {
 			entities = append(entities, &pb.Entity{
 				EntityType: "SM", EntityValue: sm,

--- a/tests/data/health-events-analyzer-config.yaml
+++ b/tests/data/health-events-analyzer-config.yaml
@@ -38,8 +38,10 @@ data:
 
     [[rules]]
     name = "RepeatedXidErrorOnSameGPU"
-    description = "Detect occurrence of fatal XIDs 2 times within 5 minutes (E2E test window) where the burst window is 10 seconds and sticky XIDs window is 20seconds"
+    description = "Detect occurrence of fatal XIDs 2 times within 2 minutes where the burst window is 10 seconds and sticky XIDs window is 20seconds"
     recommended_action = "CONTACT_SUPPORT"
+    recommended_action_mappings = { "31" = { recommended_action = "RUN_DCGMEUD", message = "if pass: RUN_FIELDDIAGS" } }
+    
     stage = [
       '''
       {
@@ -47,7 +49,7 @@ data:
           "$expr": {
             "$gte": [
               "$healthevent.generatedtimestamp.seconds",
-              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 300]}
+              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 120]}
             ]
           }
         }
@@ -79,7 +81,7 @@ data:
                         "input": {
                           "$filter": {
                             "input": {"$ifNull": ["this.healthevent.entitiesimpacted", []]},
-                            "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                            "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
                           }
                         },
                         "in": "$$this.entityvalue"
@@ -257,7 +259,7 @@ data:
 
     [[rules]]
     name = "RepeatedXidErrorOnDifferentGPU"
-    description = "Detect occurrence of XIDs on 3+ different GPUs within 5 minutes"
+    description = "Detect occurrence of XIDs on 3+ different GPUs within 1 minutes"
     message = "run CHECK_APP_CUDA"
     recommended_action = "NONE"
     stage = [
@@ -267,7 +269,7 @@ data:
           "$expr": {
             "$gte": [
               "$healthevent.generatedtimestamp.seconds",
-              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 300]}
+              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 60]}
             ]
           }
         }
@@ -363,8 +365,8 @@ data:
                       "$map": {
                         "input": {
                           "$filter": {
-                            "input": "$healthevent.entitiesimpacted",
-                            "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                            "input": {"$ifNull": ["$healthevent.entitiesimpacted", []]},
+                            "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
                           }
                         },
                         "in": "$$this.entityvalue"
@@ -375,7 +377,7 @@ data:
                         "input": {
                           "$filter": {
                             "input": "this.healthevent.entitiesimpacted",
-                            "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                            "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
                           }
                         },
                         "in": "$$this.entityvalue"
@@ -514,7 +516,7 @@ data:
                           "$arrayElemAt": [
                             {
                               "$map": {
-                                "input": {"$filter": {"input": "$healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "GPC"]}}},
+                                "input": {"$filter": {"input": {"$ifNull": ["$healthevent.entitiesimpacted", []]}, "cond": {"$eq": ["$$this.entitytype", "GPC"]}}},
                                 "in": "$$this.entityvalue"
                               }
                             },
@@ -540,7 +542,7 @@ data:
                           "$arrayElemAt": [
                             {
                               "$map": {
-                                "input": {"$filter": {"input": "$healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "TPC"]}}},
+                                "input": {"$filter": {"input": {"$ifNull": ["$healthevent.entitiesimpacted", []]}, "cond": {"$eq": ["$$this.entitytype", "TPC"]}}},
                                 "in": "$$this.entityvalue"
                               }
                             },
@@ -610,7 +612,7 @@ data:
     
     [[rules]]
     name = "XIDErrorOnDifferentGPCAndTPC"
-    description = "Detect if XID error occurred on 3+ different GPC and TPC combinations within 2 minutes"
+    description = "Detect if XID error occurred on 3+ different GPC and TPC combinations within 1.5 minutes"
     message = "run CHECK_APP_CUDA"
     recommended_action = "NONE"
     stage = [
@@ -620,7 +622,7 @@ data:
           "$expr": {
             "$gte": [
               "$healthevent.generatedtimestamp.seconds",
-              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 120]}
+              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 90]}
             ]
           }
         }
@@ -641,8 +643,8 @@ data:
                       "$map": {
                         "input": {
                           "$filter": {
-                            "input": "$healthevent.entitiesimpacted",
-                            "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                            "input": {"$ifNull": ["$healthevent.entitiesimpacted", []]},
+                            "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
                           }
                         },
                         "in": "$$this.entityvalue"
@@ -653,7 +655,7 @@ data:
                         "input": {
                           "$filter": {
                             "input": "this.healthevent.entitiesimpacted",
-                            "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                            "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
                           }
                         },
                         "in": "$$this.entityvalue"
@@ -678,7 +680,7 @@ data:
                   "$arrayElemAt": [
                     {
                       "$map": {
-                        "input": {"$filter": {"input": "$healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "GPC"]}}},
+                        "input": {"$filter": {"input": {"$ifNull": ["$healthevent.entitiesimpacted", []]}, "cond": {"$eq": ["$$this.entitytype", "GPC"]}}},
                         "in": "$$this.entityvalue"
                       }
                     },
@@ -689,7 +691,7 @@ data:
                   "$arrayElemAt": [
                     {
                       "$map": {
-                        "input": {"$filter": {"input": "$healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "TPC"]}}},
+                        "input": {"$filter": {"input": {"$ifNull": ["$healthevent.entitiesimpacted", []]}, "cond": {"$eq": ["$$this.entitytype", "TPC"]}}},
                         "in": "$$this.entityvalue"
                       }
                     },
@@ -730,7 +732,7 @@ data:
     
     [[rules]]
     name = "XIDErrorSoloNoBurst"
-    description = "Detect if XID error occurred only once in the last burst within 2 minutes time window"
+    description = "Detect if XID error occurred only once in the last burst within 1 minutes time window"
     message = "run CHECK_APP_CUDA"
     recommended_action = "NONE"
     stage = [
@@ -740,7 +742,7 @@ data:
           "$expr": {
             "$gte": [
               "$healthevent.generatedtimestamp.seconds",
-              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 120]}
+              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 60]}
             ]
           }
         }
@@ -760,8 +762,8 @@ data:
                       "$map": {
                         "input": {
                           "$filter": {
-                            "input": "$healthevent.entitiesimpacted",
-                            "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                            "input": {"$ifNull": ["$healthevent.entitiesimpacted", []]},
+                            "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
                           }
                         },
                         "in": "$$this.entityvalue"
@@ -772,7 +774,7 @@ data:
                         "input": {
                           "$filter": {
                             "input": "this.healthevent.entitiesimpacted",
-                            "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                            "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
                           }
                         },
                         "in": "$$this.entityvalue"

--- a/tests/data/health-events-analyzer-config.yaml
+++ b/tests/data/health-events-analyzer-config.yaml
@@ -280,7 +280,7 @@ data:
     name = "RepeatedXID31OnSameGPU"
     description = "Detect if XID 31 occurred 2 or more times on the same GPU within 2 minutes where the burst window is 20 seconds and sticky XIDs window is 30 seconds"
     recommended_action = "RUN_DCGMEUD"
-    message = "if DCGM EUD tests passes, run field diagnostics"
+    message = "if DCGM EUD tests pass, run field diagnostics"
     stage = [
       '''
       {
@@ -520,7 +520,7 @@ data:
 
     [[rules]]
     name = "RepeatedXID31OnDifferentGPU"
-    description = "Detect if XID 31 occurred 2 or more times on different GPUs within 1 minutes"
+    description = "Detect if XID 31 occurred 2 or more times on different GPUs within 1 minute"
     message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support"
     recommended_action = "NONE"
     stage = [
@@ -609,7 +609,7 @@ data:
     [[rules]]
     name = "RepeatedXID13OnSameGPCAndTPC"
     description = "Detect if XID 13 occurred 2 or more times on the same GPC and TPC within 3 minutes"
-    message = "if DCGM EUD tests passes, run field diagnostics" 
+    message = "if DCGM EUD tests pass, run field diagnostics" 
     recommended_action = "RUN_DCGMEUD"
     stage = [
       '''
@@ -1044,7 +1044,7 @@ data:
     
     [[rules]]
     name = "XIDErrorSoloNoBurst"
-    description = "Detect if XID error occurred only once in the last burst within 1 minutes time window"
+    description = "Detect if XID error occurred only once in the last burst within 1 minute time window"
     message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support"
     recommended_action = "NONE"
     stage = [

--- a/tests/data/health-events-analyzer-config.yaml
+++ b/tests/data/health-events-analyzer-config.yaml
@@ -254,12 +254,30 @@ data:
         }
       }
       ''',
-      '{"$match": {"count": {"$gte": 2}}}'
+      '''
+      {
+      "$match": {
+          "$expr": {
+          "$gte": [
+              "$count",
+              {
+              "$switch": {
+                  "branches": [
+                  { "case": { "$eq": ["this.healthevent.errorcode.0", "31"] }, "then": 2 }
+                  ],
+                  "default": 2
+              }
+              }
+          ]
+          }
+      }
+      }
+      '''
     ]
 
     [[rules]]
     name = "RepeatedXidErrorOnDifferentGPU"
-    description = "Detect occurrence of XIDs on 3+ different GPUs within 1 minutes"
+    description = "Detect occurrence of XIDs on 2 or more different GPUs within 1 minutes"
     message = "run CHECK_APP_CUDA"
     recommended_action = "NONE"
     stage = [
@@ -326,7 +344,7 @@ data:
       {
         "$match": {
           "$expr": {
-            "$gte": [{"$size": "$uniqueGPUs"}, 3]
+            "$gte": [{"$size": "$uniqueGPUs"}, 2]
           }
         }
       }
@@ -335,7 +353,7 @@ data:
     
     [[rules]]
     name = "XIDErrorOnSameGPCAndTPC"
-    description = "Detect if XID error occurred 3 times on the same GPC and TPC within 2 minutes"
+    description = "Detect if XID error occurred 2 or more times on the same GPC and TPC within 2 minutes"
     message = "if pass run RUN_FIELDDIAGS" 
     recommended_action = "RUN_DCGMEUD"
     stage = [
@@ -548,8 +566,28 @@ data:
                 {
                   "$and": [
                     {"$eq": [{"$arrayElemAt": ["$healthevent.errorcode", 0]}, "this.healthevent.errorcode.0"]},
-                    {"$eq": ["$gpcValue", "this.gpcValue"]},
-                    {"$eq": ["$tpcValue", "this.tpcValue"]}
+                    {"$eq": ["$gpcValue", {
+                      "$arrayElemAt": [
+                        {
+                          "$map": {
+                            "input": {"$filter": {"input": "this.healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "GPC"]}}},
+                            "in": "$$this.entityvalue"
+                          }
+                        },
+                        0
+                      ]
+                    }]},
+                    {"$eq": ["$tpcValue", {
+                      "$arrayElemAt": [
+                        {
+                          "$map": {
+                            "input": {"$filter": {"input": "this.healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "TPC"]}}},
+                            "in": "$$this.entityvalue"
+                          }
+                        },
+                        0
+                      ]
+                    }]}
                   ]
                 },
                 1,
@@ -595,12 +633,12 @@ data:
         }
       }
       ''',
-      '{"$match": {"count": {"$gte": 3}}}'
+      '{"$match": {"count": {"$gte": 2}}}'
     ]
     
     [[rules]]
     name = "XIDErrorOnDifferentGPCAndTPC"
-    description = "Detect if XID error occurred on 3+ different GPC and TPC combinations within 1.5 minutes"
+    description = "Detect if XID error occurred on 2 or more different GPC and TPC combinations within 1.5 minutes"
     message = "run CHECK_APP_CUDA"
     recommended_action = "NONE"
     stage = [
@@ -718,7 +756,7 @@ data:
       {
         "$match": {
           "$expr": {
-            "$gte": [{"$size": "$uniqueGPCAndTPCCombinations"}, 3]
+            "$gte": [{"$size": "$uniqueGPCAndTPCCombinations"}, 2]
           }
         }
       }

--- a/tests/data/health-events-analyzer-config.yaml
+++ b/tests/data/health-events-analyzer-config.yaml
@@ -37,7 +37,7 @@ data:
 
     [[rules]]
     name = "RepeatedXIDErrorOnSameGPU"
-    description = "Detect occurrence of fatal XIDs 2 times within 3 minutes where the burst window is 10 seconds and sticky XIDs window is 20seconds"
+    description = "Detect occurrence of fatal XIDs 2 times within 2 minutes where the burst window is 20 seconds and sticky XIDs window is 30seconds"
     recommended_action = "CONTACT_SUPPORT"
     stage = [
       '''
@@ -278,7 +278,7 @@ data:
 
     [[rules]]
     name = "RepeatedXID31OnSameGPU"
-    description = "Detect if XID 31 occurred 2 or more times on the same GPU within 2 minutes where the burst window is 10 seconds and sticky XIDs window is 20seconds"
+    description = "Detect if XID 31 occurred 2 or more times on the same GPU within 2 minutes where the burst window is 20 seconds and sticky XIDs window is 30seconds"
     recommended_action = "RUN_DCGMEUD"
     message = "if pass: RUN_FIELDDIAGS"
     stage = [

--- a/tests/data/health-events-analyzer-config.yaml
+++ b/tests/data/health-events-analyzer-config.yaml
@@ -37,7 +37,7 @@ data:
     ]
 
     [[rules]]
-    name = "RepeatedXidError"
+    name = "RepeatedXidErrorOnSameGPU"
     description = "Detect occurrence of fatal XIDs 2 times within 5 minutes (E2E test window) where the burst window is 10 seconds and sticky XIDs window is 20seconds"
     recommended_action = "CONTACT_SUPPORT"
     stage = [
@@ -68,7 +68,7 @@ data:
                         "input": {
                           "$filter": {
                             "input": {"$ifNull": ["$healthevent.entitiesimpacted", []]},
-                            "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                            "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
                           }
                         },
                         "in": "$$this.entityvalue"
@@ -254,11 +254,88 @@ data:
       ''',
       '{"$match": {"count": {"$gte": 2}}}'
     ]
+
+    [[rules]]
+    name = "RepeatedXidErrorOnDifferentGPU"
+    description = "Detect occurrence of XIDs on 3+ different GPUs within 5 minutes"
+    message = "run CHECK_APP_CUDA"
+    recommended_action = "NONE"
+    stage = [
+      '''
+      {
+        "$match": {
+          "$expr": {
+            "$gte": [
+              "$healthevent.generatedtimestamp.seconds",
+              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 300]}
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$match": {
+          "healthevent.ishealthy": false,
+          "healthevent.nodename": "this.healthevent.nodename",
+          "healthevent.errorcode": "this.healthevent.errorcode.0"
+        }
+      }
+      ''',
+      '''
+      {
+        "$addFields": {
+          "gpuUuid": {
+            "$let": {
+              "vars": {
+                "uuid": {
+                  "$arrayElemAt": [
+                    {
+                      "$map": {
+                        "input": {"$filter": {"input": {"$ifNull": ["$healthevent.entitiesimpacted", []]}, "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}}},
+                        "in": "$$this.entityvalue"
+                      }
+                    },
+                    0
+                  ]
+                }
+              },
+              "in": {
+                "$cond": [
+                  {"$ne": ["$$uuid", null]},
+                  "$$uuid",
+                  null
+                ]
+              }
+            }
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$group": {
+          "_id": null,
+          "uniqueGPUs": {"$addToSet": "$gpuUuid"}
+        }
+      }
+      ''',
+      '''
+      {
+        "$match": {
+          "$expr": {
+            "$gte": [{"$size": "$uniqueGPUs"}, 3]
+          }
+        }
+      }
+      '''
+    ]
     
     [[rules]]
     name = "XIDErrorOnSameGPCAndTPC"
     description = "Detect if XID error occurred 3 times on the same GPC and TPC within 2 minutes"
-    recommended_action = "RUN_FIELDDIAG"
+    message = "if pass run RUN_FIELDDIAGS" 
+    recommended_action = "RUN_DCGMEUD"
     stage = [
       '''
       {
@@ -534,7 +611,8 @@ data:
     [[rules]]
     name = "XIDErrorOnDifferentGPCAndTPC"
     description = "Detect if XID error occurred on 3+ different GPC and TPC combinations within 2 minutes"
-    recommended_action = "CHECK_APP_CUDA"
+    message = "run CHECK_APP_CUDA"
+    recommended_action = "NONE"
     stage = [
       '''
       {
@@ -653,7 +731,8 @@ data:
     [[rules]]
     name = "XIDErrorSoloNoBurst"
     description = "Detect if XID error occurred only once in the last burst within 2 minutes time window"
-    recommended_action = "CHECK_APP_CUDA"
+    message = "run CHECK_APP_CUDA"
+    recommended_action = "NONE"
     stage = [
       '''
       {

--- a/tests/data/health-events-analyzer-config.yaml
+++ b/tests/data/health-events-analyzer-config.yaml
@@ -37,7 +37,7 @@ data:
 
     [[rules]]
     name = "RepeatedXIDErrorOnSameGPU"
-    description = "Detect occurrence of fatal XIDs 2 times within 2 minutes where the burst window is 20 seconds and sticky XIDs window is 30seconds"
+    description = "Detect occurrence of fatal XIDs 2 times within 2 minutes where the burst window is 20 seconds and sticky XIDs window is 30 seconds"
     recommended_action = "CONTACT_SUPPORT"
     stage = [
       '''
@@ -278,9 +278,9 @@ data:
 
     [[rules]]
     name = "RepeatedXID31OnSameGPU"
-    description = "Detect if XID 31 occurred 2 or more times on the same GPU within 2 minutes where the burst window is 20 seconds and sticky XIDs window is 30seconds"
+    description = "Detect if XID 31 occurred 2 or more times on the same GPU within 2 minutes where the burst window is 20 seconds and sticky XIDs window is 30 seconds"
     recommended_action = "RUN_DCGMEUD"
-    message = "if pass: RUN_FIELDDIAGS"
+    message = "if DCGM EUD tests passes, run field diagnostics"
     stage = [
       '''
       {
@@ -521,7 +521,7 @@ data:
     [[rules]]
     name = "RepeatedXID31OnDifferentGPU"
     description = "Detect if XID 31 occurred 2 or more times on different GPUs within 1 minutes"
-    message = "run CHECK_APP_CUDA"
+    message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, report if driver issue"
     recommended_action = "NONE"
     stage = [
       '''
@@ -609,7 +609,7 @@ data:
     [[rules]]
     name = "RepeatedXID13OnSameGPCAndTPC"
     description = "Detect if XID 13 occurred 2 or more times on the same GPC and TPC within 3 minutes"
-    message = "if pass run RUN_FIELDDIAGS" 
+    message = "if DCGM EUD tests passes, run field diagnostics" 
     recommended_action = "RUN_DCGMEUD"
     stage = [
       '''
@@ -906,7 +906,7 @@ data:
     [[rules]]
     name = "RepeatedXID13OnDifferentGPCAndTPC"
     description = "Detect if XID 13 occurred 2 or more times on different GPC and TPC combinations within 1.5 minutes"
-    message = "run CHECK_APP_CUDA"
+    message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, report if driver issue"
     recommended_action = "NONE"
     stage = [
       '''
@@ -1045,7 +1045,7 @@ data:
     [[rules]]
     name = "XIDErrorSoloNoBurst"
     description = "Detect if XID error occurred only once in the last burst within 1 minutes time window"
-    message = "run CHECK_APP_CUDA"
+    message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, report if driver issue"
     recommended_action = "NONE"
     stage = [
       '''

--- a/tests/data/health-events-analyzer-config.yaml
+++ b/tests/data/health-events-analyzer-config.yaml
@@ -521,7 +521,7 @@ data:
     [[rules]]
     name = "RepeatedXID31OnDifferentGPU"
     description = "Detect if XID 31 occurred 2 or more times on different GPUs within 1 minutes"
-    message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, report if driver issue"
+    message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support"
     recommended_action = "NONE"
     stage = [
       '''
@@ -906,7 +906,7 @@ data:
     [[rules]]
     name = "RepeatedXID13OnDifferentGPCAndTPC"
     description = "Detect if XID 13 occurred 2 or more times on different GPC and TPC combinations within 1.5 minutes"
-    message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, report if driver issue"
+    message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support"
     recommended_action = "NONE"
     stage = [
       '''
@@ -1045,7 +1045,7 @@ data:
     [[rules]]
     name = "XIDErrorSoloNoBurst"
     description = "Detect if XID error occurred only once in the last burst within 1 minutes time window"
-    message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, report if driver issue"
+    message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support"
     recommended_action = "NONE"
     stage = [
       '''

--- a/tests/data/health-events-analyzer-config.yaml
+++ b/tests/data/health-events-analyzer-config.yaml
@@ -501,6 +501,44 @@ data:
       ''',
       '''
       {
+        "$addFields": {
+          "gpcValue": {
+            "$arrayElemAt": [
+              {
+                "$map": {
+                  "input": {"$filter": {"input": {"$ifNull": ["$healthevent.entitiesimpacted", []]}, "cond": {"$eq": ["$$this.entitytype", "GPC"]}}},
+                  "in": "$$this.entityvalue"
+                }
+              },
+              0
+            ]
+          },
+          "tpcValue": {
+            "$arrayElemAt": [
+              {
+                "$map": {
+                  "input": {"$filter": {"input": {"$ifNull": ["$healthevent.entitiesimpacted", []]}, "cond": {"$eq": ["$$this.entitytype", "TPC"]}}},
+                  "in": "$$this.entityvalue"
+                }
+              },
+              0
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$match": {
+          "$and": [
+            {"gpcValue": {"$ne": null}},
+            {"tpcValue": {"$ne": null}}
+          ]
+        }
+      }
+      ''',
+      '''
+      {
         "$group": {
           "_id": {"burstId": "$burstId"},
           "uniqueXidsInBurst": {"$addToSet": {"$arrayElemAt": ["$healthevent.errorcode", 0]}},
@@ -510,58 +548,8 @@ data:
                 {
                   "$and": [
                     {"$eq": [{"$arrayElemAt": ["$healthevent.errorcode", 0]}, "this.healthevent.errorcode.0"]},
-                    {
-                      "$eq": [
-                        {
-                          "$arrayElemAt": [
-                            {
-                              "$map": {
-                                "input": {"$filter": {"input": {"$ifNull": ["$healthevent.entitiesimpacted", []]}, "cond": {"$eq": ["$$this.entitytype", "GPC"]}}},
-                                "in": "$$this.entityvalue"
-                              }
-                            },
-                            0
-                          ]
-                        },
-                        {
-                          "$arrayElemAt": [
-                            {
-                              "$map": {
-                                "input": {"$filter": {"input": "this.healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "GPC"]}}},
-                                "in": "$$this.entityvalue"
-                              }
-                            },
-                            0
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "$eq": [
-                        {
-                          "$arrayElemAt": [
-                            {
-                              "$map": {
-                                "input": {"$filter": {"input": {"$ifNull": ["$healthevent.entitiesimpacted", []]}, "cond": {"$eq": ["$$this.entitytype", "TPC"]}}},
-                                "in": "$$this.entityvalue"
-                              }
-                            },
-                            0
-                          ]
-                        },
-                        {
-                          "$arrayElemAt": [
-                            {
-                              "$map": {
-                                "input": {"$filter": {"input": "this.healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "TPC"]}}},
-                                "in": "$$this.entityvalue"
-                              }
-                            },
-                            0
-                          ]
-                        }
-                      ]
-                    }
+                    {"$eq": ["$gpcValue", "this.gpcValue"]},
+                    {"$eq": ["$tpcValue", "this.tpcValue"]}
                   ]
                 },
                 1,
@@ -708,6 +696,13 @@ data:
               }
             }
           }
+        }
+      }
+      ''',
+      '''
+      {
+        "$match": {
+          "gpcTpcCombination": {"$ne": null}
         }
       }
       ''',

--- a/tests/data/health-events-analyzer-config.yaml
+++ b/tests/data/health-events-analyzer-config.yaml
@@ -38,7 +38,7 @@ data:
 
     [[rules]]
     name = "RepeatedXidErrorOnSameGPU"
-    description = "Detect occurrence of fatal XIDs 2 times within 2 minutes where the burst window is 10 seconds and sticky XIDs window is 20seconds"
+    description = "Detect occurrence of fatal XIDs 2 times within 3 minutes where the burst window is 10 seconds and sticky XIDs window is 20seconds"
     recommended_action = "CONTACT_SUPPORT"
     recommended_action_mappings = { "31" = { recommended_action = "RUN_DCGMEUD", message = "if pass: RUN_FIELDDIAGS" } }
     
@@ -155,7 +155,7 @@ data:
                             ["74", "79", "95", "109", "119"]
                           ]
                         },
-                        {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 20]}
+                        {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 30]}
                       ]
                     }
                   }
@@ -188,7 +188,7 @@ data:
                       "then": 0,
                       "else": {
                         "$cond": {
-                          "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 10]},
+                          "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 20]},
                           "then": 1,
                           "else": 0
                         }
@@ -353,7 +353,7 @@ data:
     
     [[rules]]
     name = "XIDErrorOnSameGPCAndTPC"
-    description = "Detect if XID error occurred 2 or more times on the same GPC and TPC within 2 minutes"
+    description = "Detect if XID error occurred 2 or more times on the same GPC and TPC within 3 minutes"
     message = "if pass run RUN_FIELDDIAGS" 
     recommended_action = "RUN_DCGMEUD"
     stage = [
@@ -363,7 +363,7 @@ data:
           "$expr": {
             "$gte": [
               "$healthevent.generatedtimestamp.seconds",
-              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 120]}
+              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 180]}
             ]
           }
         }
@@ -469,7 +469,7 @@ data:
                             ["74", "79", "95", "109", "119"]
                           ]
                         },
-                        {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 20]}
+                        {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 30]}
                       ]
                     }
                   }
@@ -502,7 +502,7 @@ data:
                       "then": 0,
                       "else": {
                         "$cond": {
-                          "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 4]},
+                          "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 20]},
                           "then": 1,
                           "else": 0
                         }

--- a/tests/data/health-events-analyzer-config.yaml
+++ b/tests/data/health-events-analyzer-config.yaml
@@ -9,7 +9,6 @@ data:
     name = "MultipleRemediations"
     description = "Detect if multiple remediations are performed within 1.5 minutes on a node"
     recommended_action = "CONTACT_SUPPORT"
-
     stage = [
       '''
       {
@@ -37,11 +36,9 @@ data:
     ]
 
     [[rules]]
-    name = "RepeatedXidErrorOnSameGPU"
+    name = "RepeatedXIDErrorOnSameGPU"
     description = "Detect occurrence of fatal XIDs 2 times within 3 minutes where the burst window is 10 seconds and sticky XIDs window is 20seconds"
     recommended_action = "CONTACT_SUPPORT"
-    recommended_action_mappings = { "31" = { recommended_action = "RUN_DCGMEUD", message = "if pass: RUN_FIELDDIAGS" } }
-    
     stage = [
       '''
       {
@@ -50,6 +47,18 @@ data:
             "$gte": [
               "$healthevent.generatedtimestamp.seconds",
               {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 120]}
+            ]
+          }
+        }
+      }
+      ''',
+       '''
+      {
+        "$match": {
+        "$expr": {
+            "$ne": [
+              "this.healthevent.errorcode.0",
+              "31"
             ]
           }
         }
@@ -259,15 +268,249 @@ data:
       "$match": {
           "$expr": {
           "$gte": [
-              "$count",
+              "$count", 2
+            ]
+          }
+      }
+      }
+      '''
+    ]
+
+    [[rules]]
+    name = "RepeatedXID31OnSameGPU"
+    description = "Detect if XID 31 occurred 2 or more times on the same GPU within 2 minutes where the burst window is 10 seconds and sticky XIDs window is 20seconds"
+    recommended_action = "RUN_DCGMEUD"
+    message = "if pass: RUN_FIELDDIAGS"
+    stage = [
+      '''
+      {
+        "$match": {
+          "$expr": {
+            "$gte": [
+              "$healthevent.generatedtimestamp.seconds",
+              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 120]}
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$match": {
+        "$expr": {
+            "$eq": [
+              "this.healthevent.errorcode.0",
+              "31"
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$match": {
+          "healthevent.ishealthy": false,
+          "healthevent.nodename": "this.healthevent.nodename",
+          "$expr": {
+            "$gt": [
               {
-              "$switch": {
-                  "branches": [
-                  { "case": { "$eq": ["this.healthevent.errorcode.0", "31"] }, "then": 2 }
-                  ],
-                  "default": 2
+                "$size": {
+                  "$setIntersection": [
+                    {
+                      "$map": {
+                        "input": {
+                          "$filter": {
+                            "input": {"$ifNull": ["$healthevent.entitiesimpacted", []]},
+                            "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
+                          }
+                        },
+                        "in": "$$this.entityvalue"
+                      }
+                    },
+                    {
+                      "$map": {
+                        "input": {
+                          "$filter": {
+                            "input": "this.healthevent.entitiesimpacted",
+                            "cond": {"$eq": ["$$this.entitytype", "GPU_UUID"]}
+                          }
+                        },
+                        "in": "$$this.entityvalue"
+                      }
+                    }
+                  ]
+                }
+              },
+              0
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$setWindowFields": {
+          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+          "output": {
+            "prevTimestamp": {
+              "$shift": {
+                "output": "$healthevent.generatedtimestamp.seconds",
+                "by": -1
               }
+            }
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$addFields": {
+          "isStickyXid": {
+            "$in": [
+              {"$arrayElemAt": ["$healthevent.errorcode", 0]},
+              ["74", "79", "95", "109", "119"]
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$setWindowFields": {
+          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+          "output": {
+            "allPreviousEvents": {
+              "$push": "$$ROOT",
+              "window": {"documents": ["unbounded", -1]}
+            }
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$addFields": {
+          "stickyXidWithin3Hours": {
+            "$cond": {
+              "if": "$isStickyXid",
+              "then": {
+                "$anyElementTrue": {
+                  "$map": {
+                    "input": "$allPreviousEvents",
+                    "as": "prevEvent",
+                    "in": {
+                      "$and": [
+                        {
+                          "$in": [
+                            {"$arrayElemAt": ["$$prevEvent.healthevent.errorcode", 0]},
+                            ["74", "79", "95", "109", "119"]
+                          ]
+                        },
+                        {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 30]}
+                      ]
+                    }
+                  }
+                }
+              },
+              "else": false
+            }
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$setWindowFields": {
+          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+          "output": {
+            "burstId": {
+              "$sum": {
+                "$cond": {
+                  "if": {"$eq": ["$prevTimestamp", null]},
+                  "then": 1,
+                  "else": {
+                    "$cond": {
+                      "if": {
+                        "$and": [
+                          "$isStickyXid",
+                          "$stickyXidWithin3Hours"
+                        ]
+                      },
+                      "then": 0,
+                      "else": {
+                        "$cond": {
+                          "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 20]},
+                          "then": 1,
+                          "else": 0
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "window": {"documents": ["unbounded", "current"]}
+            }
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$group": {
+          "_id": {"burstId": "$burstId"},
+          "uniqueXidsInBurst": {"$addToSet": {"$arrayElemAt": ["$healthevent.errorcode", 0]}},
+          "targetXidCount": {
+            "$sum": {
+              "$cond": [
+                {"$eq": [{"$arrayElemAt": ["$healthevent.errorcode", 0]}, "this.healthevent.errorcode.0"]},
+                1,
+                0
+              ]
+            }
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$setWindowFields": {
+          "sortBy": {"_id.burstId": 1},
+          "output": {"maxBurstId": {"$max": "$_id.burstId"}}
+        }
+      }
+      ''',
+      '''
+      {
+        "$match": {
+          "$expr": {
+            "$and": [
+              {"$in": ["this.healthevent.errorcode.0", "$uniqueXidsInBurst"]},
+              {
+                "$or": [
+                  {"$ne": ["$_id.burstId", "$maxBurstId"]},
+                  {"$eq": ["$targetXidCount", 1]}
+                ]
               }
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$group": {
+          "_id": null,
+          "count": {"$sum": 1},
+          "bursts": {"$push": {"burstId": "$_id.burstId", "uniqueXids": "$uniqueXidsInBurst"}}
+        }
+      }
+      ''',
+      '''
+      {
+      "$match": {
+          "$expr": {
+          "$gte": [
+              "$count", 2
           ]
           }
       }
@@ -276,8 +519,8 @@ data:
     ]
 
     [[rules]]
-    name = "RepeatedXidErrorOnDifferentGPU"
-    description = "Detect occurrence of XIDs on 2 or more different GPUs within 1 minutes"
+    name = "RepeatedXID31OnDifferentGPU"
+    description = "Detect if XID 31 occurred 2 or more times on different GPUs within 1 minutes"
     message = "run CHECK_APP_CUDA"
     recommended_action = "NONE"
     stage = [
@@ -288,6 +531,18 @@ data:
             "$gte": [
               "$healthevent.generatedtimestamp.seconds",
               {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 60]}
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$match": {
+        "$expr": {
+            "$eq": [
+              "this.healthevent.errorcode.0",
+              "31"
             ]
           }
         }
@@ -352,8 +607,8 @@ data:
     ]
     
     [[rules]]
-    name = "XIDErrorOnSameGPCAndTPC"
-    description = "Detect if XID error occurred 2 or more times on the same GPC and TPC within 3 minutes"
+    name = "RepeatedXID13OnSameGPCAndTPC"
+    description = "Detect if XID 13 occurred 2 or more times on the same GPC and TPC within 3 minutes"
     message = "if pass run RUN_FIELDDIAGS" 
     recommended_action = "RUN_DCGMEUD"
     stage = [
@@ -364,6 +619,18 @@ data:
             "$gte": [
               "$healthevent.generatedtimestamp.seconds",
               {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 180]}
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$match": {
+        "$expr": {
+            "$eq": [
+              "this.healthevent.errorcode.0",
+              "13"
             ]
           }
         }
@@ -637,8 +904,8 @@ data:
     ]
     
     [[rules]]
-    name = "XIDErrorOnDifferentGPCAndTPC"
-    description = "Detect if XID error occurred on 2 or more different GPC and TPC combinations within 1.5 minutes"
+    name = "RepeatedXID13OnDifferentGPCAndTPC"
+    description = "Detect if XID 13 occurred 2 or more times on different GPC and TPC combinations within 1.5 minutes"
     message = "run CHECK_APP_CUDA"
     recommended_action = "NONE"
     stage = [
@@ -649,6 +916,18 @@ data:
             "$gte": [
               "$healthevent.generatedtimestamp.seconds",
               {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 90]}
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$match": {
+        "$expr": {
+            "$eq": [
+              "this.healthevent.errorcode.0",
+              "13"
             ]
           }
         }
@@ -776,6 +1055,18 @@ data:
             "$gte": [
               "$healthevent.generatedtimestamp.seconds",
               {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 60]}
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$match": {
+          "$expr": {
+            "$in": [
+              "this.healthevent.errorcode.0",
+              ["13", "31"]
             ]
           }
         }

--- a/tests/data/health-events-analyzer-config.yaml
+++ b/tests/data/health-events-analyzer-config.yaml
@@ -254,3 +254,601 @@ data:
       ''',
       '{"$match": {"count": {"$gte": 2}}}'
     ]
+    
+    [[rules]]
+    name = "XIDErrorOnSameGPCAndTPC"
+    description = "Detect if XID error occurred 3 times on the same GPC and TPC within 2 minutes"
+    recommended_action = "RUN_FIELDDIAG"
+    stage = [
+      '''
+      {
+        "$match": {
+          "$expr": {
+            "$gte": [
+              "$healthevent.generatedtimestamp.seconds",
+              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 120]}
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$match": {
+          "healthevent.ishealthy": false,
+          "healthevent.nodename": "this.healthevent.nodename",
+          "$expr": {
+            "$gt": [
+              {
+                "$size": {
+                  "$setIntersection": [
+                    {
+                      "$map": {
+                        "input": {
+                          "$filter": {
+                            "input": "$healthevent.entitiesimpacted",
+                            "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                          }
+                        },
+                        "in": "$$this.entityvalue"
+                      }
+                    },
+                    {
+                      "$map": {
+                        "input": {
+                          "$filter": {
+                            "input": "this.healthevent.entitiesimpacted",
+                            "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                          }
+                        },
+                        "in": "$$this.entityvalue"
+                      }
+                    }
+                  ]
+                }
+              },
+              0
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$setWindowFields": {
+          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+          "output": {
+            "prevTimestamp": {
+              "$shift": {
+                "output": "$healthevent.generatedtimestamp.seconds",
+                "by": -1
+              }
+            }
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$addFields": {
+          "isStickyXid": {
+            "$in": [
+              {"$arrayElemAt": ["$healthevent.errorcode", 0]},
+              ["74", "79", "95", "109", "119"]
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$setWindowFields": {
+          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+          "output": {
+            "allPreviousEvents": {
+              "$push": "$$ROOT",
+              "window": {"documents": ["unbounded", -1]}
+            }
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$addFields": {
+          "stickyXidWithin3Hours": {
+            "$cond": {
+              "if": "$isStickyXid",
+              "then": {
+                "$anyElementTrue": {
+                  "$map": {
+                    "input": "$allPreviousEvents",
+                    "as": "prevEvent",
+                    "in": {
+                      "$and": [
+                        {
+                          "$in": [
+                            {"$arrayElemAt": ["$$prevEvent.healthevent.errorcode", 0]},
+                            ["74", "79", "95", "109", "119"]
+                          ]
+                        },
+                        {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 20]}
+                      ]
+                    }
+                  }
+                }
+              },
+              "else": false
+            }
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$setWindowFields": {
+          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+          "output": {
+            "burstId": {
+              "$sum": {
+                "$cond": {
+                  "if": {"$eq": ["$prevTimestamp", null]},
+                  "then": 1,
+                  "else": {
+                    "$cond": {
+                      "if": {
+                        "$and": [
+                          "$isStickyXid",
+                          "$stickyXidWithin3Hours"
+                        ]
+                      },
+                      "then": 0,
+                      "else": {
+                        "$cond": {
+                          "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 4]},
+                          "then": 1,
+                          "else": 0
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "window": {"documents": ["unbounded", "current"]}
+            }
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$group": {
+          "_id": {"burstId": "$burstId"},
+          "uniqueXidsInBurst": {"$addToSet": {"$arrayElemAt": ["$healthevent.errorcode", 0]}},
+          "targetXidCount": {
+            "$sum": {
+              "$cond": [
+                {
+                  "$and": [
+                    {"$eq": [{"$arrayElemAt": ["$healthevent.errorcode", 0]}, "this.healthevent.errorcode.0"]},
+                    {
+                      "$eq": [
+                        {
+                          "$arrayElemAt": [
+                            {
+                              "$map": {
+                                "input": {"$filter": {"input": "$healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "GPC"]}}},
+                                "in": "$$this.entityvalue"
+                              }
+                            },
+                            0
+                          ]
+                        },
+                        {
+                          "$arrayElemAt": [
+                            {
+                              "$map": {
+                                "input": {"$filter": {"input": "this.healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "GPC"]}}},
+                                "in": "$$this.entityvalue"
+                              }
+                            },
+                            0
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "$eq": [
+                        {
+                          "$arrayElemAt": [
+                            {
+                              "$map": {
+                                "input": {"$filter": {"input": "$healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "TPC"]}}},
+                                "in": "$$this.entityvalue"
+                              }
+                            },
+                            0
+                          ]
+                        },
+                        {
+                          "$arrayElemAt": [
+                            {
+                              "$map": {
+                                "input": {"$filter": {"input": "this.healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "TPC"]}}},
+                                "in": "$$this.entityvalue"
+                              }
+                            },
+                            0
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                1,
+                0
+              ]
+            }
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$setWindowFields": {
+          "sortBy": {"_id.burstId": 1},
+          "output": {"maxBurstId": {"$max": "$_id.burstId"}}
+        }
+      }
+      ''',
+      '''
+      {
+        "$match": {
+          "$expr": {
+            "$and": [
+              {"$in": ["this.healthevent.errorcode.0", "$uniqueXidsInBurst"]},
+              {"$gt": ["$targetXidCount", 0]},
+              {
+                "$or": [
+                  {"$ne": ["$_id.burstId", "$maxBurstId"]},
+                  {"$gte": ["$targetXidCount", 1]}
+                ]
+              }
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$group": {
+          "_id": null,
+          "count": {"$sum": 1},
+          "bursts": {"$push": {"burstId": "$_id.burstId", "uniqueXids": "$uniqueXidsInBurst"}}
+        }
+      }
+      ''',
+      '{"$match": {"count": {"$gte": 3}}}'
+    ]
+    
+    [[rules]]
+    name = "XIDErrorOnDifferentGPCAndTPC"
+    description = "Detect if XID error occurred on 3+ different GPC and TPC combinations within 2 minutes"
+    recommended_action = "CHECK_APP_CUDA"
+    stage = [
+      '''
+      {
+        "$match": {
+          "$expr": {
+            "$gte": [
+              "$healthevent.generatedtimestamp.seconds",
+              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 120]}
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$match": {
+          "healthevent.ishealthy": false,
+          "healthevent.nodename": "this.healthevent.nodename",
+          "healthevent.errorcode": "this.healthevent.errorcode.0",
+          "$expr": {
+            "$gt": [
+              {
+                "$size": {
+                  "$setIntersection": [
+                    {
+                      "$map": {
+                        "input": {
+                          "$filter": {
+                            "input": "$healthevent.entitiesimpacted",
+                            "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                          }
+                        },
+                        "in": "$$this.entityvalue"
+                      }
+                    },
+                    {
+                      "$map": {
+                        "input": {
+                          "$filter": {
+                            "input": "this.healthevent.entitiesimpacted",
+                            "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                          }
+                        },
+                        "in": "$$this.entityvalue"
+                      }
+                    }
+                  ]
+                }
+              },
+              0
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$addFields": {
+          "gpcTpcCombination": {
+            "$let": {
+              "vars": {
+                "gpc": {
+                  "$arrayElemAt": [
+                    {
+                      "$map": {
+                        "input": {"$filter": {"input": "$healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "GPC"]}}},
+                        "in": "$$this.entityvalue"
+                      }
+                    },
+                    0
+                  ]
+                },
+                "tpc": {
+                  "$arrayElemAt": [
+                    {
+                      "$map": {
+                        "input": {"$filter": {"input": "$healthevent.entitiesimpacted", "cond": {"$eq": ["$$this.entitytype", "TPC"]}}},
+                        "in": "$$this.entityvalue"
+                      }
+                    },
+                    0
+                  ]
+                }
+              },
+              "in": {
+                "$cond": [
+                  {"$and": [{"$ne": ["$$gpc", null]}, {"$ne": ["$$tpc", null]}]},
+                  {"$concat": ["GPC:", "$$gpc", "-TPC:", "$$tpc"]},
+                  null
+                ]
+              }
+            }
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$group": {
+          "_id": null,
+          "uniqueGPCAndTPCCombinations": {"$addToSet": "$gpcTpcCombination"}
+        }
+      }
+      ''',
+      '''
+      {
+        "$match": {
+          "$expr": {
+            "$gte": [{"$size": "$uniqueGPCAndTPCCombinations"}, 3]
+          }
+        }
+      }
+      '''
+    ]
+    
+    [[rules]]
+    name = "XIDErrorSoloNoBurst"
+    description = "Detect if XID error occurred only once in the last burst within 2 minutes time window"
+    recommended_action = "CHECK_APP_CUDA"
+    stage = [
+      '''
+      {
+        "$match": {
+          "$expr": {
+            "$gte": [
+              "$healthevent.generatedtimestamp.seconds",
+              {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 120]}
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$match": {
+          "healthevent.ishealthy": false,
+          "healthevent.nodename": "this.healthevent.nodename",
+          "$expr": {
+            "$gt": [
+              {
+                "$size": {
+                  "$setIntersection": [
+                    {
+                      "$map": {
+                        "input": {
+                          "$filter": {
+                            "input": "$healthevent.entitiesimpacted",
+                            "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                          }
+                        },
+                        "in": "$$this.entityvalue"
+                      }
+                    },
+                    {
+                      "$map": {
+                        "input": {
+                          "$filter": {
+                            "input": "this.healthevent.entitiesimpacted",
+                            "cond": {"$eq": ["$$this.entitytype", "GPU"]}
+                          }
+                        },
+                        "in": "$$this.entityvalue"
+                      }
+                    }
+                  ]
+                }
+              },
+              0
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$setWindowFields": {
+          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+          "output": {
+            "prevTimestamp": {
+              "$shift": {
+                "output": "$healthevent.generatedtimestamp.seconds",
+                "by": -1
+              }
+            }
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$addFields": {
+          "isStickyXid": {
+            "$in": [
+              {"$arrayElemAt": ["$healthevent.errorcode", 0]},
+              ["74", "79", "95", "109", "119"]
+            ]
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$setWindowFields": {
+          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+          "output": {
+            "allPreviousEvents": {
+              "$push": "$$ROOT",
+              "window": {"documents": ["unbounded", -1]}
+            }
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$addFields": {
+          "stickyXidWithin3Hours": {
+            "$cond": {
+              "if": "$isStickyXid",
+              "then": {
+                "$anyElementTrue": {
+                  "$map": {
+                    "input": "$allPreviousEvents",
+                    "as": "prevEvent",
+                    "in": {
+                      "$and": [
+                        {
+                          "$in": [
+                            {"$arrayElemAt": ["$$prevEvent.healthevent.errorcode", 0]},
+                            ["74", "79", "95", "109", "119"]
+                          ]
+                        },
+                        {"$lte": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$$prevEvent.healthevent.generatedtimestamp.seconds"]}, 20]}
+                      ]
+                    }
+                  }
+                }
+              },
+              "else": false
+            }
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$setWindowFields": {
+          "sortBy": {"healthevent.generatedtimestamp.seconds": 1},
+          "output": {
+            "burstId": {
+              "$sum": {
+                "$cond": {
+                  "if": {"$eq": ["$prevTimestamp", null]},
+                  "then": 1,
+                  "else": {
+                    "$cond": {
+                      "if": {
+                        "$and": [
+                          "$isStickyXid",
+                          "$stickyXidWithin3Hours"
+                        ]
+                      },
+                      "then": 0,
+                      "else": {
+                        "$cond": {
+                          "if": {"$gt": [{"$subtract": ["$healthevent.generatedtimestamp.seconds", "$prevTimestamp"]}, 4]},
+                          "then": 1,
+                          "else": 0
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "window": {"documents": ["unbounded", "current"]}
+            }
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$group": {
+          "_id": {"burstId": "$burstId"},
+          "targetXidCount": {
+            "$sum": {
+              "$cond": [
+                {"$eq": [{"$arrayElemAt": ["$healthevent.errorcode", 0]}, "this.healthevent.errorcode.0"]},
+                1,
+                0
+              ]
+            }
+          }
+        }
+      }
+      ''',
+      '''
+      {
+        "$setWindowFields": {
+          "sortBy": {"_id.burstId": 1},
+          "output": {"maxBurstId": {"$max": "$_id.burstId"}}
+        }
+      }
+      ''',
+      '''
+      {
+        "$match": {
+          "$expr": {
+            "$and": [
+              {"$eq": ["$_id.burstId", "$maxBurstId"]},
+              {"$eq": ["$targetXidCount", 1]}
+            ]
+          }
+        }
+      }
+      '''
+    ]

--- a/tests/health_events_analyzer_test.go
+++ b/tests/health_events_analyzer_test.go
@@ -373,8 +373,13 @@ func TestRepeatedXID31OnSameGPU(t *testing.T) {
 		}
 		helpers.InjectSyslogMessages(t, stubJournalHTTPPort, xidMessages)
 
-		message := fmt.Sprintf("ErrorCode:%s PCI:0002:00:00 GPU_UUID:GPU-22222222-2222-2222-2222-222222222222 run CHECK_APP_CUDA Recommended Action=NONE;", helpers.ERRORCODE_31)
-		helpers.WaitForNodeConditionWithCheckName(ctx, t, client, testNodeName, "RepeatedXID31OnDifferentGPU", message)
+		expectedEvent := v1.Event{
+			Type:    "RepeatedXID31OnDifferentGPU",
+			Reason:  "RepeatedXID31OnDifferentGPUIsNotHealthy",
+			Message: "ErrorCode:31 PCI:0002:00:00 GPU_UUID:GPU-22222222-2222-2222-2222-222222222222 App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, report if driver issue Recommended Action=NONE;",
+		}
+
+		helpers.WaitForNodeEvent(ctx, t, client, testNodeName, expectedEvent)
 
 		helpers.EnsureNodeConditionNotPresent(ctx, t, client, testNodeName, "RepeatedXID31OnSameGPU")
 
@@ -390,7 +395,7 @@ func TestRepeatedXID31OnSameGPU(t *testing.T) {
 		}
 		helpers.InjectSyslogMessages(t, stubJournalHTTPPort, xidMessages)
 
-		message = fmt.Sprintf("ErrorCode:%s PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 if pass: RUN_FIELDDIAGS Recommended Action=RUN_DCGMEUD;", helpers.ERRORCODE_31)
+		message := fmt.Sprintf("ErrorCode:%s PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 if DCGM EUD tests passes, run field diagnostics Recommended Action=RUN_DCGMEUD;", helpers.ERRORCODE_31)
 		helpers.WaitForNodeConditionWithCheckName(ctx, t, client, testNodeName, "RepeatedXID31OnSameGPU",
 			message, "RepeatedXidErrorIsNotHealthy", v1.ConditionTrue)
 
@@ -516,7 +521,13 @@ func TestRepeatedXID31OnDifferentGPU(t *testing.T) {
 
 		nodeName := ctx.Value(keyNodeName).(string)
 
-		helpers.WaitForNodeConditionWithCheckName(ctx, t, client, nodeName, "RepeatedXID31OnDifferentGPU", "ErrorCode:31 PCI:0002:00:00 GPU_UUID:GPU-22222222-2222-2222-2222-222222222222 run CHECK_APP_CUDA Recommended Action=NONE;")
+		expectedEvent := v1.Event{
+			Type:    "RepeatedXID31OnDifferentGPU",
+			Reason:  "RepeatedXID31OnDifferentGPUIsNotHealthy",
+			Message: "ErrorCode:31 PCI:0002:00:00 GPU_UUID:GPU-22222222-2222-2222-2222-222222222222 App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, report if driver issue Recommended Action=NONE;",
+		}
+
+		helpers.WaitForNodeEvent(ctx, t, client, nodeName, expectedEvent)
 
 		return ctx
 	})
@@ -639,8 +650,13 @@ func TestXIDErrorOnGPCAndTPC(t *testing.T) {
 		}
 		helpers.InjectSyslogMessages(t, stubJournalHTTPPort, xidMessages)
 
-		expectedMessage := "ErrorCode:13 PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 GPC:0 TPC:0 SM:1 run CHECK_APP_CUDA Recommended Action=NONE;"
-		helpers.WaitForNodeConditionWithCheckName(ctx, t, client, testNodeName, "RepeatedXID13OnDifferentGPCAndTPC", expectedMessage)
+		expectedEvent := v1.Event{
+			Type:    "RepeatedXID13OnDifferentGPCAndTPC",
+			Reason:  "RepeatedXID13OnDifferentGPCAndTPCIsNotHealthy",
+			Message: "ErrorCode:13 PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 GPC:0 TPC:0 SM:1 App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, report if driver issue Recommended Action=NONE;",
+		}
+
+		helpers.WaitForNodeEvent(ctx, t, client, testNodeName, expectedEvent)
 
 		// EXPECTED: RepeatedXID13OnSameGPCAndTPC is not present.
 		// Burst 1: XID 13 on GPC: 0, TPC: 1, SM: 0
@@ -665,8 +681,13 @@ func TestXIDErrorOnGPCAndTPC(t *testing.T) {
 		}
 		helpers.InjectSyslogMessages(t, stubJournalHTTPPort, xidMessages)
 
-		expectedMessage = expectedMessage + "ErrorCode:13 PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 GPC:0 TPC:1 SM:1 run CHECK_APP_CUDA Recommended Action=NONE;"
-		helpers.WaitForNodeConditionWithCheckName(ctx, t, client, testNodeName, "RepeatedXID13OnDifferentGPCAndTPC", expectedMessage)
+		expectedEvent = v1.Event{
+			Type:    "RepeatedXID13OnDifferentGPCAndTPC",
+			Reason:  "RepeatedXID13OnDifferentGPCAndTPCIsNotHealthy",
+			Message: "ErrorCode:13 PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 GPC:0 TPC:1 SM:1 App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, report if driver issue Recommended Action=NONE;",
+		}
+
+		helpers.WaitForNodeEvent(ctx, t, client, testNodeName, expectedEvent)
 
 		return ctx
 	})
@@ -681,7 +702,7 @@ func TestXIDErrorOnGPCAndTPC(t *testing.T) {
 		//          XID 13 on GPC: 0, TPC: 1, SM: 0
 		// Burst 3: XID 13 on GPC: 0, TPC: 1, SM: 1
 		// Errors 1 and 2 are combined into a single burst and thus counted only once.
-		helpers.WaitForNodeConditionWithCheckName(ctx, t, client, testNodeName, "RepeatedXID13OnSameGPCAndTPC", "ErrorCode:13 PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 GPC:0 TPC:1 SM:1 if pass run RUN_FIELDDIAGS Recommended Action=RUN_DCGMEUD;")
+		helpers.WaitForNodeConditionWithCheckName(ctx, t, client, testNodeName, "RepeatedXID13OnSameGPCAndTPC", "ErrorCode:13 PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 GPC:0 TPC:1 SM:1 if DCGM EUD tests passes, run field diagnostics Recommended Action=RUN_DCGMEUD;")
 
 		return ctx
 	})
@@ -802,7 +823,13 @@ func TestSoloNoBurstRule(t *testing.T) {
 		require.NoError(t, err)
 		nodeName := ctx.Value(keyNodeName).(string)
 
-		helpers.WaitForNodeConditionWithCheckName(ctx, t, client, nodeName, "XIDErrorSoloNoBurst", "ErrorCode:13 PCI:0002:00:00 GPU_UUID:GPU-22222222-2222-2222-2222-222222222222 run CHECK_APP_CUDA Recommended Action=NONE;")
+		expectedEvent := v1.Event{
+			Type:    "XIDErrorSoloNoBurst",
+			Reason:  "XIDErrorSoloNoBurstIsNotHealthy",
+			Message: "ErrorCode:13 PCI:0002:00:00 GPU_UUID:GPU-22222222-2222-2222-2222-222222222222 App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, report if driver issue Recommended Action=NONE;",
+		}
+
+		helpers.WaitForNodeEvent(ctx, t, client, nodeName, expectedEvent)
 
 		return ctx
 	})

--- a/tests/health_events_analyzer_test.go
+++ b/tests/health_events_analyzer_test.go
@@ -396,7 +396,7 @@ func TestRepeatedXID31OnSameGPU(t *testing.T) {
 		}
 		helpers.InjectSyslogMessages(t, stubJournalHTTPPort, xidMessages)
 
-		message := fmt.Sprintf("ErrorCode:%s PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 if DCGM EUD tests passes, run field diagnostics Recommended Action=RUN_DCGMEUD;", helpers.ERRORCODE_31)
+		message := fmt.Sprintf("ErrorCode:%s PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 if DCGM EUD tests pass, run field diagnostics Recommended Action=RUN_DCGMEUD;", helpers.ERRORCODE_31)
 		helpers.WaitForNodeConditionWithCheckName(ctx, t, client, testNodeName, "RepeatedXID31OnSameGPU",
 			message, "RepeatedXID31OnSameGPUIsNotHealthy", v1.ConditionTrue)
 
@@ -703,7 +703,7 @@ func TestXIDErrorOnGPCAndTPC(t *testing.T) {
 		//          XID 13 on GPC: 0, TPC: 1, SM: 0
 		// Burst 3: XID 13 on GPC: 0, TPC: 1, SM: 1
 		// Errors 1 and 2 are combined into a single burst and thus counted only once.
-		message := "ErrorCode:13 PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 GPC:0 TPC:1 SM:1 if DCGM EUD tests passes, run field diagnostics Recommended Action=RUN_DCGMEUD;"
+		message := "ErrorCode:13 PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 GPC:0 TPC:1 SM:1 if DCGM EUD tests pass, run field diagnostics Recommended Action=RUN_DCGMEUD;"
 		helpers.WaitForNodeConditionWithCheckName(ctx, t, client, testNodeName, "RepeatedXID13OnSameGPCAndTPC",
 			message, "RepeatedXID13OnSameGPCAndTPCIsNotHealthy", v1.ConditionTrue)
 

--- a/tests/health_events_analyzer_test.go
+++ b/tests/health_events_analyzer_test.go
@@ -205,7 +205,7 @@ func TestRepeatedXIDOnSameGPU(t *testing.T) {
 
 		message := fmt.Sprintf("ErrorCode:%s PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 Recommended Action=CONTACT_SUPPORT;", helpers.ERRORCODE_120)
 		helpers.WaitForNodeConditionWithCheckName(ctx, t, client, testNodeName, "RepeatedXIDErrorOnSameGPU",
-			message, "RepeatedXidErrorIsNotHealthy", v1.ConditionTrue)
+			message, "RepeatedXIDErrorOnSameGPUIsNotHealthy", v1.ConditionTrue)
 
 		t.Logf("Waiting 12s to create burst gap")
 		time.Sleep(12 * time.Second)
@@ -224,7 +224,7 @@ func TestRepeatedXIDOnSameGPU(t *testing.T) {
 		message += fmt.Sprintf("ErrorCode:%s PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 Recommended Action=CONTACT_SUPPORT;", helpers.ERRORCODE_119)
 		message += fmt.Sprintf("ErrorCode:%s PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 Recommended Action=CONTACT_SUPPORT;", helpers.ERRORCODE_48)
 		helpers.WaitForNodeConditionWithCheckName(ctx, t, client, testNodeName, "RepeatedXIDErrorOnSameGPU",
-			message, "RepeatedXidErrorIsNotHealthy", v1.ConditionTrue)
+			message, "RepeatedXIDErrorOnSameGPUIsNotHealthy", v1.ConditionTrue)
 
 		t.Logf("Waiting 12s to create burst gap")
 		time.Sleep(12 * time.Second)
@@ -249,7 +249,8 @@ func TestRepeatedXIDOnSameGPU(t *testing.T) {
 		}
 		helpers.InjectSyslogMessages(t, stubJournalHTTPPort, xidMessages)
 
-		helpers.WaitForNodeConditionWithCheckName(ctx, t, client, testNodeName, "RepeatedXIDErrorOnSameGPU", message)
+		helpers.WaitForNodeConditionWithCheckName(ctx, t, client, testNodeName, "RepeatedXIDErrorOnSameGPU",
+			message, "RepeatedXIDErrorOnSameGPUIsNotHealthy", v1.ConditionTrue)
 
 		return ctx
 	})
@@ -376,7 +377,7 @@ func TestRepeatedXID31OnSameGPU(t *testing.T) {
 		expectedEvent := v1.Event{
 			Type:    "RepeatedXID31OnDifferentGPU",
 			Reason:  "RepeatedXID31OnDifferentGPUIsNotHealthy",
-			Message: "ErrorCode:31 PCI:0002:00:00 GPU_UUID:GPU-22222222-2222-2222-2222-222222222222 App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, report if driver issue Recommended Action=NONE;",
+			Message: "ErrorCode:31 PCI:0002:00:00 GPU_UUID:GPU-22222222-2222-2222-2222-222222222222 App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support Recommended Action=NONE;",
 		}
 
 		helpers.WaitForNodeEvent(ctx, t, client, testNodeName, expectedEvent)
@@ -397,7 +398,7 @@ func TestRepeatedXID31OnSameGPU(t *testing.T) {
 
 		message := fmt.Sprintf("ErrorCode:%s PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 if DCGM EUD tests passes, run field diagnostics Recommended Action=RUN_DCGMEUD;", helpers.ERRORCODE_31)
 		helpers.WaitForNodeConditionWithCheckName(ctx, t, client, testNodeName, "RepeatedXID31OnSameGPU",
-			message, "RepeatedXidErrorIsNotHealthy", v1.ConditionTrue)
+			message, "RepeatedXID31OnSameGPUIsNotHealthy", v1.ConditionTrue)
 
 		return ctx
 	})
@@ -524,7 +525,7 @@ func TestRepeatedXID31OnDifferentGPU(t *testing.T) {
 		expectedEvent := v1.Event{
 			Type:    "RepeatedXID31OnDifferentGPU",
 			Reason:  "RepeatedXID31OnDifferentGPUIsNotHealthy",
-			Message: "ErrorCode:31 PCI:0002:00:00 GPU_UUID:GPU-22222222-2222-2222-2222-222222222222 App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, report if driver issue Recommended Action=NONE;",
+			Message: "ErrorCode:31 PCI:0002:00:00 GPU_UUID:GPU-22222222-2222-2222-2222-222222222222 App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support Recommended Action=NONE;",
 		}
 
 		helpers.WaitForNodeEvent(ctx, t, client, nodeName, expectedEvent)
@@ -653,7 +654,7 @@ func TestXIDErrorOnGPCAndTPC(t *testing.T) {
 		expectedEvent := v1.Event{
 			Type:    "RepeatedXID13OnDifferentGPCAndTPC",
 			Reason:  "RepeatedXID13OnDifferentGPCAndTPCIsNotHealthy",
-			Message: "ErrorCode:13 PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 GPC:0 TPC:0 SM:1 App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, report if driver issue Recommended Action=NONE;",
+			Message: "ErrorCode:13 PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 GPC:0 TPC:0 SM:1 App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support Recommended Action=NONE;",
 		}
 
 		helpers.WaitForNodeEvent(ctx, t, client, testNodeName, expectedEvent)
@@ -684,7 +685,7 @@ func TestXIDErrorOnGPCAndTPC(t *testing.T) {
 		expectedEvent = v1.Event{
 			Type:    "RepeatedXID13OnDifferentGPCAndTPC",
 			Reason:  "RepeatedXID13OnDifferentGPCAndTPCIsNotHealthy",
-			Message: "ErrorCode:13 PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 GPC:0 TPC:1 SM:1 App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, report if driver issue Recommended Action=NONE;",
+			Message: "ErrorCode:13 PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 GPC:0 TPC:1 SM:1 App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support Recommended Action=NONE;",
 		}
 
 		helpers.WaitForNodeEvent(ctx, t, client, testNodeName, expectedEvent)
@@ -702,7 +703,9 @@ func TestXIDErrorOnGPCAndTPC(t *testing.T) {
 		//          XID 13 on GPC: 0, TPC: 1, SM: 0
 		// Burst 3: XID 13 on GPC: 0, TPC: 1, SM: 1
 		// Errors 1 and 2 are combined into a single burst and thus counted only once.
-		helpers.WaitForNodeConditionWithCheckName(ctx, t, client, testNodeName, "RepeatedXID13OnSameGPCAndTPC", "ErrorCode:13 PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 GPC:0 TPC:1 SM:1 if DCGM EUD tests passes, run field diagnostics Recommended Action=RUN_DCGMEUD;")
+		message := "ErrorCode:13 PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 GPC:0 TPC:1 SM:1 if DCGM EUD tests passes, run field diagnostics Recommended Action=RUN_DCGMEUD;"
+		helpers.WaitForNodeConditionWithCheckName(ctx, t, client, testNodeName, "RepeatedXID13OnSameGPCAndTPC",
+			message, "RepeatedXID13OnSameGPCAndTPCIsNotHealthy", v1.ConditionTrue)
 
 		return ctx
 	})
@@ -826,7 +829,7 @@ func TestSoloNoBurstRule(t *testing.T) {
 		expectedEvent := v1.Event{
 			Type:    "XIDErrorSoloNoBurst",
 			Reason:  "XIDErrorSoloNoBurstIsNotHealthy",
-			Message: "ErrorCode:13 PCI:0002:00:00 GPU_UUID:GPU-22222222-2222-2222-2222-222222222222 App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, report if driver issue Recommended Action=NONE;",
+			Message: "ErrorCode:13 PCI:0002:00:00 GPU_UUID:GPU-22222222-2222-2222-2222-222222222222 App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support Recommended Action=NONE;",
 		}
 
 		helpers.WaitForNodeEvent(ctx, t, client, nodeName, expectedEvent)

--- a/tests/helpers/health_events_analyzer.go
+++ b/tests/helpers/health_events_analyzer.go
@@ -16,7 +16,8 @@ package helpers
 
 import (
 	"context"
-	"math/rand"
+	"crypto/rand"
+	"math/big"
 	"testing"
 
 	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
@@ -59,7 +60,11 @@ func SetupHealthEventsAnalyzerTest(ctx context.Context,
 		gpuNodes, err := GetAllNodesNames(ctx, client)
 		require.NoError(t, err, "failed to get nodes")
 		require.True(t, len(gpuNodes) > 0, "no gpu nodes found")
-		gpuNodeName = gpuNodes[rand.Intn(len(gpuNodes))]
+
+		index, err := rand.Int(rand.Reader, big.NewInt(int64(len(gpuNodes))))
+		require.NoError(t, err, "failed to generate random index")
+
+		gpuNodeName = gpuNodes[index.Int64()]
 	}
 
 	testCtx := &HealthEventsAnalyzerTestContext{

--- a/tests/helpers/health_events_analyzer.go
+++ b/tests/helpers/health_events_analyzer.go
@@ -50,6 +50,7 @@ func SetupHealthEventsAnalyzerTest(ctx context.Context,
 
 	client, err := c.NewClient()
 	require.NoError(t, err)
+
 	gpuNodeName := ""
 
 	if testNodeName != "" {
@@ -66,72 +67,7 @@ func SetupHealthEventsAnalyzerTest(ctx context.Context,
 		NodeName:      gpuNodeName,
 	}
 
-	t.Logf("Cleaning up any existing node conditions for node %s", testCtx.NodeName)
-	// Note: Using default agent (gpu-health-monitor) instead of health-events-analyzer
-	// because the reconciler filters out events from health-events-analyzer to prevent infinite loops
-	event := NewHealthEvent(testCtx.NodeName).
-		WithHealthy(true).
-		WithFatal(false).
-		WithMessage("No health failures").
-		WithComponentClass("GPU").
-		WithCheckName("MultipleRemediations")
-
-	event.EntitiesImpacted = []EntityImpacted{}
-
-	SendHealthEvent(ctx, t, event)
-
-	event = NewHealthEvent(testCtx.NodeName).
-		WithHealthy(true).
-		WithFatal(false).
-		WithMessage("No health failures").
-		WithComponentClass("GPU").
-		WithCheckName("RepeatedXidErrorOnSameGPU")
-
-	event.EntitiesImpacted = []EntityImpacted{}
-	SendHealthEvent(ctx, t, event)
-
-	event = NewHealthEvent(testCtx.NodeName).
-		WithAgent(HEALTH_EVENTS_ANALYZER_AGENT).
-		WithHealthy(true).
-		WithFatal(false).
-		WithMessage("No health failures").
-		WithComponentClass("GPU").
-		WithCheckName("XIDErrorOnSameGPCAndTPC")
-
-	event.EntitiesImpacted = []EntityImpacted{}
-	SendHealthEvent(ctx, t, event)
-
-	event = NewHealthEvent(testCtx.NodeName).
-		WithAgent(HEALTH_EVENTS_ANALYZER_AGENT).
-		WithHealthy(true).
-		WithFatal(false).
-		WithMessage("No health failures").
-		WithComponentClass("GPU").
-		WithCheckName("XIDErrorOnDifferentGPCAndTPC")
-
-	event.EntitiesImpacted = []EntityImpacted{}
-	SendHealthEvent(ctx, t, event)
-
-	event = NewHealthEvent(testCtx.NodeName).
-		WithAgent(HEALTH_EVENTS_ANALYZER_AGENT).
-		WithHealthy(true).
-		WithFatal(false).
-		WithMessage("No health failures").
-		WithComponentClass("GPU").
-		WithCheckName("XIDErrorSoloNoBurst")
-
-	event.EntitiesImpacted = []EntityImpacted{}
-	SendHealthEvent(ctx, t, event)
-
-	event = NewHealthEvent(testCtx.NodeName).
-		WithAgent(HEALTH_EVENTS_ANALYZER_AGENT).
-		WithHealthy(true).
-		WithFatal(false).
-		WithMessage("No health failures").
-		WithComponentClass("GPU").
-		WithCheckName("RepeatedXidErrorOnDifferentGPU")
-	event.EntitiesImpacted = []EntityImpacted{}
-	SendHealthEvent(ctx, t, event)
+	clearHealthEventsAnalyzerConditions(ctx, t, gpuNodeName)
 
 	t.Log("Backing up current health-events-analyzer configmap")
 
@@ -145,6 +81,87 @@ func SetupHealthEventsAnalyzerTest(ctx context.Context,
 	require.NoError(t, err)
 
 	return ctx, testCtx
+}
+
+func clearHealthEventsAnalyzerConditions(ctx context.Context, t *testing.T, nodeName string) {
+	t.Logf("Cleaning up any existing node conditions for node %s", nodeName)
+	// Note: Using default agent (gpu-health-monitor) instead of health-events-analyzer
+	// because the reconciler filters out events from health-events-analyzer to prevent infinite loops
+	event := NewHealthEvent(nodeName).
+		WithHealthy(true).
+		WithFatal(false).
+		WithMessage("No health failures").
+		WithComponentClass("GPU").
+		WithCheckName("MultipleRemediations")
+
+	event.EntitiesImpacted = []EntityImpacted{}
+
+	SendHealthEvent(ctx, t, event)
+
+	event = NewHealthEvent(nodeName).
+		WithAgent(HEALTH_EVENTS_ANALYZER_AGENT).
+		WithHealthy(true).
+		WithFatal(false).
+		WithMessage("No health failures").
+		WithComponentClass("GPU").
+		WithCheckName("RepeatedXIDErrorOnSameGPU")
+
+	event.EntitiesImpacted = []EntityImpacted{}
+	SendHealthEvent(ctx, t, event)
+
+	event = NewHealthEvent(nodeName).
+		WithAgent(HEALTH_EVENTS_ANALYZER_AGENT).
+		WithHealthy(true).
+		WithFatal(false).
+		WithMessage("No health failures").
+		WithComponentClass("GPU").
+		WithCheckName("RepeatedXID31OnSameGPU")
+
+	event.EntitiesImpacted = []EntityImpacted{}
+	SendHealthEvent(ctx, t, event)
+
+	event = NewHealthEvent(nodeName).
+		WithAgent(HEALTH_EVENTS_ANALYZER_AGENT).
+		WithHealthy(true).
+		WithFatal(false).
+		WithMessage("No health failures").
+		WithComponentClass("GPU").
+		WithCheckName("RepeatedXID31OnDifferentGPU")
+	event.EntitiesImpacted = []EntityImpacted{}
+	SendHealthEvent(ctx, t, event)
+
+	event = NewHealthEvent(nodeName).
+		WithAgent(HEALTH_EVENTS_ANALYZER_AGENT).
+		WithHealthy(true).
+		WithFatal(false).
+		WithMessage("No health failures").
+		WithComponentClass("GPU").
+		WithCheckName("RepeatedXID13OnSameGPCAndTPC")
+
+	event.EntitiesImpacted = []EntityImpacted{}
+	SendHealthEvent(ctx, t, event)
+
+	event = NewHealthEvent(nodeName).
+		WithAgent(HEALTH_EVENTS_ANALYZER_AGENT).
+		WithHealthy(true).
+		WithFatal(false).
+		WithMessage("No health failures").
+		WithComponentClass("GPU").
+		WithCheckName("RepeatedXID13OnDifferentGPCAndTPC")
+
+	event.EntitiesImpacted = []EntityImpacted{}
+	SendHealthEvent(ctx, t, event)
+
+	event = NewHealthEvent(nodeName).
+		WithAgent(HEALTH_EVENTS_ANALYZER_AGENT).
+		WithHealthy(true).
+		WithFatal(false).
+		WithMessage("No health failures").
+		WithComponentClass("GPU").
+		WithCheckName("XIDErrorSoloNoBurst")
+
+	event.EntitiesImpacted = []EntityImpacted{}
+	SendHealthEvent(ctx, t, event)
 }
 
 func applyHealthEventsAnalyzerConfigAndRestart(
@@ -219,59 +236,10 @@ func waitForRemediationToComplete(ctx context.Context, t *testing.T, client klie
 }
 
 func TeardownHealthEventsAnalyzer(ctx context.Context, t *testing.T,
-	c *envconf.Config, nodeName string, configMapBackup []byte, xid string) context.Context {
+	c *envconf.Config, nodeName string, configMapBackup []byte) context.Context {
 	t.Logf("Starting cleanup for node %s", nodeName)
 
-	// Note: Using default agent (gpu-health-monitor) instead of health-events-analyzer
-	// because the reconciler filters out events from health-events-analyzer to prevent infinite loops
-	event := NewHealthEvent(nodeName).
-		WithHealthy(true).
-		WithFatal(false).
-		WithMessage("No health failures").
-		WithCheckName("MultipleRemediations").
-		WithErrorCode(xid)
-
-	event.EntitiesImpacted = []EntityImpacted{}
-	SendHealthEvent(ctx, t, event)
-
-	event = NewHealthEvent(nodeName).
-		WithHealthy(true).
-		WithFatal(false).
-		WithMessage("No health failures").
-		WithCheckName("RepeatedXidErrorOnSameGPU")
-	event.EntitiesImpacted = []EntityImpacted{}
-	SendHealthEvent(ctx, t, event)
-
-	event = NewHealthEvent(nodeName).
-		WithAgent(HEALTH_EVENTS_ANALYZER_AGENT).
-		WithHealthy(true).
-		WithFatal(false).
-		WithMessage("No health failures").
-		WithCheckName("XIDErrorOnSameGPCAndTPC")
-	event.EntitiesImpacted = []EntityImpacted{}
-	SendHealthEvent(ctx, t, event)
-
-	event = NewHealthEvent(nodeName).
-		WithAgent(HEALTH_EVENTS_ANALYZER_AGENT).
-		WithHealthy(true).
-		WithFatal(false).
-		WithMessage("No health failures").
-		WithCheckName("XIDErrorOnDifferentGPCAndTPC")
-
-	event.EntitiesImpacted = []EntityImpacted{}
-	SendHealthEvent(ctx, t, event)
-
-	event = NewHealthEvent(nodeName).
-		WithAgent(HEALTH_EVENTS_ANALYZER_AGENT).
-		WithHealthy(true).
-		WithFatal(false).
-		WithMessage("No health failures").
-		WithCheckName("RepeatedXidErrorOnDifferentGPU")
-
-	event.EntitiesImpacted = []EntityImpacted{}
-	SendHealthEvent(ctx, t, event)
-
-	SendHealthyEvent(ctx, t, nodeName)
+	clearHealthEventsAnalyzerConditions(ctx, t, nodeName)
 
 	restoreHealthEventsAnalyzerConfig(ctx, t, c, configMapBackup)
 

--- a/tests/helpers/health_events_analyzer.go
+++ b/tests/helpers/health_events_analyzer.go
@@ -81,6 +81,15 @@ func SetupHealthEventsAnalyzerTest(ctx context.Context,
 		WithCheckName("RepeatedXidError")
 	SendHealthEvent(ctx, t, event)
 
+	event = NewHealthEvent(testCtx.NodeName).
+		WithAgent(HEALTH_EVENTS_ANALYZER_AGENT).
+		WithHealthy(true).
+		WithFatal(false).
+		WithMessage("No health failures").
+		WithComponentClass("GPU").
+		WithCheckName("XID13OnSameGPCAndTPC")
+	SendHealthEvent(ctx, t, event)
+
 	t.Log("Backing up current health-events-analyzer configmap")
 
 	backupData, err := BackupConfigMap(ctx, client, "health-events-analyzer-config", NVSentinelNamespace)
@@ -186,6 +195,22 @@ func TeardownHealthEventsAnalyzer(ctx context.Context, t *testing.T,
 		WithFatal(false).
 		WithMessage("No health failures").
 		WithCheckName("RepeatedXidError")
+	SendHealthEvent(ctx, t, event)
+
+	event = NewHealthEvent(nodeName).
+		WithAgent(HEALTH_EVENTS_ANALYZER_AGENT).
+		WithHealthy(true).
+		WithFatal(false).
+		WithMessage("No health failures").
+		WithCheckName("XIDErrorOnSameGPCAndTPC")
+	SendHealthEvent(ctx, t, event)
+
+	event = NewHealthEvent(nodeName).
+		WithAgent(HEALTH_EVENTS_ANALYZER_AGENT).
+		WithHealthy(true).
+		WithFatal(false).
+		WithMessage("No health failures").
+		WithCheckName("XIDErrorOnDifferentGPCAndTPC")
 	SendHealthEvent(ctx, t, event)
 
 	SendHealthyEvent(ctx, t, nodeName)

--- a/tests/helpers/health_events_analyzer.go
+++ b/tests/helpers/health_events_analyzer.go
@@ -78,7 +78,7 @@ func SetupHealthEventsAnalyzerTest(ctx context.Context,
 		WithFatal(false).
 		WithMessage("No health failures").
 		WithComponentClass("GPU").
-		WithCheckName("RepeatedXidError")
+		WithCheckName("RepeatedXidErrorOnSameGPU")
 	SendHealthEvent(ctx, t, event)
 
 	event = NewHealthEvent(testCtx.NodeName).
@@ -194,7 +194,7 @@ func TeardownHealthEventsAnalyzer(ctx context.Context, t *testing.T,
 		WithHealthy(true).
 		WithFatal(false).
 		WithMessage("No health failures").
-		WithCheckName("RepeatedXidError")
+		WithCheckName("RepeatedXidErrorOnSameGPU")
 	SendHealthEvent(ctx, t, event)
 
 	event = NewHealthEvent(nodeName).

--- a/tests/helpers/health_events_analyzer.go
+++ b/tests/helpers/health_events_analyzer.go
@@ -120,6 +120,16 @@ func SetupHealthEventsAnalyzerTest(ctx context.Context,
 	event.EntitiesImpacted = []EntityImpacted{}
 	SendHealthEvent(ctx, t, event)
 
+	event = NewHealthEvent(testCtx.NodeName).
+		WithAgent(HEALTH_EVENTS_ANALYZER_AGENT).
+		WithHealthy(true).
+		WithFatal(false).
+		WithMessage("No health failures").
+		WithComponentClass("GPU").
+		WithCheckName("RepeatedXidErrorOnDifferentGPU")
+	event.EntitiesImpacted = []EntityImpacted{}
+	SendHealthEvent(ctx, t, event)
+
 	t.Log("Backing up current health-events-analyzer configmap")
 
 	backupData, err := BackupConfigMap(ctx, client, "health-events-analyzer-config", NVSentinelNamespace)
@@ -218,6 +228,7 @@ func TeardownHealthEventsAnalyzer(ctx context.Context, t *testing.T,
 		WithCheckName("MultipleRemediations").
 		WithErrorCode(xid)
 
+	event.EntitiesImpacted = []EntityImpacted{}
 	SendHealthEvent(ctx, t, event)
 
 	event = NewHealthEvent(nodeName).
@@ -225,6 +236,7 @@ func TeardownHealthEventsAnalyzer(ctx context.Context, t *testing.T,
 		WithFatal(false).
 		WithMessage("No health failures").
 		WithCheckName("RepeatedXidErrorOnSameGPU")
+	event.EntitiesImpacted = []EntityImpacted{}
 	SendHealthEvent(ctx, t, event)
 
 	event = NewHealthEvent(nodeName).
@@ -233,6 +245,7 @@ func TeardownHealthEventsAnalyzer(ctx context.Context, t *testing.T,
 		WithFatal(false).
 		WithMessage("No health failures").
 		WithCheckName("XIDErrorOnSameGPCAndTPC")
+	event.EntitiesImpacted = []EntityImpacted{}
 	SendHealthEvent(ctx, t, event)
 
 	event = NewHealthEvent(nodeName).
@@ -241,6 +254,18 @@ func TeardownHealthEventsAnalyzer(ctx context.Context, t *testing.T,
 		WithFatal(false).
 		WithMessage("No health failures").
 		WithCheckName("XIDErrorOnDifferentGPCAndTPC")
+
+	event.EntitiesImpacted = []EntityImpacted{}
+	SendHealthEvent(ctx, t, event)
+
+	event = NewHealthEvent(nodeName).
+		WithAgent(HEALTH_EVENTS_ANALYZER_AGENT).
+		WithHealthy(true).
+		WithFatal(false).
+		WithMessage("No health failures").
+		WithCheckName("RepeatedXidErrorOnDifferentGPU")
+
+	event.EntitiesImpacted = []EntityImpacted{}
 	SendHealthEvent(ctx, t, event)
 
 	SendHealthyEvent(ctx, t, nodeName)

--- a/tests/helpers/health_events_analyzer.go
+++ b/tests/helpers/health_events_analyzer.go
@@ -44,19 +44,22 @@ type HealthEventsAnalyzerTestContext struct {
 func SetupHealthEventsAnalyzerTest(ctx context.Context,
 	t *testing.T,
 	c *envconf.Config,
-	configMapPath, testNamespace string) (
+	configMapPath, testNamespace string, testNodeName string) (
 	context.Context, *HealthEventsAnalyzerTestContext) {
 	t.Helper()
 
 	client, err := c.NewClient()
 	require.NoError(t, err)
+	gpuNodeName := ""
 
-	gpuNodes, err := GetAllNodesNames(ctx, client)
-	require.NoError(t, err, "failed to get nodes")
-	require.True(t, len(gpuNodes) > 0, "no gpu nodes found")
-
-	gpuNodeName := gpuNodes[rand.Intn(len(gpuNodes))] // #nosec G404 - weak random acceptable for test node selection
-	gpuNodeName = "kwok-node-40"
+	if testNodeName != "" {
+		gpuNodeName = testNodeName
+	} else {
+		gpuNodes, err := GetAllNodesNames(ctx, client)
+		require.NoError(t, err, "failed to get nodes")
+		require.True(t, len(gpuNodes) > 0, "no gpu nodes found")
+		gpuNodeName = gpuNodes[rand.Intn(len(gpuNodes))] // #nosec G404 - weak random acceptable for test node selection
+	}
 
 	testCtx := &HealthEventsAnalyzerTestContext{
 		TestNamespace: testNamespace,

--- a/tests/helpers/health_events_analyzer.go
+++ b/tests/helpers/health_events_analyzer.go
@@ -59,7 +59,7 @@ func SetupHealthEventsAnalyzerTest(ctx context.Context,
 		gpuNodes, err := GetAllNodesNames(ctx, client)
 		require.NoError(t, err, "failed to get nodes")
 		require.True(t, len(gpuNodes) > 0, "no gpu nodes found")
-		gpuNodeName = gpuNodes[rand.Intn(len(gpuNodes))] // #nosec G404 - weak random acceptable for test node selection
+		gpuNodeName = gpuNodes[rand.Intn(len(gpuNodes))]
 	}
 
 	testCtx := &HealthEventsAnalyzerTestContext{
@@ -85,9 +85,9 @@ func SetupHealthEventsAnalyzerTest(ctx context.Context,
 
 func clearHealthEventsAnalyzerConditions(ctx context.Context, t *testing.T, nodeName string) {
 	t.Logf("Cleaning up any existing node conditions for node %s", nodeName)
-	// Note: Using default agent (gpu-health-monitor) instead of health-events-analyzer
-	// because the reconciler filters out events from health-events-analyzer to prevent infinite loops
+
 	event := NewHealthEvent(nodeName).
+		WithAgent(HEALTH_EVENTS_ANALYZER_AGENT).
 		WithHealthy(true).
 		WithFatal(false).
 		WithMessage("No health failures").

--- a/tests/helpers/health_events_analyzer.go
+++ b/tests/helpers/health_events_analyzer.go
@@ -56,6 +56,7 @@ func SetupHealthEventsAnalyzerTest(ctx context.Context,
 	require.True(t, len(gpuNodes) > 0, "no gpu nodes found")
 
 	gpuNodeName := gpuNodes[rand.Intn(len(gpuNodes))] // #nosec G404 - weak random acceptable for test node selection
+	gpuNodeName = "kwok-node-40"
 
 	testCtx := &HealthEventsAnalyzerTestContext{
 		TestNamespace: testNamespace,
@@ -71,6 +72,9 @@ func SetupHealthEventsAnalyzerTest(ctx context.Context,
 		WithMessage("No health failures").
 		WithComponentClass("GPU").
 		WithCheckName("MultipleRemediations")
+
+	event.EntitiesImpacted = []EntityImpacted{}
+
 	SendHealthEvent(ctx, t, event)
 
 	event = NewHealthEvent(testCtx.NodeName).
@@ -79,6 +83,8 @@ func SetupHealthEventsAnalyzerTest(ctx context.Context,
 		WithMessage("No health failures").
 		WithComponentClass("GPU").
 		WithCheckName("RepeatedXidErrorOnSameGPU")
+
+	event.EntitiesImpacted = []EntityImpacted{}
 	SendHealthEvent(ctx, t, event)
 
 	event = NewHealthEvent(testCtx.NodeName).
@@ -87,7 +93,31 @@ func SetupHealthEventsAnalyzerTest(ctx context.Context,
 		WithFatal(false).
 		WithMessage("No health failures").
 		WithComponentClass("GPU").
-		WithCheckName("XID13OnSameGPCAndTPC")
+		WithCheckName("XIDErrorOnSameGPCAndTPC")
+
+	event.EntitiesImpacted = []EntityImpacted{}
+	SendHealthEvent(ctx, t, event)
+
+	event = NewHealthEvent(testCtx.NodeName).
+		WithAgent(HEALTH_EVENTS_ANALYZER_AGENT).
+		WithHealthy(true).
+		WithFatal(false).
+		WithMessage("No health failures").
+		WithComponentClass("GPU").
+		WithCheckName("XIDErrorOnDifferentGPCAndTPC")
+
+	event.EntitiesImpacted = []EntityImpacted{}
+	SendHealthEvent(ctx, t, event)
+
+	event = NewHealthEvent(testCtx.NodeName).
+		WithAgent(HEALTH_EVENTS_ANALYZER_AGENT).
+		WithHealthy(true).
+		WithFatal(false).
+		WithMessage("No health failures").
+		WithComponentClass("GPU").
+		WithCheckName("XIDErrorSoloNoBurst")
+
+	event.EntitiesImpacted = []EntityImpacted{}
 	SendHealthEvent(ctx, t, event)
 
 	t.Log("Backing up current health-events-analyzer configmap")

--- a/tests/helpers/healthevent.go
+++ b/tests/helpers/healthevent.go
@@ -103,12 +103,6 @@ func (h *HealthEventTemplate) WithEntity(entityType, entityValue string) *Health
 	return h
 }
 
-func (h *HealthEventTemplate) WithEntities(entities []EntityImpacted) *HealthEventTemplate {
-	h.EntitiesImpacted = entities
-
-	return h
-}
-
 func (h *HealthEventTemplate) WithFatal(isFatal bool) *HealthEventTemplate {
 	h.IsFatal = isFatal
 	return h

--- a/tests/helpers/healthevent.go
+++ b/tests/helpers/healthevent.go
@@ -103,7 +103,6 @@ func (h *HealthEventTemplate) WithEntity(entityType, entityValue string) *Health
 	return h
 }
 
-// WithOnlyEntity replaces all entities with a single entity (doesn't append)
 func (h *HealthEventTemplate) WithEntities(entities []EntityImpacted) *HealthEventTemplate {
 	h.EntitiesImpacted = entities
 
@@ -258,8 +257,8 @@ func sendHealthEventData(nodeNames []string, eventData []byte) error {
 
 func SendHealthEvent(ctx context.Context, t *testing.T, event *HealthEventTemplate) {
 	t.Helper()
-	t.Logf("Sending health event to node %s: checkName=%s, isFatal=%v",
-		event.NodeName, event.CheckName, event.IsFatal)
+	t.Logf("Sending health event to node %s: checkName=%s, isFatal=%v, errorCode=%v",
+		event.NodeName, event.CheckName, event.IsFatal, event.ErrorCode)
 
 	eventData, err := json.MarshalIndent(event, "", "    ")
 	require.NoError(t, err)

--- a/tests/helpers/healthevent.go
+++ b/tests/helpers/healthevent.go
@@ -103,6 +103,13 @@ func (h *HealthEventTemplate) WithEntity(entityType, entityValue string) *Health
 	return h
 }
 
+// WithOnlyEntity replaces all entities with a single entity (doesn't append)
+func (h *HealthEventTemplate) WithEntities(entities []EntityImpacted) *HealthEventTemplate {
+	h.EntitiesImpacted = entities
+
+	return h
+}
+
 func (h *HealthEventTemplate) WithFatal(isFatal bool) *HealthEventTemplate {
 	h.IsFatal = isFatal
 	return h

--- a/tests/helpers/kube.go
+++ b/tests/helpers/kube.go
@@ -345,7 +345,8 @@ func WaitForNodeLabelNotEqual(
 		"expected node %s label %s to not equal %s", nodeName, labelKey, notExpectedValue)
 }
 
-func WaitForNodeEvent(ctx context.Context, t *testing.T, c klient.Client, nodeName string, expectedEvent v1.Event) {
+func WaitForNodeEvent(ctx context.Context, t *testing.T, c klient.Client, nodeName string,
+	expectedEvent v1.Event) {
 	require.Eventually(t, func() bool {
 		fieldSelector := resources.WithFieldSelector(fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Node", nodeName))
 
@@ -359,7 +360,19 @@ func WaitForNodeEvent(ctx context.Context, t *testing.T, c klient.Client, nodeNa
 
 		for _, event := range eventsForNode.Items {
 			if event.Type == expectedEvent.Type && event.Reason == expectedEvent.Reason {
+				if expectedEvent.Message != "" {
+					t.Logf("Matching message for event %v", expectedEvent.Type)
+					t.Logf("Event message: %s", event.Message)
+					t.Logf("Expected message: %s", expectedEvent.Message)
+
+					if event.Message != expectedEvent.Message {
+						t.Logf("Event message does not match expected message: %s != %s", event.Message, expectedEvent.Message)
+						continue
+					}
+				}
+
 				t.Logf("Matching event for node %s: %v", nodeName, event)
+
 				return true
 			}
 		}


### PR DESCRIPTION
## Summary

<!-- Brief description of your changes -->

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [x] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Summary 
Design doc https://github.com/NVIDIA/NVSentinel/blob/main/docs/designs/012-workflow-XID-13-and-31.md

## Testing
Tested on tilt cluster by running written E2E tests for each case of workflows like repeat of XID 31 on same GPU/diff GPU etc.

Tested on dev cluster nvs-dgxc-k8s-oci-lhr-dev3. Injected multiple log messages which were picked up by syslog-health-monitor and published a new health-event in db.

XID 13 with parsed GPC, TPC and SM value

<img width="1250" height="774" alt="xid_13_error" src="https://github.com/user-attachments/assets/7966130a-9e26-40d4-a702-c069e5e3089d" />

XID 31 health event

<img width="1470" height="614" alt="xid_31_error" src="https://github.com/user-attachments/assets/cd1181e7-a7c0-45ff-baed-b47a8031c5db" />

RepeatedXidErrorOnSameGPU triggered for XID 31
<img width="496" height="593" alt="same_gpu" src="https://github.com/user-attachments/assets/d85ccfe0-e310-4d0f-ba8d-932875bdb7ed" />

XIDErrorSoloNoBurst fatal event

<img width="476" height="598" alt="solo_no_burst" src="https://github.com/user-attachments/assets/8b1e8249-8b84-4fa7-9c17-3fbcc442b71e" />


XIDErrorOnSameGPCAndTPC for XID 13
<img width="500" height="764" alt="same_gpc_tpc" src="https://github.com/user-attachments/assets/b136e2b0-da41-4e7a-8730-297867228a45" />

XIDErrorOnDifferentGPCAndTPC for XID 13

<img width="471" height="765" alt="diff_gpc_tpc" src="https://github.com/user-attachments/assets/ce2bd428-ee59-43af-9ee5-e1e8b765e7c2" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded XID detection: multi-GPU, GPU-UUID correlation, GPC/TPC-aware scenarios, refined burst/sticky windows and many granular XID cases.
  * Events now include parsed metadata (GPC/TPC/SM), carry rule-provided messages, and set fatal flag based on recommended action.
  * Two new recommended actions added.

* **Tests**
  * Extended end-to-end tests and orchestration covering cross-GPU/GPC/TPC scenarios, syslog-driven feeds, and additional XID cases.

* **Chores**
  * Rule renamed and many new public rules added; test helpers and setup/teardown flows updated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->