### PR TITLE
Prevent triggering of an inactive issue/PR checks for forked repository

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   codeql-pr-analysis:
-    if: startsWith(github.ref, 'refs/heads/pull-request/')
+    if: github.repository == 'nvidia/nvsentinel' && startsWith(github.ref, 'refs/heads/pull-request/')
     name: CodeQL PR Analysis
     runs-on: linux-amd64-cpu32
     timeout-minutes: 360
@@ -81,7 +81,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   codeql-baseline-analysis:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.repository == 'nvidia/nvsentinel' && github.ref == 'refs/heads/main' && github.event_name == 'push'
     name: CodeQL Baseline Analysis
     runs-on: linux-amd64-cpu4
     timeout-minutes: 360

--- a/.github/workflows/container-build-test.yml
+++ b/.github/workflows/container-build-test.yml
@@ -46,6 +46,7 @@ permissions:
 
 jobs:
   container-build-test:
+    if: github.repository == 'nvidia/nvsentinel'
     runs-on: linux-amd64-cpu32
     timeout-minutes: 45
     strategy:
@@ -96,6 +97,7 @@ jobs:
 
   # Test ko-based builds (Go modules)
   ko-build-test:
+    if: github.repository == 'nvidia/nvsentinel'
     runs-on: linux-amd64-cpu32
     timeout-minutes: 30
     strategy:
@@ -140,7 +142,7 @@ jobs:
   container-build-summary:
     runs-on: linux-amd64-cpu32
     needs: [container-build-test, ko-build-test]
-    if: always()
+    if: always() && github.repository == 'nvidia/nvsentinel'
     steps:
       - name: Check build results
         run: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -40,6 +40,7 @@ permissions:
 
 jobs:
   e2e-test:
+    if: github.repository == 'nvidia/nvsentinel'
     # Run E2E tests on both AMD64 and ARM64 architectures with both MongoDB and PostgreSQL
     strategy:
       fail-fast: false  # Allow all combinations to complete even if some fail

--- a/.github/workflows/integration-aws.yml
+++ b/.github/workflows/integration-aws.yml
@@ -29,6 +29,7 @@ permissions:
 
 jobs:
   integration-test-aws:
+    if: github.repository == 'nvidia/nvsentinel'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:

--- a/.github/workflows/integration-gcp.yml
+++ b/.github/workflows/integration-gcp.yml
@@ -29,6 +29,7 @@ permissions:
 
 jobs:
   integration-test-gcp:
+    if: github.repository == 'nvidia/nvsentinel'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -39,6 +39,7 @@ env:
 
 jobs:
   simple-lint:
+    if: github.repository == 'nvidia/nvsentinel'
     runs-on: linux-amd64-cpu16
     timeout-minutes: 30
     strategy:
@@ -100,6 +101,7 @@ jobs:
         run: make helm-lint
 
   health-monitors-lint-test:
+    if: github.repository == 'nvidia/nvsentinel'
     runs-on: linux-amd64-cpu16
     timeout-minutes: 30
     strategy:
@@ -132,6 +134,7 @@ jobs:
 
 
   modules-lint-test:
+    if: github.repository == 'nvidia/nvsentinel'
     runs-on: linux-amd64-cpu16
     timeout-minutes: 30
     strategy:
@@ -169,6 +172,7 @@ jobs:
             ${{ matrix.component }}/report.xml
 
   tilt-modules-lint-test:
+    if: github.repository == 'nvidia/nvsentinel'
     runs-on: linux-amd64-cpu16
     timeout-minutes: 30
     strategy:
@@ -194,7 +198,7 @@ jobs:
             ${{ matrix.component }}/report.xml
 
   consolidated-coverage-report:
-    if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/pull-request/')
+    if: github.repository == 'nvidia/nvsentinel' && (github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/pull-request/'))
     runs-on: linux-amd64-cpu16
     timeout-minutes: 15
     needs: [health-monitors-lint-test, modules-lint-test, tilt-modules-lint-test]
@@ -391,7 +395,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   consolidated-coverage-baseline:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.repository == 'nvidia/nvsentinel' && github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: linux-amd64-cpu16
     timeout-minutes: 15
     needs: [health-monitors-lint-test, modules-lint-test, tilt-modules-lint-test]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,7 @@ permissions:
 
 jobs:
   build-image-list:
+    if: github.repository == 'nvidia/nvsentinel'
     runs-on: linux-amd64-cpu32
     timeout-minutes: 60
     outputs:
@@ -85,6 +86,7 @@ jobs:
           retention-days: 90
 
   build-images-docker:
+    if: github.repository == 'nvidia/nvsentinel'
     runs-on: linux-amd64-cpu32
     timeout-minutes: 60
     permissions:
@@ -150,6 +152,7 @@ jobs:
 
   # Build images using ko and attest provenance
   build-images-ko:
+    if: github.repository == 'nvidia/nvsentinel'
     runs-on: linux-amd64-cpu32
     timeout-minutes: 60
     permissions:
@@ -199,6 +202,7 @@ jobs:
         run: scripts/buildko.sh
 
   attest-and-sbom-ko:
+    if: github.repository == 'nvidia/nvsentinel'
     needs: build-images-ko
     runs-on: linux-amd64-cpu32
     permissions:
@@ -223,6 +227,7 @@ jobs:
           registry_password: ${{ secrets.GITHUB_TOKEN }}
 
   e2e-test:
+    if: github.repository == 'nvidia/nvsentinel'
     name: "E2E Test Published Images"
     runs-on: linux-amd64-cpu32
     timeout-minutes: 60

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ permissions:
 
 jobs:
   build-image-list:
+    if: github.repository == 'nvidia/nvsentinel'
     runs-on: linux-amd64-cpu32
     timeout-minutes: 30
     steps:
@@ -74,6 +75,7 @@ jobs:
           retention-days: 90
 
   helm-publish:
+    if: github.repository == 'nvidia/nvsentinel'
     runs-on: linux-amd64-cpu4
     timeout-minutes: 45
     needs: build-image-list
@@ -123,6 +125,7 @@ jobs:
         run: make -C distros/kubernetes helm-publish
 
   create-github-release:
+    if: github.repository == 'nvidia/nvsentinel'
     runs-on: linux-amd64-cpu4
     timeout-minutes: 15
     needs:

--- a/.github/workflows/vuln-scan.yml
+++ b/.github/workflows/vuln-scan.yml
@@ -37,6 +37,7 @@ env:
 
 jobs:
   trivy-repo-scan:
+    if: github.repository == 'nvidia/nvsentinel'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Summary

Stop running CI jobs in the forked repos!

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [x] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added repository-level execution gates across CI/CD workflows (code scanning, container builds, e2e/integration tests, linting, publishing, release, and vulnerability scanning) so automated jobs run only in the primary repository. Jobs’ internal behavior and steps remain unchanged; this prevents runs in forks or other repositories and reduces unnecessary CI activity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->