### PR TITLE
fix: change audit logger default to disabled when env var not set

### DIFF
--- a/commons/pkg/auditlogger/auditlogger.go
+++ b/commons/pkg/auditlogger/auditlogger.go
@@ -68,7 +68,7 @@ func InitAuditLogger(comp string) error {
 		return fmt.Errorf("component name cannot be empty")
 	}
 
-	if !envutil.GetEnvBool(EnvAuditEnabled, true) {
+	if !envutil.GetEnvBool(EnvAuditEnabled, false) {
 		return nil
 	}
 

--- a/commons/pkg/auditlogger/auditlogger_test.go
+++ b/commons/pkg/auditlogger/auditlogger_test.go
@@ -36,11 +36,13 @@ func TestInitAuditLogger(t *testing.T) {
 			name:      "successful initialization with valid component",
 			component: "test-component",
 			setupEnv: func() {
+				os.Setenv(EnvAuditEnabled, "true")
 				os.Setenv(EnvPodName, "test-pod")
 				tmpDir := t.TempDir()
 				os.Setenv(EnvAuditLogBasePath, tmpDir)
 			},
 			cleanupEnv: func() {
+				os.Unsetenv(EnvAuditEnabled)
 				os.Unsetenv(EnvPodName)
 				os.Unsetenv(EnvAuditLogBasePath)
 				CloseAuditLogger()
@@ -74,11 +76,13 @@ func TestInitAuditLogger(t *testing.T) {
 			name:      "uses component name when POD_NAME not set",
 			component: "fallback-component",
 			setupEnv: func() {
+				os.Setenv(EnvAuditEnabled, "true")
 				tmpDir := t.TempDir()
 				os.Setenv(EnvAuditLogBasePath, tmpDir)
 				os.Unsetenv(EnvPodName)
 			},
 			cleanupEnv: func() {
+				os.Unsetenv(EnvAuditEnabled)
 				os.Unsetenv(EnvAuditLogBasePath)
 				CloseAuditLogger()
 			},
@@ -104,8 +108,10 @@ func TestInitAuditLogger(t *testing.T) {
 
 func TestLog(t *testing.T) {
 	tmpDir := t.TempDir()
+	os.Setenv(EnvAuditEnabled, "true")
 	os.Setenv(EnvAuditLogBasePath, tmpDir)
 	os.Setenv(EnvPodName, "test-pod")
+	defer os.Unsetenv(EnvAuditEnabled)
 	defer os.Unsetenv(EnvAuditLogBasePath)
 	defer os.Unsetenv(EnvPodName)
 
@@ -237,8 +243,10 @@ func TestLogWhenNotInitialized(t *testing.T) {
 
 func TestCloseAuditLogger(t *testing.T) {
 	tmpDir := t.TempDir()
+	os.Setenv(EnvAuditEnabled, "true")
 	os.Setenv(EnvAuditLogBasePath, tmpDir)
 	os.Setenv(EnvPodName, "test-pod")
+	defer os.Unsetenv(EnvAuditEnabled)
 	defer os.Unsetenv(EnvAuditLogBasePath)
 	defer os.Unsetenv(EnvPodName)
 

--- a/commons/pkg/auditlogger/roundtripper_test.go
+++ b/commons/pkg/auditlogger/roundtripper_test.go
@@ -75,8 +75,10 @@ func TestNewAuditingRoundTripper(t *testing.T) {
 
 func TestAuditingRoundTripper_WriteMethod(t *testing.T) {
 	tmpDir := t.TempDir()
+	os.Setenv(EnvAuditEnabled, "true")
 	os.Setenv(EnvAuditLogBasePath, tmpDir)
 	os.Setenv(EnvPodName, "test-pod")
+	defer os.Unsetenv(EnvAuditEnabled)
 	defer os.Unsetenv(EnvAuditLogBasePath)
 	defer os.Unsetenv(EnvPodName)
 
@@ -197,8 +199,10 @@ func TestAuditingRoundTripper_WriteMethod(t *testing.T) {
 
 func TestAuditingRoundTripper_ReadMethod(t *testing.T) {
 	tmpDir := t.TempDir()
+	os.Setenv(EnvAuditEnabled, "true")
 	os.Setenv(EnvAuditLogBasePath, tmpDir)
 	os.Setenv(EnvPodName, "test-pod-read")
+	defer os.Unsetenv(EnvAuditEnabled)
 	defer os.Unsetenv(EnvAuditLogBasePath)
 	defer os.Unsetenv(EnvPodName)
 
@@ -237,8 +241,10 @@ func TestAuditingRoundTripper_ReadMethod(t *testing.T) {
 
 func TestAuditingRoundTripper_ErrorResponse(t *testing.T) {
 	tmpDir := t.TempDir()
+	os.Setenv(EnvAuditEnabled, "true")
 	os.Setenv(EnvAuditLogBasePath, tmpDir)
 	os.Setenv(EnvPodName, "test-pod-error")
+	defer os.Unsetenv(EnvAuditEnabled)
 	defer os.Unsetenv(EnvAuditLogBasePath)
 	defer os.Unsetenv(EnvPodName)
 
@@ -280,9 +286,11 @@ func TestAuditingRoundTripper_ErrorResponse(t *testing.T) {
 
 func TestAuditingRoundTripper_NilRequestBody(t *testing.T) {
 	tmpDir := t.TempDir()
+	os.Setenv(EnvAuditEnabled, "true")
 	os.Setenv(EnvAuditLogBasePath, tmpDir)
 	os.Setenv(EnvPodName, "test-pod-nilbody")
 	os.Setenv(EnvAuditLogRequestBody, "true")
+	defer os.Unsetenv(EnvAuditEnabled)
 	defer os.Unsetenv(EnvAuditLogBasePath)
 	defer os.Unsetenv(EnvPodName)
 	defer os.Unsetenv(EnvAuditLogRequestBody)
@@ -330,9 +338,11 @@ func (e *errorReader) Read(p []byte) (n int, err error) {
 
 func TestAuditingRoundTripper_ReadAllError(t *testing.T) {
 	tmpDir := t.TempDir()
+	os.Setenv(EnvAuditEnabled, "true")
 	os.Setenv(EnvAuditLogBasePath, tmpDir)
 	os.Setenv(EnvPodName, "test-pod-readerror")
 	os.Setenv(EnvAuditLogRequestBody, "true")
+	defer os.Unsetenv(EnvAuditEnabled)
 	defer os.Unsetenv(EnvAuditLogBasePath)
 	defer os.Unsetenv(EnvPodName)
 	defer os.Unsetenv(EnvAuditLogRequestBody)
@@ -400,9 +410,11 @@ func (b *bodyCapturingRoundTripper) RoundTrip(req *http.Request) (*http.Response
 
 func TestAuditingRoundTripper_PreservesRequestBody(t *testing.T) {
 	tmpDir := t.TempDir()
+	os.Setenv(EnvAuditEnabled, "true")
 	os.Setenv(EnvAuditLogBasePath, tmpDir)
 	os.Setenv(EnvPodName, "test-pod-preserve")
 	os.Setenv(EnvAuditLogRequestBody, "true")
+	defer os.Unsetenv(EnvAuditEnabled)
 	defer os.Unsetenv(EnvAuditLogBasePath)
 	defer os.Unsetenv(EnvPodName)
 	defer os.Unsetenv(EnvAuditLogRequestBody)


### PR DESCRIPTION
## Summary

Fix audit logger to default to disabled when the AUDIT_ENABLED environment variable is not set.
**Problem**
When auditLogging.enabled: false is set in Helm values, no hostPath volume is mounted for audit logs. However, the audit logger's default value was true, causing it to attempt writing audit logs to /var/log/nvsentinel/ and failing with:
audit: failed to write entry: can't make directories for new logfile: mkdir /var/log/nvsentinel: permission denied
**Solution**
Changed the default value for AUDIT_ENABLED from true to false in InitAuditLogger(). This ensures that when the Helm chart disables audit logging (by not setting the env var), the audit logger remains disabled.
## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Default Behavior**
  * Audit logging is now disabled by default; enable it by setting AUDIT_ENABLED to a truthy value.
* **Tests**
  * Test suites now explicitly enable and clean up the audit-enabled environment variable so audit logging is active during relevant tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->