### PR TITLE
feat: restrict node condition message length to 1024Bytes(1KB)

### DIFF
--- a/distros/kubernetes/nvsentinel/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/templates/configmap.yaml
@@ -24,6 +24,7 @@ data:
       "enableK8sPlatformConnector": "{{ .Values.platformConnector.k8sConnector.enabled }}",
       "K8sConnectorQps": {{ printf "%.2f" .Values.platformConnector.k8sConnector.qps }},
       "K8sConnectorBurst": {{ .Values.platformConnector.k8sConnector.burst }},
+      "MaxNodeConditionMessageLength": {{ .Values.platformConnector.k8sConnector.maxNodeConditionMessageLength }},
       "enableMongoDBStorePlatformConnector": "{{ .Values.global.mongodbStore.enabled }}",
       "enablePostgresDBStorePlatformConnector": {{ if and .Values.global.datastore .Values.global.datastore.provider }}{{ eq .Values.global.datastore.provider "postgresql" | quote }}{{ else }}"false"{{ end }}
       {{- if .Values.platformConnector.nodeMetadata }}

--- a/distros/kubernetes/nvsentinel/values-full.yaml
+++ b/distros/kubernetes/nvsentinel/values-full.yaml
@@ -259,6 +259,11 @@ platformConnector:
   # Kubernetes connector configuration
   # Handles updating Kubernetes node status and conditions
   k8sConnector:
+    # Maximum length of the node condition message
+    # This is the maximum length of the node condition message that will be stored in the Kubernetes node status
+    # If the node condition message is longer than this value, it will be truncated
+    # This is to prevent the node condition message from being too long and causing the Kubernetes node status to be too large
+    maxNodeConditionMessageLength: 1024
     # Enable Kubernetes status updates
     enabled: true
     # Rate limiting for Kubernetes API calls

--- a/distros/kubernetes/nvsentinel/values-tilt.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt.yaml
@@ -284,6 +284,11 @@ csp-health-monitor:
 
 # Enable node metadata enrichment for testing
 platformConnector:
+  k8sConnector:
+    enabled: true
+    maxNodeConditionMessageLength: 1024
+    qps: 5.0
+    burst: 10
   nodeMetadata:
     enabled: true
 

--- a/distros/kubernetes/nvsentinel/values.yaml
+++ b/distros/kubernetes/nvsentinel/values.yaml
@@ -102,6 +102,7 @@ platformConnector:
 
   k8sConnector:
     enabled: true
+    maxNodeConditionMessageLength: 1024
     qps: 5.0
     burst: 10
 

--- a/docs/configuration/platform-connectors.md
+++ b/docs/configuration/platform-connectors.md
@@ -38,6 +38,7 @@ Configures the Kubernetes API client used for node metadata enrichment.
 platformConnector:
   k8sConnector:
     enabled: true
+    maxNodeConditionMessageLength: 1024
     qps: 5.0
     burst: 10
 ```
@@ -59,6 +60,7 @@ Maximum burst of queries allowed to the Kubernetes API server.
 platformConnector:
   k8sConnector:
     enabled: true
+    maxNodeConditionMessageLength: 1024
     qps: 10.0
     burst: 20
 ```

--- a/platform-connectors/main.go
+++ b/platform-connectors/main.go
@@ -96,12 +96,19 @@ func initializeK8sConnector(
 
 	qps := float32(qpsTemp)
 
+	maxNodeConditionMessageLength, ok := config["MaxNodeConditionMessageLength"].(int64)
+	if !ok {
+		return nil, nil, fmt.Errorf("failed to convert MaxNodeConditionMessageLength to int64: %v",
+			config["MaxNodeConditionMessageLength"])
+	}
+
 	burst, ok := config["K8sConnectorBurst"].(int64)
 	if !ok {
 		return nil, nil, fmt.Errorf("failed to convert K8sConnectorBurst to int: %v", config["K8sConnectorBurst"])
 	}
 
-	k8sConnector, clientset, err := kubernetes.InitializeK8sConnector(ctx, k8sRingBuffer, qps, int(burst), stopCh)
+	k8sConnector, clientset, err := kubernetes.InitializeK8sConnector(ctx, k8sRingBuffer, qps, int(burst),
+		stopCh, maxNodeConditionMessageLength)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to initialize K8sConnector: %w", err)
 	}

--- a/platform-connectors/pkg/connectors/kubernetes/k8s_connector.go
+++ b/platform-connectors/pkg/connectors/kubernetes/k8s_connector.go
@@ -36,25 +36,27 @@ type K8sConnector struct {
 	// clientset is the Kubernetes client
 	clientset kubernetes.Interface
 	// ringBuffer are client for pushing data to the resource count sink
-	ringBuffer *ringbuffer.RingBuffer
-	stopCh     <-chan struct{}
-	ctx        context.Context
+	ringBuffer                    *ringbuffer.RingBuffer
+	stopCh                        <-chan struct{}
+	ctx                           context.Context
+	maxNodeConditionMessageLength int64
 }
 
 func NewK8sConnector(
 	client kubernetes.Interface,
 	ringBuffer *ringbuffer.RingBuffer,
-	stopCh <-chan struct{}, ctx context.Context) *K8sConnector {
+	stopCh <-chan struct{}, ctx context.Context, maxNodeConditionMessageLength int64) *K8sConnector {
 	return &K8sConnector{
-		clientset:  client,
-		ringBuffer: ringBuffer,
-		stopCh:     stopCh,
-		ctx:        ctx,
+		clientset:                     client,
+		ringBuffer:                    ringBuffer,
+		stopCh:                        stopCh,
+		ctx:                           ctx,
+		maxNodeConditionMessageLength: maxNodeConditionMessageLength,
 	}
 }
 
 func InitializeK8sConnector(ctx context.Context, ringbuffer *ringbuffer.RingBuffer,
-	qps float32, burst int, stopCh <-chan struct{},
+	qps float32, burst int, stopCh <-chan struct{}, maxNodeConditionMessageLength int64,
 ) (*K8sConnector, kubernetes.Interface, error) {
 	// Create the in-cluster config
 	config, err := rest.InClusterConfig()
@@ -70,7 +72,7 @@ func InitializeK8sConnector(ctx context.Context, ringbuffer *ringbuffer.RingBuff
 		return nil, nil, fmt.Errorf("error creating kubernetes clientset: %w", err)
 	}
 
-	kubernetesConnector := NewK8sConnector(clientSet, ringbuffer, stopCh, ctx)
+	kubernetesConnector := NewK8sConnector(clientSet, ringbuffer, stopCh, ctx, maxNodeConditionMessageLength)
 
 	return kubernetesConnector, clientSet, nil
 }

--- a/platform-connectors/pkg/connectors/kubernetes/k8s_connector.go
+++ b/platform-connectors/pkg/connectors/kubernetes/k8s_connector.go
@@ -58,6 +58,11 @@ func NewK8sConnector(
 func InitializeK8sConnector(ctx context.Context, ringbuffer *ringbuffer.RingBuffer,
 	qps float32, burst int, stopCh <-chan struct{}, maxNodeConditionMessageLength int64,
 ) (*K8sConnector, kubernetes.Interface, error) {
+	if maxNodeConditionMessageLength <= 0 {
+		return nil, nil, fmt.Errorf("maxNodeConditionMessageLength must be greater than 0, got %d",
+			maxNodeConditionMessageLength)
+	}
+
 	// Create the in-cluster config
 	config, err := rest.InClusterConfig()
 	if err != nil {

--- a/platform-connectors/pkg/connectors/kubernetes/k8s_connector_envtest_test.go
+++ b/platform-connectors/pkg/connectors/kubernetes/k8s_connector_envtest_test.go
@@ -61,7 +61,9 @@ func TestK8sConnector_WithEnvtest_NodeConditionUpdate(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx)
+	maxNodeConditionMessageLength := int64(1024)
+
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,
@@ -143,7 +145,9 @@ func TestK8sConnector_WithEnvtest_NodeConditionClear(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx)
+	maxNodeConditionMessageLength := int64(1024)
+
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,
@@ -200,7 +204,9 @@ func TestK8sConnector_WithEnvtest_NodeEventCreation(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx)
+	maxNodeConditionMessageLength := int64(1024)
+
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,
@@ -269,7 +275,8 @@ func TestK8sConnector_WithEnvtest_AddMessages(t *testing.T) {
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	connector := NewK8sConnector(cli, nil, stopCh, ctx)
+	maxNodeConditionMessageLength := int64(1024)
+	connector := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
 
 	healthEvents := []*protos.HealthEvent{
 		{
@@ -329,7 +336,8 @@ func TestK8sConnector_WithEnvtest_RemoveMessages(t *testing.T) {
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	connector := NewK8sConnector(cli, nil, stopCh, ctx)
+	maxNodeConditionMessageLength := int64(1024)
+	connector := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
 
 	healthEvents := []*protos.HealthEvent{
 		{
@@ -375,7 +383,8 @@ func TestK8sConnector_WithEnvtest_MultipleEventsForSameNode(t *testing.T) {
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	connector := NewK8sConnector(cli, nil, stopCh, ctx)
+	maxNodeConditionMessageLength := int64(1024)
+	connector := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
 
 	healthEventsProto := &protos.HealthEvents{
 		Events: []*protos.HealthEvent{
@@ -460,7 +469,8 @@ func TestK8sConnector_WithEnvtest_TransitionTimeUpdates(t *testing.T) {
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	connector := NewK8sConnector(cli, nil, stopCh, ctx)
+	maxNodeConditionMessageLength := int64(1024)
+	connector := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
 
 	healthEvents := []*protos.HealthEvent{
 		{
@@ -508,7 +518,8 @@ func TestK8sConnector_WithEnvtest_EventCountIncrement(t *testing.T) {
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	connector := NewK8sConnector(cli, nil, stopCh, ctx)
+	maxNodeConditionMessageLength := int64(1024)
+	connector := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
 
 	healthEvent := &protos.HealthEvent{
 		CheckName:          "GpuThermalWatch",
@@ -560,7 +571,8 @@ func TestK8sConnector_WithEnvtest_NodeNotFound(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx)
+	maxNodeConditionMessageLength := int64(1024)
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,
@@ -604,7 +616,8 @@ func TestK8sConnector_WithEnvtest_EmptyHealthEvents(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx)
+	maxNodeConditionMessageLength := int64(1024)
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,
@@ -633,7 +646,8 @@ func TestK8sConnector_WithEnvtest_MultipleEntities(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx)
+	maxNodeConditionMessageLength := int64(1024)
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,
@@ -697,7 +711,8 @@ func TestK8sConnector_WithEnvtest_SpecialCharactersInMessage(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx)
+	maxNodeConditionMessageLength := int64(1024)
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,
@@ -753,7 +768,8 @@ func TestK8sConnector_WithEnvtest_MultipleCheckTypes(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx)
+	maxNodeConditionMessageLength := int64(1024)
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,

--- a/platform-connectors/pkg/connectors/kubernetes/k8s_connector_envtest_test.go
+++ b/platform-connectors/pkg/connectors/kubernetes/k8s_connector_envtest_test.go
@@ -29,6 +29,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
+const defaultMaxNodeConditionMessageLength = int64(1024)
+
 // go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 // source <(setup-envtest use -p env)
 func setupEnvtest(t *testing.T) (*envtest.Environment, *kubernetes.Clientset) {
@@ -61,9 +63,7 @@ func TestK8sConnector_WithEnvtest_NodeConditionUpdate(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	maxNodeConditionMessageLength := int64(1024)
-
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,
@@ -145,9 +145,7 @@ func TestK8sConnector_WithEnvtest_NodeConditionClear(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	maxNodeConditionMessageLength := int64(1024)
-
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,
@@ -204,9 +202,7 @@ func TestK8sConnector_WithEnvtest_NodeEventCreation(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	maxNodeConditionMessageLength := int64(1024)
-
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,
@@ -275,8 +271,7 @@ func TestK8sConnector_WithEnvtest_AddMessages(t *testing.T) {
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	maxNodeConditionMessageLength := int64(1024)
-	connector := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
+	connector := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
 
 	healthEvents := []*protos.HealthEvent{
 		{
@@ -336,8 +331,7 @@ func TestK8sConnector_WithEnvtest_RemoveMessages(t *testing.T) {
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	maxNodeConditionMessageLength := int64(1024)
-	connector := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
+	connector := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
 
 	healthEvents := []*protos.HealthEvent{
 		{
@@ -383,8 +377,7 @@ func TestK8sConnector_WithEnvtest_MultipleEventsForSameNode(t *testing.T) {
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	maxNodeConditionMessageLength := int64(1024)
-	connector := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
+	connector := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
 
 	healthEventsProto := &protos.HealthEvents{
 		Events: []*protos.HealthEvent{
@@ -469,8 +462,7 @@ func TestK8sConnector_WithEnvtest_TransitionTimeUpdates(t *testing.T) {
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	maxNodeConditionMessageLength := int64(1024)
-	connector := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
+	connector := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
 
 	healthEvents := []*protos.HealthEvent{
 		{
@@ -518,8 +510,7 @@ func TestK8sConnector_WithEnvtest_EventCountIncrement(t *testing.T) {
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	maxNodeConditionMessageLength := int64(1024)
-	connector := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
+	connector := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
 
 	healthEvent := &protos.HealthEvent{
 		CheckName:          "GpuThermalWatch",
@@ -571,8 +562,7 @@ func TestK8sConnector_WithEnvtest_NodeNotFound(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	maxNodeConditionMessageLength := int64(1024)
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,
@@ -616,8 +606,7 @@ func TestK8sConnector_WithEnvtest_EmptyHealthEvents(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	maxNodeConditionMessageLength := int64(1024)
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,
@@ -646,8 +635,7 @@ func TestK8sConnector_WithEnvtest_MultipleEntities(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	maxNodeConditionMessageLength := int64(1024)
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,
@@ -711,8 +699,7 @@ func TestK8sConnector_WithEnvtest_SpecialCharactersInMessage(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	maxNodeConditionMessageLength := int64(1024)
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,
@@ -768,8 +755,7 @@ func TestK8sConnector_WithEnvtest_MultipleCheckTypes(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	maxNodeConditionMessageLength := int64(1024)
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, maxNodeConditionMessageLength)
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,

--- a/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
+++ b/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
@@ -140,7 +140,7 @@ func (r *K8sConnector) updateNodeConditions(ctx context.Context, healthEvents []
 			}
 
 			if len(messages) > 0 {
-				matchedCondition.Message = fmt.Sprintf("%s;", strings.Join(messages, ";"))
+				matchedCondition.Message = r.truncateNodeConditionMessage(messages)
 				matchedCondition.Status = corev1.ConditionTrue
 				matchedCondition.Reason = r.updateHealthEventReason(events[len(events)-1].CheckName, false)
 			} else {
@@ -547,4 +547,43 @@ func isKubernetesStringError(errStr string) bool {
 	}
 
 	return false
+}
+
+// truncateNodeConditionMessage builds the node condition message while respecting the max node condition
+// message length. It preserves complete error entries and adds a truncation indicator if needed.
+func (r *K8sConnector) truncateNodeConditionMessage(messages []string) string {
+	if len(messages) == 0 {
+		return NoHealthFailureMsg
+	}
+
+	truncationSuffix := "..."
+	maxLen := int(r.maxNodeConditionMessageLength) - len(truncationSuffix)
+
+	var result strings.Builder
+	truncated := false
+
+	for i, msg := range messages {
+		var newEntry string
+		if i == 0 {
+			newEntry = msg
+		} else {
+			newEntry = ";" + msg
+		}
+
+		// Check if adding this entry would exceed the limit (+1 for trailing semicolon)
+		if result.Len()+len(newEntry)+1 > maxLen {
+			truncated = true
+			break
+		}
+
+		result.WriteString(newEntry)
+	}
+
+	result.WriteString(";")
+
+	if truncated {
+		result.WriteString(truncationSuffix)
+	}
+
+	return result.String()
 }

--- a/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
+++ b/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
@@ -552,10 +552,6 @@ func isKubernetesStringError(errStr string) bool {
 // truncateNodeConditionMessage builds the node condition message while respecting the max node condition
 // message length. It preserves complete error entries and adds a truncation indicator if needed.
 func (r *K8sConnector) truncateNodeConditionMessage(messages []string) string {
-	if len(messages) == 0 {
-		return NoHealthFailureMsg
-	}
-
 	truncationSuffix := "..."
 	maxLen := int(r.maxNodeConditionMessageLength) - len(truncationSuffix)
 

--- a/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
+++ b/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
@@ -556,6 +556,7 @@ func (r *K8sConnector) truncateNodeConditionMessage(messages []string) string {
 	maxLen := int(r.maxNodeConditionMessageLength) - len(truncationSuffix)
 
 	var result strings.Builder
+
 	truncated := false
 
 	for i, msg := range messages {

--- a/tests/syslog_health_monitor_test.go
+++ b/tests/syslog_health_monitor_test.go
@@ -179,6 +179,170 @@ func TestSyslogHealthMonitorXIDDetection(t *testing.T) {
 	testEnv.Test(t, feature.Feature())
 }
 
+// TestSyslogHealthMonitorXIDFloodWithDuplicates tests burst XID injection
+func TestSyslogHealthMonitorXIDFloodWithDuplicates(t *testing.T) {
+	feature := features.New("Syslog Health Monitor - XID Flood With Duplicates").
+		WithLabel("suite", "syslog-health-monitor").
+		WithLabel("component", "xid-flood-duplicates")
+
+	var testNodeName string
+	var syslogPod *v1.Pod
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err, "failed to create kubernetes client")
+
+		// Wait for pod to be available and ready (handles race condition from previous test teardown)
+		t.Log("Waiting for syslog-health-monitor pod to be ready...")
+		require.Eventually(t, func() bool {
+			var podErr error
+			syslogPod, podErr = helpers.GetPodOnWorkerNode(ctx, t, client, helpers.NVSentinelNamespace, "syslog-health-monitor")
+			if podErr != nil {
+				t.Logf("Waiting for pod: %v", podErr)
+				return false
+			}
+			// Verify pod is ready with all containers running
+			for _, containerStatus := range syslogPod.Status.ContainerStatuses {
+				if !containerStatus.Ready {
+					t.Logf("Container %s not ready yet", containerStatus.Name)
+					return false
+				}
+			}
+			return syslogPod != nil
+		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval, "syslog-health-monitor pod should be ready")
+
+		require.NotNil(t, syslogPod, "syslog health monitor pod should exist")
+
+		testNodeName = syslogPod.Spec.NodeName
+		t.Logf("Using syslog health monitor pod: %s on node: %s", syslogPod.Name, testNodeName)
+
+		metadata := helpers.CreateTestMetadata(testNodeName)
+		helpers.InjectMetadata(t, ctx, client, syslogPod.Namespace, testNodeName, metadata)
+
+		t.Logf("Setting up port-forward to pod %s on port %d", syslogPod.Name, stubJournalHTTPPort)
+		stopChan, readyChan := helpers.PortForwardPod(
+			ctx,
+			client.RESTConfig(),
+			syslogPod.Namespace,
+			syslogPod.Name,
+			stubJournalHTTPPort,
+			stubJournalHTTPPort,
+		)
+		<-readyChan
+		t.Log("Port-forward ready")
+
+		t.Logf("Setting ManagedByNVSentinel=false on node %s", testNodeName)
+		err = helpers.SetNodeManagedByNVSentinel(ctx, client, testNodeName, false)
+		require.NoError(t, err, "failed to set ManagedByNVSentinel label")
+
+		ctx = context.WithValue(ctx, keyNodeName, testNodeName)
+		ctx = context.WithValue(ctx, keySyslogPodName, syslogPod.Name)
+		ctx = context.WithValue(ctx, keyStopChan, stopChan)
+		return ctx
+	})
+
+	feature.Assess("Inject flood of duplicate XID errors and verify aggregation within 1KB", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err, "failed to create kubernetes client")
+
+		nodeName := ctx.Value(keyNodeName).(string)
+
+		xidMessages := []string{
+			// Fatal XIDs that go to node condition
+			"kernel: [16450076.435595] NVRM: Xid (PCI:0000:19:00): 45, pid=2864945, name=kit, Ch 0000000b",
+			"kernel: [16450076.436857] NVRM: Xid (PCI:0000:19:00): 45, pid=2864945, name=kit, Ch 0000000c",
+			"kernel: [16450076.449750] NVRM: Xid (PCI:0000:19:00): 45, pid=2864945, name=kit, Ch 0000000d",
+			"kernel: [16450076.463693] NVRM: Xid (PCI:0000:19:00): 45, pid=2864945, name=kit, Ch 0000000e",
+		}
+
+		// Expected patterns for all fatal XIDs in node condition (including XID 45 duplicates)
+		expectedSequencePatterns := []string{
+			`ErrorCode:45 PCI:0000:19:00 GPU_UUID:GPU-[0-9a-fA-F-]+ kernel:.*?NVRM: Xid \(PCI:0000:19:00\): 45.*?Ch 0000000b.*?Recommended Action=CONTACT_SUPPORT`,
+			`ErrorCode:45 PCI:0000:19:00 GPU_UUID:GPU-[0-9a-fA-F-]+ kernel:.*?NVRM: Xid \(PCI:0000:19:00\): 45.*?Ch 0000000c.*?Recommended Action=CONTACT_SUPPORT`,
+			`ErrorCode:45 PCI:0000:19:00 GPU_UUID:GPU-[0-9a-fA-F-]+ kernel:.*?NVRM: Xid \(PCI:0000:19:00\): 45.*?Ch 0000000d.*?Recommended Action=CONTACT_SUPPORT`,
+			`ErrorCode:45 PCI:0000:19:00 GPU_UUID:GPU-[0-9a-fA-F-]+ kernel:.*?NVRM: Xid \(PCI:0000:19:00\): 45.*?Ch 0000000e.*?Recommended Action=CONTACT_SUPPORT`,
+		}
+
+		helpers.InjectSyslogMessages(t, stubJournalHTTPPort, xidMessages)
+
+		t.Log("Verifying node condition contains all XID patterns including duplicate XID 45s")
+		require.Eventually(t, func() bool {
+			return helpers.VerifyNodeConditionMatchesSequence(t, ctx, client, nodeName,
+				"SysLogsXIDError", "SysLogsXIDErrorIsNotHealthy", expectedSequencePatterns)
+		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval, "Node condition should contain all XIDs including duplicates")
+
+		// Verify node condition message is within 1KB and NOT truncated
+		t.Log("Verifying node condition message is within 1KB limit and NOT truncated")
+		require.Eventually(t, func() bool {
+			condition, err := helpers.CheckNodeConditionExists(ctx, client, nodeName,
+				"SysLogsXIDError", "SysLogsXIDErrorIsNotHealthy")
+			if err != nil || condition == nil {
+				return false
+			}
+			// Check that message is NOT truncated and within 1KB limit
+			isNotTruncated := !strings.HasSuffix(condition.Message, "...")
+			isWithinLimit := len(condition.Message) <= 1024
+			t.Logf("Message length: %d bytes, not truncated: %v, within 1KB limit: %v", len(condition.Message), isNotTruncated, isWithinLimit)
+			return isNotTruncated && isWithinLimit
+		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval, "Node condition message should be within 1KB and NOT truncated")
+
+		return ctx
+	})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		if stopChanVal := ctx.Value(keyStopChan); stopChanVal != nil {
+			t.Log("Stopping port-forward")
+			close(stopChanVal.(chan struct{}))
+		}
+
+		client, err := c.NewClient()
+		if err != nil {
+			t.Logf("Warning: failed to create client for teardown: %v", err)
+			return ctx
+		}
+
+		nodeNameVal := ctx.Value(keyNodeName)
+		if nodeNameVal == nil {
+			t.Log("Skipping teardown: nodeName not set (setup likely failed early)")
+			return ctx
+		}
+		nodeName := nodeNameVal.(string)
+
+		podNameVal := ctx.Value(keySyslogPodName)
+		if podNameVal != nil {
+			podName := podNameVal.(string)
+			t.Logf("Restarting syslog-health-monitor pod %s to clear conditions", podName)
+			err = helpers.DeletePod(ctx, client, helpers.NVSentinelNamespace, podName)
+			if err != nil {
+				t.Logf("Warning: failed to delete pod: %v", err)
+			} else {
+				t.Logf("Waiting for SysLogsXIDError condition to be cleared from node %s", nodeName)
+				require.Eventually(t, func() bool {
+					condition, err := helpers.CheckNodeConditionExists(ctx, client, nodeName,
+						"SysLogsXIDError", "SysLogsXIDErrorIsHealthy")
+					if err != nil {
+						return false
+					}
+					return condition != nil && condition.Status == v1.ConditionFalse
+				}, helpers.EventuallyWaitTimeout, helpers.WaitInterval, "SysLogsXIDError condition should be cleared")
+			}
+		}
+
+		t.Logf("Cleaning up metadata from node %s", nodeName)
+		helpers.DeleteMetadata(t, ctx, client, helpers.NVSentinelNamespace, nodeName)
+
+		t.Logf("Removing ManagedByNVSentinel label from node %s", nodeName)
+		err = helpers.RemoveNodeManagedByNVSentinelLabel(ctx, client, nodeName)
+		if err != nil {
+			t.Logf("Warning: failed to remove ManagedByNVSentinel label: %v", err)
+		}
+
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}
+
 // TestSyslogHealthMonitorXIDWithoutMetadata tests XID detection works without metadata file
 func TestSyslogHealthMonitorXIDWithoutMetadata(t *testing.T) {
 	feature := features.New("Syslog Health Monitor - XID Without Metadata").

--- a/tests/syslog_health_monitor_test.go
+++ b/tests/syslog_health_monitor_test.go
@@ -507,7 +507,6 @@ func TestSyslogHealthMonitorNodeConditionTruncation(t *testing.T) {
 			messageLen := len(condition.Message)
 			t.Logf("Node condition message length: %d characters", messageLen)
 
-			// Verify message length is within the 1KB limit
 			if messageLen > maxConditionMessageLength {
 				t.Logf("FAIL: Message length %d exceeds max %d", messageLen, maxConditionMessageLength)
 				return false

--- a/tests/syslog_health_monitor_test.go
+++ b/tests/syslog_health_monitor_test.go
@@ -188,6 +188,8 @@ func TestSyslogHealthMonitorXIDFloodAndTruncation(t *testing.T) {
 		WithLabel("component", "xid-flood-truncation")
 
 	const (
+		// maxConditionMessageLength must match the default value in Helm values.yaml
+		// and the system's ConfigMap configuration for accurate truncation testing
 		maxConditionMessageLength = 1024
 		truncationSuffix          = "..."
 	)
@@ -215,7 +217,7 @@ func TestSyslogHealthMonitorXIDFloodAndTruncation(t *testing.T) {
 					return false
 				}
 			}
-			return syslogPod != nil
+			return true
 		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval, "syslog-health-monitor pod should be ready")
 
 		require.NotNil(t, syslogPod, "syslog health monitor pod should exist")

--- a/tests/syslog_health_monitor_test.go
+++ b/tests/syslog_health_monitor_test.go
@@ -353,7 +353,7 @@ func TestSyslogHealthMonitorXIDFloodAndTruncation(t *testing.T) {
 				return false
 			}
 
-			t.Logf("Phase 2 - Message length: %d chars (exactly at or near 1KB limit), truncated with suffix '%s'",
+			t.Logf("Phase 2 - Message length: %d bytes (exactly at or near 1KB limit), truncated with suffix '%s'",
 				messageLen, truncationSuffix)
 			return true
 		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval,

--- a/tests/syslog_health_monitor_test.go
+++ b/tests/syslog_health_monitor_test.go
@@ -179,11 +179,18 @@ func TestSyslogHealthMonitorXIDDetection(t *testing.T) {
 	testEnv.Test(t, feature.Feature())
 }
 
-// TestSyslogHealthMonitorXIDFloodWithDuplicates tests burst XID injection
-func TestSyslogHealthMonitorXIDFloodWithDuplicates(t *testing.T) {
-	feature := features.New("Syslog Health Monitor - XID Flood With Duplicates").
+// TestSyslogHealthMonitorXIDFloodAndTruncation tests two scenarios in sequence:
+// 1. First, injects duplicate XID errors and verifies they are all captured in the node condition (within 1KB, not truncated)
+// 2. Then, injects many more XIDs to exceed the 1KB limit and verifies truncation happens correctly
+func TestSyslogHealthMonitorXIDFloodAndTruncation(t *testing.T) {
+	feature := features.New("Syslog Health Monitor - XID Flood and Truncation").
 		WithLabel("suite", "syslog-health-monitor").
-		WithLabel("component", "xid-flood-duplicates")
+		WithLabel("component", "xid-flood-truncation")
+
+	const (
+		maxConditionMessageLength = 1024
+		truncationSuffix          = "..."
+	)
 
 	var testNodeName string
 	var syslogPod *v1.Pod
@@ -241,37 +248,45 @@ func TestSyslogHealthMonitorXIDFloodWithDuplicates(t *testing.T) {
 		return ctx
 	})
 
-	feature.Assess("Inject flood of duplicate XID errors and verify aggregation within 1KB", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+	// Phase 1: Inject varied XIDs to fill ~80-90% of 1KB limit (no truncation)
+	// Each message in node condition is ~180-250 bytes, so 5 messages should reach ~850-900 bytes
+	feature.Assess("Phase 1: Inject varied XID errors to fill ~80-90% of 1KB limit", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		client, err := c.NewClient()
 		require.NoError(t, err, "failed to create kubernetes client")
 
 		nodeName := ctx.Value(keyNodeName).(string)
 
+		// Use varied XID formats (different error codes and message types) to fill ~75-85% of 1KB
+		// All are fatal XIDs that will go to node condition
+		// Each message in condition is ~200-220 bytes, so 4 messages = ~800-880 bytes (~80% of 1KB)
 		xidMessages := []string{
-			// Fatal XIDs that go to node condition
+			// XID 79 - GPU fallen off bus (~210 bytes in condition)
+			"kernel: [16450076.435595] NVRM: Xid (PCI:0001:00:00): 79, pid=123456, name=test, GPU has fallen off the bus.",
+			// XID 62 - GPU memory errors with hex data (~230 bytes in condition)
+			"kernel: [16450076.435584] NVRM: Xid (PCI:0000:19:00): 62, 32260b5e 000154b0 00000000 2026da96 202b5626 202b5832 202b5872 202b58be",
+			// XID 45 - Channel errors with duplicate on same PCI (~210 bytes each in condition)
 			"kernel: [16450076.435595] NVRM: Xid (PCI:0000:19:00): 45, pid=2864945, name=kit, Ch 0000000b",
 			"kernel: [16450076.436857] NVRM: Xid (PCI:0000:19:00): 45, pid=2864945, name=kit, Ch 0000000c",
-			"kernel: [16450076.449750] NVRM: Xid (PCI:0000:19:00): 45, pid=2864945, name=kit, Ch 0000000d",
-			"kernel: [16450076.463693] NVRM: Xid (PCI:0000:19:00): 45, pid=2864945, name=kit, Ch 0000000e",
 		}
 
-		// Expected patterns for all fatal XIDs in node condition (including XID 45 duplicates)
+		// Expected patterns for all 4 fatal XIDs in order
 		expectedSequencePatterns := []string{
+			`ErrorCode:79 PCI:0001:00:00 GPU_UUID:GPU-[0-9a-fA-F-]+ kernel:.*?NVRM: Xid \(PCI:0001:00:00\): 79.*?GPU has fallen off the bus.*?Recommended Action=RESTART_BM`,
+			`ErrorCode:62 PCI:0000:19:00 GPU_UUID:GPU-[0-9a-fA-F-]+ kernel:.*?NVRM: Xid \(PCI:0000:19:00\): 62.*?Recommended Action=COMPONENT_RESET`,
 			`ErrorCode:45 PCI:0000:19:00 GPU_UUID:GPU-[0-9a-fA-F-]+ kernel:.*?NVRM: Xid \(PCI:0000:19:00\): 45.*?Ch 0000000b.*?Recommended Action=CONTACT_SUPPORT`,
 			`ErrorCode:45 PCI:0000:19:00 GPU_UUID:GPU-[0-9a-fA-F-]+ kernel:.*?NVRM: Xid \(PCI:0000:19:00\): 45.*?Ch 0000000c.*?Recommended Action=CONTACT_SUPPORT`,
-			`ErrorCode:45 PCI:0000:19:00 GPU_UUID:GPU-[0-9a-fA-F-]+ kernel:.*?NVRM: Xid \(PCI:0000:19:00\): 45.*?Ch 0000000d.*?Recommended Action=CONTACT_SUPPORT`,
-			`ErrorCode:45 PCI:0000:19:00 GPU_UUID:GPU-[0-9a-fA-F-]+ kernel:.*?NVRM: Xid \(PCI:0000:19:00\): 45.*?Ch 0000000e.*?Recommended Action=CONTACT_SUPPORT`,
 		}
 
+		t.Logf("Phase 1: Injecting %d varied XID messages to fill ~75-85%% of 1KB", len(xidMessages))
 		helpers.InjectSyslogMessages(t, stubJournalHTTPPort, xidMessages)
 
-		t.Log("Verifying node condition contains all XID patterns including duplicate XID 45s")
+		t.Log("Verifying node condition contains all 4 XID patterns")
 		require.Eventually(t, func() bool {
 			return helpers.VerifyNodeConditionMatchesSequence(t, ctx, client, nodeName,
 				"SysLogsXIDError", "SysLogsXIDErrorIsNotHealthy", expectedSequencePatterns)
-		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval, "Node condition should contain all XIDs including duplicates")
+		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval, "Node condition should contain all 4 XIDs")
 
-		// Verify node condition message is within 1KB and NOT truncated
+		// Verify message is within 1KB and NOT truncated
 		t.Log("Verifying node condition message is within 1KB limit and NOT truncated")
 		require.Eventually(t, func() bool {
 			condition, err := helpers.CheckNodeConditionExists(ctx, client, nodeName,
@@ -279,13 +294,72 @@ func TestSyslogHealthMonitorXIDFloodWithDuplicates(t *testing.T) {
 			if err != nil || condition == nil {
 				return false
 			}
-			// Check that message is NOT truncated and within 1KB limit
-			isNotTruncated := !strings.HasSuffix(condition.Message, "...")
-			isWithinLimit := len(condition.Message) <= 1024
-			t.Logf("Message length: %d bytes, not truncated: %v, within 1KB limit: %v", len(condition.Message), isNotTruncated, isWithinLimit)
+			isNotTruncated := !strings.HasSuffix(condition.Message, truncationSuffix)
+			isWithinLimit := len(condition.Message) <= maxConditionMessageLength
+			percentUsed := float64(len(condition.Message)) / float64(maxConditionMessageLength) * 100
+			t.Logf("Phase 1 - Message length: %d bytes (%.1f%% of 1KB), not truncated: %v",
+				len(condition.Message), percentUsed, isNotTruncated)
 			return isNotTruncated && isWithinLimit
 		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval, "Node condition message should be within 1KB and NOT truncated")
 
+		t.Log("Phase 1 PASSED: All varied XIDs captured within 1KB without truncation")
+		return ctx
+	})
+
+	// Phase 2: Add 1-2 more XIDs to exceed 1KB and trigger truncation
+	// The previous XIDs from Phase 1 are still in the node condition, so we just need to add enough to exceed 1KB
+	feature.Assess("Phase 2: Add more XIDs to exceed 1KB and verify truncation", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err, "failed to create kubernetes client")
+
+		nodeName := ctx.Value(keyNodeName).(string)
+
+		// Add 1 more fatal XID with a longer message to push over 1KB
+		// Phase 1 has ~850 bytes, this XID 119 adds ~250 bytes → total ~1100 bytes → triggers truncation
+		additionalXidMessages := []string{
+			// XID 119 - Longer GSP RPC timeout message (~250 bytes in condition)
+			"kernel: [16450076.435595] NVRM: Xid (PCI:0002:00:00): 119, pid=1582259, name=nvc:[driver], Timeout after 6s of waiting for RPC response from GPU1 GSP! Expected function 76 (GSP_RM_CONTROL) (0x20802a02 0x8).",
+		}
+
+		t.Logf("Phase 2: Injecting %d additional XID message to exceed 1KB (added to existing 4 from Phase 1)", len(additionalXidMessages))
+		helpers.InjectSyslogMessages(t, stubJournalHTTPPort, additionalXidMessages)
+
+		t.Log("Verifying node condition message is truncated to 1KB limit")
+		require.Eventually(t, func() bool {
+			condition, err := helpers.CheckNodeConditionExists(ctx, client, nodeName,
+				"SysLogsXIDError", "SysLogsXIDErrorIsNotHealthy")
+			if err != nil || condition == nil {
+				t.Logf("Condition not found yet: %v", err)
+				return false
+			}
+
+			messageLen := len(condition.Message)
+
+			// Check 1: Message must not exceed 1KB
+			if messageLen > maxConditionMessageLength {
+				t.Logf("FAIL: Message length %d exceeds max %d", messageLen, maxConditionMessageLength)
+				return false
+			}
+
+			// Check 2: Must have truncation suffix (indicating truncation occurred)
+			if !strings.HasSuffix(condition.Message, truncationSuffix) {
+				t.Logf("FAIL: Message should end with truncation suffix '%s'", truncationSuffix)
+				return false
+			}
+
+			// Check 3: Should contain XIDs from Phase 1 (at least the first ones)
+			if !strings.Contains(condition.Message, "ErrorCode:79") {
+				t.Logf("FAIL: Message should contain ErrorCode:79 from Phase 1")
+				return false
+			}
+
+			t.Logf("Phase 2 - Message length: %d chars (exactly at or near 1KB limit), truncated with suffix '%s'",
+				messageLen, truncationSuffix)
+			return true
+		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval,
+			"Node condition message should be truncated to 1KB with truncation suffix")
+
+		t.Log("Phase 2 PASSED: Message correctly truncated to 1KB limit while preserving earlier XIDs")
 		return ctx
 	})
 
@@ -585,162 +659,6 @@ func TestSyslogHealthMonitorSXIDDetection(t *testing.T) {
 		err = helpers.RemoveNodeManagedByNVSentinelLabel(ctx, client, nodeName)
 		if err != nil {
 			t.Logf("Warning: failed to remove label: %v", err)
-		}
-
-		return ctx
-	})
-
-	testEnv.Test(t, feature.Feature())
-}
-
-// TestSyslogHealthMonitorNodeConditionTruncation tests that node condition messages are truncated to 1KB
-func TestSyslogHealthMonitorNodeConditionTruncation(t *testing.T) {
-	feature := features.New("Syslog Health Monitor - Node Condition Truncation").
-		WithLabel("suite", "syslog-health-monitor").
-		WithLabel("component", "xid-detection")
-
-	const (
-		maxConditionMessageLength = 1024
-		truncationSuffix          = "..."
-	)
-
-	var testNodeName string
-	var syslogPod *v1.Pod
-
-	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-		client, err := c.NewClient()
-		require.NoError(t, err, "failed to create kubernetes client")
-
-		syslogPod, err = helpers.GetPodOnWorkerNode(ctx, t, client, helpers.NVSentinelNamespace, "syslog-health-monitor")
-		require.NoError(t, err, "failed to find syslog health monitor pod")
-		require.NotNil(t, syslogPod, "syslog health monitor pod should exist")
-
-		testNodeName = syslogPod.Spec.NodeName
-		t.Logf("Using syslog health monitor pod: %s on node: %s", syslogPod.Name, testNodeName)
-
-		t.Logf("Setting up port-forward to pod %s on port %d", syslogPod.Name, stubJournalHTTPPort)
-		stopChan, readyChan := helpers.PortForwardPod(
-			ctx,
-			client.RESTConfig(),
-			syslogPod.Namespace,
-			syslogPod.Name,
-			stubJournalHTTPPort,
-			stubJournalHTTPPort,
-		)
-		<-readyChan
-		t.Log("Port-forward ready")
-
-		t.Logf("Setting ManagedByNVSentinel=false on node %s", testNodeName)
-		err = helpers.SetNodeManagedByNVSentinel(ctx, client, testNodeName, false)
-		require.NoError(t, err, "failed to set ManagedByNVSentinel label")
-
-		ctx = context.WithValue(ctx, keyNodeName, testNodeName)
-		ctx = context.WithValue(ctx, keySyslogPodName, syslogPod.Name)
-		ctx = context.WithValue(ctx, keyStopChan, stopChan)
-		return ctx
-	})
-
-	feature.Assess("Inject many XID errors and verify message truncation to 1KB", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-		client, err := c.NewClient()
-		require.NoError(t, err, "failed to create kubernetes client")
-
-		nodeName := ctx.Value(keyNodeName).(string)
-
-		// Generate 15 fatal XID errors - each generates ~200+ chars in the condition message
-		// This should easily exceed the 1KB limit and trigger truncation
-		var xidMessages []string
-		for i := 0; i < 15; i++ {
-			// Use different PCI addresses to ensure each message is unique and not deduplicated
-			pciAddr := "0000:" + string(rune('1'+i/10)) + string(rune('0'+i%10)) + ":00"
-			msg := "kernel: [16450076.435595] NVRM: Xid (PCI:" + pciAddr + "): 79, pid=123456, name=test, GPU has fallen off the bus."
-			xidMessages = append(xidMessages, msg)
-		}
-
-		t.Logf("Injecting %d XID messages to trigger truncation", len(xidMessages))
-		helpers.InjectSyslogMessages(t, stubJournalHTTPPort, xidMessages)
-
-		t.Log("Verifying node condition message is truncated to 1KB limit")
-		require.Eventually(t, func() bool {
-			condition, err := helpers.CheckNodeConditionExists(ctx, client, nodeName,
-				"SysLogsXIDError", "SysLogsXIDErrorIsNotHealthy")
-			if err != nil || condition == nil {
-				t.Logf("Condition not found yet: %v", err)
-				return false
-			}
-
-			messageLen := len(condition.Message)
-			t.Logf("Node condition message length: %d characters", messageLen)
-
-			if messageLen > maxConditionMessageLength {
-				t.Logf("FAIL: Message length %d exceeds max %d", messageLen, maxConditionMessageLength)
-				return false
-			}
-
-			// Verify truncation suffix is present (indicates truncation occurred)
-			if !strings.HasSuffix(condition.Message, truncationSuffix) {
-				t.Logf("FAIL: Message should end with truncation suffix '%s'", truncationSuffix)
-				t.Logf("Message ends with: ...%s", condition.Message[max(0, messageLen-50):])
-				return false
-			}
-
-			// Verify at least some error content is present
-			if !strings.Contains(condition.Message, "ErrorCode:79") {
-				t.Logf("FAIL: Message should contain ErrorCode:79")
-				return false
-			}
-
-			t.Logf("SUCCESS: Message truncated correctly to %d chars with suffix '%s'",
-				messageLen, truncationSuffix)
-			return true
-		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval,
-			"Node condition message should be truncated to 1KB with truncation suffix")
-
-		return ctx
-	})
-
-	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-		if stopChanVal := ctx.Value(keyStopChan); stopChanVal != nil {
-			t.Log("Stopping port-forward")
-			close(stopChanVal.(chan struct{}))
-		}
-
-		client, err := c.NewClient()
-		if err != nil {
-			t.Logf("Warning: failed to create client for teardown: %v", err)
-			return ctx
-		}
-
-		nodeNameVal := ctx.Value(keyNodeName)
-		if nodeNameVal == nil {
-			t.Log("Skipping teardown: nodeName not set")
-			return ctx
-		}
-		nodeName := nodeNameVal.(string)
-
-		podNameVal := ctx.Value(keySyslogPodName)
-		if podNameVal != nil {
-			podName := podNameVal.(string)
-			t.Logf("Restarting syslog-health-monitor pod %s to clear conditions", podName)
-			err = helpers.DeletePod(ctx, client, helpers.NVSentinelNamespace, podName)
-			if err != nil {
-				t.Logf("Warning: failed to delete pod: %v", err)
-			} else {
-				t.Logf("Waiting for SysLogsXIDError condition to be cleared from node %s", nodeName)
-				require.Eventually(t, func() bool {
-					condition, err := helpers.CheckNodeConditionExists(ctx, client, nodeName,
-						"SysLogsXIDError", "SysLogsXIDErrorIsHealthy")
-					if err != nil {
-						return false
-					}
-					return condition != nil && condition.Status == v1.ConditionFalse
-				}, helpers.EventuallyWaitTimeout, helpers.WaitInterval, "SysLogsXIDError condition should be cleared")
-			}
-		}
-
-		t.Logf("Removing ManagedByNVSentinel label from node %s", nodeName)
-		err = helpers.RemoveNodeManagedByNVSentinelLabel(ctx, client, nodeName)
-		if err != nil {
-			t.Logf("Warning: failed to remove ManagedByNVSentinel label: %v", err)
 		}
 
 		return ctx


### PR DESCRIPTION
## Summary

<!-- Brief description of your changes -->
restrict node condition message field to be configurable and have been set to 1024 by default which can be changed as per need

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable maximum node condition message length for the Kubernetes connector (default: 1024 bytes); long messages are truncated with "..." and always end with a trailing semicolon.
  * Validation added to ensure a positive length value.

* **Documentation**
  * Configuration docs and examples updated to include the new setting under the Kubernetes connector.

* **Tests**
  * Added/updated tests covering truncation behavior, duplicate XID handling, and flood/truncation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->