### PR TITLE
fix: use SAFE_REF for helm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,7 @@ jobs:
           HELM_REGISTRY_TYPE: oci
           HELM_OCI_REGISTRY: ghcr.io
           HELM_OCI_REPOSITORY: nvidia
+          SAFE_REF: ${{ steps.ref-name.outputs.value }}
         run: make -C distros/kubernetes helm-publish
 
   create-github-release:

--- a/distros/kubernetes/Makefile
+++ b/distros/kubernetes/Makefile
@@ -11,23 +11,23 @@ lint:
 .PHONY: helm-publish
 helm-publish:
 	@echo "Publishing Kubernetes Helm chart..."
-	@if [ -z "$$SAFE_REF_NAME" ]; then \
-		echo "Warning: SAFE_REF_NAME not set, skipping publish"; \
+	@if [ -z "$$SAFE_REF" ]; then \
+		echo "Warning: SAFE_REF not set, skipping publish"; \
 	else \
-		echo "Updating chart files for release $$SAFE_REF_NAME..."; \
+		echo "Updating chart files for release $$SAFE_REF..."; \
 		SED_CMD="sed"; \
 		if command -v gsed >/dev/null 2>&1; then \
 			SED_CMD="gsed"; \
 			echo "Using GNU sed (gsed) for compatibility"; \
 		fi; \
-		$$SED_CMD -i.bak "s|tag: \"main\"|tag: \"$$SAFE_REF_NAME\"|" nvsentinel/values.yaml && \
-		$$SED_CMD -i.bak "s|appVersion: \"1.0.0\"|appVersion: \"$$SAFE_REF_NAME\"|" nvsentinel/Chart.yaml && \
-		echo "Updated global.image.tag to $$SAFE_REF_NAME in values.yaml"; \
-		echo "Updated appVersion to $$SAFE_REF_NAME in Chart.yaml"; \
+		$$SED_CMD -i.bak "s|tag: \"main\"|tag: \"$$SAFE_REF\"|" nvsentinel/values.yaml && \
+		$$SED_CMD -i.bak "s|appVersion: \"1.0.0\"|appVersion: \"$$SAFE_REF\"|" nvsentinel/Chart.yaml && \
+		echo "Updated global.image.tag to $$SAFE_REF in values.yaml"; \
+		echo "Updated appVersion to $$SAFE_REF in Chart.yaml"; \
 		HELM_OCI_REPO_LOWER=$$(echo "$$HELM_OCI_REPOSITORY" | tr '[:upper:]' '[:lower:]'); \
 		echo "Publishing to OCI registry: $$HELM_OCI_REGISTRY/$$HELM_OCI_REPO_LOWER"; \
-		helm package nvsentinel --version $$SAFE_REF_NAME && \
-		helm push nvsentinel-$$SAFE_REF_NAME.tgz oci://$$HELM_OCI_REGISTRY/$$HELM_OCI_REPO_LOWER; \
+		helm package nvsentinel --version $$SAFE_REF && \
+		helm push nvsentinel-$$SAFE_REF.tgz oci://$$HELM_OCI_REGISTRY/$$HELM_OCI_REPO_LOWER; \
 	fi
 
 # All Kubernetes/Helm operations
@@ -46,9 +46,9 @@ help:
 	@echo "  help          - Show this help message"
 	@echo ""
 	@echo "Notes:"
-	@echo "  - helm-publish requires SAFE_REF_NAME environment variable"
-	@echo "  - helm-publish automatically updates image tags from 'main' to SAFE_REF_NAME"
-	@echo "  - helm-publish automatically updates Chart.yaml appVersion to SAFE_REF_NAME"
+	@echo "  - helm-publish requires SAFE_REF environment variable"
+	@echo "  - helm-publish automatically updates image tags from 'main' to SAFE_REF"
+	@echo "  - helm-publish automatically updates Chart.yaml appVersion to SAFE_REF"
 	@echo "  - helm-publish uses gsed (GNU sed) when available, falls back to sed"
 	@echo "  - For OCI registry (ghcr.io): set HELM_REGISTRY_TYPE=oci, HELM_OCI_REGISTRY, HELM_OCI_REPOSITORY"
 	@echo "  - For traditional registry (default): requires NGC_USER_NAME, NGC_PASSWORD"


### PR DESCRIPTION
## Summary

Use the correct safe ref variable for helm publish

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [x] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized the Helm chart packaging and versioning flow to use a single sanitized release reference, ensuring consistent tarball names and publish behavior.

* **Documentation**
  * Updated release guidance and help text to reflect the new release-reference handling and how image tags and chart appVersion are substituted during publishing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->