### PR TITLE
feat: selectively enable health events analyzer rules

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/configmap.yaml
@@ -18,4 +18,4 @@ metadata:
   name: {{ include "health-events-analyzer.fullname" . }}-config
 data:
   config.toml: |
-    {{ .Values.config | nindent 6 }}
+    {{ tpl .Values.config . | nindent 6 }}

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
@@ -42,6 +42,7 @@ config: |
   name = "MultipleRemediations"
   description = "Detect if multiple remediations are performed within 7 days on a node"
   recommended_action = "CONTACT_SUPPORT"
+  evaluate_rule = {{ if hasKey .Values "enableMultipleRemediationsRule" }}{{ .Values.enableMultipleRemediationsRule }}{{ else }}true{{ end }}
   stage = [
     '''
     {
@@ -72,6 +73,7 @@ config: |
   name = "RepeatedXIDErrorOnSameGPU"
   description = "Detect occurrence of fatal XIDs 5 times within 24 hours where the burst window is 3 minutes and sticky XIDs window is 3 hours"
   recommended_action = "CONTACT_SUPPORT"
+  evaluate_rule = {{ if hasKey .Values "enableRepeatedXIDErrorOnSameGPURule" }}{{ .Values.enableRepeatedXIDErrorOnSameGPURule }}{{ else }}true{{ end }}
   stage = [
     '''
     {
@@ -314,6 +316,7 @@ config: |
   description = "Detect if XID 31 occurred 2 or more times on the same GPU within 24 hours where the burst window is 3 minutes and sticky XIDs window is 3 hours"
   recommended_action = "RUN_DCGMEUD"
   message = "if DCGM EUD tests pass, run field diagnostics"
+  evaluate_rule = {{ if hasKey .Values "enableRepeatedXID31OnSameGPURule" }}{{ .Values.enableRepeatedXID31OnSameGPURule }}{{ else }}true{{ end }}
   stage = [
     '''
     {
@@ -556,6 +559,7 @@ config: |
   description = "Detect if XID 31 occurred 2 or more times on different GPUs within 24 hours"
   message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support"
   recommended_action = "NONE"
+  evaluate_rule = {{ if hasKey .Values "enableRepeatedXID31OnDifferentGPURule" }}{{ .Values.enableRepeatedXID31OnDifferentGPURule }}{{ else }}true{{ end }}
   stage = [
     '''
     {
@@ -644,6 +648,7 @@ config: |
   description = "Detect if XID 13 occurred 2 or more times on the same GPC and TPC within 24 hours"
   message = "if DCGM EUD tests pass, run field diagnostics"
   recommended_action = "RUN_DCGMEUD"
+  evaluate_rule = {{ if hasKey .Values "enableRepeatedXID13OnSameGPCAndTPCRule" }}{{ .Values.enableRepeatedXID13OnSameGPCAndTPCRule }}{{ else }}true{{ end }}
   stage = [
     '''
     {
@@ -941,6 +946,7 @@ config: |
   description = "Detect if XID 13 occurred 2 or more times on different GPC and TPC combinations within 24 hours"
   message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support"
   recommended_action = "NONE"
+  evaluate_rule = {{ if hasKey .Values "enableRepeatedXID13OnDifferentGPCAndTPCRule" }}{{ .Values.enableRepeatedXID13OnDifferentGPCAndTPCRule }}{{ else }}true{{ end }}
   stage = [
     '''
     {
@@ -1080,6 +1086,7 @@ config: |
   description = "Detect if XID error occurred only once in the last burst within 24 hours time window"
   message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support"
   recommended_action = "NONE"
+  evaluate_rule = {{ if hasKey .Values "enableXIDErrorSoloNoBurstRule" }}{{ .Values.enableXIDErrorSoloNoBurstRule }}{{ else }}true{{ end }}
   stage = [
     '''
     {

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
@@ -31,6 +31,14 @@ resources:
 
 logLevel: info
 
+enableMultipleRemediationsRule: true
+enableRepeatedXIDErrorOnSameGPURule: true
+enableRepeatedXID31OnSameGPURule: true
+enableRepeatedXID31OnDifferentGPURule: true
+enableRepeatedXID13OnSameGPCAndTPCRule: true
+enableRepeatedXID13OnDifferentGPCAndTPCRule: true
+enableXIDErrorSoloNoBurstRule: true
+
 # Client certificate mount path for database connections
 clientCertMountPath: /etc/ssl/client-certs
 
@@ -42,7 +50,7 @@ config: |
   name = "MultipleRemediations"
   description = "Detect if multiple remediations are performed within 7 days on a node"
   recommended_action = "CONTACT_SUPPORT"
-  evaluate_rule = {{ if hasKey .Values "enableMultipleRemediationsRule" }}{{ .Values.enableMultipleRemediationsRule }}{{ else }}true{{ end }}
+  evaluate_rule = {{ .Values.enableMultipleRemediationsRule }}
   stage = [
     '''
     {
@@ -73,7 +81,7 @@ config: |
   name = "RepeatedXIDErrorOnSameGPU"
   description = "Detect occurrence of fatal XIDs 5 times within 24 hours where the burst window is 3 minutes and sticky XIDs window is 3 hours"
   recommended_action = "CONTACT_SUPPORT"
-  evaluate_rule = {{ if hasKey .Values "enableRepeatedXIDErrorOnSameGPURule" }}{{ .Values.enableRepeatedXIDErrorOnSameGPURule }}{{ else }}true{{ end }}
+  evaluate_rule = {{ .Values.enableRepeatedXIDErrorOnSameGPURule }}
   stage = [
     '''
     {
@@ -316,7 +324,7 @@ config: |
   description = "Detect if XID 31 occurred 2 or more times on the same GPU within 24 hours where the burst window is 3 minutes and sticky XIDs window is 3 hours"
   recommended_action = "RUN_DCGMEUD"
   message = "if DCGM EUD tests pass, run field diagnostics"
-  evaluate_rule = {{ if hasKey .Values "enableRepeatedXID31OnSameGPURule" }}{{ .Values.enableRepeatedXID31OnSameGPURule }}{{ else }}true{{ end }}
+  evaluate_rule = {{ .Values.enableRepeatedXID31OnSameGPURule }}
   stage = [
     '''
     {
@@ -559,7 +567,7 @@ config: |
   description = "Detect if XID 31 occurred 2 or more times on different GPUs within 24 hours"
   message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support"
   recommended_action = "NONE"
-  evaluate_rule = {{ if hasKey .Values "enableRepeatedXID31OnDifferentGPURule" }}{{ .Values.enableRepeatedXID31OnDifferentGPURule }}{{ else }}true{{ end }}
+  evaluate_rule = {{ .Values.enableRepeatedXID31OnDifferentGPURule }}
   stage = [
     '''
     {
@@ -648,7 +656,7 @@ config: |
   description = "Detect if XID 13 occurred 2 or more times on the same GPC and TPC within 24 hours"
   message = "if DCGM EUD tests pass, run field diagnostics"
   recommended_action = "RUN_DCGMEUD"
-  evaluate_rule = {{ if hasKey .Values "enableRepeatedXID13OnSameGPCAndTPCRule" }}{{ .Values.enableRepeatedXID13OnSameGPCAndTPCRule }}{{ else }}true{{ end }}
+  evaluate_rule = {{ .Values.enableRepeatedXID13OnSameGPCAndTPCRule }}
   stage = [
     '''
     {
@@ -946,7 +954,7 @@ config: |
   description = "Detect if XID 13 occurred 2 or more times on different GPC and TPC combinations within 24 hours"
   message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support"
   recommended_action = "NONE"
-  evaluate_rule = {{ if hasKey .Values "enableRepeatedXID13OnDifferentGPCAndTPCRule" }}{{ .Values.enableRepeatedXID13OnDifferentGPCAndTPCRule }}{{ else }}true{{ end }}
+  evaluate_rule = {{ .Values.enableRepeatedXID13OnDifferentGPCAndTPCRule }}
   stage = [
     '''
     {
@@ -1086,7 +1094,7 @@ config: |
   description = "Detect if XID error occurred only once in the last burst within 24 hours time window"
   message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support"
   recommended_action = "NONE"
-  evaluate_rule = {{ if hasKey .Values "enableXIDErrorSoloNoBurstRule" }}{{ .Values.enableXIDErrorSoloNoBurstRule }}{{ else }}true{{ end }}
+  evaluate_rule = {{ .Values.enableXIDErrorSoloNoBurstRule }}
   stage = [
     '''
     {

--- a/health-events-analyzer/pkg/config/rules.go
+++ b/health-events-analyzer/pkg/config/rules.go
@@ -26,6 +26,7 @@ type HealthEventsAnalyzerRule struct {
 	Stage             []string `toml:"stage"`
 	RecommendedAction string   `toml:"recommended_action"`
 	Message           string   `toml:"message"`
+	EvaluateRule      bool     `toml:"evaluate_rule"`
 }
 
 type TomlConfig struct {

--- a/health-events-analyzer/pkg/reconciler/reconciler.go
+++ b/health-events-analyzer/pkg/reconciler/reconciler.go
@@ -201,6 +201,11 @@ func (r *Reconciler) handleEvent(ctx context.Context, event *datamodels.HealthEv
 
 	// Process regular rules
 	for _, rule := range r.config.HealthEventsAnalyzerRules.Rules {
+		if !rule.EvaluateRule {
+			slog.Info("Skipping rule evaluation", "rule_name", rule.Name)
+			continue
+		}
+
 		published, err := r.processRule(ctx, rule, event)
 		if err != nil {
 			multiErr = multierror.Append(multiErr, err)

--- a/health-events-analyzer/pkg/reconciler/reconciler_test.go
+++ b/health-events-analyzer/pkg/reconciler/reconciler_test.go
@@ -168,6 +168,7 @@ var (
 				`{"$match": {"count": {"$gte": 5}}}`,
 			},
 			RecommendedAction: "CONTACT_SUPPORT",
+			EvaluateRule:      true,
 		},
 		{
 			Name:        "rule2",
@@ -180,6 +181,7 @@ var (
 			},
 			RecommendedAction: "CONTACT_SUPPORT",
 			Message:           "XID error occurred",
+			EvaluateRule:      true,
 		},
 		{
 			Name:        "rule3",
@@ -191,6 +193,7 @@ var (
 				`{"$match": {"count": {"$gte": 1}}}`,
 			},
 			RecommendedAction: "CONTACT_SUPPORT",
+			EvaluateRule:      true,
 		},
 	}
 	healthEvent_13 = datamodels.HealthEventWithStatus{

--- a/tests/data/health-events-analyzer-config.yaml
+++ b/tests/data/health-events-analyzer-config.yaml
@@ -9,6 +9,7 @@ data:
     name = "MultipleRemediations"
     description = "Detect if multiple remediations are performed within 1.5 minutes on a node"
     recommended_action = "CONTACT_SUPPORT"
+    evaluate_rule = true
     stage = [
       '''
       {
@@ -39,6 +40,7 @@ data:
     name = "RepeatedXIDErrorOnSameGPU"
     description = "Detect occurrence of fatal XIDs 2 times within 2 minutes where the burst window is 20 seconds and sticky XIDs window is 30 seconds"
     recommended_action = "CONTACT_SUPPORT"
+    evaluate_rule = true
     stage = [
       '''
       {
@@ -281,6 +283,7 @@ data:
     description = "Detect if XID 31 occurred 2 or more times on the same GPU within 3 minutes where the burst window is 20 seconds and sticky XIDs window is 30 seconds"
     recommended_action = "RUN_DCGMEUD"
     message = "if DCGM EUD tests pass, run field diagnostics"
+    evaluate_rule = true
     stage = [
       '''
       {
@@ -523,6 +526,7 @@ data:
     description = "Detect if XID 31 occurred 2 or more times on different GPUs within 1 minute"
     message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support"
     recommended_action = "NONE"
+    evaluate_rule = true
     stage = [
       '''
       {
@@ -611,6 +615,7 @@ data:
     description = "Detect if XID 13 occurred 2 or more times on the same GPC and TPC within 3 minutes"
     message = "if DCGM EUD tests pass, run field diagnostics" 
     recommended_action = "RUN_DCGMEUD"
+    evaluate_rule = true
     stage = [
       '''
       {
@@ -908,6 +913,7 @@ data:
     description = "Detect if XID 13 occurred 2 or more times on different GPC and TPC combinations within 1.5 minutes"
     message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support"
     recommended_action = "NONE"
+    evaluate_rule = true
     stage = [
       '''
       {
@@ -1047,6 +1053,7 @@ data:
     description = "Detect if XID error occurred only once in the last burst within 1 minute time window"
     message = "App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support"
     recommended_action = "NONE"
+    evaluate_rule = true
     stage = [
       '''
       {


### PR DESCRIPTION
## Summary

<!-- Brief description of your changes -->

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [x] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review

Issue: https://github.com/NVIDIA/NVSentinel/issues/389

### Testing
1. Tested on tilt cluster by updating values-tilt.yaml where I disabled the rules by mentioning the disable flags
```
health-events-analyzer:
  enableRepeatedXID13OnDifferentGPCAndTPCRule: true
  enableXIDErrorSoloNoBurstRule: false
  logLevel: debug
```
Checked that config file only had two rules disabled (for which disable flag is mentioned) and rule evaluation skipped for those rules.

logs 
```
tanishag@9dfd649-lcedt ~/n/N/tests (389-selectively-enable-rules)> kubectl logs -n nvsentinel deployment/health-eve
nts-analyzer | grep -i "skipping"
{"time":"2025-12-10T11:03:14.04076287Z","level":"INFO","source":{"function":"[github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler.(*Reconciler).handleEvent](http://github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler.(*Reconciler).handleEvent)","file":"[github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler/reconciler.go](http://github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler/reconciler.go)","line":205},"msg":"Skipping rule evaluation","module":"health-events-analyzer","version":"dev","rule_name":"RepeatedXID13OnDifferentGPCAndTPC"}
{"time":"2025-12-10T11:03:14.040766081Z","level":"INFO","source":{"function":"[github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler.(*Reconciler).handleEvent](http://github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler.(*Reconciler).handleEvent)","file":"[github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler/reconciler.go](http://github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler/reconciler.go)","line":205},"msg":"Skipping rule evaluation","module":"health-events-analyzer","version":"dev","rule_name":"XIDErrorSoloNoBurst"}
{"time":"2025-12-10T11:03:14.049319643Z","level":"INFO","source":{"function":"[github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler.(*Reconciler).handleEvent](http://github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler.(*Reconciler).handleEvent)","file":"[github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler/reconciler.go](http://github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler/reconciler.go)","line":205},"msg":"Skipping rule evaluation","module":"health-events-analyzer","version":"dev","rule_name":"RepeatedXID13OnDifferentGPCAndTPC"}
{"time":"2025-12-10T11:03:14.049321535Z","level":"INFO","source":{"function":"[github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler.(*Reconciler).handleEvent](http://github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler.(*Reconciler).handleEvent)","file":"[github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler/reconciler.go](http://github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler/reconciler.go)","line":205},"msg":"Skipping rule evaluation","module":"health-events-analyzer","version":"dev","rule_name":"XIDErrorSoloNoBurst"}
{"time":"2025-12-10T11:03:19.059678987Z","level":"INFO","source":{"function":"[github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler.(*Reconciler).handleEvent](http://github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler.(*Reconciler).handleEvent)","file":"[github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler/reconciler.go](http://github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler/reconciler.go)","line":205},"msg":"Skipping rule evaluation","module":"health-events-analyzer","version":"dev","rule_name":"RepeatedXID13OnDifferentGPCAndTPC"}
{"time":"2025-12-10T11:03:19.059686682Z","level":"INFO","source":{"function":"[github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler.(*Reconciler).handleEvent](http://github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler.(*Reconciler).handleEvent)","file":"[github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler/reconciler.go](http://github.com/nvidia/nvsentinel/health-events-analyzer/pkg/reconciler/reconciler.go)","line":205},"msg":"Skipping rule evaluation","module":"health-events-analyzer","version":"dev","rule_name":"XIDErrorSoloNoBurst"}
```

2. Tested on dev cluster by doing helm installation and disabled the two rules using disable flag. I updated the global values.yaml file with these values
``` 
health-events-analyzer:
  enableXIDErrorSoloNoBurstRule: false
  enableRepeatedXID13OnDifferentGPCAndTPCRule: false
```
and only these two rules were disabled in config file, rest others were enabled
<img width="659" height="234" alt="Screenshot 2025-12-10 at 4 02 21 PM" src="https://github.com/user-attachments/assets/f4ff5339-513b-4065-8228-51f24ad7a7c2" />
<img width="665" height="206" alt="Screenshot 2025-12-10 at 4 02 29 PM" src="https://github.com/user-attachments/assets/0810592d-7480-4392-adf4-a215130bae33" />
<img width="694" height="252" alt="Screenshot 2025-12-10 at 4 02 34 PM" src="https://github.com/user-attachments/assets/b4033e24-0a5b-4c59-ac90-a4b045f9e305" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable toggles to enable or disable individual health analyzer rules; defaults to enabled.
  * Embedded template expressions inside analyzer configuration are now evaluated at render time, allowing dynamic config content.

* **Tests**
  * Added tests verifying disabled rules are skipped during event processing and enabled rules continue to run.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->