### PR TITLE
feat(janitor): Add Nebius CSP environment variable and secret support

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/janitor/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/templates/deployment.yaml
@@ -130,6 +130,31 @@ spec:
               value: {{ .Values.csp.oci.profile | quote }}
             {{- end }}
             {{- end }}
+            {{- if eq (.Values.csp.provider | default "kind") "nebius" }}
+            # Nebius-specific environment variables
+            {{- if .Values.csp.nebius.serviceAccountKeySecret }}
+            # When using serviceAccountKeySecret, the key is mounted at /etc/nebius/sa-credentials.json
+            - name: NEBIUS_SA_KEY_FILE
+              value: "/etc/nebius/sa-credentials.json"
+            {{- else if .Values.csp.nebius.serviceAccountKeyFile }}
+            - name: NEBIUS_SA_KEY_FILE
+              value: {{ .Values.csp.nebius.serviceAccountKeyFile | quote }}
+            {{- end }}
+            {{- /* iamTokenSecretRef takes precedence over iamToken if both are set */}}
+            {{- if .Values.csp.nebius.iamTokenSecretRef }}
+            - name: NEBIUS_IAM_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.csp.nebius.iamTokenSecretRef.name }}
+                  key: {{ .Values.csp.nebius.iamTokenSecretRef.key | default "token" }}
+            {{- else if .Values.csp.nebius.iamToken }}
+            - name: NEBIUS_IAM_TOKEN
+              value: {{ .Values.csp.nebius.iamToken | quote }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           ports:
@@ -153,6 +178,11 @@ spec:
             {{- end }}
             {{- if .Values.global.auditLogging.enabled }}
             {{- include "nvsentinel.auditLogging.volumeMount" . | nindent 12 }}
+            {{- end }}
+            {{- if and (eq (.Values.csp.provider | default "kind") "nebius") .Values.csp.nebius.serviceAccountKeySecret }}
+            - name: nebius-sa-key
+              mountPath: /etc/nebius
+              readOnly: true
             {{- end }}
       restartPolicy: Always
       volumes:
@@ -178,6 +208,12 @@ spec:
         {{- end }}
         {{- if .Values.global.auditLogging.enabled }}
         {{- include "nvsentinel.auditLogging.volume" . | nindent 8 }}
+        {{- end }}
+        {{- if and (eq (.Values.csp.provider | default "kind") "nebius") .Values.csp.nebius.serviceAccountKeySecret }}
+        - name: nebius-sa-key
+          secret:
+            secretName: {{ .Values.csp.nebius.serviceAccountKeySecret }}
+            defaultMode: 420
         {{- end }}
       {{- with (((.Values.global).systemNodeSelector) | default .Values.nodeSelector) }}
       nodeSelector:

--- a/distros/kubernetes/nvsentinel/charts/janitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/values.yaml
@@ -84,6 +84,18 @@ tolerations: []
 
 affinity: {}
 
+# Extra environment variables to add to the janitor container
+# Example:
+# extraEnv:
+#   - name: MY_VAR
+#     value: "my-value"
+#   - name: SECRET_VAR
+#     valueFrom:
+#       secretKeyRef:
+#         name: my-secret
+#         key: secret-key
+extraEnv: []
+
 config:
   # Global timeout - used as default for controllers that don't specify their own timeout
   # Should be set to a reasonable default that works for most operations
@@ -226,11 +238,21 @@ csp:
     # Example: "/etc/nebius/sa-credentials.json"
     # Set via NEBIUS_SA_KEY_FILE environment variable
     serviceAccountKeyFile: ""
+    # Secret containing service account key (recommended for production with Kubernetes)
+    # The secret should contain the key file as 'sa-credentials.json'
+    # When set, automatically mounts at /etc/nebius and sets NEBIUS_SA_KEY_FILE
+    serviceAccountKeySecret: ""
     # Direct IAM token (for testing only)
     # Tokens expire and require manual refresh - not recommended for production
     # Set via NEBIUS_IAM_TOKEN environment variable
     # Obtain token: nebius iam get-access-token
     iamToken: ""
+    # Reference to secret containing IAM token (alternative to iamToken value)
+    # Example:
+    #   iamTokenSecretRef:
+    #     name: nebius-janitor-token
+    #     key: token
+    iamTokenSecretRef: {}
     # Note: Nebius credentials are provided via environment variables:
     # - NEBIUS_SA_KEY_FILE: Path to service account credentials JSON file (recommended)
     #   The service account must have compute.instances.stop and compute.instances.start permissions

--- a/janitor/go.mod
+++ b/janitor/go.mod
@@ -104,7 +104,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/nebius/gosdk v0.0.0-20251217093515-85d26a34ceb2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/janitor/go.mod
+++ b/janitor/go.mod
@@ -104,6 +104,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/nebius/gosdk v0.0.0-20251217093515-85d26a34ceb2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect


### PR DESCRIPTION
## Summary

Add helm chart support for Nebius credentials in the janitor deployment, enabling authentication with Nebius Compute API for node reboot operations. The deployment template previously only handled AWS/GCP/Azure/OCI environment variables -- Nebius env vars (`NEBIUS_SA_KEY_FILE`, `NEBIUS_IAM_TOKEN`) were never injected even if secrets existed.

This should enable Terraform and Flux updates of NVSentinel.

## Type of Change
- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [X] Janitor
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review

## Changes
- Add Nebius-specific environment variable rendering in deployment template
- Add `serviceAccountKeySecret` to mount SA key as volume at `/etc/nebius/sa-credentials.json`
- Add `iamTokenSecretRef` to reference IAM token from a Kubernetes secret
- Add `extraEnv` support for custom environment variables

## Usage
janitor:
  csp:
    provider: "nebius"
    nebius:
      # Option 1: Mount SA key from secret (recommended)
      serviceAccountKeySecret: "nebius-janitor-sa-key"
      
      # Option 2: Reference IAM token from secret
      iamTokenSecretRef:
        name: nebius-janitor-token
        key: token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Nebius cloud provider support with secure credential management through Kubernetes secrets, enhancing deployment security and reliability.
  * Implemented flexible authentication mechanisms including service account key credentials and configurable IAM token references for Nebius environments.
  * Introduced customizable environment variables support for the janitor service, allowing operators to extend deployment configuration with custom parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->