### PR TITLE
feat(helm): add option to enable automatic certificate hot-reloading

### DIFF
--- a/distros/kubernetes/nvsentinel/templates/configmap-datastore.yaml
+++ b/distros/kubernetes/nvsentinel/templates/configmap-datastore.yaml
@@ -72,6 +72,12 @@ data:
   DATASTORE_SSLROOTCERT: {{ .Values.global.datastore.connection.sslrootcert | quote }}
   {{- end }}
 
+  # Certificate rotation configuration (MongoDB only)
+  # When enabled, client certificates can be rotated without restarting pods
+  {{- if eq .Values.global.datastore.provider "mongodb" }}
+  MONGODB_ENABLE_CERT_ROTATION: {{ .Values.global.certificateRotationEnabled | default false | quote }}
+  {{- end }}
+
   # Legacy MongoDB environment variables for backward compatibility
   # These are set for all providers to support legacy code paths that still use the old config system
   {{- if eq .Values.global.datastore.provider "mongodb" }}

--- a/distros/kubernetes/nvsentinel/values-tilt-mongodb.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt-mongodb.yaml
@@ -27,6 +27,9 @@ global:
   # Use ctrl runtime in mongo and leave postgres with legacy so both get test coverage
   ctrlRuntimeEnabled: true
 
+  # Enable certificate rotation for testing hot-reload functionality
+  certificateRotationEnabled: true
+
   # Configure MongoDB as the datastore provider
   datastore:
     provider: "mongodb"

--- a/distros/kubernetes/nvsentinel/values.yaml
+++ b/distros/kubernetes/nvsentinel/values.yaml
@@ -33,6 +33,12 @@ global:
   #     port: 27017
   #     database: "nvsentinel"
 
+  # Certificate rotation (MongoDB only)
+  # When enabled, client certificates can be rotated without restarting pods.
+  # Uses controller-runtime's certwatcher to detect file changes and automatically
+  # provide updated certificates to new MongoDB connections.
+  certificateRotationEnabled: false
+
   # Shared metadata path used by metadata-collector and syslog-health-monitor
   metadataPath: /var/lib/nvsentinel/gpu_metadata.json
 


### PR DESCRIPTION
## Summary

 Adds Helm chart configuration for MongoDB certificate hot-reloading.

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added configurable certificate rotation support for MongoDB deployments. Users can now enable or disable certificate rotation behavior for MongoDB datastores in Kubernetes environments through a new global configuration setting. Sensible defaults are provided for both production and development deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->