### PR TITLE
feat: event handling strategies in health monitors

### DIFF
--- a/data-models/pkg/protos/health_event.pb.go
+++ b/data-models/pkg/protos/health_event.pb.go
@@ -37,6 +37,55 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// ProcessingStrategy defines how downstream modules should handle the event.
+// EXECUTE_REMEDIATION: normal behavior; downstream modules may update cluster state.
+// STORE_ONLY: observability-only behavior; event should be persisted/exported but should not modify cluster resources.
+type ProcessingStrategy int32
+
+const (
+	ProcessingStrategy_EXECUTE_REMEDIATION ProcessingStrategy = 0
+	ProcessingStrategy_STORE_ONLY          ProcessingStrategy = 1
+)
+
+// Enum value maps for ProcessingStrategy.
+var (
+	ProcessingStrategy_name = map[int32]string{
+		0: "EXECUTE_REMEDIATION",
+		1: "STORE_ONLY",
+	}
+	ProcessingStrategy_value = map[string]int32{
+		"EXECUTE_REMEDIATION": 0,
+		"STORE_ONLY":          1,
+	}
+)
+
+func (x ProcessingStrategy) Enum() *ProcessingStrategy {
+	p := new(ProcessingStrategy)
+	*p = x
+	return p
+}
+
+func (x ProcessingStrategy) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ProcessingStrategy) Descriptor() protoreflect.EnumDescriptor {
+	return file_health_event_proto_enumTypes[0].Descriptor()
+}
+
+func (ProcessingStrategy) Type() protoreflect.EnumType {
+	return &file_health_event_proto_enumTypes[0]
+}
+
+func (x ProcessingStrategy) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ProcessingStrategy.Descriptor instead.
+func (ProcessingStrategy) EnumDescriptor() ([]byte, []int) {
+	return file_health_event_proto_rawDescGZIP(), []int{0}
+}
+
 type RecommendedAction int32
 
 const (
@@ -88,11 +137,11 @@ func (x RecommendedAction) String() string {
 }
 
 func (RecommendedAction) Descriptor() protoreflect.EnumDescriptor {
-	return file_health_event_proto_enumTypes[0].Descriptor()
+	return file_health_event_proto_enumTypes[1].Descriptor()
 }
 
 func (RecommendedAction) Type() protoreflect.EnumType {
-	return &file_health_event_proto_enumTypes[0]
+	return &file_health_event_proto_enumTypes[1]
 }
 
 func (x RecommendedAction) Number() protoreflect.EnumNumber {
@@ -101,7 +150,7 @@ func (x RecommendedAction) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use RecommendedAction.Descriptor instead.
 func (RecommendedAction) EnumDescriptor() ([]byte, []int) {
-	return file_health_event_proto_rawDescGZIP(), []int{0}
+	return file_health_event_proto_rawDescGZIP(), []int{1}
 }
 
 type HealthEvents struct {
@@ -225,6 +274,7 @@ type HealthEvent struct {
 	NodeName            string                 `protobuf:"bytes,13,opt,name=nodeName,proto3" json:"nodeName,omitempty"`
 	QuarantineOverrides *BehaviourOverrides    `protobuf:"bytes,14,opt,name=quarantineOverrides,proto3" json:"quarantineOverrides,omitempty"`
 	DrainOverrides      *BehaviourOverrides    `protobuf:"bytes,15,opt,name=drainOverrides,proto3" json:"drainOverrides,omitempty"`
+	ProcessingStrategy  ProcessingStrategy     `protobuf:"varint,16,opt,name=processingStrategy,proto3,enum=datamodels.ProcessingStrategy" json:"processingStrategy,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache
 }
@@ -364,6 +414,13 @@ func (x *HealthEvent) GetDrainOverrides() *BehaviourOverrides {
 	return nil
 }
 
+func (x *HealthEvent) GetProcessingStrategy() ProcessingStrategy {
+	if x != nil {
+		return x.ProcessingStrategy
+	}
+	return ProcessingStrategy_EXECUTE_REMEDIATION
+}
+
 type BehaviourOverrides struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Force         bool                   `protobuf:"varint,1,opt,name=force,proto3" json:"force,omitempty"`
@@ -429,7 +486,7 @@ const file_health_event_proto_rawDesc = "" +
 	"\n" +
 	"entityType\x18\x01 \x01(\tR\n" +
 	"entityType\x12 \n" +
-	"\ventityValue\x18\x02 \x01(\tR\ventityValue\"\x82\x06\n" +
+	"\ventityValue\x18\x02 \x01(\tR\ventityValue\"\xd2\x06\n" +
 	"\vHealthEvent\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\rR\aversion\x12\x14\n" +
 	"\x05agent\x18\x02 \x01(\tR\x05agent\x12&\n" +
@@ -446,13 +503,18 @@ const file_health_event_proto_rawDesc = "" +
 	"\x12generatedTimestamp\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\x12generatedTimestamp\x12\x1a\n" +
 	"\bnodeName\x18\r \x01(\tR\bnodeName\x12P\n" +
 	"\x13quarantineOverrides\x18\x0e \x01(\v2\x1e.datamodels.BehaviourOverridesR\x13quarantineOverrides\x12F\n" +
-	"\x0edrainOverrides\x18\x0f \x01(\v2\x1e.datamodels.BehaviourOverridesR\x0edrainOverrides\x1a;\n" +
+	"\x0edrainOverrides\x18\x0f \x01(\v2\x1e.datamodels.BehaviourOverridesR\x0edrainOverrides\x12N\n" +
+	"\x12processingStrategy\x18\x10 \x01(\x0e2\x1e.datamodels.ProcessingStrategyR\x12processingStrategy\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\">\n" +
 	"\x12BehaviourOverrides\x12\x14\n" +
 	"\x05force\x18\x01 \x01(\bR\x05force\x12\x12\n" +
-	"\x04skip\x18\x02 \x01(\bR\x04skip*\xa8\x01\n" +
+	"\x04skip\x18\x02 \x01(\bR\x04skip*=\n" +
+	"\x12ProcessingStrategy\x12\x17\n" +
+	"\x13EXECUTE_REMEDIATION\x10\x00\x12\x0e\n" +
+	"\n" +
+	"STORE_ONLY\x10\x01*\xa8\x01\n" +
 	"\x11RecommendedAction\x12\b\n" +
 	"\x04NONE\x10\x00\x12\x13\n" +
 	"\x0fCOMPONENT_RESET\x10\x02\x12\x13\n" +
@@ -481,33 +543,35 @@ func file_health_event_proto_rawDescGZIP() []byte {
 	return file_health_event_proto_rawDescData
 }
 
-var file_health_event_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_health_event_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_health_event_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_health_event_proto_goTypes = []any{
-	(RecommendedAction)(0),        // 0: datamodels.RecommendedAction
-	(*HealthEvents)(nil),          // 1: datamodels.HealthEvents
-	(*Entity)(nil),                // 2: datamodels.Entity
-	(*HealthEvent)(nil),           // 3: datamodels.HealthEvent
-	(*BehaviourOverrides)(nil),    // 4: datamodels.BehaviourOverrides
-	nil,                           // 5: datamodels.HealthEvent.MetadataEntry
-	(*timestamppb.Timestamp)(nil), // 6: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),         // 7: google.protobuf.Empty
+	(ProcessingStrategy)(0),       // 0: datamodels.ProcessingStrategy
+	(RecommendedAction)(0),        // 1: datamodels.RecommendedAction
+	(*HealthEvents)(nil),          // 2: datamodels.HealthEvents
+	(*Entity)(nil),                // 3: datamodels.Entity
+	(*HealthEvent)(nil),           // 4: datamodels.HealthEvent
+	(*BehaviourOverrides)(nil),    // 5: datamodels.BehaviourOverrides
+	nil,                           // 6: datamodels.HealthEvent.MetadataEntry
+	(*timestamppb.Timestamp)(nil), // 7: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),         // 8: google.protobuf.Empty
 }
 var file_health_event_proto_depIdxs = []int32{
-	3, // 0: datamodels.HealthEvents.events:type_name -> datamodels.HealthEvent
-	0, // 1: datamodels.HealthEvent.recommendedAction:type_name -> datamodels.RecommendedAction
-	2, // 2: datamodels.HealthEvent.entitiesImpacted:type_name -> datamodels.Entity
-	5, // 3: datamodels.HealthEvent.metadata:type_name -> datamodels.HealthEvent.MetadataEntry
-	6, // 4: datamodels.HealthEvent.generatedTimestamp:type_name -> google.protobuf.Timestamp
-	4, // 5: datamodels.HealthEvent.quarantineOverrides:type_name -> datamodels.BehaviourOverrides
-	4, // 6: datamodels.HealthEvent.drainOverrides:type_name -> datamodels.BehaviourOverrides
-	1, // 7: datamodels.PlatformConnector.HealthEventOccurredV1:input_type -> datamodels.HealthEvents
-	7, // 8: datamodels.PlatformConnector.HealthEventOccurredV1:output_type -> google.protobuf.Empty
-	8, // [8:9] is the sub-list for method output_type
-	7, // [7:8] is the sub-list for method input_type
-	7, // [7:7] is the sub-list for extension type_name
-	7, // [7:7] is the sub-list for extension extendee
-	0, // [0:7] is the sub-list for field type_name
+	4, // 0: datamodels.HealthEvents.events:type_name -> datamodels.HealthEvent
+	1, // 1: datamodels.HealthEvent.recommendedAction:type_name -> datamodels.RecommendedAction
+	3, // 2: datamodels.HealthEvent.entitiesImpacted:type_name -> datamodels.Entity
+	6, // 3: datamodels.HealthEvent.metadata:type_name -> datamodels.HealthEvent.MetadataEntry
+	7, // 4: datamodels.HealthEvent.generatedTimestamp:type_name -> google.protobuf.Timestamp
+	5, // 5: datamodels.HealthEvent.quarantineOverrides:type_name -> datamodels.BehaviourOverrides
+	5, // 6: datamodels.HealthEvent.drainOverrides:type_name -> datamodels.BehaviourOverrides
+	0, // 7: datamodels.HealthEvent.processingStrategy:type_name -> datamodels.ProcessingStrategy
+	2, // 8: datamodels.PlatformConnector.HealthEventOccurredV1:input_type -> datamodels.HealthEvents
+	8, // 9: datamodels.PlatformConnector.HealthEventOccurredV1:output_type -> google.protobuf.Empty
+	9, // [9:10] is the sub-list for method output_type
+	8, // [8:9] is the sub-list for method input_type
+	8, // [8:8] is the sub-list for extension type_name
+	8, // [8:8] is the sub-list for extension extendee
+	0, // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_health_event_proto_init() }
@@ -520,7 +584,7 @@ func file_health_event_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_health_event_proto_rawDesc), len(file_health_event_proto_rawDesc)),
-			NumEnums:      1,
+			NumEnums:      2,
 			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/data-models/protobufs/health_event.proto
+++ b/data-models/protobufs/health_event.proto
@@ -29,6 +29,14 @@ message HealthEvents {
   repeated HealthEvent events = 2;
 }
 
+// ProcessingStrategy defines how downstream modules should handle the event.
+// EXECUTE_REMEDIATION: normal behavior; downstream modules may update cluster state.
+// STORE_ONLY: observability-only behavior; event should be persisted/exported but should not modify cluster resources.
+enum ProcessingStrategy {
+  EXECUTE_REMEDIATION = 0;
+  STORE_ONLY = 1;
+}
+
 enum RecommendedAction {
   NONE = 0;
   COMPONENT_RESET = 2;
@@ -66,6 +74,7 @@ message HealthEvent {
   string nodeName = 13;
   BehaviourOverrides quarantineOverrides = 14;
   BehaviourOverrides drainOverrides = 15;
+  ProcessingStrategy processingStrategy = 16;
 }
 
 message BehaviourOverrides {

--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/daemonset-dcgm-3.x.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/daemonset-dcgm-3.x.yaml
@@ -58,6 +58,8 @@ spec:
             - {{ .Values.dcgm.dcgmK8sServiceEnabled | quote }}
             - --metadata-path
             - {{ .Values.global.metadataPath | quote }}
+            - --processing-strategy
+            - {{ .Values.processingStrategy | quote }}
           securityContext:
             runAsUser: 0
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default ((.Values.global).image).tag | default .Chart.AppVersion }}-dcgm-3.x"

--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/daemonset-dcgm-4.x.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/daemonset-dcgm-4.x.yaml
@@ -58,6 +58,8 @@ spec:
             - {{ .Values.dcgm.dcgmK8sServiceEnabled | quote }}
             - --metadata-path
             - {{ .Values.global.metadataPath | quote }}
+            - --processing-strategy
+            - {{ .Values.processingStrategy | quote }}
           securityContext:
             runAsUser: 0
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default ((.Values.global).image).tag | default .Chart.AppVersion }}-dcgm-4.x"

--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/values.yaml
@@ -54,4 +54,9 @@ podAnnotations: {}
 
 verbose: "False"
 
+# Processing strategy for health events
+# valid values: EXECUTE_REMEDIATION, STORE_ONLY
+# default: EXECUTE_REMEDIATION
+# EXECUTE_REMEDIATION: normal behavior; downstream modules may update cluster state.
+# STORE_ONLY: observability-only behavior; event should be persisted/exported but should not modify cluster resources (i.e., no node conditions, no quarantine, no drain, no remediation).
 processingStrategy: EXECUTE_REMEDIATION

--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/values.yaml
@@ -53,3 +53,5 @@ tolerations: []
 podAnnotations: {}
 
 verbose: "False"
+
+processingStrategy: EXECUTE_REMEDIATION

--- a/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/templates/_helpers.tpl
+++ b/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/templates/_helpers.tpl
@@ -100,6 +100,8 @@ spec:
             - "{{ join "," $root.Values.enabledChecks }}"
             - "--metadata-path"
             - "{{ $root.Values.global.metadataPath }}"
+            - "--processing-strategy"
+            - {{ $root.Values.processingStrategy }}
           resources:
             {{- toYaml $root.Values.resources | nindent 12 }}
           ports:

--- a/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/values.yaml
@@ -48,4 +48,9 @@ tolerations: []
 
 logLevel: info
 
+# Processing strategy for health events
+# valid values: EXECUTE_REMEDIATION, STORE_ONLY
+# default: EXECUTE_REMEDIATION
+# EXECUTE_REMEDIATION: normal behavior; downstream modules may update cluster state.
+# STORE_ONLY: observability-only behavior; event should be persisted/exported but should not modify cluster resources (i.e., no node conditions, no quarantine, no drain, no remediation).
 processingStrategy: EXECUTE_REMEDIATION

--- a/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/values.yaml
@@ -47,3 +47,5 @@ affinity: {}
 tolerations: []
 
 logLevel: info
+
+processingStrategy: EXECUTE_REMEDIATION

--- a/event-exporter/pkg/transformer/cloudevents.go
+++ b/event-exporter/pkg/transformer/cloudevents.go
@@ -63,6 +63,7 @@ func ToCloudEvent(event *pb.HealthEvent, metadata map[string]string) (*CloudEven
 		"entitiesImpacted":   entities,
 		"generatedTimestamp": timestamp,
 		"nodeName":           event.NodeName,
+		"processingStrategy": event.ProcessingStrategy.String(),
 	}
 
 	if len(event.Metadata) > 0 {

--- a/event-exporter/pkg/transformer/cloudevents_test.go
+++ b/event-exporter/pkg/transformer/cloudevents_test.go
@@ -66,6 +66,7 @@ func TestToCloudEvent(t *testing.T) {
 					Force: false,
 					Skip:  true,
 				},
+				ProcessingStrategy: pb.ProcessingStrategy_STORE_ONLY,
 			},
 			metadata: map[string]string{
 				"cluster":     "prod-cluster-1",
@@ -101,6 +102,9 @@ func TestToCloudEvent(t *testing.T) {
 				}
 				if healthEvent["recommendedAction"] != "RESTART_VM" {
 					t.Errorf("recommendedAction = %v, want %v", healthEvent["recommendedAction"], "RESTART_VM")
+				}
+				if healthEvent["processingStrategy"] != "STORE_ONLY" {
+					t.Errorf("processingStrategy = %v, want STORE_ONLY", healthEvent["processingStrategy"])
 				}
 
 				entities := healthEvent["entitiesImpacted"].([]map[string]any)

--- a/fault-quarantine/pkg/evaluator/rule_evaluator_test.go
+++ b/fault-quarantine/pkg/evaluator/rule_evaluator_test.go
@@ -260,6 +260,7 @@ func TestRoundTrip(t *testing.T) {
 			"nanos":   float64(eventTime.GetNanos()),
 		},
 		"nodeName":            "test-node",
+		"processingStrategy":  float64(0),
 		"quarantineOverrides": nil,
 		"drainOverrides":      nil,
 	}

--- a/fault-quarantine/pkg/initializer/init.go
+++ b/fault-quarantine/pkg/initializer/init.go
@@ -63,7 +63,7 @@ func InitializeAll(ctx context.Context, params InitializationParams) (*Component
 	}
 
 	builder := client.GetPipelineBuilder()
-	pipeline := builder.BuildAllHealthEventInsertsPipeline()
+	pipeline := builder.BuildProcessableHealthEventInsertsPipeline()
 
 	var tomlCfg config.TomlConfig
 	if err := configmanager.LoadTOMLConfig(params.TomlConfigPath, &tomlCfg); err != nil {

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/platform_connector/platform_connector.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/platform_connector/platform_connector.py
@@ -48,6 +48,7 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
         state_file_path: str,
         dcgm_health_conditions_categorization_mapping_config: dict[str, str],
         metadata_path: str,
+        processing_strategy: platformconnector_pb2.ProcessingStrategy,
     ) -> None:
         self._exit = exit
         self._socket_path = socket_path
@@ -62,6 +63,7 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
         self.entity_cache: dict[str, CachedEntityState] = {}
         self.dcgm_health_conditions_categorization_mapping_config = dcgm_health_conditions_categorization_mapping_config
         self._metadata_reader = MetadataReader(metadata_path)
+        self._processing_strategy = processing_strategy
 
     def read_old_system_bootid_from_state_file(self) -> str:
         bootid = ""
@@ -115,6 +117,7 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
                 recommendedAction=platformconnector_pb2.NONE,
                 nodeName=self._node_name,
                 metadata=event_metadata,
+                processingStrategy=self._processing_strategy,
             )
             health_events.append(health_event)
 
@@ -215,6 +218,7 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
                                     recommendedAction=recommended_action,
                                     nodeName=self._node_name,
                                     metadata=event_metadata,
+                                    processingStrategy=self._processing_strategy,
                                 )
                             )
                             severity = (
@@ -278,6 +282,7 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
                                         recommendedAction=platformconnector_pb2.NONE,
                                         nodeName=self._node_name,
                                         metadata=event_metadata,
+                                        processingStrategy=self._processing_strategy,
                                     )
                                 )
                             severity = (
@@ -372,6 +377,7 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
                     recommendedAction=platformconnector_pb2.CONTACT_SUPPORT,
                     nodeName=self._node_name,
                     metadata=event_metadata,
+                    processingStrategy=self._processing_strategy,
                 )
                 health_events.append(health_event)
                 metrics.dcgm_health_active_events.labels(event_type=check_name, gpu_id="", severity="fatal").set(1)

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/protos/health_event_pb2.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/protos/health_event_pb2.py
@@ -21,7 +21,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x12health_event.proto\x12\ndatamodels\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1bgoogle/protobuf/empty.proto"H\n\x0cHealthEvents\x12\x0f\n\x07version\x18\x01 \x01(\r\x12\'\n\x06\x65vents\x18\x02 \x03(\x0b\x32\x17.datamodels.HealthEvent"1\n\x06\x45ntity\x12\x12\n\nentityType\x18\x01 \x01(\t\x12\x13\n\x0b\x65ntityValue\x18\x02 \x01(\t"\xb1\x04\n\x0bHealthEvent\x12\x0f\n\x07version\x18\x01 \x01(\r\x12\r\n\x05\x61gent\x18\x02 \x01(\t\x12\x16\n\x0e\x63omponentClass\x18\x03 \x01(\t\x12\x11\n\tcheckName\x18\x04 \x01(\t\x12\x0f\n\x07isFatal\x18\x05 \x01(\x08\x12\x11\n\tisHealthy\x18\x06 \x01(\x08\x12\x0f\n\x07message\x18\x07 \x01(\t\x12\x38\n\x11recommendedAction\x18\x08 \x01(\x0e\x32\x1d.datamodels.RecommendedAction\x12\x11\n\terrorCode\x18\t \x03(\t\x12,\n\x10\x65ntitiesImpacted\x18\n \x03(\x0b\x32\x12.datamodels.Entity\x12\x37\n\x08metadata\x18\x0b \x03(\x0b\x32%.datamodels.HealthEvent.MetadataEntry\x12\x36\n\x12generatedTimestamp\x18\x0c \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x10\n\x08nodeName\x18\r \x01(\t\x12;\n\x13quarantineOverrides\x18\x0e \x01(\x0b\x32\x1e.datamodels.BehaviourOverrides\x12\x36\n\x0e\x64rainOverrides\x18\x0f \x01(\x0b\x32\x1e.datamodels.BehaviourOverrides\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"1\n\x12\x42\x65haviourOverrides\x12\r\n\x05\x66orce\x18\x01 \x01(\x08\x12\x0c\n\x04skip\x18\x02 \x01(\x08*\xa8\x01\n\x11RecommendedAction\x12\x08\n\x04NONE\x10\x00\x12\x13\n\x0f\x43OMPONENT_RESET\x10\x02\x12\x13\n\x0f\x43ONTACT_SUPPORT\x10\x05\x12\x11\n\rRUN_FIELDDIAG\x10\x06\x12\x0e\n\nRESTART_VM\x10\x0f\x12\x0e\n\nRESTART_BM\x10\x18\x12\x0e\n\nREPLACE_VM\x10\x19\x12\x0f\n\x0bRUN_DCGMEUD\x10\x1a\x12\x0b\n\x07UNKNOWN\x10\x63\x32`\n\x11PlatformConnector\x12K\n\x15HealthEventOccurredV1\x12\x18.datamodels.HealthEvents\x1a\x16.google.protobuf.Empty"\x00\x42\x35Z3github.com/nvidia/nvsentinel/data-models/pkg/protosb\x06proto3'
+    b'\n\x12health_event.proto\x12\ndatamodels\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1bgoogle/protobuf/empty.proto"H\n\x0cHealthEvents\x12\x0f\n\x07version\x18\x01 \x01(\r\x12\'\n\x06\x65vents\x18\x02 \x03(\x0b\x32\x17.datamodels.HealthEvent"1\n\x06\x45ntity\x12\x12\n\nentityType\x18\x01 \x01(\t\x12\x13\n\x0b\x65ntityValue\x18\x02 \x01(\t"\xed\x04\n\x0bHealthEvent\x12\x0f\n\x07version\x18\x01 \x01(\r\x12\r\n\x05\x61gent\x18\x02 \x01(\t\x12\x16\n\x0e\x63omponentClass\x18\x03 \x01(\t\x12\x11\n\tcheckName\x18\x04 \x01(\t\x12\x0f\n\x07isFatal\x18\x05 \x01(\x08\x12\x11\n\tisHealthy\x18\x06 \x01(\x08\x12\x0f\n\x07message\x18\x07 \x01(\t\x12\x38\n\x11recommendedAction\x18\x08 \x01(\x0e\x32\x1d.datamodels.RecommendedAction\x12\x11\n\terrorCode\x18\t \x03(\t\x12,\n\x10\x65ntitiesImpacted\x18\n \x03(\x0b\x32\x12.datamodels.Entity\x12\x37\n\x08metadata\x18\x0b \x03(\x0b\x32%.datamodels.HealthEvent.MetadataEntry\x12\x36\n\x12generatedTimestamp\x18\x0c \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x10\n\x08nodeName\x18\r \x01(\t\x12;\n\x13quarantineOverrides\x18\x0e \x01(\x0b\x32\x1e.datamodels.BehaviourOverrides\x12\x36\n\x0e\x64rainOverrides\x18\x0f \x01(\x0b\x32\x1e.datamodels.BehaviourOverrides\x12:\n\x12processingStrategy\x18\x10 \x01(\x0e\x32\x1e.datamodels.ProcessingStrategy\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"1\n\x12\x42\x65haviourOverrides\x12\r\n\x05\x66orce\x18\x01 \x01(\x08\x12\x0c\n\x04skip\x18\x02 \x01(\x08*=\n\x12ProcessingStrategy\x12\x17\n\x13\x45XECUTE_REMEDIATION\x10\x00\x12\x0e\n\nSTORE_ONLY\x10\x01*\xa8\x01\n\x11RecommendedAction\x12\x08\n\x04NONE\x10\x00\x12\x13\n\x0f\x43OMPONENT_RESET\x10\x02\x12\x13\n\x0f\x43ONTACT_SUPPORT\x10\x05\x12\x11\n\rRUN_FIELDDIAG\x10\x06\x12\x0e\n\nRESTART_VM\x10\x0f\x12\x0e\n\nRESTART_BM\x10\x18\x12\x0e\n\nREPLACE_VM\x10\x19\x12\x0f\n\x0bRUN_DCGMEUD\x10\x1a\x12\x0b\n\x07UNKNOWN\x10\x63\x32`\n\x11PlatformConnector\x12K\n\x15HealthEventOccurredV1\x12\x18.datamodels.HealthEvents\x1a\x16.google.protobuf.Empty"\x00\x42\x35Z3github.com/nvidia/nvsentinel/data-models/pkg/protosb\x06proto3'
 )
 
 _globals = globals()
@@ -32,18 +32,20 @@ if not _descriptor._USE_C_DESCRIPTORS:
     _globals["DESCRIPTOR"]._serialized_options = b"Z3github.com/nvidia/nvsentinel/data-models/pkg/protos"
     _globals["_HEALTHEVENT_METADATAENTRY"]._loaded_options = None
     _globals["_HEALTHEVENT_METADATAENTRY"]._serialized_options = b"8\001"
-    _globals["_RECOMMENDEDACTION"]._serialized_start = 837
-    _globals["_RECOMMENDEDACTION"]._serialized_end = 1005
+    _globals["_PROCESSINGSTRATEGY"]._serialized_start = 896
+    _globals["_PROCESSINGSTRATEGY"]._serialized_end = 957
+    _globals["_RECOMMENDEDACTION"]._serialized_start = 960
+    _globals["_RECOMMENDEDACTION"]._serialized_end = 1128
     _globals["_HEALTHEVENTS"]._serialized_start = 96
     _globals["_HEALTHEVENTS"]._serialized_end = 168
     _globals["_ENTITY"]._serialized_start = 170
     _globals["_ENTITY"]._serialized_end = 219
     _globals["_HEALTHEVENT"]._serialized_start = 222
-    _globals["_HEALTHEVENT"]._serialized_end = 783
-    _globals["_HEALTHEVENT_METADATAENTRY"]._serialized_start = 736
-    _globals["_HEALTHEVENT_METADATAENTRY"]._serialized_end = 783
-    _globals["_BEHAVIOUROVERRIDES"]._serialized_start = 785
-    _globals["_BEHAVIOUROVERRIDES"]._serialized_end = 834
-    _globals["_PLATFORMCONNECTOR"]._serialized_start = 1007
-    _globals["_PLATFORMCONNECTOR"]._serialized_end = 1103
+    _globals["_HEALTHEVENT"]._serialized_end = 843
+    _globals["_HEALTHEVENT_METADATAENTRY"]._serialized_start = 796
+    _globals["_HEALTHEVENT_METADATAENTRY"]._serialized_end = 843
+    _globals["_BEHAVIOUROVERRIDES"]._serialized_start = 845
+    _globals["_BEHAVIOUROVERRIDES"]._serialized_end = 894
+    _globals["_PLATFORMCONNECTOR"]._serialized_start = 1130
+    _globals["_PLATFORMCONNECTOR"]._serialized_end = 1226
 # @@protoc_insertion_point(module_scope)

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/protos/health_event_pb2.pyi
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/protos/health_event_pb2.pyi
@@ -11,6 +11,11 @@ from typing import ClassVar as _ClassVar, Optional as _Optional, Union as _Union
 
 DESCRIPTOR: _descriptor.FileDescriptor
 
+class ProcessingStrategy(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    EXECUTE_REMEDIATION: _ClassVar[ProcessingStrategy]
+    STORE_ONLY: _ClassVar[ProcessingStrategy]
+
 class RecommendedAction(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
     __slots__ = ()
     NONE: _ClassVar[RecommendedAction]
@@ -23,6 +28,8 @@ class RecommendedAction(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
     RUN_DCGMEUD: _ClassVar[RecommendedAction]
     UNKNOWN: _ClassVar[RecommendedAction]
 
+EXECUTE_REMEDIATION: ProcessingStrategy
+STORE_ONLY: ProcessingStrategy
 NONE: RecommendedAction
 COMPONENT_RESET: RecommendedAction
 CONTACT_SUPPORT: RecommendedAction
@@ -68,6 +75,7 @@ class HealthEvent(_message.Message):
         "nodeName",
         "quarantineOverrides",
         "drainOverrides",
+        "processingStrategy",
     )
 
     class MetadataEntry(_message.Message):
@@ -93,6 +101,7 @@ class HealthEvent(_message.Message):
     NODENAME_FIELD_NUMBER: _ClassVar[int]
     QUARANTINEOVERRIDES_FIELD_NUMBER: _ClassVar[int]
     DRAINOVERRIDES_FIELD_NUMBER: _ClassVar[int]
+    PROCESSINGSTRATEGY_FIELD_NUMBER: _ClassVar[int]
     version: int
     agent: str
     componentClass: str
@@ -108,6 +117,7 @@ class HealthEvent(_message.Message):
     nodeName: str
     quarantineOverrides: BehaviourOverrides
     drainOverrides: BehaviourOverrides
+    processingStrategy: ProcessingStrategy
     def __init__(
         self,
         version: _Optional[int] = ...,
@@ -125,6 +135,7 @@ class HealthEvent(_message.Message):
         nodeName: _Optional[str] = ...,
         quarantineOverrides: _Optional[_Union[BehaviourOverrides, _Mapping]] = ...,
         drainOverrides: _Optional[_Union[BehaviourOverrides, _Mapping]] = ...,
+        processingStrategy: _Optional[_Union[ProcessingStrategy, str]] = ...,
     ) -> None: ...
 
 class BehaviourOverrides(_message.Message):

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_platform_connector/test_platform_connector.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_platform_connector/test_platform_connector.py
@@ -104,6 +104,7 @@ class TestPlatformConnectors(unittest.TestCase):
             "statefile",
             dcgm_health_conditions_categorization_mapping_config,
             "/tmp/test_metadata.json",
+            platformconnector_pb2.STORE_ONLY,
         )
         dcgm_health_events = watcher._get_health_status_dict()
         dcgm_health_events["DCGM_HEALTH_WATCH_INFOROM"] = dcgmtypes.HealthDetails(
@@ -238,6 +239,7 @@ class TestPlatformConnectors(unittest.TestCase):
             "statefile",
             dcgm_health_conditions_categorization_mapping_config,
             "/tmp/test_metadata.json",
+            platformconnector_pb2.STORE_ONLY,
         )
 
         # Simulate multiple NvLink failures for GPU 0 (4 links down: 8, 9, 14, 15)
@@ -296,6 +298,8 @@ class TestPlatformConnectors(unittest.TestCase):
         # Verify the complete aggregated message is preserved
         assert nvlink_failure_event.message == aggregated_message
 
+        assert nvlink_failure_event.processingStrategy == platformconnector_pb2.STORE_ONLY
+
         server.stop(0)
 
     def test_health_event_multiple_gpus_multiple_failures_each(self):
@@ -352,6 +356,7 @@ class TestPlatformConnectors(unittest.TestCase):
             "statefile",
             dcgm_health_conditions_categorization_mapping_config,
             "/tmp/test_metadata.json",
+            platformconnector_pb2.STORE_ONLY,
         )
 
         # Simulate multiple NvLink failures for GPU 0 and GPU 1
@@ -413,6 +418,7 @@ class TestPlatformConnectors(unittest.TestCase):
         assert "link 15" in gpu0_event.message
         assert gpu0_event.message.count(";") == 3
         assert gpu0_event.message == gpu0_message
+        assert gpu0_event.processingStrategy == platformconnector_pb2.STORE_ONLY
 
         # Verify GPU 1 event
         assert gpu1_event is not None, "NvLink failure event for GPU 1 not found"
@@ -427,6 +433,7 @@ class TestPlatformConnectors(unittest.TestCase):
         assert "link 13" in gpu1_event.message
         assert gpu1_event.message.count(";") == 3
         assert gpu1_event.message == gpu1_message
+        assert gpu1_event.processingStrategy == platformconnector_pb2.STORE_ONLY
 
         server.stop(0)
 
@@ -463,6 +470,7 @@ class TestPlatformConnectors(unittest.TestCase):
                 state_file_path=state_file_path,
                 dcgm_health_conditions_categorization_mapping_config=dcgm_health_conditions_categorization_mapping_config,
                 metadata_path="/tmp/test_metadata.json",
+                processing_strategy=platformconnector_pb2.STORE_ONLY,
             )
 
             # Trigger connectivity failure
@@ -482,6 +490,7 @@ class TestPlatformConnectors(unittest.TestCase):
                 assert event.recommendedAction == platformconnector_pb2.CONTACT_SUPPORT
                 assert event.nodeName == node_name
                 assert event.entitiesImpacted == []
+                assert event.processingStrategy == platformconnector_pb2.STORE_ONLY
 
             server.stop(0)
         finally:
@@ -511,6 +520,7 @@ class TestPlatformConnectors(unittest.TestCase):
             state_file_path="statefile",
             dcgm_health_conditions_categorization_mapping_config=dcgm_health_conditions_categorization_mapping_config,
             metadata_path="/tmp/test_metadata.json",
+            processing_strategy=platformconnector_pb2.EXECUTE_REMEDIATION,
         )
 
         timestamp = Timestamp()
@@ -536,6 +546,7 @@ class TestPlatformConnectors(unittest.TestCase):
         assert restored_event.errorCode == []
         assert restored_event.message == "DCGM connectivity reported no errors"
         assert restored_event.recommendedAction == platformconnector_pb2.NONE
+        assert restored_event.processingStrategy == platformconnector_pb2.EXECUTE_REMEDIATION
 
         server.stop(0)
 
@@ -589,6 +600,7 @@ class TestPlatformConnectors(unittest.TestCase):
                 state_file_path=state_file_path,
                 dcgm_health_conditions_categorization_mapping_config=dcgm_health_conditions_categorization_mapping_config,
                 metadata_path="/tmp/test_metadata.json",
+                processing_strategy=platformconnector_pb2.STORE_ONLY,
             )
 
             # Verify cache is empty initially

--- a/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler.go
+++ b/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler.go
@@ -28,7 +28,9 @@ import (
 
 // NewGPUFallenHandler creates a new GPUFallenHandler instance.
 func NewGPUFallenHandler(nodeName, defaultAgentName,
-	defaultComponentClass, checkName string) (*GPUFallenHandler, error) {
+	defaultComponentClass, checkName string,
+	processingStrategy pb.ProcessingStrategy,
+) (*GPUFallenHandler, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	h := &GPUFallenHandler{
@@ -36,6 +38,7 @@ func NewGPUFallenHandler(nodeName, defaultAgentName,
 		defaultAgentName:      defaultAgentName,
 		defaultComponentClass: defaultComponentClass,
 		checkName:             checkName,
+		processingStrategy:    processingStrategy,
 		recentXIDs:            make(map[string]xidRecord),
 		xidWindow:             5 * time.Minute, // Remember XIDs for 5 minutes
 		cancelCleanup:         cancel,
@@ -232,6 +235,7 @@ func (h *GPUFallenHandler) createHealthEventFromError(event *gpuFallenErrorEvent
 		NodeName:           h.nodeName,
 		RecommendedAction:  pb.RecommendedAction_RESTART_BM,
 		ErrorCode:          []string{"GPU_FALLEN_OFF_BUS"},
+		ProcessingStrategy: h.processingStrategy,
 	}
 
 	return &pb.HealthEvents{

--- a/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/gpufallen/gpufallen_handler_test.go
@@ -169,6 +169,7 @@ func TestProcessLine(t *testing.T) {
 				"test-agent",
 				"GPU",
 				"test-check",
+				pb.ProcessingStrategy_STORE_ONLY,
 			)
 			require.NoError(t, err)
 			defer handler.Close()
@@ -181,6 +182,7 @@ func TestProcessLine(t *testing.T) {
 				if tc.validateEvent != nil {
 					tc.validateEvent(t, events, tc.message)
 				}
+				assert.Equal(t, pb.ProcessingStrategy_STORE_ONLY, events.Events[0].ProcessingStrategy)
 			} else {
 				assert.Nil(t, events, "Expected no event to be generated")
 			}
@@ -196,6 +198,7 @@ func TestXIDTracking(t *testing.T) {
 			"test-agent",
 			"GPU",
 			"test-check",
+			pb.ProcessingStrategy_EXECUTE_REMEDIATION,
 		)
 		require.NoError(t, err)
 		defer handler.Close() // Cleanup goroutine to prevent leaks
@@ -222,6 +225,7 @@ func TestXIDTracking(t *testing.T) {
 			"test-agent",
 			"GPU",
 			"test-check",
+			pb.ProcessingStrategy_EXECUTE_REMEDIATION,
 		)
 		require.NoError(t, err)
 		defer handler2.Close()
@@ -234,6 +238,7 @@ func TestXIDTracking(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, events, "Should generate event when no recent XID")
 		require.Len(t, events.Events, 1)
+		assert.Equal(t, handler2.processingStrategy, events.Events[0].ProcessingStrategy)
 	})
 
 	t.Run("XID expires after time window", func(t *testing.T) {
@@ -243,6 +248,7 @@ func TestXIDTracking(t *testing.T) {
 			"test-agent",
 			"GPU",
 			"test-check",
+			pb.ProcessingStrategy_EXECUTE_REMEDIATION,
 		)
 		require.NoError(t, err)
 		defer handler3.Close()
@@ -270,6 +276,7 @@ func TestXIDTracking(t *testing.T) {
 			"test-agent",
 			"GPU",
 			"test-check",
+			pb.ProcessingStrategy_EXECUTE_REMEDIATION,
 		)
 		require.NoError(t, err)
 		defer handler4.Close()
@@ -298,6 +305,7 @@ func TestXIDTracking(t *testing.T) {
 			"test-agent",
 			"GPU",
 			"test-check",
+			pb.ProcessingStrategy_EXECUTE_REMEDIATION,
 		)
 		require.NoError(t, err)
 		defer handler5.Close()
@@ -315,6 +323,7 @@ func TestXIDTracking(t *testing.T) {
 			"test-agent",
 			"GPU",
 			"test-check",
+			pb.ProcessingStrategy_EXECUTE_REMEDIATION,
 		)
 		require.NoError(t, err)
 		defer handler6.Close()
@@ -340,6 +349,7 @@ func TestXIDTracking(t *testing.T) {
 			"test-agent",
 			"GPU",
 			"test-check",
+			pb.ProcessingStrategy_EXECUTE_REMEDIATION,
 		)
 		require.NoError(t, err)
 		defer handler7.Close()
@@ -379,6 +389,7 @@ func TestXIDTracking(t *testing.T) {
 			"test-agent",
 			"GPU",
 			"test-check",
+			pb.ProcessingStrategy_EXECUTE_REMEDIATION,
 		)
 		require.NoError(t, err)
 		defer handler8.Close()

--- a/health-monitors/syslog-health-monitor/pkg/gpufallen/types.go
+++ b/health-monitors/syslog-health-monitor/pkg/gpufallen/types.go
@@ -19,6 +19,8 @@ import (
 	"regexp"
 	"sync"
 	"time"
+
+	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
 )
 
 var (
@@ -47,6 +49,7 @@ type GPUFallenHandler struct {
 	defaultAgentName      string
 	defaultComponentClass string
 	checkName             string
+	processingStrategy    pb.ProcessingStrategy
 	mu                    sync.RWMutex
 	recentXIDs            map[string]xidRecord // pciAddr -> XID record
 	xidWindow             time.Duration        // how long to remember XID errors

--- a/health-monitors/syslog-health-monitor/pkg/sxid/sxid_handler.go
+++ b/health-monitors/syslog-health-monitor/pkg/sxid/sxid_handler.go
@@ -28,12 +28,15 @@ import (
 )
 
 func NewSXIDHandler(nodeName, defaultAgentName,
-	defaultComponentClass, checkName, metadataPath string) (*SXIDHandler, error) {
+	defaultComponentClass, checkName, metadataPath string,
+	processingStrategy pb.ProcessingStrategy,
+) (*SXIDHandler, error) {
 	return &SXIDHandler{
 		nodeName:              nodeName,
 		defaultAgentName:      defaultAgentName,
 		defaultComponentClass: defaultComponentClass,
 		checkName:             checkName,
+		processingStrategy:    processingStrategy,
 		metadataReader:        metadata.NewReader(metadataPath),
 	}, nil
 }
@@ -103,6 +106,7 @@ func (sxidHandler *SXIDHandler) ProcessLine(message string) (*pb.HealthEvents, e
 		RecommendedAction:  errRes,
 		ErrorCode:          []string{fmt.Sprint(sxidErrorEvent.ErrorNum)},
 		Metadata:           metadata,
+		ProcessingStrategy: sxidHandler.processingStrategy,
 	}
 
 	return &pb.HealthEvents{

--- a/health-monitors/syslog-health-monitor/pkg/sxid/types.go
+++ b/health-monitors/syslog-health-monitor/pkg/sxid/types.go
@@ -17,6 +17,7 @@ package sxid
 import (
 	"regexp"
 
+	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	"github.com/nvidia/nvsentinel/health-monitors/syslog-health-monitor/pkg/metadata"
 )
 
@@ -30,6 +31,7 @@ type SXIDHandler struct {
 	defaultAgentName      string
 	defaultComponentClass string
 	checkName             string
+	processingStrategy    pb.ProcessingStrategy
 	metadataReader        *metadata.Reader
 }
 

--- a/health-monitors/syslog-health-monitor/pkg/syslog-monitor/syslogmonitor_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/syslog-monitor/syslogmonitor_test.go
@@ -307,13 +307,14 @@ func TestNewSyslogMonitor(t *testing.T) {
 	filePath := testStateFile
 
 	monitor, err := NewSyslogMonitor(args.NodeName,
-		args.Checks, args.PcClient, args.DefaultAgentName, args.DefaultComponentClass, args.PollingInterval, filePath, "http://localhost:8080", "/tmp/metadata.json")
+		args.Checks, args.PcClient, args.DefaultAgentName, args.DefaultComponentClass, args.PollingInterval, filePath, "http://localhost:8080", "/tmp/metadata.json", pb.ProcessingStrategy_STORE_ONLY)
 	assert.NoError(t, err)
 	assert.NotNil(t, monitor)
 	assert.Equal(t, args.NodeName, monitor.nodeName)
 	assert.Equal(t, args.Checks, monitor.checks)
 	assert.NotNil(t, monitor.journalFactory, "Journal factory should not be nil")
 	assert.Equal(t, testStateFile, monitor.stateFilePath)
+	assert.Equal(t, pb.ProcessingStrategy_STORE_ONLY, monitor.processingStrategy)
 
 	// Test case 2: With specific fake factory
 	fakeJournalFactory := NewFakeJournalFactory()
@@ -326,7 +327,7 @@ func TestNewSyslogMonitor(t *testing.T) {
 
 	filePath = testStateFile2
 	monitor, err = NewSyslogMonitorWithFactory(args.NodeName,
-		args.Checks, args.PcClient, args.DefaultAgentName, args.DefaultComponentClass, args.PollingInterval, filePath, fakeJournalFactory, "http://localhost:8080", "/tmp/metadata.json")
+		args.Checks, args.PcClient, args.DefaultAgentName, args.DefaultComponentClass, args.PollingInterval, filePath, fakeJournalFactory, "http://localhost:8080", "/tmp/metadata.json", pb.ProcessingStrategy_EXECUTE_REMEDIATION)
 	assert.NoError(t, err)
 	assert.NotNil(t, monitor)
 	assert.Equal(t, fakeJournalFactory, monitor.journalFactory)
@@ -398,6 +399,7 @@ func TestJournalProcessingLogic(t *testing.T) {
 		fakeJournalFactory,
 		"http://localhost:8080",
 		"/tmp/metadata.json",
+		pb.ProcessingStrategy_EXECUTE_REMEDIATION,
 	)
 	assert.NoError(t, err)
 
@@ -500,6 +502,7 @@ func TestJournalStateManagement(t *testing.T) {
 		mockFactory,
 		"http://localhost:8080",
 		"/tmp/metadata.json",
+		pb.ProcessingStrategy_EXECUTE_REMEDIATION,
 	)
 	assert.NoError(t, err)
 
@@ -531,6 +534,7 @@ func TestJournalStateManagement(t *testing.T) {
 		mockFactory,
 		"http://localhost:8080",
 		"/tmp/metadata.json",
+		pb.ProcessingStrategy_EXECUTE_REMEDIATION,
 	)
 	assert.NoError(t, err)
 
@@ -578,6 +582,7 @@ func TestBootIDChangeHandling(t *testing.T) {
 		mockFactory,
 		"http://localhost:8080",
 		"/tmp/metadata.json",
+		pb.ProcessingStrategy_EXECUTE_REMEDIATION,
 	)
 	assert.NoError(t, err)
 
@@ -627,6 +632,7 @@ func TestRunMultipleChecks(t *testing.T) {
 		mockFactory,
 		"http://localhost:8080",
 		"/tmp/metadata.json",
+		pb.ProcessingStrategy_EXECUTE_REMEDIATION,
 	)
 	assert.NoError(t, err)
 
@@ -667,6 +673,7 @@ func TestGPUFallenOffHandlerInitialization(t *testing.T) {
 		mockFactory,
 		"http://localhost:8080",
 		"/tmp/metadata.json",
+		pb.ProcessingStrategy_EXECUTE_REMEDIATION,
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, sm.checkToHandlerMap[GPUFallenOffCheck], "GPU Fallen Off handler should be initialized")

--- a/health-monitors/syslog-health-monitor/pkg/syslog-monitor/types.go
+++ b/health-monitors/syslog-health-monitor/pkg/syslog-monitor/types.go
@@ -50,6 +50,7 @@ type SyslogMonitor struct {
 	pcClient              pb.PlatformConnectorClient
 	defaultAgentName      string
 	defaultComponentClass string
+	processingStrategy    pb.ProcessingStrategy
 	pollingInterval       string
 	// Map of check name to last processed cursor
 	checkLastCursors map[string]string

--- a/health-monitors/syslog-health-monitor/pkg/xid/types.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/types.go
@@ -17,6 +17,7 @@ package xid
 import (
 	"regexp"
 
+	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	"github.com/nvidia/nvsentinel/health-monitors/syslog-health-monitor/pkg/metadata"
 	"github.com/nvidia/nvsentinel/health-monitors/syslog-health-monitor/pkg/xid/parser"
 )
@@ -30,6 +31,7 @@ type XIDHandler struct {
 	defaultAgentName      string
 	defaultComponentClass string
 	checkName             string
+	processingStrategy    pb.ProcessingStrategy
 
 	pciToGPUUUID   map[string]string
 	parser         parser.Parser

--- a/health-monitors/syslog-health-monitor/pkg/xid/xid_handler.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/xid_handler.go
@@ -31,7 +31,9 @@ import (
 )
 
 func NewXIDHandler(nodeName, defaultAgentName,
-	defaultComponentClass, checkName, xidAnalyserEndpoint, metadataPath string) (*XIDHandler, error) {
+	defaultComponentClass, checkName, xidAnalyserEndpoint, metadataPath string,
+	processingStrategy pb.ProcessingStrategy,
+) (*XIDHandler, error) {
 	config := parser.ParserConfig{
 		NodeName:            nodeName,
 		XidAnalyserEndpoint: xidAnalyserEndpoint,
@@ -48,6 +50,7 @@ func NewXIDHandler(nodeName, defaultAgentName,
 		defaultAgentName:      defaultAgentName,
 		defaultComponentClass: defaultComponentClass,
 		checkName:             checkName,
+		processingStrategy:    processingStrategy,
 		pciToGPUUUID:          make(map[string]string),
 		parser:                xidParser,
 		metadataReader:        metadata.NewReader(metadataPath),
@@ -183,6 +186,7 @@ func (xidHandler *XIDHandler) createHealthEventFromResponse(
 		RecommendedAction:  recommendedAction,
 		ErrorCode:          []string{xidResp.Result.DecodedXIDStr},
 		Metadata:           metadata,
+		ProcessingStrategy: xidHandler.processingStrategy,
 	}
 
 	return &pb.HealthEvents{

--- a/store-client/pkg/client/mongodb_client.go
+++ b/store-client/pkg/client/mongodb_client.go
@@ -286,14 +286,14 @@ func BuildNodeQuarantineStatusUpdatesPipeline() datastore.Pipeline {
 	return builder.BuildNodeQuarantineStatusPipeline()
 }
 
-// BuildProcessableNonFatalUnhealthyInsertsPipeline creates a pipeline that watches for non-fatal,
-// unhealthy event inserts with processingStrategy=EXECUTE_REMEDIATION.
+// BuildNonFatalUnhealthyInsertsPipeline creates a pipeline that watches for non-fatal, unhealthy event inserts
+// This is used by health-events-analyzer to detect warning-level health events for pattern analysis
 //
-// Deprecated: Use GetPipelineBuilder().BuildProcessableNonFatalUnhealthyInsertsPipeline() instead.
+// Deprecated: Use GetPipelineBuilder().BuildNonFatalUnhealthyInsertsPipeline() instead.
 // This function is maintained for backward compatibility and will be removed in a future version.
-func BuildProcessableNonFatalUnhealthyInsertsPipeline() datastore.Pipeline {
+func BuildNonFatalUnhealthyInsertsPipeline() datastore.Pipeline {
 	builder := GetPipelineBuilder()
-	return builder.BuildProcessableNonFatalUnhealthyInsertsPipeline()
+	return builder.BuildNonFatalUnhealthyInsertsPipeline()
 }
 
 // BuildQuarantinedAndDrainedNodesPipeline creates a pipeline that watches for nodes ready for remediation

--- a/store-client/pkg/client/mongodb_client.go
+++ b/store-client/pkg/client/mongodb_client.go
@@ -286,14 +286,14 @@ func BuildNodeQuarantineStatusUpdatesPipeline() datastore.Pipeline {
 	return builder.BuildNodeQuarantineStatusPipeline()
 }
 
-// BuildNonFatalUnhealthyInsertsPipeline creates a pipeline that watches for non-fatal, unhealthy event inserts
-// This is used by health-events-analyzer to detect warning-level health events for pattern analysis
+// BuildProcessableNonFatalUnhealthyInsertsPipeline creates a pipeline that watches for non-fatal,
+// unhealthy event inserts with processingStrategy=EXECUTE_REMEDIATION.
 //
-// Deprecated: Use GetPipelineBuilder().BuildNonFatalUnhealthyInsertsPipeline() instead.
+// Deprecated: Use GetPipelineBuilder().BuildProcessableNonFatalUnhealthyInsertsPipeline() instead.
 // This function is maintained for backward compatibility and will be removed in a future version.
-func BuildNonFatalUnhealthyInsertsPipeline() datastore.Pipeline {
+func BuildProcessableNonFatalUnhealthyInsertsPipeline() datastore.Pipeline {
 	builder := GetPipelineBuilder()
-	return builder.BuildNonFatalUnhealthyInsertsPipeline()
+	return builder.BuildProcessableNonFatalUnhealthyInsertsPipeline()
 }
 
 // BuildQuarantinedAndDrainedNodesPipeline creates a pipeline that watches for nodes ready for remediation

--- a/store-client/pkg/client/mongodb_pipeline_builder.go
+++ b/store-client/pkg/client/mongodb_pipeline_builder.go
@@ -99,16 +99,15 @@ func (b *MongoDBPipelineBuilder) BuildProcessableHealthEventInsertsPipeline() da
 	)
 }
 
-// BuildProcessableNonFatalUnhealthyInsertsPipeline creates a pipeline for non-fatal unhealthy events
-// with processingStrategy=EXECUTE_REMEDIATION.
-func (b *MongoDBPipelineBuilder) BuildProcessableNonFatalUnhealthyInsertsPipeline() datastore.Pipeline {
+// BuildNonFatalUnhealthyInsertsPipeline creates a pipeline for non-fatal, unhealthy event inserts
+// This is used by health-events-analyzer to detect warning-level health events for pattern analysis.
+func (b *MongoDBPipelineBuilder) BuildNonFatalUnhealthyInsertsPipeline() datastore.Pipeline {
 	return datastore.ToPipeline(
 		datastore.D(
 			datastore.E("$match", datastore.D(
 				datastore.E("operationType", "insert"),
 				datastore.E("fullDocument.healthevent.agent", datastore.D(datastore.E("$ne", "health-events-analyzer"))),
 				datastore.E("fullDocument.healthevent.ishealthy", false),
-				datastore.E("fullDocument.healthevent.processingstrategy", int32(protos.ProcessingStrategy_EXECUTE_REMEDIATION)),
 			)),
 		),
 	)

--- a/store-client/pkg/client/pipeline_builder.go
+++ b/store-client/pkg/client/pipeline_builder.go
@@ -37,10 +37,9 @@ type PipelineBuilder interface {
 	// Used by: fault-quarantine to ignore observability-only events (processingStrategy=STORE_ONLY)
 	BuildProcessableHealthEventInsertsPipeline() datastore.Pipeline
 
-	// BuildProcessableNonFatalUnhealthyInsertsPipeline creates a pipeline for non-fatal unhealthy events
-	// excluding observability-only events (processingStrategy=STORE_ONLY).
+	// BuildNonFatalUnhealthyInsertsPipeline creates a pipeline for non-fatal unhealthy events
 	// Used by: health-events-analyzer for pattern detection.
-	BuildProcessableNonFatalUnhealthyInsertsPipeline() datastore.Pipeline
+	BuildNonFatalUnhealthyInsertsPipeline() datastore.Pipeline
 
 	// BuildQuarantinedAndDrainedNodesPipeline creates a pipeline for remediation-ready nodes
 	// Used by: fault-remediation to detect when nodes are ready for reboot

--- a/store-client/pkg/client/pipeline_builder.go
+++ b/store-client/pkg/client/pipeline_builder.go
@@ -32,9 +32,15 @@ type PipelineBuilder interface {
 	// Used by: fault-quarantine to detect new health events
 	BuildAllHealthEventInsertsPipeline() datastore.Pipeline
 
-	// BuildNonFatalUnhealthyInsertsPipeline creates a pipeline for non-fatal unhealthy events
-	// Used by: health-events-analyzer for pattern analysis
-	BuildNonFatalUnhealthyInsertsPipeline() datastore.Pipeline
+	// BuildProcessableHealthEventInsertsPipeline creates a pipeline that watches for "processable" health event inserts,
+	// i.e. events with processingStrategy=EXECUTE_REMEDIATION.
+	// Used by: fault-quarantine to ignore observability-only events (processingStrategy=STORE_ONLY)
+	BuildProcessableHealthEventInsertsPipeline() datastore.Pipeline
+
+	// BuildProcessableNonFatalUnhealthyInsertsPipeline creates a pipeline for non-fatal unhealthy events
+	// excluding observability-only events (processingStrategy=STORE_ONLY).
+	// Used by: health-events-analyzer for pattern detection.
+	BuildProcessableNonFatalUnhealthyInsertsPipeline() datastore.Pipeline
 
 	// BuildQuarantinedAndDrainedNodesPipeline creates a pipeline for remediation-ready nodes
 	// Used by: fault-remediation to detect when nodes are ready for reboot

--- a/store-client/pkg/client/pipeline_builder_test.go
+++ b/store-client/pkg/client/pipeline_builder_test.go
@@ -66,7 +66,7 @@ func TestAllHealthEventInsertsPipeline(t *testing.T) {
 	}
 }
 
-func TestNonFatalUnhealthyInsertsPipeline(t *testing.T) {
+func TestProcessableHealthEventInsertsPipeline(t *testing.T) {
 	testCases := []struct {
 		name    string
 		builder PipelineBuilder
@@ -77,7 +77,26 @@ func TestNonFatalUnhealthyInsertsPipeline(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			pipeline := tc.builder.BuildNonFatalUnhealthyInsertsPipeline()
+			pipeline := tc.builder.BuildProcessableHealthEventInsertsPipeline()
+			require.NotNil(t, pipeline)
+			require.NotEmpty(t, pipeline)
+			assert.Len(t, pipeline, 1, "Pipeline should have 1 stage")
+		})
+	}
+}
+
+func TestProcessableNonFatalUnhealthyInsertsPipeline(t *testing.T) {
+	testCases := []struct {
+		name    string
+		builder PipelineBuilder
+	}{
+		{"MongoDB", NewMongoDBPipelineBuilder()},
+		{"PostgreSQL", NewPostgreSQLPipelineBuilder()},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pipeline := tc.builder.BuildProcessableNonFatalUnhealthyInsertsPipeline()
 			require.NotNil(t, pipeline)
 			require.NotEmpty(t, pipeline)
 			assert.Len(t, pipeline, 1, "Pipeline should have 1 stage")
@@ -163,8 +182,8 @@ func TestBackwardCompatibility(t *testing.T) {
 		require.NotEmpty(t, pipeline)
 	})
 
-	t.Run("BuildNonFatalUnhealthyInsertsPipeline", func(t *testing.T) {
-		pipeline := BuildNonFatalUnhealthyInsertsPipeline()
+	t.Run("BuildProcessableNonFatalUnhealthyInsertsPipeline", func(t *testing.T) {
+		pipeline := BuildProcessableNonFatalUnhealthyInsertsPipeline()
 		require.NotNil(t, pipeline)
 		require.NotEmpty(t, pipeline)
 	})

--- a/store-client/pkg/client/pipeline_builder_test.go
+++ b/store-client/pkg/client/pipeline_builder_test.go
@@ -85,7 +85,7 @@ func TestProcessableHealthEventInsertsPipeline(t *testing.T) {
 	}
 }
 
-func TestProcessableNonFatalUnhealthyInsertsPipeline(t *testing.T) {
+func TestNonFatalUnhealthyInsertsPipeline(t *testing.T) {
 	testCases := []struct {
 		name    string
 		builder PipelineBuilder
@@ -96,7 +96,7 @@ func TestProcessableNonFatalUnhealthyInsertsPipeline(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			pipeline := tc.builder.BuildProcessableNonFatalUnhealthyInsertsPipeline()
+			pipeline := tc.builder.BuildNonFatalUnhealthyInsertsPipeline()
 			require.NotNil(t, pipeline)
 			require.NotEmpty(t, pipeline)
 			assert.Len(t, pipeline, 1, "Pipeline should have 1 stage")
@@ -182,8 +182,8 @@ func TestBackwardCompatibility(t *testing.T) {
 		require.NotEmpty(t, pipeline)
 	})
 
-	t.Run("BuildProcessableNonFatalUnhealthyInsertsPipeline", func(t *testing.T) {
-		pipeline := BuildProcessableNonFatalUnhealthyInsertsPipeline()
+	t.Run("BuildNonFatalUnhealthyInsertsPipeline", func(t *testing.T) {
+		pipeline := BuildNonFatalUnhealthyInsertsPipeline()
 		require.NotNil(t, pipeline)
 		require.NotEmpty(t, pipeline)
 	})

--- a/store-client/pkg/client/postgresql_pipeline_builder.go
+++ b/store-client/pkg/client/postgresql_pipeline_builder.go
@@ -131,16 +131,16 @@ func (b *PostgreSQLPipelineBuilder) BuildProcessableHealthEventInsertsPipeline()
 	)
 }
 
-// BuildProcessableNonFatalUnhealthyInsertsPipeline creates a pipeline for non-fatal unhealthy events
-// with processingStrategy=EXECUTE_REMEDIATION
-func (b *PostgreSQLPipelineBuilder) BuildProcessableNonFatalUnhealthyInsertsPipeline() datastore.Pipeline {
+// BuildNonFatalUnhealthyInsertsPipeline creates a pipeline for non-fatal, unhealthy event inserts
+// For PostgreSQL, we need to handle both INSERT and UPDATE operations because platform-connectors
+// may insert a record and then immediately update it, causing the trigger to fire UPDATE events.
+func (b *PostgreSQLPipelineBuilder) BuildNonFatalUnhealthyInsertsPipeline() datastore.Pipeline {
 	return datastore.ToPipeline(
 		datastore.D(
 			datastore.E("$match", datastore.D(
 				datastore.E("operationType", datastore.D(datastore.E("$in", datastore.A("insert", "update")))),
 				datastore.E("fullDocument.healthevent.agent", datastore.D(datastore.E("$ne", "health-events-analyzer"))),
 				datastore.E("fullDocument.healthevent.ishealthy", false),
-				datastore.E("fullDocument.healthevent.processingstrategy", int32(protos.ProcessingStrategy_EXECUTE_REMEDIATION)),
 			)),
 		),
 	)

--- a/store-client/pkg/client/postgresql_pipeline_builder.go
+++ b/store-client/pkg/client/postgresql_pipeline_builder.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"github.com/nvidia/nvsentinel/data-models/pkg/model"
+	"github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	"github.com/nvidia/nvsentinel/store-client/pkg/datastore"
 )
 
@@ -115,16 +116,31 @@ func (b *PostgreSQLPipelineBuilder) BuildAllHealthEventInsertsPipeline() datasto
 	)
 }
 
-// BuildNonFatalUnhealthyInsertsPipeline creates a pipeline for non-fatal, unhealthy event inserts
-// For PostgreSQL, we need to handle both INSERT and UPDATE operations because platform-connectors
-// may insert a record and then immediately update it, causing the trigger to fire UPDATE events.
-func (b *PostgreSQLPipelineBuilder) BuildNonFatalUnhealthyInsertsPipeline() datastore.Pipeline {
+// BuildProcessableHealthEventInsertsPipeline creates a pipeline that watches for health event inserts
+// with processingStrategy=EXECUTE_REMEDIATION
+func (b *PostgreSQLPipelineBuilder) BuildProcessableHealthEventInsertsPipeline() datastore.Pipeline {
+	return datastore.ToPipeline(
+		datastore.D(
+			datastore.E("$match", datastore.D(
+				datastore.E("operationType", datastore.D(
+					datastore.E("$in", datastore.A("insert")),
+				)),
+				datastore.E("fullDocument.healthevent.processingstrategy", int32(protos.ProcessingStrategy_EXECUTE_REMEDIATION)),
+			)),
+		),
+	)
+}
+
+// BuildProcessableNonFatalUnhealthyInsertsPipeline creates a pipeline for non-fatal unhealthy events
+// with processingStrategy=EXECUTE_REMEDIATION
+func (b *PostgreSQLPipelineBuilder) BuildProcessableNonFatalUnhealthyInsertsPipeline() datastore.Pipeline {
 	return datastore.ToPipeline(
 		datastore.D(
 			datastore.E("$match", datastore.D(
 				datastore.E("operationType", datastore.D(datastore.E("$in", datastore.A("insert", "update")))),
 				datastore.E("fullDocument.healthevent.agent", datastore.D(datastore.E("$ne", "health-events-analyzer"))),
 				datastore.E("fullDocument.healthevent.ishealthy", false),
+				datastore.E("fullDocument.healthevent.processingstrategy", int32(protos.ProcessingStrategy_EXECUTE_REMEDIATION)),
 			)),
 		),
 	)

--- a/store-client/pkg/datastore/providers/postgresql/sql_filter_builder_test.go
+++ b/store-client/pkg/datastore/providers/postgresql/sql_filter_builder_test.go
@@ -17,6 +17,7 @@ package postgresql
 import (
 	"testing"
 
+	"github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -357,10 +358,10 @@ func TestSQLFilterBuilder_RealWorldHealthEventsAnalyzerPipeline(t *testing.T) {
 // ============================================================================
 
 // TestSQLFilterBuilder_HealthEventsAnalyzerPipeline tests the pipeline used by health-events-analyzer
-// From postgresql_pipeline_builder.go: BuildNonFatalUnhealthyInsertsPipeline
+	// From postgresql_pipeline_builder.go: BuildProcessableNonFatalUnhealthyInsertsPipeline
 // This is the pipeline that caused the 12+ minute event processing lag in CI
 func TestSQLFilterBuilder_HealthEventsAnalyzerPipeline(t *testing.T) {
-	// Actual pipeline from BuildNonFatalUnhealthyInsertsPipeline
+	// Actual pipeline from BuildProcessableNonFatalUnhealthyInsertsPipeline
 	// Uses datastore.Pipeline format (as seen in CI logs)
 	pipeline := datastore.ToPipeline(
 		datastore.D(
@@ -368,6 +369,7 @@ func TestSQLFilterBuilder_HealthEventsAnalyzerPipeline(t *testing.T) {
 				datastore.E("operationType", datastore.D(datastore.E("$in", datastore.A("insert", "update")))),
 				datastore.E("fullDocument.healthevent.agent", datastore.D(datastore.E("$ne", "health-events-analyzer"))),
 				datastore.E("fullDocument.healthevent.ishealthy", false),
+				datastore.E("fullDocument.healthevent.processingstrategy", int32(protos.ProcessingStrategy_EXECUTE_REMEDIATION)),
 			)),
 		),
 	)

--- a/store-client/pkg/datastore/providers/postgresql/sql_filter_builder_test.go
+++ b/store-client/pkg/datastore/providers/postgresql/sql_filter_builder_test.go
@@ -17,7 +17,6 @@ package postgresql
 import (
 	"testing"
 
-	"github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -358,10 +357,10 @@ func TestSQLFilterBuilder_RealWorldHealthEventsAnalyzerPipeline(t *testing.T) {
 // ============================================================================
 
 // TestSQLFilterBuilder_HealthEventsAnalyzerPipeline tests the pipeline used by health-events-analyzer
-	// From postgresql_pipeline_builder.go: BuildProcessableNonFatalUnhealthyInsertsPipeline
+// From postgresql_pipeline_builder.go: BuildNonFatalUnhealthyInsertsPipeline
 // This is the pipeline that caused the 12+ minute event processing lag in CI
 func TestSQLFilterBuilder_HealthEventsAnalyzerPipeline(t *testing.T) {
-	// Actual pipeline from BuildProcessableNonFatalUnhealthyInsertsPipeline
+	// Actual pipeline from BuildNonFatalUnhealthyInsertsPipeline
 	// Uses datastore.Pipeline format (as seen in CI logs)
 	pipeline := datastore.ToPipeline(
 		datastore.D(
@@ -369,7 +368,6 @@ func TestSQLFilterBuilder_HealthEventsAnalyzerPipeline(t *testing.T) {
 				datastore.E("operationType", datastore.D(datastore.E("$in", datastore.A("insert", "update")))),
 				datastore.E("fullDocument.healthevent.agent", datastore.D(datastore.E("$ne", "health-events-analyzer"))),
 				datastore.E("fullDocument.healthevent.ishealthy", false),
-				datastore.E("fullDocument.healthevent.processingstrategy", int32(protos.ProcessingStrategy_EXECUTE_REMEDIATION)),
 			)),
 		),
 	)

--- a/tests/event_exporter_test.go
+++ b/tests/event_exporter_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"tests/helpers"
+
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +31,6 @@ import (
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
-	"tests/helpers"
 )
 
 func TestEventExporterChangeStream(t *testing.T) {
@@ -81,7 +82,7 @@ func TestEventExporterChangeStream(t *testing.T) {
 
 		t.Log("Validating received CloudEvent")
 		require.NotNil(t, receivedEvent)
-		helpers.ValidateCloudEvent(t, receivedEvent, nodeName, testMessage, "GpuXidError", "79")
+		helpers.ValidateCloudEvent(t, receivedEvent, nodeName, testMessage, "GpuXidError", "79", "EXECUTE_REMEDIATION")
 
 		return ctx
 	})

--- a/tests/gpu_health_monitor_test.go
+++ b/tests/gpu_health_monitor_test.go
@@ -23,20 +23,29 @@ import (
 	"strings"
 	"testing"
 
+	"tests/helpers"
+
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
-	"tests/helpers"
 )
 
 const (
-	dcgmServiceHost      = "nvidia-dcgm.gpu-operator.svc"
-	dcgmServicePort      = "5555"
-	gpuOperatorNamespace = "gpu-operator"
-	dcgmServiceName      = "nvidia-dcgm"
-	dcgmOriginalPort     = 5555
-	dcgmBrokenPort       = 1555
+	dcgmServiceHost               = "nvidia-dcgm.gpu-operator.svc"
+	dcgmServicePort               = "5555"
+	gpuOperatorNamespace          = "gpu-operator"
+	dcgmServiceName               = "nvidia-dcgm"
+	dcgmOriginalPort              = 5555
+	dcgmBrokenPort                = 1555
+	GPUHealthMonitorContainerName = "gpu-health-monitor"
+	GPUHealthMonitorDaemonSetName = "gpu-health-monitor-dcgm-4.x"
+)
+
+const (
+	keyGpuHealthMonitorPodName contextKey = "gpuHealthMonitorPodName"
+	keyOriginalDaemonSet       contextKey = "originalDaemonSet"
 )
 
 // TestGPUHealthMonitorMultipleErrors verifies GPU health monitor handles multiple concurrent errors
@@ -397,6 +406,154 @@ func TestGPUHealthMonitorDCGMConnectionError(t *testing.T) {
 		}
 
 		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}
+
+func TestGpuHealthMonitorStoreOnlyEvents(t *testing.T) {
+	feature := features.New("GPU Health Monitor - Store Only Events").
+		WithLabel("suite", "gpu-health-monitor").
+		WithLabel("component", "store-only-events")
+
+	var testNodeName string
+	var gpuHealthMonitorPodName string
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err, "failed to create kubernetes client")
+
+		originalDaemonSet, err := helpers.UpdateDaemonSetProcessingStrategy(ctx, t, client, GPUHealthMonitorDaemonSetName, GPUHealthMonitorContainerName)
+		require.NoError(t, err, "failed to update GPU health monitor processing strategy")
+
+		gpuHealthMonitorPod, err := helpers.GetDaemonSetPodOnWorkerNode(ctx, t, client, GPUHealthMonitorDaemonSetName, "gpu-health-monitor-dcgm-4.x")
+		require.NoError(t, err, "failed to find GPU health monitor pod on worker node")
+		require.NotNil(t, gpuHealthMonitorPod, "GPU health monitor pod should exist on worker node")
+
+		testNodeName = gpuHealthMonitorPod.Spec.NodeName
+		gpuHealthMonitorPodName = gpuHealthMonitorPod.Name
+		t.Logf("Using GPU health monitor pod: %s on node: %s", gpuHealthMonitorPodName, testNodeName)
+
+		metadata := helpers.CreateTestMetadata(testNodeName)
+		helpers.InjectMetadata(t, ctx, client, helpers.NVSentinelNamespace, testNodeName, metadata)
+
+		t.Logf("Setting ManagedByNVSentinel=false on node %s", testNodeName)
+		err = helpers.SetNodeManagedByNVSentinel(ctx, client, testNodeName, false)
+		require.NoError(t, err, "failed to set ManagedByNVSentinel label")
+
+		ctx = context.WithValue(ctx, keyNodeName, testNodeName)
+		ctx = context.WithValue(ctx, keyOriginalDaemonSet, originalDaemonSet)
+		ctx = context.WithValue(ctx, keyGpuHealthMonitorPodName, gpuHealthMonitorPodName)
+
+		restConfig := client.RESTConfig()
+
+		nodeName := ctx.Value(keyNodeName).(string)
+		podName := ctx.Value(keyGpuHealthMonitorPodName).(string)
+
+		t.Logf("Injecting Inforom error on node %s", nodeName)
+		cmd := []string{"/bin/sh", "-c",
+			fmt.Sprintf("dcgmi test --host %s:%s --inject --gpuid 0 -f 84 -v 0",
+				dcgmServiceHost, dcgmServicePort)}
+
+		stdout, stderr, execErr := helpers.ExecInPod(ctx, restConfig, helpers.NVSentinelNamespace, podName, "", cmd)
+		require.NoError(t, execErr, "failed to inject Inforom error: %s", stderr)
+		require.Contains(t, stdout, "Successfully injected", "Inforom error injection failed")
+
+		return ctx
+	})
+
+	feature.Assess("Cluster state remains unaffected", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err, "failed to create kubernetes client")
+
+		nodeName := ctx.Value(keyNodeName).(string)
+
+		t.Logf("Checking node condition is not applied on node %s", nodeName)
+		helpers.EnsureNodeConditionNotPresent(ctx, t, client, nodeName, "GpuInforomWatch")
+
+		t.Log("Verifying node was not cordoned when processing STORE_ONLY strategy")
+		helpers.AssertQuarantineState(ctx, t, client, nodeName, helpers.QuarantineAssertion{
+			ExpectCordoned:   false,
+			ExpectAnnotation: false,
+		})
+
+		return ctx
+	})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		// t.Logf("Waiting 30 seconds for the checking")
+		// time.Sleep(30 * time.Second)
+
+		client, err := c.NewClient()
+		require.NoError(t, err, "failed to create kubernetes client")
+
+		nodeName := ctx.Value(keyNodeName).(string)
+		originalDaemonSet := ctx.Value(keyOriginalDaemonSet).(*appsv1.DaemonSet)
+
+		err = helpers.RestoreDaemonSet(ctx, t, client, originalDaemonSet, "gpu-health-monitor-dcgm-4.x")
+		require.NoError(t, err, "failed to restore GPU health monitor daemon set")
+
+		restConfig := client.RESTConfig()
+
+		podNameVal := ctx.Value(keyGpuHealthMonitorPodName)
+		if podNameVal == nil {
+			t.Log("Skipping teardown: podName not set (setup likely failed early)")
+			return ctx
+		}
+		podName := podNameVal.(string)
+
+		clearCommands := []struct {
+			name      string
+			fieldID   string
+			value     string
+			condition string
+		}{
+			{"Inforom", "84", "1", "GpuInforomWatch"},
+			{"Memory", "395", "0", "GpuMemWatch"},
+		}
+
+		t.Logf("Clearing injected errors on node %s", nodeName)
+		for _, clearCmd := range clearCommands {
+			cmd := []string{"/bin/sh", "-c",
+				fmt.Sprintf("dcgmi test --host %s:%s --inject --gpuid 0 -f %s -v %s",
+					dcgmServiceHost, dcgmServicePort, clearCmd.fieldID, clearCmd.value)}
+			_, _, _ = helpers.ExecInPod(ctx, restConfig, helpers.NVSentinelNamespace, podName, "", cmd)
+		}
+
+		t.Logf("Waiting for node conditions to be cleared automatically on %s", nodeName)
+		for _, clearCmd := range clearCommands {
+			t.Logf("  Waiting for %s condition to clear", clearCmd.condition)
+			require.Eventually(t, func() bool {
+				condition, err := helpers.CheckNodeConditionExists(ctx, client, nodeName,
+					clearCmd.condition, "")
+				if err != nil {
+					return false
+				}
+				// Condition should either be removed or become healthy (Status=False)
+				if condition == nil {
+					t.Logf("  %s condition removed", clearCmd.condition)
+					return true
+				}
+				if condition.Status == v1.ConditionFalse {
+					t.Logf("  %s condition became healthy", clearCmd.condition)
+					return true
+				}
+				t.Logf("  %s condition still unhealthy: %s", clearCmd.condition, condition.Message)
+				return false
+			}, helpers.EventuallyWaitTimeout, helpers.WaitInterval, "%s condition should be cleared", clearCmd.condition)
+		}
+
+		t.Logf("Cleaning up metadata from node %s", nodeName)
+		helpers.DeleteMetadata(t, ctx, client, helpers.NVSentinelNamespace, nodeName)
+
+		t.Logf("Removing ManagedByNVSentinel label from node %s", nodeName)
+		err = helpers.RemoveNodeManagedByNVSentinelLabel(ctx, client, nodeName)
+		if err != nil {
+			t.Logf("Warning: failed to remove ManagedByNVSentinel label: %v", err)
+		}
+
+		return ctx
+
 	})
 
 	testEnv.Test(t, feature.Feature())

--- a/tests/gpu_health_monitor_test.go
+++ b/tests/gpu_health_monitor_test.go
@@ -481,9 +481,6 @@ func TestGpuHealthMonitorStoreOnlyEvents(t *testing.T) {
 	})
 
 	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-		// t.Logf("Waiting 30 seconds for the checking")
-		// time.Sleep(30 * time.Second)
-
 		client, err := c.NewClient()
 		require.NoError(t, err, "failed to create kubernetes client")
 

--- a/tests/helpers/event_exporter.go
+++ b/tests/helpers/event_exporter.go
@@ -222,6 +222,7 @@ func ValidateCloudEvent(
 	t *testing.T,
 	event map[string]any,
 	expectedNodeName, expectedMessage, expectedCheckName, expectedErrorCode string,
+	expectedProcessingStrategy string,
 ) {
 	t.Helper()
 	t.Logf("Validating CloudEvent: %+v", event)
@@ -241,5 +242,6 @@ func ValidateCloudEvent(
 	require.Equal(t, expectedCheckName, healthEvent["checkName"])
 	require.Equal(t, expectedNodeName, healthEvent["nodeName"])
 	require.Equal(t, expectedMessage, healthEvent["message"])
+	require.Equal(t, expectedProcessingStrategy, healthEvent["processingStrategy"])
 	require.Contains(t, healthEvent["errorCode"], expectedErrorCode)
 }

--- a/tests/helpers/healthevent.go
+++ b/tests/helpers/healthevent.go
@@ -45,6 +45,7 @@ type HealthEventTemplate struct {
 	Metadata            map[string]string    `json:"metadata,omitempty"`
 	QuarantineOverrides *QuarantineOverrides `json:"quarantineOverrides,omitempty"`
 	NodeName            string               `json:"nodeName"`
+	ProcessingStrategy  int                  `json:"processingStrategy,omitempty"`
 }
 
 type EntityImpacted struct {
@@ -146,6 +147,11 @@ func (h *HealthEventTemplate) WithMetadata(key, value string) *HealthEventTempla
 
 func (h *HealthEventTemplate) WithRecommendedAction(action int) *HealthEventTemplate {
 	h.RecommendedAction = action
+	return h
+}
+
+func (h *HealthEventTemplate) WithProcessingStrategy(strategy int) *HealthEventTemplate {
+	h.ProcessingStrategy = strategy
 	return h
 }
 

--- a/tests/helpers/syslog-health-monitor.go
+++ b/tests/helpers/syslog-health-monitor.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/e2e-framework/klient"
+)
+
+const (
+	StubJournalHTTPPort = 9091
+	SyslogContainerName = "syslog-health-monitor"
+	SyslogDaemonSetName = "syslog-health-monitor-regular"
+)
+
+// helper function to set up syslog health monitor and port forward to it
+func SetUpSyslogHealthMonitor(ctx context.Context, t *testing.T,
+	client klient.Client, updatedDaemonSet bool) (string, *appsv1.DaemonSet, *v1.Pod, chan struct{}) {
+	var originalDaemonSet *appsv1.DaemonSet
+
+	var err error
+
+	var syslogPod *v1.Pod
+
+	if updatedDaemonSet {
+		originalDaemonSet, err = UpdateDaemonSetProcessingStrategy(ctx, t, client, SyslogDaemonSetName, SyslogContainerName)
+		require.NoError(t, err, "failed to update syslog health monitor processing strategy")
+	}
+
+	syslogPod, err = GetDaemonSetPodOnWorkerNode(ctx, t, client, SyslogDaemonSetName, "syslog-health-monitor-regular")
+	require.NoError(t, err, "failed to get syslog health monitor pod on worker node")
+	require.NotNil(t, syslogPod, "syslog health monitor pod should exist on worker node")
+
+	testNodeName := syslogPod.Spec.NodeName
+	t.Logf("Using syslog health monitor pod: %s on node: %s", syslogPod.Name, testNodeName)
+
+	metadata := CreateTestMetadata(testNodeName)
+	InjectMetadata(t, ctx, client, NVSentinelNamespace, testNodeName, metadata)
+
+	t.Logf("Setting up port-forward to pod %s on port %d", syslogPod.Name, StubJournalHTTPPort)
+	stopChan, readyChan := PortForwardPod(
+		ctx,
+		client.RESTConfig(),
+		syslogPod.Namespace,
+		syslogPod.Name,
+		StubJournalHTTPPort,
+		StubJournalHTTPPort,
+	)
+	<-readyChan
+	t.Log("Port-forward ready")
+
+	t.Logf("Setting ManagedByNVSentinel=false on node %s", testNodeName)
+	err = SetNodeManagedByNVSentinel(ctx, client, testNodeName, false)
+	require.NoError(t, err, "failed to set ManagedByNVSentinel label")
+
+	return testNodeName, originalDaemonSet, syslogPod, stopChan
+}
+
+// helper function to roll back syslog health monitor daemonset and stop the port forward
+func TearDownSyslogHealthMonitor(ctx context.Context, t *testing.T, client klient.Client,
+	originalDaemonSet *appsv1.DaemonSet, nodeName string, stopChan chan struct{},
+	updatedDaemonSet bool, podName string) {
+	t.Log("Stopping port-forward")
+	close(stopChan)
+
+	if updatedDaemonSet {
+		err := RestoreDaemonSet(ctx, t, client, originalDaemonSet, "syslog-health-monitor-regular")
+		require.NoError(t, err, "failed to restore syslog health monitor daemon set")
+	}
+
+	t.Logf("Restarting syslog-health-monitor pod %s to clear conditions", podName)
+
+	err := DeletePod(ctx, client, NVSentinelNamespace, podName)
+	if err != nil {
+		t.Logf("Warning: failed to delete pod: %v", err)
+	} else {
+		t.Logf("Waiting for SysLogsXIDError condition to be cleared from node %s", nodeName)
+		require.Eventually(t, func() bool {
+			condition, err := CheckNodeConditionExists(ctx, client, nodeName,
+				"SysLogsXIDError", "SysLogsXIDErrorIsHealthy")
+			if err != nil {
+				t.Logf("Failed to check node condition: %v", err)
+				return false
+			}
+
+			return condition != nil && condition.Status == v1.ConditionFalse
+		}, EventuallyWaitTimeout, WaitInterval, "SysLogsXIDError condition should be cleared")
+	}
+
+	t.Logf("Cleaning up metadata from node %s", nodeName)
+	DeleteMetadata(t, ctx, client, NVSentinelNamespace, nodeName)
+
+	t.Logf("Removing ManagedByNVSentinel label from node %s", nodeName)
+
+	err = RemoveNodeManagedByNVSentinelLabel(ctx, client, nodeName)
+	if err != nil {
+		t.Logf("Warning: failed to remove label: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

<!-- Brief description of your changes -->

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [x] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [ ] Ready for review

Issue: https://github.com/NVIDIA/NVSentinel/issues/390


### Testing
#### Tested on tilt cluster
1. Tested on syslog health monitor running on STORE_ONLY mode 

- no node condition
- FQM didn’t cordon the node
- The event was inserted with processing strategy STORE_ONLY
<img width="599" height="801" alt="Screenshot 2025-12-18 at 10 25 28 AM" src="https://github.com/user-attachments/assets/3e552839-6bfe-4620-93c4-5c7a17890306" />

- Event exporter exported it with STORE_ONLY strategy
<img width="1254" height="340" alt="event-exporter-syslog" src="https://github.com/user-attachments/assets/a04ce058-3251-435a-84d1-bab26f53e358" />

2. Tested the changes for gpu-health-monitor also where configured strategy was STORE_ONLY. The new event inserted with STORE_ONLY strategy
<img width="690" height="791" alt="gpu-dcgm-error" src="https://github.com/user-attachments/assets/70bba460-6cba-4839-8249-1da65efae684" />

no node condition/event was added for the inserted error and no node cordoning was done.

3. If any health monitor is running in STORE_ONLY strategy then the event is also inserted with STORE_ONLY strategy. By default they follow EXECUTE_REMEDIATION strategy.
4. Checked platform-connector is not adding node events or any node condition for STORE_ONLY events
5. FQM is not cordoning the node as we have updated its pipeline to receive only EXECUTE_REMEDIATION events
6. node-drainer and FRM is not acting on STORE_ONLY events as FQM didn't complete its operation

#### Tested on dev cluster
 1. Tested by running gpu-health-monitor in STORE_ONLY mode. The inserted event was with STORE_ONLY strategy
 
<img width="529" height="698" alt="Screenshot 2025-12-19 at 12 21 32 PM" src="https://github.com/user-attachments/assets/de40cdd7-d963-452b-933e-1a380535c278" />

2. Checked the events exported by event-exporter and the event contained the configured strategy
<img width="2212" height="301" alt="Screenshot 2025-12-19 at 12 19 51 PM" src="https://github.com/user-attachments/assets/21c441c2-f9bc-4e44-a86d-8e016e42fb01" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable processing strategy for health events: EXECUTE_REMEDIATION (default) or STORE_ONLY.
  * Strategy configurable via CLI flags and Helm values for GPU and syslog monitors.
  * Exposed processingStrategy on exported event payloads and CloudEvents.

* **Behavioral**
  * STORE_ONLY events are recorded but excluded from node-condition updates and Kubernetes event generation.

* **Tests**
  * Added tests and helpers validating STORE_ONLY vs EXECUTE_REMEDIATION behavior and rollout handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->