### PR TITLE
bug: install tilt from temp dir

### DIFF
--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -552,7 +552,12 @@ if [[ "${SKIP_TOOLS}" == "false" ]]; then
             if [[ "${OS}" == "darwin" ]]; then
                 brew install tilt
             elif [[ "${OS}" == "linux" ]]; then
+                # Install to /tmp to avoid conflicts with tilt/ directory in repo
+                TILT_INSTALL_DIR=$(mktemp -d)
+                pushd "${TILT_INSTALL_DIR}" > /dev/null
                 curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
+                popd > /dev/null
+                rm -rf "${TILT_INSTALL_DIR}"
             fi
             log_success "Tilt installed"
         fi


### PR DESCRIPTION
## Summary

Fixes #500 

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [x] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the development environment setup script to install Tilt in an isolated temporary directory instead of the repository root, with automatic cleanup procedures. This prevents potential conflicts with existing Tilt installations and provides developers with a cleaner, more reliable setup experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->