### PR TITLE
fix(store-client): non-blocking certificate watcher

### DIFF
--- a/store-client/go.mod
+++ b/store-client/go.mod
@@ -7,6 +7,7 @@ toolchain go1.25.3
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/caarlos0/env/v11 v11.3.1
+	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.10.9
 	github.com/nvidia/nvsentinel/commons v0.0.0
@@ -25,7 +26,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-openapi/jsonpointer v0.22.3 // indirect
 	github.com/go-openapi/jsonreference v0.21.3 // indirect
 	github.com/go-openapi/swag v0.25.4 // indirect


### PR DESCRIPTION
## Summary

`certwatcher.Start()` is a blocking call, which I did not realize after refactoring my original PR.

This makes the certificate watcher start on a separate goroutine to avoid blocking progress of the main goroutine

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * MongoDB client initialization now starts certificate monitoring asynchronously to avoid blocking startup and improve availability.
  * Certificate watcher failures are logged but no longer prevent client creation, increasing resilience.
  * Logging integration enhanced for better visibility into certificate monitoring and related errors.

* **Chores**
  * Dependency declarations adjusted to include the logging library directly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->