### PR TITLE
fix: fix for GpuNvlinkWatch Stale Node Condition due to Message Parsing logic collision

### DIFF
--- a/platform-connectors/pkg/connectors/kubernetes/k8s_platform_connector_test.go
+++ b/platform-connectors/pkg/connectors/kubernetes/k8s_platform_connector_test.go
@@ -406,50 +406,6 @@ func equalStringSlices(a, b []string) bool {
 	return true
 }
 
-func TestSanitizeMessageSemicolons(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "message without semicolons unchanged",
-			input:    "Thermal watch error on GPU 0",
-			expected: "Thermal watch error on GPU 0",
-		},
-		{
-			name:     "semicolons replaced with dots",
-			input:    "XID error on GPU 0; XID error on GPU 1; XID error on GPU 2",
-			expected: "XID error on GPU 0. XID error on GPU 1. XID error on GPU 2",
-		},
-		{
-			name:     "semicolon after dot - no double dot",
-			input:    "Run a field diagnostic on the GPU.; Check NVLink status on GPU 1",
-			expected: "Run a field diagnostic on the GPU. Check NVLink status on GPU 1",
-		},
-		{
-			name: "GpuNvlinkWatch error from issue 656",
-			input: "Detected 7 nvlink_flit_crc_error_count_total NvLink errors on GPU 7's NVLink " +
-				"which exceeds threshold of 1 Monitor the NVLink. It can still perform workload.; " +
-				"Detected 97 nvlink_replay_error_count_total NvLink errors on GPU 7's NVLink (should be 0) " +
-				"Run a field diagnostic on the GPU.; Detected 1 nvlink_recovery_error_count_total NvLink errors " +
-				"on GPU 7's NVLink (should be 0) Run a field diagnostic on the GPU.",
-			expected: "Detected 7 nvlink_flit_crc_error_count_total NvLink errors on GPU 7's NVLink " +
-				"which exceeds threshold of 1 Monitor the NVLink. It can still perform workload. " +
-				"Detected 97 nvlink_replay_error_count_total NvLink errors on GPU 7's NVLink (should be 0) " +
-				"Run a field diagnostic on the GPU. Detected 1 nvlink_recovery_error_count_total NvLink errors " +
-				"on GPU 7's NVLink (should be 0) Run a field diagnostic on the GPU.",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := sanitizeMessageSemicolons(tt.input)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestAddMessageIfNotExist(t *testing.T) {
 	tests := []struct {
 		messages []string

--- a/platform-connectors/pkg/connectors/kubernetes/k8s_platform_connector_test.go
+++ b/platform-connectors/pkg/connectors/kubernetes/k8s_platform_connector_test.go
@@ -406,6 +406,50 @@ func equalStringSlices(a, b []string) bool {
 	return true
 }
 
+func TestSanitizeMessageSemicolons(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "message without semicolons unchanged",
+			input:    "Thermal watch error on GPU 0",
+			expected: "Thermal watch error on GPU 0",
+		},
+		{
+			name:     "semicolons replaced with dots",
+			input:    "XID error on GPU 0; XID error on GPU 1; XID error on GPU 2",
+			expected: "XID error on GPU 0. XID error on GPU 1. XID error on GPU 2",
+		},
+		{
+			name:     "semicolon after dot - no double dot",
+			input:    "Run a field diagnostic on the GPU.; Check NVLink status on GPU 1",
+			expected: "Run a field diagnostic on the GPU. Check NVLink status on GPU 1",
+		},
+		{
+			name: "GpuNvlinkWatch error from issue 656",
+			input: "Detected 7 nvlink_flit_crc_error_count_total NvLink errors on GPU 7's NVLink " +
+				"which exceeds threshold of 1 Monitor the NVLink. It can still perform workload.; " +
+				"Detected 97 nvlink_replay_error_count_total NvLink errors on GPU 7's NVLink (should be 0) " +
+				"Run a field diagnostic on the GPU.; Detected 1 nvlink_recovery_error_count_total NvLink errors " +
+				"on GPU 7's NVLink (should be 0) Run a field diagnostic on the GPU.",
+			expected: "Detected 7 nvlink_flit_crc_error_count_total NvLink errors on GPU 7's NVLink " +
+				"which exceeds threshold of 1 Monitor the NVLink. It can still perform workload. " +
+				"Detected 97 nvlink_replay_error_count_total NvLink errors on GPU 7's NVLink (should be 0) " +
+				"Run a field diagnostic on the GPU. Detected 1 nvlink_recovery_error_count_total NvLink errors " +
+				"on GPU 7's NVLink (should be 0) Run a field diagnostic on the GPU.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeMessageSemicolons(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestAddMessageIfNotExist(t *testing.T) {
 	tests := []struct {
 		messages []string

--- a/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
+++ b/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
@@ -314,41 +314,14 @@ func (r *K8sConnector) constructHealthEventMessage(healthEvent *protos.HealthEve
 	}
 
 	if healthEvent.Message != "" {
-		// Sanitize semicolons in the message to prevent delimiter collision
-		// The platform-connector uses ";" as a delimiter between health events
-		sanitizedMsg := sanitizeMessageSemicolons(healthEvent.Message)
-		message += fmt.Sprintf("%s ", sanitizedMsg)
+		// Replace semicolons with dots in the message to prevent delimiter collision
+		sanitizedMessage := strings.ReplaceAll(healthEvent.Message, ";", ".")
+		message += fmt.Sprintf("%s ", sanitizedMessage)
 	}
 
 	message += fmt.Sprintf("Recommended Action=%s;", healthEvent.RecommendedAction.String())
 
 	return message
-}
-
-// sanitizeMessageSemicolons removes semicolons to prevent delimiter collision.
-func sanitizeMessageSemicolons(msg string) string {
-	if !strings.Contains(msg, ";") {
-		return msg
-	}
-
-	var result strings.Builder
-	result.Grow(len(msg))
-
-	for i, c := range msg {
-		if c != ';' {
-			result.WriteRune(c)
-			continue
-		}
-		// Semicolon found: replace with dot only if no adjacent dot
-		prevDot := i > 0 && msg[i-1] == '.'
-		nextDot := i < len(msg)-1 && msg[i+1] == '.'
-
-		if !prevDot && !nextDot {
-			result.WriteByte('.')
-		}
-	}
-
-	return result.String()
 }
 
 func (r *K8sConnector) processHealthEvents(ctx context.Context, healthEvents *protos.HealthEvents) error {

--- a/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
+++ b/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
@@ -314,12 +314,41 @@ func (r *K8sConnector) constructHealthEventMessage(healthEvent *protos.HealthEve
 	}
 
 	if healthEvent.Message != "" {
-		message += fmt.Sprintf("%s ", healthEvent.Message)
+		// Sanitize semicolons in the message to prevent delimiter collision
+		// The platform-connector uses ";" as a delimiter between health events
+		sanitizedMsg := sanitizeMessageSemicolons(healthEvent.Message)
+		message += fmt.Sprintf("%s ", sanitizedMsg)
 	}
 
 	message += fmt.Sprintf("Recommended Action=%s;", healthEvent.RecommendedAction.String())
 
 	return message
+}
+
+// sanitizeMessageSemicolons removes semicolons to prevent delimiter collision.
+func sanitizeMessageSemicolons(msg string) string {
+	if !strings.Contains(msg, ";") {
+		return msg
+	}
+
+	var result strings.Builder
+	result.Grow(len(msg))
+
+	for i, c := range msg {
+		if c != ';' {
+			result.WriteRune(c)
+			continue
+		}
+		// Semicolon found: replace with dot only if no adjacent dot
+		prevDot := i > 0 && msg[i-1] == '.'
+		nextDot := i < len(msg)-1 && msg[i+1] == '.'
+
+		if !prevDot && !nextDot {
+			result.WriteByte('.')
+		}
+	}
+
+	return result.String()
 }
 
 func (r *K8sConnector) processHealthEvents(ctx context.Context, healthEvents *protos.HealthEvents) error {

--- a/tests/gpu_health_monitor_test.go
+++ b/tests/gpu_health_monitor_test.go
@@ -482,8 +482,8 @@ func TestGpuNvlinkWatchSemicolonMessageParsing(t *testing.T) {
 			}
 
 			expectedSanitizedMessage := "" +
-				"Detected 7 nvlink_flit_crc_error_count_total NvLink errors on GPU 7's NVLink which exceeds threshold of 1 Monitor the NVLink. It can still perform workload. " +
-				"Detected 97 nvlink_replay_error_count_total NvLink errors on GPU 7's NVLink (should be 0) Run a field diagnostic on the GPU. " +
+				"Detected 7 nvlink_flit_crc_error_count_total NvLink errors on GPU 7's NVLink which exceeds threshold of 1 Monitor the NVLink. It can still perform workload.. " +
+				"Detected 97 nvlink_replay_error_count_total NvLink errors on GPU 7's NVLink (should be 0) Run a field diagnostic on the GPU.. " +
 				"Detected 1 nvlink_recovery_error_count_total NvLink errors on GPU 7's NVLink (should be 0). Run a field diagnostic on the GPU."
 			if !strings.Contains(condition.Message, expectedSanitizedMessage) {
 				t.Logf("Condition message did not contain the full expected NVLink error message: got: %q", condition.Message)
@@ -546,8 +546,8 @@ func TestGpuNvlinkWatchSemicolonMessageParsing(t *testing.T) {
 
 			// Validate the complete sanitized message for GPU 7 is still present
 			expectedGPU7Message := "" +
-				"Detected 7 nvlink_flit_crc_error_count_total NvLink errors on GPU 7's NVLink which exceeds threshold of 1 Monitor the NVLink. It can still perform workload. " +
-				"Detected 97 nvlink_replay_error_count_total NvLink errors on GPU 7's NVLink (should be 0) Run a field diagnostic on the GPU. " +
+				"Detected 7 nvlink_flit_crc_error_count_total NvLink errors on GPU 7's NVLink which exceeds threshold of 1 Monitor the NVLink. It can still perform workload.. " +
+				"Detected 97 nvlink_replay_error_count_total NvLink errors on GPU 7's NVLink (should be 0) Run a field diagnostic on the GPU.. " +
 				"Detected 1 nvlink_recovery_error_count_total NvLink errors on GPU 7's NVLink (should be 0). Run a field diagnostic on the GPU."
 			if !strings.Contains(condition.Message, expectedGPU7Message) {
 				t.Logf("Condition message did not contain the expected GPU 7 NVLink error message (may have been corrupted by semicolon parsing)")

--- a/tests/gpu_health_monitor_test.go
+++ b/tests/gpu_health_monitor_test.go
@@ -23,11 +23,12 @@ import (
 	"strings"
 	"testing"
 
+	"tests/helpers"
+
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
-	"tests/helpers"
 )
 
 const (
@@ -389,6 +390,250 @@ func TestGPUHealthMonitorDCGMConnectionError(t *testing.T) {
 			t.Logf("Condition still present: Status=%s", condition.Status)
 			return false
 		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval, "GpuDcgmConnectivityFailure should clear")
+
+		t.Logf("Removing ManagedByNVSentinel label from node %s", nodeName)
+		err = helpers.RemoveNodeManagedByNVSentinelLabel(ctx, client, nodeName)
+		if err != nil {
+			t.Logf("Warning: failed to remove ManagedByNVSentinel label: %v", err)
+		}
+
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}
+
+// TestGpuNvlinkWatchSemicolonMessageParsing tests the parsing of GpuNvlinkWatch error messages
+func TestGpuNvlinkWatchSemicolonMessageParsing(t *testing.T) {
+	feature := features.New("GpuNvlinkWatch error message parsing").
+		WithLabel("suite", "gpu-health-monitor").
+		WithLabel("component", "nvlink-error-message-parsing")
+
+	var testNodeName string
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err, "failed to create kubernetes client")
+
+		gpuHealthMonitorPod, err := helpers.GetPodOnWorkerNode(ctx, t, client, helpers.NVSentinelNamespace, "gpu-health-monitor")
+		require.NoError(t, err, "failed to find GPU health monitor pod on worker node")
+		require.NotNil(t, gpuHealthMonitorPod, "GPU health monitor pod should exist on worker node")
+
+		testNodeName = gpuHealthMonitorPod.Spec.NodeName
+		t.Logf("Using test node: %s", testNodeName)
+
+		t.Logf("Setting ManagedByNVSentinel=false on node %s", testNodeName)
+		err = helpers.SetNodeManagedByNVSentinel(ctx, client, testNodeName, false)
+		require.NoError(t, err, "failed to set ManagedByNVSentinel label")
+
+		ctx = context.WithValue(ctx, keyNodeName, testNodeName)
+		return ctx
+	})
+
+	feature.Assess("Inject first NVLink error with semicolons in message", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err, "failed to create kubernetes client")
+
+		nodeName := ctx.Value(keyNodeName).(string)
+
+		nvlinkMessage := "Detected 7 nvlink_flit_crc_error_count_total NvLink errors on GPU 7's NVLink " +
+			"which exceeds threshold of 1 Monitor the NVLink. It can still perform workload.; " +
+			"Detected 97 nvlink_replay_error_count_total NvLink errors on GPU 7's NVLink (should be 0) " +
+			"Run a field diagnostic on the GPU.; " +
+			"Detected 1 nvlink_recovery_error_count_total NvLink errors on GPU 7's NVLink (should be 0). " +
+			"Run a field diagnostic on the GPU."
+
+		t.Logf("Injecting GpuNvlinkWatch error for GPU 7 with semicolons in message")
+		event := helpers.NewHealthEvent(nodeName).
+			WithCheckName("GpuNvlinkWatch").
+			WithAgent("gpu-health-monitor").
+			WithComponentClass("GPU").
+			WithErrorCode("DCGM_FR_NVLINK_ERROR_THRESHOLD").
+			WithMessage(nvlinkMessage).
+			WithEntitiesImpacted([]helpers.EntityImpacted{
+				{EntityType: "GPU", EntityValue: "7"},
+				{EntityType: "PCI", EntityValue: "0000:da:00.0"},
+				{EntityType: "GPU_UUID", EntityValue: "GPU-b610ad95-f331-ffd3-1ac5-e152e87f3a8c"},
+			}).
+			WithRecommendedAction(5)
+
+		helpers.SendHealthEvent(ctx, t, event)
+
+		t.Logf("Waiting for GpuNvlinkWatch condition to appear on node %s", nodeName)
+		require.Eventually(t, func() bool {
+			condition, err := helpers.CheckNodeConditionExists(ctx, client, nodeName,
+				"GpuNvlinkWatch", "GpuNvlinkWatchIsNotHealthy")
+			if err != nil {
+				t.Logf("Error checking condition: %v", err)
+				return false
+			}
+			if condition == nil {
+				t.Log("Condition not found yet")
+				return false
+			}
+
+			t.Logf("Found GpuNvlinkWatch condition - Status: %s, Message: %s",
+				condition.Status, condition.Message)
+
+			// Verify GPU 7 entity is in the message
+			if !strings.Contains(condition.Message, "GPU:7") {
+				t.Log("Condition message missing GPU:7 entity")
+				return false
+			}
+
+			expectedSanitizedMessage := "" +
+				"Detected 7 nvlink_flit_crc_error_count_total NvLink errors on GPU 7's NVLink which exceeds threshold of 1 Monitor the NVLink. It can still perform workload. " +
+				"Detected 97 nvlink_replay_error_count_total NvLink errors on GPU 7's NVLink (should be 0) Run a field diagnostic on the GPU. " +
+				"Detected 1 nvlink_recovery_error_count_total NvLink errors on GPU 7's NVLink (should be 0). Run a field diagnostic on the GPU."
+			if !strings.Contains(condition.Message, expectedSanitizedMessage) {
+				t.Logf("Condition message did not contain the full expected NVLink error message: got: %q", condition.Message)
+				return false
+			}
+
+			return condition.Status == v1.ConditionTrue
+		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval, "GpuNvlinkWatch condition should appear")
+
+		return ctx
+	})
+
+	feature.Assess("Inject second NVLink error for different GPU with semicolons", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err, "failed to create kubernetes client")
+
+		nodeName := ctx.Value(keyNodeName).(string)
+
+		// Second NVLink error for GPU 3
+		nvlinkMessage := "Detected 71 nvlink_replay_error_count_total NvLink errors on GPU 3's NVLink " +
+			"(should be 0). Run a field diagnostic on the GPU."
+
+		t.Logf("Injecting GpuNvlinkWatch error for GPU 3 with semicolons in message")
+		event := helpers.NewHealthEvent(nodeName).
+			WithCheckName("GpuNvlinkWatch").
+			WithAgent("gpu-health-monitor").
+			WithComponentClass("GPU").
+			WithErrorCode("DCGM_FR_NVLINK_ERROR_THRESHOLD").
+			WithMessage(nvlinkMessage).
+			WithEntitiesImpacted([]helpers.EntityImpacted{
+				{EntityType: "GPU", EntityValue: "3"},
+				{EntityType: "PCI", EntityValue: "0000:db:00.0"},
+				{EntityType: "GPU_UUID", EntityValue: "GPU-c721be06-f442-ffe4-2bd6-f263f98g4b9d"},
+			}).
+			WithRecommendedAction(5)
+		helpers.SendHealthEvent(ctx, t, event)
+
+		t.Logf("Waiting for GpuNvlinkWatch condition to include GPU 3 on node %s", nodeName)
+		require.Eventually(t, func() bool {
+			condition, err := helpers.CheckNodeConditionExists(ctx, client, nodeName,
+				"GpuNvlinkWatch", "GpuNvlinkWatchIsNotHealthy")
+			if err != nil || condition == nil {
+				return false
+			}
+
+			t.Logf("Condition message: %s", condition.Message)
+
+			// Both GPU 7 and GPU 3 should be in the message
+			hasGPU7 := strings.Contains(condition.Message, "GPU:7")
+			hasGPU3 := strings.Contains(condition.Message, "GPU:3")
+
+			if !hasGPU7 {
+				t.Log("Warning: GPU:7 not found in condition message (may have been incorrectly parsed)")
+				return false
+			}
+			if !hasGPU3 {
+				t.Log("Waiting for GPU:3 to appear in condition message")
+				return false
+			}
+
+			// Validate the complete sanitized message for GPU 7 is still present
+			expectedGPU7Message := "" +
+				"Detected 7 nvlink_flit_crc_error_count_total NvLink errors on GPU 7's NVLink which exceeds threshold of 1 Monitor the NVLink. It can still perform workload. " +
+				"Detected 97 nvlink_replay_error_count_total NvLink errors on GPU 7's NVLink (should be 0) Run a field diagnostic on the GPU. " +
+				"Detected 1 nvlink_recovery_error_count_total NvLink errors on GPU 7's NVLink (should be 0). Run a field diagnostic on the GPU."
+			if !strings.Contains(condition.Message, expectedGPU7Message) {
+				t.Logf("Condition message did not contain the expected GPU 7 NVLink error message (may have been corrupted by semicolon parsing)")
+				return false
+			}
+
+			// Validate the complete sanitized message for GPU 3
+			expectedGPU3Message := "Detected 71 nvlink_replay_error_count_total NvLink errors on GPU 3's NVLink " +
+				"(should be 0). Run a field diagnostic on the GPU."
+			if !strings.Contains(condition.Message, expectedGPU3Message) {
+				t.Logf("Condition message did not contain the expected GPU 3 NVLink error message")
+				return false
+			}
+
+			return condition.Status == v1.ConditionTrue
+		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval, "GpuNvlinkWatch should include GPU 3 with complete sanitized message")
+
+		return ctx
+	})
+
+	feature.Assess("Send healthy event and verify condition clears correctly", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err, "failed to create kubernetes client")
+
+		nodeName := ctx.Value(keyNodeName).(string)
+
+		t.Logf("Sending healthy GpuNvlinkWatch event to clear all errors")
+		healthyEvent := helpers.NewHealthEvent(nodeName).
+			WithCheckName("GpuNvlinkWatch").
+			WithAgent("gpu-health-monitor").
+			WithComponentClass("GPU").
+			WithHealthy(true).
+			WithFatal(true).
+			WithMessage("No Health Failures").
+			WithEntitiesImpacted([]helpers.EntityImpacted{}) // Empty entities clears all
+
+		helpers.SendHealthEvent(ctx, t, healthyEvent)
+
+		t.Logf("Waiting for GpuNvlinkWatch condition to become healthy on node %s", nodeName)
+		require.Eventually(t, func() bool {
+			condition, err := helpers.CheckNodeConditionExists(ctx, client, nodeName,
+				"GpuNvlinkWatch", "GpuNvlinkWatchIsHealthy")
+			if err != nil {
+				t.Logf("Error checking condition: %v", err)
+				return false
+			}
+
+			if condition == nil {
+				t.Log("Healthy condition not found yet, still waiting...")
+				return false
+			}
+
+			t.Logf("Condition state - Status: %s, Reason: %s, Message: %s",
+				condition.Status, condition.Reason, condition.Message)
+
+			// Verify healthy condition properties
+			if condition.Status != v1.ConditionFalse {
+				t.Logf("Condition status is not False: %s", condition.Status)
+				return false
+			}
+
+			if condition.Message != "No Health Failures" {
+				t.Logf("Condition message is not 'No Health Failures': %s", condition.Message)
+				return false
+			}
+
+			t.Log("GpuNvlinkWatch condition became healthy (Status=False, Message='No Health Failures')")
+			return true
+		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval, "GpuNvlinkWatch should become healthy")
+
+		return ctx
+	})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		if err != nil {
+			t.Logf("Warning: failed to create client for teardown: %v", err)
+			return ctx
+		}
+
+		nodeNameVal := ctx.Value(keyNodeName)
+		if nodeNameVal == nil {
+			t.Log("Skipping teardown: nodeName not set")
+			return ctx
+		}
+		nodeName := nodeNameVal.(string)
 
 		t.Logf("Removing ManagedByNVSentinel label from node %s", nodeName)
 		err = helpers.RemoveNodeManagedByNVSentinelLabel(ctx, client, nodeName)

--- a/tests/health_events_analyzer_test.go
+++ b/tests/health_events_analyzer_test.go
@@ -386,7 +386,7 @@ func TestRepeatedXID31OnSameGPU(t *testing.T) {
 		expectedEvent := v1.Event{
 			Type:    "RepeatedXID31OnDifferentGPU",
 			Reason:  "RepeatedXID31OnDifferentGPUIsNotHealthy",
-			Message: "ErrorCode:31 PCI:0002:00:00 GPU_UUID:GPU-22222222-2222-2222-2222-222222222222 App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support Recommended Action=NONE;",
+			Message: "ErrorCode:31 PCI:0002:00:00 GPU_UUID:GPU-22222222-2222-2222-2222-222222222222 App passing bad data or using incorrect GPU methods. check error PID to identify source of the problem, if application is known good and problem persists, then contact support Recommended Action=NONE;",
 		}
 
 		helpers.WaitForNodeEvent(ctx, t, client, testNodeName, expectedEvent)
@@ -583,7 +583,7 @@ func TestXIDErrorOnGPCAndTPC(t *testing.T) {
 		expectedEvent := v1.Event{
 			Type:    "RepeatedXID13OnDifferentGPCAndTPC",
 			Reason:  "RepeatedXID13OnDifferentGPCAndTPCIsNotHealthy",
-			Message: "ErrorCode:13 PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 GPC:0 TPC:0 SM:1 App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support Recommended Action=NONE;",
+			Message: "ErrorCode:13 PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 GPC:0 TPC:0 SM:1 App passing bad data or using incorrect GPU methods. check error PID to identify source of the problem, if application is known good and problem persists, then contact support Recommended Action=NONE;",
 		}
 
 		helpers.WaitForNodeEvent(ctx, t, client, testNodeName, expectedEvent)
@@ -624,7 +624,7 @@ func TestXIDErrorOnGPCAndTPC(t *testing.T) {
 		expectedEvent = v1.Event{
 			Type:    "RepeatedXID13OnDifferentGPCAndTPC",
 			Reason:  "RepeatedXID13OnDifferentGPCAndTPCIsNotHealthy",
-			Message: "ErrorCode:13 PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 GPC:0 TPC:1 SM:1 App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support Recommended Action=NONE;",
+			Message: "ErrorCode:13 PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 GPC:0 TPC:1 SM:1 App passing bad data or using incorrect GPU methods. check error PID to identify source of the problem, if application is known good and problem persists, then contact support Recommended Action=NONE;",
 		}
 
 		helpers.WaitForNodeEvent(ctx, t, client, testNodeName, expectedEvent)
@@ -755,7 +755,7 @@ func TestSoloNoBurstRule(t *testing.T) {
 		expectedEvent := v1.Event{
 			Type:    "XIDErrorSoloNoBurst",
 			Reason:  "XIDErrorSoloNoBurstIsNotHealthy",
-			Message: "ErrorCode:13 PCI:0002:00:00 GPU_UUID:GPU-22222222-2222-2222-2222-222222222222 App passing bad data or using incorrect GPU methods; check error PID to identify source of the problem, if application is known good and problem persists, then contact support Recommended Action=NONE;",
+			Message: "ErrorCode:13 PCI:0002:00:00 GPU_UUID:GPU-22222222-2222-2222-2222-222222222222 App passing bad data or using incorrect GPU methods. check error PID to identify source of the problem, if application is known good and problem persists, then contact support Recommended Action=NONE;",
 		}
 
 		helpers.WaitForNodeEvent(ctx, t, client, testNodeName, expectedEvent)


### PR DESCRIPTION


## Summary
Issue => https://github.com/NVIDIA/NVSentinel/issues/656

<!-- Brief description of your changes -->
Update the platform-connector code to remove the semicolon field from the message field of the healthevent if it exists and replace it with dot(.). This is needed to  avoid message parsing logic collision of the healthevent where if the original healthevent has a message with semicolons in it and a new same type of unhealthy event for the different gpu, then the message field  of node condition should be updated properly. prior to this, what was happening is when new healthevent arrives for different gpu, then while merging it with prior healthevent, the logic gets messed up because platform-connector splits multiple healthevents of same type on the same node with  semicolon and that interfares with the healthevent message field semicolon and trim some part of it.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sanitized health event messages by replacing semicolons with periods to improve readability and consistent display.

* **Tests**
  * Added GPU health monitoring test verifying sanitized multi-part NVLink messages and behavior across error and recovery scenarios.
  * Updated health-event expectations to match revised punctuation and message formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->