### PR TITLE
fix demo - use arm compatible mongodb image from bitnami

### DIFF
--- a/demos/local-fault-injection-demo/scripts/00-demo-values-arm.yaml
+++ b/demos/local-fault-injection-demo/scripts/00-demo-values-arm.yaml
@@ -1,0 +1,9 @@
+# ARM specific overrides
+mongodb-store:
+
+  # Bitnami configuration
+  mongodb:
+    image:
+      registry: "docker.io"
+      repository: "dlavrenuek/bitnami-mongodb-arm"
+      tag: "8.0.4"

--- a/demos/local-fault-injection-demo/scripts/00-demo-values.yaml
+++ b/demos/local-fault-injection-demo/scripts/00-demo-values.yaml
@@ -1,0 +1,130 @@
+# Minimal NVSentinel configuration for local demo
+global:
+  dryRun: false
+
+  # Enable GPU health monitor for Error detection (works with fake DCGM)
+  gpuHealthMonitor:
+    enabled: true
+  syslogHealthMonitor:
+    enabled: false
+  cspHealthMonitor:
+    enabled: false
+  kubernetesObjectMonitor:
+    enabled: false
+
+  # Enable only core components needed for demo
+  platformConnector:
+    enabled: true
+    replicas: 1
+
+  faultQuarantine:
+    enabled: true
+    replicas: 1
+
+  # Disable other components
+  nodeDrainer:
+    enabled: false
+  faultRemediation:
+    enabled: false
+  healthEventsAnalyzer:
+    enabled: false
+  janitor:
+    enabled: false
+  labeler:
+    enabled: false  # Disabled to prevent removing our demo labels
+  metadataCollector:
+    enabled: false
+
+  # Enable MongoDB for event storage
+  mongodbStore:
+    enabled: true
+
+# Disable monitoring (no Prometheus in this demo)
+monitoring:
+  enabled: false
+
+# MongoDB Store configuration - copied from values-tilt.yaml (lines 73-184)
+mongodb-store:
+  useBitnami: true
+  usePerconaOperator: false
+
+  job:
+    nodeSelector:
+      node-role.kubernetes.io/control-plane: ""
+    tolerations:
+      - operator: Exists
+
+  # Bitnami configuration
+  mongodb:
+    replicaCount: 1
+    nodeSelector:
+      node-role.kubernetes.io/control-plane: ""
+
+    tolerations:
+    - operator: Exists
+
+    jobTolerations:
+    - operator: Exists
+
+    image:
+      registry: "docker.io"
+      repository: "bitnamilegacy/mongodb"
+      tag: "8.0.3-debian-12-r1"
+      pullPolicy: "IfNotPresent"
+
+    tls:
+      replicaset:
+        existingSecrets:
+          - "mongo-server-cert-0"
+
+      image:
+        registry: "docker.io"
+        repository: "bitnamilegacy/nginx"
+        tag: "1.27.2-debian-12-r2"
+        pullPolicy: "IfNotPresent"
+
+    metrics:
+      enabled: true
+      image:
+        registry: docker.io
+        repository: bitnamilegacy/mongodb-exporter
+        tag: 0.41.2-debian-12-r1
+
+    # Demo-specific overrides
+    auth:
+      enabled: true
+      rootPassword: "demo-password"
+    persistence:
+      enabled: false
+
+# Platform Connector configuration
+platformConnector:
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "100m"
+    limits:
+      memory: "256Mi"
+      cpu: "500m"
+
+# Fault Quarantine configuration
+faultQuarantine:
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "100m"
+    limits:
+      memory: "256Mi"
+      cpu: "500m"
+
+# Simple Health Client for injecting test events
+simpleHealthClient:
+  enabled: true
+  replicas: 1
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
+    limits:
+      memory: "128Mi"
+      cpu: "200m"

--- a/demos/local-fault-injection-demo/scripts/00-setup.sh
+++ b/demos/local-fault-injection-demo/scripts/00-setup.sh
@@ -210,8 +210,8 @@ mongodb-store:
 
     image:
       registry: "docker.io"
-      repository: "bitnamilegacy/mongodb"
-      tag: "8.0.3-debian-12-r1"
+      repository: "bitnamisecure/mongodb"
+      tag: "latest"
       pullPolicy: "IfNotPresent"
 
     tls:


### PR DESCRIPTION
## Summary

while trying to run the demo on mac(arm64), mongo image is missing for arm64, 
```
 message: 'Back-off pulling image "docker.io/bitnamilegacy/mongodb:8.0.3-debian-12-r1":                                             │
│           ErrImagePull: rpc error: code = NotFound desc = failed to pull and unpack                                                        │
│           image "docker.io/bitnamilegacy/mongodb:8.0.3-debian-12-r1": no match for                                                         │
│           platform in manifest: not found' 
```
so using arm64 available image from bitnami: https://hub.docker.com/r/bitnamisecure/mongodb

## Type of Change
- [x] 🐛 Demo fix for arm64 processor
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [x] Other:  DEMO

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local fault-injection demo now supports architecture-specific overrides (ARM64) and uses an external demo values file for easier customization.
* **Chores**
  * Switched demo component installation to OCI-based manifests and consolidated configuration into a single external values file.
  * Updated MongoDB container image and simplified demo setup and sequencing for more reliable local deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->