### PR TITLE
fix: missing default cspProviderHostvalue

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/janitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/values.yaml
@@ -100,6 +100,8 @@ config:
   # Global timeout - used as default for controllers that don't specify their own timeout
   # Should be set to a reasonable default that works for most operations
   timeout: "25m"
+  # host where the provider is running
+  cspProviderHost: "janitor-provider.nvsentinel.svc.cluster.local:50051"
   # Manual mode - if true, controllers won't send actual reboot/terminate signals
   manualMode: false
   # HTTP endpoint port for exposing runtime configuration


### PR DESCRIPTION
## Summary

Add missing default value for cspProviderHost

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new configuration parameter to support CSP provider connectivity with a default service endpoint.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->