### PR TITLE
bug: must-gather toogle and multiple log collector job triggred at same time handling

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/fault-remediation/files/log-collector-job.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-remediation/files/log-collector-job.yaml
@@ -49,12 +49,10 @@ spec:
                   fieldPath: spec.nodeName
             - name: KEEP_ALIVE
               value: "false"
-            - name: GPU_OPERATOR_NAMESPACES
+            - name: GPU_OPERATOR_NAMESPACE
               value: {{ .Values.logCollector.gpuOperatorNamespaces | default "gpu-operator" | quote }}
             - name: ENABLE_GPU_OPERATOR_MUST_GATHER
-              value: "false"
-            - name: COLLECTION_TIMEOUT_SECONDS
-              value: "900"
+              value: {{ .Values.logCollector.enableGpuOperatorMustGather | quote }}
             - name: UPLOAD_URL_BASE
               value: {{ .Values.logCollector.uploadURL | quote }}
             - name: ENABLE_GCP_SOS_COLLECTION

--- a/distros/kubernetes/nvsentinel/charts/fault-remediation/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-remediation/values.yaml
@@ -105,11 +105,19 @@ logCollector:
   uploadURL: "http://nvsentinel-incluster-file-server.nvsentinel.svc.cluster.local/upload"
   # Comma-separated list of namespaces where GPU operator components run (for collecting GPU operator logs)
   gpuOperatorNamespaces: "gpu-operator"
+  # Enable GPU Operator must-gather collection (disabled by default)
+  # WARNING: must-gather collects logs from ALL nodes in the cluster, which can be very
+  # time-consuming for large clusters (e.g., GB200 clusters with 100+ nodes).
+  # If enabling this, you MUST increase the timeout accordingly.
+  # Recommended timeout: ~2-3 minutes per node (e.g., 100 nodes = 200-300 minutes)
+  enableGpuOperatorMustGather: false
   # Enable GCP-specific SOS report collection
   enableGcpSosCollection: false
   # Enable AWS-specific SOS report collection
   enableAwsSosCollection: false
   # Timeout for waiting for log collection job to complete
+  # Default: 10m (sufficient for nvidia-bug-report only)
+  # If enableGpuOperatorMustGather is true, increase to: ~2-3 min per node in cluster
   timeout: "10m"
   # Additional environment variables to pass to the log-collector container
   # Example:

--- a/distros/kubernetes/nvsentinel/values-full.yaml
+++ b/distros/kubernetes/nvsentinel/values-full.yaml
@@ -620,6 +620,17 @@ fault-remediation:
     # Can be multiple namespaces separated by commas
     gpuOperatorNamespaces: "gpu-operator"
     
+    # Enable GPU Operator must-gather collection (disabled by default)
+    # WARNING: must-gather collects logs from ALL nodes in the cluster, which can be very
+    # time-consuming for large clusters
+    # If enabling this, you MUST increase the timeout accordingly.
+    # Recommended timeout: ~2-3 minutes per node 
+    enableGpuOperatorMustGather: false
+    
+    # Timeout for log collection job (default: 10m)
+    # If enableGpuOperatorMustGather is true, increase to: ~2-3 min per node in cluster
+    timeout: "10m"
+    
     # Enable GCP-specific SOS report collection
     # Requires running on GCP and appropriate permissions
     enableGcpSosCollection: false

--- a/fault-remediation/pkg/reconciler/reconciler.go
+++ b/fault-remediation/pkg/reconciler/reconciler.go
@@ -306,8 +306,6 @@ func (r *Reconciler) handleRemediationEvent(
 	healthEvent := healthEventWithStatus.HealthEvent
 	nodeName := healthEvent.NodeName
 
-	r.runLogCollector(ctx, healthEvent)
-
 	// Check if we should skip this event (NONE actions or unsupported actions)
 	if r.shouldSkipEvent(ctx, healthEventWithStatus.HealthEventWithStatus) {
 		if err := watcherInstance.MarkProcessed(ctx, eventWithToken.ResumeToken); err != nil {
@@ -338,6 +336,10 @@ func (r *Reconciler) handleRemediationEvent(
 
 		return
 	}
+
+	// Run log collector only when we're about to create a new CR
+	// This prevents duplicate log-collector jobs when multiple events arrive for the same node
+	r.runLogCollector(ctx, healthEvent)
 
 	nodeRemediatedStatus, _ := r.performRemediation(ctx, healthEventWithStatus)
 


### PR DESCRIPTION
## Summary
_1. Disable GPU Operator Must-Gather by Default (Issue 1)_
 **Problem**: Must-gather collects logs from ALL nodes in the cluster, which is very time-consuming for large clusters (e.g., GB200 clusters with 100+ nodes).
**Solution**:
Added ENABLE_GPU_OPERATOR_MUST_GATHER environment variable check in entrypoint.sh
Must-gather is now disabled by default (enableGpuOperatorMustGather: false)
Added Helm configuration option to enable when needed
Updated documentation with timeout recommendations (2-3 min per node when enabled)

_2. Prevent Duplicate Log-Collector Jobs (Issue 2 & 3)_
**Problem**: Multiple log-collector jobs could run on the same node when multiple health events arrive in quick succession.
**Solution**:
Moved runLogCollector() call to after the checkExistingCRStatus() check
Log collector now only runs when shouldCreateCR=true
If an existing CR is in progress for the node, both CR creation and log collection are skipped

Test result- 
`
    --- PASS: TestCrossActionRemediationWithEquivalenceGroups/ComponentReset_vs_NodeReboot_SameGroup_NotSucceeded (0.00s)
    --- PASS: TestCrossActionRemediationWithEquivalenceGroups/NodeReboot_vs_RestartVM_SameGroup_Succeeded (0.00s)
    --- PASS: TestCrossActionRemediationWithEquivalenceGroups/ResetGPU_vs_RestartBM_SameGroup_NotSucceeded (0.00s)
    --- PASS: TestCrossActionRemediationWithEquivalenceGroups/ComponentReset_vs_NONE_NotInGroup (0.00s)
=== RUN   TestLogCollectorOnlyCalledWhenShouldCreateCR
=== RUN   TestLogCollectorOnlyCalledWhenShouldCreateCR/ShouldCreateCR_True_LogCollectorCalled
2025/12/01 17:18:27 INFO Log collector feature enabled; running log collector for node node=test-node
=== RUN   TestLogCollectorOnlyCalledWhenShouldCreateCR/ShouldCreateCR_False_LogCollectorSkipped
--- PASS: TestLogCollectorOnlyCalledWhenShouldCreateCR (0.00s)
    --- PASS: TestLogCollectorOnlyCalledWhenShouldCreateCR/ShouldCreateCR_True_LogCollectorCalled (0.00s)
    --- PASS: TestLogCollectorOnlyCalledWhenShouldCreateCR/ShouldCreateCR_False_LogCollectorSkipped (0.00s)
=== RUN   TestNewK8sClient
=== RUN   TestNewK8sClient/Empty_kubeconfig_without_in-cluster_config
=== RUN   TestNewK8sClient/Invalid_kubeconfig_path
--- PASS: TestNewK8sClient (0.00s)
    --- PASS: TestNewK8sClient/Empty_kubeconfig_without_in-cluster_config (0.00s)
    --- PASS: TestNewK8sClient/Invalid_kubeconfig_path (0.00s)
=== RUN   TestCreateRebootNodeResource
=== RUN   TestCreateRebootNodeResource/Successful_rebootnode_creation
2025/12/01 17:18:27 Creating RebootNode CR for node: test-node-1 (UID: test-uid)
2025/12/01 17:18:27 Generated YAML: apiVersion: janitor.dgxc.nvidia.com/v1alpha1
kind: RebootNode
metadata:
  name: maintenance-test-node-1-67c3b6d1-bb0d-4ebc-b1ae-83cccc1266f5
spec:
  nodeName: test-node-1
2025/12/01 17:18:27 INFO Added owner reference to CR for automatic garbage collection node=test-node-1 nodeUID=test-uid crName=maintenance-test-node-1-67c3b6d1-bb0d-4ebc-b1ae-83cccc1266f5
2025/12/01 17:18:27 Created Maintenance CR maintenance-test-node-1-67c3b6d1-bb0d-4ebc-b1ae-83cccc1266f5 successfully for node test-node-1
=== RUN   TestCreateRebootNodeResource/Skip_rebootnode_creation_with_dry_run
2025/12/01 17:18:27 DRY-RUN: Skipping custom resource creation for node test-node-2
--- PASS: TestCreateRebootNodeResource (0.00s)
    --- PASS: TestCreateRebootNodeResource/Successful_rebootnode_creation (0.00s)
    --- PASS: TestCreateRebootNodeResource/Skip_rebootnode_creation_with_dry_run (0.00s)
=== RUN   TestRunLogCollectorJob
=== RUN   TestRunLogCollectorJob/Missing_manifest_file
=== RUN   TestRunLogCollectorJob/Dry_run_mode
--- PASS: TestRunLogCollectorJob (0.00s)
    --- PASS: TestRunLogCollectorJob/Missing_manifest_file (0.00s)
    --- PASS: TestRunLogCollectorJob/Dry_run_mode (0.00s)
=== RUN   TestLogCollectorJobErrorHandling
=== RUN   TestLogCollectorJobErrorHandling/Invalid_node_name
=== RUN   TestLogCollectorJobErrorHandling/Long_node_name
--- PASS: TestLogCollectorJobErrorHandling (0.00s)
    --- PASS: TestLogCollectorJobErrorHandling/Invalid_node_name (0.00s)
    --- PASS: TestLogCollectorJobErrorHandling/Long_node_name (0.00s)
=== RUN   TestRunLogCollectorJobDryRun
2025/12/01 17:18:27 DRY-RUN: Skipping log collector job for node test-node-dry-run
--- PASS: TestRunLogCollectorJobDryRun (0.00s)
PASS
ok      github.com/nvidia/nvsentinel/fault-remediation/pkg/reconciler   13.635s`


Bug- https://github.com/NVIDIA/NVSentinel/issues/441

<!-- Brief description of your changes -->

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [x] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional GPU Operator must-gather (disabled by default) with new enable flag and configurable timeout; guidance for large clusters.
* **Bug Fixes**
  * Prevents duplicate log-collector runs by invoking collection only when a new remediation record will be created.
* **Behavior**
  * Must-gather runs only when enabled; archives created/uploaded only if data exists; tolerant failure handling and clearer messages.
* **Configuration**
  * GPU operator env var renamed; legacy collection-timeout env removed; new enable and timeout configuration fields added.
* **Documentation**
  * Updated docs with must-gather guidance, timeout recommendations, examples, and trigger/workflow clarifications.
* **Tests**
  * New tests and helpers verify invocation conditions and ensure no unwanted jobs are created.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->