### PR TITLE
fix: custom node drainer demo setup

### DIFF
--- a/demos/local-slinky-drain-demo/scripts/00-setup.sh
+++ b/demos/local-slinky-drain-demo/scripts/00-setup.sh
@@ -44,6 +44,7 @@ check_prerequisites() {
     command -v docker &>/dev/null || missing+=("docker")
     command -v helm &>/dev/null || missing+=("helm")
     command -v ko &>/dev/null || missing+=("ko")
+    command -v go &>/dev/null || missing+=("go")
     
     if [ ${#missing[@]} -gt 0 ]; then
         log "❌ Missing required tools: ${missing[*]}"
@@ -130,8 +131,20 @@ EOF
 install_custom_drain_crd() {
     section "Phase 4: Installing Custom Drain CRD"
     
+    local crd_file="$PROJECT_ROOT/plugins/slinky-drainer/config/crd/nvsentinel.nvidia.com_drainrequests.yaml"
+    
+    # Generate CRD if it doesn't exist
+    if [ ! -f "$crd_file" ]; then
+        log "CRD file not found, generating it..."
+        cd "$PROJECT_ROOT/plugins/slinky-drainer"
+        make generate
+        log "✓ CRD generated"
+    else
+        log "CRD file already exists, skipping generation"
+    fi
+    
     log "Installing DrainRequest CRD (required by node-drainer)..."
-    kubectl apply -f "$PROJECT_ROOT/plugins/slinky-drainer/config/crd/nvsentinel.nvidia.com_drainrequests.yaml"
+    kubectl apply -f "$crd_file"
     
     log "✓ DrainRequest CRD installed"
 }
@@ -146,7 +159,6 @@ install_nvsentinel() {
     
     log "Installing NVSentinel Helm chart from local directory..."
     log "Using image tag: ${nvsentinel_version}"
-    log "(node-drainer will be patched with locally built image for custom drain support)"
     
     helm upgrade --install nvsentinel \
         "$PROJECT_ROOT/distros/kubernetes/nvsentinel" \
@@ -170,13 +182,7 @@ build_and_load_plugin_images() {
     section "Phase 6: Building Custom Plugin Images"
     
     check_ko
-    
-    log "Building node-drainer..."
-    cd "$PROJECT_ROOT/node-drainer"
-    KO_DOCKER_REPO=ko.local ko build --bare --local . --tags demo
-    docker tag ko.local:demo node-drainer:demo
-    kind load docker-image node-drainer:demo --name "$CLUSTER_NAME"
-    
+      
     log "Building slinky-drainer..."
     cd "$PROJECT_ROOT/plugins/slinky-drainer"
     KO_DOCKER_REPO=ko.local ko build --bare --local . --tags demo
@@ -190,25 +196,6 @@ build_and_load_plugin_images() {
     kind load docker-image mock-slurm-operator:demo --name "$CLUSTER_NAME"
     
     log "✓ All plugin images built and loaded"
-}
-
-patch_node_drainer() {
-    section "Phase 7: Patching Node Drainer with Local Image"
-    
-    log "Patching node-drainer to use locally built image..."
-    kubectl set image deployment/node-drainer \
-        node-drainer=node-drainer:demo \
-        -n "$NAMESPACE"
-    
-    kubectl patch deployment node-drainer \
-        -n "$NAMESPACE" \
-        --type=json \
-        -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/imagePullPolicy", "value": "Never"}]'
-    
-    log "Waiting for node-drainer to restart with new image..."
-    kubectl rollout status deployment/node-drainer -n "$NAMESPACE" --timeout=120s
-    
-    log "✓ Node drainer patched with local image"
 }
 
 create_slinky_namespace() {
@@ -389,7 +376,6 @@ main() {
     install_custom_drain_crd
     install_nvsentinel
     build_and_load_plugin_images
-    patch_node_drainer
     create_slinky_namespace
     deploy_slinky_drainer
     deploy_mock_slurm

--- a/demos/local-slinky-drain-demo/scripts/00-setup.sh
+++ b/demos/local-slinky-drain-demo/scripts/00-setup.sh
@@ -343,7 +343,7 @@ show_summary() {
      - MongoDB
      - Platform Connectors
      - Fault Quarantine
-     - Node Drainer (patched with local image)
+     - Node Drainer
    ✓ Custom Plugins:
      - Slinky Drainer Plugin
      - Mock Slurm Operator


### PR DESCRIPTION
## Summary
1. If CRD file not found, then generate it
2. Since node drainer now supports custom drain in its official release, we no longer need to build it locally for this demo

After making this change:
```
$ make setup
[2025-12-15 19:01:32] Starting Slinky Drain Demo setup...


━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Checking Prerequisites
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

[2025-12-15 19:01:32] ✓ All prerequisites found

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Phase 1: Creating KIND Cluster
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

[2025-12-15 19:01:32] Creating KIND cluster with 2 nodes...
Creating cluster "nvsentinel-demo" ...
 ✓ Ensuring node image (kindest/node:v1.34.0) 🖼
 ✓ Preparing nodes 📦 📦  
 ✓ Writing configuration 📜 
 ✓ Starting control-plane 🕹️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾 
 ✓ Joining worker nodes 🚜 
Set kubectl context to "kind-nvsentinel-demo"
You can now use your cluster with:

kubectl cluster-info --context kind-nvsentinel-demo

Thanks for using kind! 😊
[2025-12-15 19:02:00] ✓ KIND cluster created

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Phase 2: Installing cert-manager
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

[2025-12-15 19:02:00] Installing cert-manager...
namespace/cert-manager created
customresourcedefinition.apiextensions.k8s.io/certificaterequests.cert-manager.io created
Warning: unrecognized format "int64"
Warning: unrecognized format "int32"
customresourcedefinition.apiextensions.k8s.io/certificates.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/challenges.acme.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/clusterissuers.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/issuers.cert-manager.io created
customresourcedefinition.apiextensions.k8s.io/orders.acme.cert-manager.io created
serviceaccount/cert-manager-cainjector created
serviceaccount/cert-manager created
serviceaccount/cert-manager-webhook created
clusterrole.rbac.authorization.k8s.io/cert-manager-cainjector created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-issuers created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-clusterissuers created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-certificates created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-orders created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-challenges created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-ingress-shim created
clusterrole.rbac.authorization.k8s.io/cert-manager-cluster-view created
clusterrole.rbac.authorization.k8s.io/cert-manager-view created
clusterrole.rbac.authorization.k8s.io/cert-manager-edit created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-approve:cert-manager-io created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-certificatesigningrequests created
clusterrole.rbac.authorization.k8s.io/cert-manager-webhook:subjectaccessreviews created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-cainjector created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-issuers created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-clusterissuers created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-certificates created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-orders created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-challenges created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-ingress-shim created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-approve:cert-manager-io created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-certificatesigningrequests created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-webhook:subjectaccessreviews created
role.rbac.authorization.k8s.io/cert-manager-cainjector:leaderelection created
role.rbac.authorization.k8s.io/cert-manager:leaderelection created
role.rbac.authorization.k8s.io/cert-manager-tokenrequest created
role.rbac.authorization.k8s.io/cert-manager-webhook:dynamic-serving created
rolebinding.rbac.authorization.k8s.io/cert-manager-cainjector:leaderelection created
rolebinding.rbac.authorization.k8s.io/cert-manager:leaderelection created
rolebinding.rbac.authorization.k8s.io/cert-manager-cert-manager-tokenrequest created
rolebinding.rbac.authorization.k8s.io/cert-manager-webhook:dynamic-serving created
service/cert-manager-cainjector created
service/cert-manager created
service/cert-manager-webhook created
deployment.apps/cert-manager-cainjector created
deployment.apps/cert-manager created
deployment.apps/cert-manager-webhook created
mutatingwebhookconfiguration.admissionregistration.k8s.io/cert-manager-webhook created
validatingwebhookconfiguration.admissionregistration.k8s.io/cert-manager-webhook created
[2025-12-15 19:02:02] Waiting for cert-manager to be ready...
deployment.apps/cert-manager condition met
deployment.apps/cert-manager-webhook condition met
deployment.apps/cert-manager-cainjector condition met
[2025-12-15 19:02:42] ✓ cert-manager installed

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Phase 3: Preparing Namespace
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

namespace/nvsentinel created
[2025-12-15 19:02:42] Creating custom drain template ConfigMap...
configmap/slinky-drain-template created
[2025-12-15 19:02:42] ✓ Namespace and drain template ready

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Phase 4: Installing Custom Drain CRD
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

[2025-12-15 19:02:42] CRD file already exists, skipping generation
[2025-12-15 19:02:42] Installing DrainRequest CRD (required by node-drainer)...
Warning: unrecognized format "int64"
customresourcedefinition.apiextensions.k8s.io/drainrequests.nvsentinel.nvidia.com created
[2025-12-15 19:02:42] ✓ DrainRequest CRD installed

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Phase 5: Installing NVSentinel
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

[2025-12-15 19:02:42] Installing Prometheus Operator CRDs (for PodMonitor)...
Warning: unrecognized format "int64"
customresourcedefinition.apiextensions.k8s.io/podmonitors.monitoring.coreos.com serverside-applied
[2025-12-15 19:02:43] Installing NVSentinel Helm chart from local directory...
[2025-12-15 19:02:43] Using image tag: v0.5.0
Release "nvsentinel" does not exist. Installing it now.
I1215 19:02:44.074241 1884031 warnings.go:110] "Warning: spec.SessionAffinity is ignored for headless services"
NAME: nvsentinel
LAST DEPLOYED: Mon Dec 15 19:02:43 2025
NAMESPACE: nvsentinel
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
NVSentinel has been successfully deployed
[2025-12-15 19:05:52] ✓ NVSentinel installed

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Phase 6: Building Custom Plugin Images
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

[2025-12-15 19:05:52] Building slinky-drainer...
2025/12/15 19:05:52 WARNING!
-----------------------------------------------------------------
The --local flag is set and KO_DOCKER_REPO is set to ko.local

You can choose either one to build a local image.

The --local flag might be deprecated in the future.
-----------------------------------------------------------------
2025/12/15 19:06:03 Using base cgr.dev/chainguard/static:latest@sha256:a301031ffd4ed67f35ca7fa6cf3dad9937b5fa47d7493955a18d9b4ca5412d1a for github.com/nvidia/nvsentinel/plugins/slinky-drainer
2025/12/15 19:06:04 git is in a dirty state
Please check in your pipeline what can be changing the following files:
 M demos/local-slinky-drain-demo/scripts/00-setup.sh
 M plugins/slinky-drainer/api/v1alpha1/zz_generated.deepcopy.go

2025/12/15 19:06:04 Building github.com/nvidia/nvsentinel/plugins/slinky-drainer for linux/amd64
2025/12/15 19:06:07 Loading ko.local:86c799b10cac3eb8991edd2f78a393f4583d69ca9ba8d37eddc7ecace00575d6
2025/12/15 19:06:07 Loaded ko.local:86c799b10cac3eb8991edd2f78a393f4583d69ca9ba8d37eddc7ecace00575d6
2025/12/15 19:06:07 Adding tag demo
2025/12/15 19:06:07 Added tag demo
ko.local:86c799b10cac3eb8991edd2f78a393f4583d69ca9ba8d37eddc7ecace00575d6
Image: "slinky-drainer:demo" with ID "sha256:4ba770a625028f8585538450839f3268d7ad6a7482b421598b5753ff1c4220d0" not yet present on node "nvsentinel-demo-worker", loading...
Image: "slinky-drainer:demo" with ID "sha256:4ba770a625028f8585538450839f3268d7ad6a7482b421598b5753ff1c4220d0" not yet present on node "nvsentinel-demo-control-plane", loading...
[2025-12-15 19:06:09] Building mock-slurm-operator...
2025/12/15 19:06:09 WARNING!
-----------------------------------------------------------------
The --local flag is set and KO_DOCKER_REPO is set to ko.local

You can choose either one to build a local image.

The --local flag might be deprecated in the future.
-----------------------------------------------------------------
2025/12/15 19:06:11 Using base cgr.dev/chainguard/static:latest@sha256:a301031ffd4ed67f35ca7fa6cf3dad9937b5fa47d7493955a18d9b4ca5412d1a for github.com/nvidia/nvsentinel/plugins/mock-slurm-operator
2025/12/15 19:06:18 git is in a dirty state
Please check in your pipeline what can be changing the following files:
 M demos/local-slinky-drain-demo/scripts/00-setup.sh
 M plugins/slinky-drainer/api/v1alpha1/zz_generated.deepcopy.go

2025/12/15 19:06:18 Building github.com/nvidia/nvsentinel/plugins/mock-slurm-operator for linux/amd64
2025/12/15 19:06:21 Loading ko.local:87fdf8aea98e585b89b8e3ca944ec17ae3c52be152f51954770d4220c281882f
2025/12/15 19:06:21 Loaded ko.local:87fdf8aea98e585b89b8e3ca944ec17ae3c52be152f51954770d4220c281882f
2025/12/15 19:06:21 Adding tag demo
2025/12/15 19:06:21 Added tag demo
ko.local:87fdf8aea98e585b89b8e3ca944ec17ae3c52be152f51954770d4220c281882f
Image: "mock-slurm-operator:demo" with ID "sha256:2179ebeeaafdb7acee852043d8067515e0d4292e4db6c0f36c257fe726f96378" not yet present on node "nvsentinel-demo-worker", loading...
Image: "mock-slurm-operator:demo" with ID "sha256:2179ebeeaafdb7acee852043d8067515e0d4292e4db6c0f36c257fe726f96378" not yet present on node "nvsentinel-demo-control-plane", loading...
[2025-12-15 19:06:23] ✓ All plugin images built and loaded

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Phase 7: Creating Slinky Namespace
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

namespace/slinky created
[2025-12-15 19:06:23] ✓ Slinky namespace created

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Phase 8: Deploying Slinky Drainer Plugin
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

[2025-12-15 19:06:23] Deploying Slinky Drainer...
customresourcedefinition.apiextensions.k8s.io/drainrequests.nvsentinel.nvidia.com configured
serviceaccount/slinky-drainer created
clusterrole.rbac.authorization.k8s.io/slinky-drainer-role created
clusterrolebinding.rbac.authorization.k8s.io/slinky-drainer-rolebinding created
deployment.apps/slinky-drainer created
deployment.apps/slinky-drainer image updated
deployment.apps/slinky-drainer patched
deployment.apps/slinky-drainer condition met
[2025-12-15 19:06:35] ✓ Slinky drainer deployed

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Phase 9: Deploying Mock Slurm Operator
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

[2025-12-15 19:06:35] Deploying Mock Slurm Operator...
serviceaccount/mock-slurm-operator created
clusterrole.rbac.authorization.k8s.io/mock-slurm-operator-role created
clusterrolebinding.rbac.authorization.k8s.io/mock-slurm-operator-rolebinding created
deployment.apps/mock-slurm-operator created
deployment.apps/mock-slurm-operator image updated
deployment.apps/mock-slurm-operator patched
deployment.apps/mock-slurm-operator condition met
[2025-12-15 19:06:49] ✓ Mock Slurm operator deployed

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Phase 10: Deploying Simple Health Client
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

[2025-12-15 19:06:49] Building simple-health-client image...
[+] Building 5.1s (18/18) FINISHED                                                                                                                                       docker:default
 => [internal] load build definition from Dockerfile                                                                                                                               0.1s
 => => transferring dockerfile: 1.57kB                                                                                                                                             0.0s
 => [internal] load metadata for nvcr.io/nvidia/distroless/go:v3.1.13                                                                                                              1.3s
 => [internal] load metadata for public.ecr.aws/docker/library/golang:1.25-trixie                                                                                                  4.9s
 => [internal] load .dockerignore                                                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                                                    0.0s
 => [builder 1/9] FROM public.ecr.aws/docker/library/golang:1.25-trixie@sha256:8e8f9c84609b6005af0a4a8227cee53d6226aab1c6dcb22daf5aeeb8b05480e1                                    0.0s
 => => resolve public.ecr.aws/docker/library/golang:1.25-trixie@sha256:8e8f9c84609b6005af0a4a8227cee53d6226aab1c6dcb22daf5aeeb8b05480e1                                            0.0s
 => [internal] load build context                                                                                                                                                  0.0s
 => => transferring context: 1.13kB                                                                                                                                                0.0s
 => [stage-1 1/3] FROM nvcr.io/nvidia/distroless/go:v3.1.13@sha256:694780ff504fb1c5e25b1f7fa4d618e55db8dcc12b8ca98b37b8959eb3f94e89                                                0.0s
 => CACHED [stage-1 2/3] WORKDIR /app                                                                                                                                              0.0s
 => CACHED [builder 2/9] WORKDIR /go/src                                                                                                                                           0.0s
 => CACHED [builder 3/9] COPY data-models/go.mod data-models/go.sum ./data-models/                                                                                                 0.0s
 => CACHED [builder 4/9] COPY tilt/simple-health-client/go.mod tilt/simple-health-client/go.sum ./tilt/simple-health-client/                                                       0.0s
 => CACHED [builder 5/9] WORKDIR /go/src/tilt/simple-health-client                                                                                                                 0.0s
 => CACHED [builder 6/9] RUN --mount=type=cache,target=/go/pkg/mod     go mod download                                                                                             0.0s
 => CACHED [builder 7/9] COPY tilt/simple-health-client/ .                                                                                                                         0.0s
 => CACHED [builder 8/9] COPY data-models/ ../../data-models/                                                                                                                      0.0s
 => CACHED [builder 9/9] RUN --mount=type=cache,target=/go/pkg/mod     go build -trimpath -o simple-health-client main.go                                                          0.0s
 => CACHED [stage-1 3/3] COPY --from=builder /go/src/tilt/simple-health-client/simple-health-client .                                                                              0.0s
 => exporting to image                                                                                                                                                             0.0s
 => => exporting layers                                                                                                                                                            0.0s
 => => writing image sha256:b3e84ccf54046288e808f288b40fe61ed35ffd8c7e39cebcee19c77b8951952b                                                                                       0.0s
 => => naming to docker.io/library/simple-health-client:demo                                                                                                                       0.0s
Image: "simple-health-client:demo" with ID "sha256:b3e84ccf54046288e808f288b40fe61ed35ffd8c7e39cebcee19c77b8951952b" not yet present on node "nvsentinel-demo-worker", loading...
Image: "simple-health-client:demo" with ID "sha256:b3e84ccf54046288e808f288b40fe61ed35ffd8c7e39cebcee19c77b8951952b" not yet present on node "nvsentinel-demo-control-plane", loading...
[2025-12-15 19:06:57] Deploying simple-health-client...
deployment.apps/simple-health-client created
service/simple-health-client created
deployment.apps/simple-health-client image updated
deployment.apps/simple-health-client patched
deployment.apps/simple-health-client condition met
[2025-12-15 19:06:58] ✓ Simple health client deployed

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Phase 11: Creating Test Workloads
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

[2025-12-15 19:06:58] Creating test pods in slinky namespace...
pod/slinky-workload-1 created
pod/slinky-workload-2 created
pod/slinky-workload-1 condition met
pod/slinky-workload-2 condition met
[2025-12-15 19:07:15] ✓ Test workloads created

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Setup Complete!
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


✅ Slinky Drain Demo Ready!

📊 Cluster Information:
   • Cluster: nvsentinel-demo
   • NVSentinel Namespace: nvsentinel
   • Slinky Namespace: slinky

🔧 Components Deployed:
   ✓ KIND Cluster (1 control-plane + 1 worker)
   ✓ cert-manager
   ✓ NVSentinel (via Helm chart):
     - MongoDB
     - Platform Connectors
     - Fault Quarantine
     - Node Drainer
   ✓ Custom Plugins:
     - Slinky Drainer Plugin
     - Mock Slurm Operator
   ✓ Test Workloads (2 pods on worker node)

📝 Next Steps:
   1. View cluster status:
      make show-cluster

   3. Inject a health event to trigger drain:
      make inject-health-event

   4. Verify the drain workflow:
      make verify-drain

🧹 Cleanup:
   make cleanup

[2025-12-15 19:07:15] ✅ Setup complete!
```

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added go prerequisite check during setup.
  * Automated CRD generation and application when missing.
  * Simplified demo setup by removing local node-drainer image build/patch steps and related rollout waits.
  * Adjusted setup messaging and deployed components summary to reflect removal of local node-drainer patching.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->