### PR TITLE
fix: case in xid 154 switch statement

### DIFF
--- a/health-monitors/syslog-health-monitor/pkg/common/common.go
+++ b/health-monitors/syslog-health-monitor/pkg/common/common.go
@@ -77,7 +77,7 @@ func MapActionStringToProto(s string) pb.RecommendedAction {
 	// If no XID 154 present, RESTART_APP. Since each XID is acted on, the recommendation for XID 154 will be
 	// applied as a part of the XID 154 cycle therefore we don't need lookback/lookforward for the XID. Hence
 	// XID_154_EVAL is considered equivalent to RESTART_APP.
-	case "RESTART_APP", "IGNORE", "XID_154_EVAL":
+	case "RESTART_APP", "IGNORE", "XID_154_Eval":
 		return pb.RecommendedAction_NONE
 	case "WORKFLOW_XID_48", "RESET_GPU", "RESET_FABRIC":
 		return pb.RecommendedAction_COMPONENT_RESET

--- a/health-monitors/syslog-health-monitor/pkg/common/common.go
+++ b/health-monitors/syslog-health-monitor/pkg/common/common.go
@@ -66,7 +66,7 @@ var embeddedXidCatalog []byte
 
 // MapActionStringToProto maps action strings to protobuf RecommendedAction values using generated protobuf map
 func MapActionStringToProto(s string) pb.RecommendedAction {
-	s = strings.TrimSpace(s)
+	s = strings.ToUpper(strings.TrimSpace(s))
 
 	if value, exists := pb.RecommendedAction_value[s]; exists {
 		return pb.RecommendedAction(value)
@@ -77,7 +77,7 @@ func MapActionStringToProto(s string) pb.RecommendedAction {
 	// If no XID 154 present, RESTART_APP. Since each XID is acted on, the recommendation for XID 154 will be
 	// applied as a part of the XID 154 cycle therefore we don't need lookback/lookforward for the XID. Hence
 	// XID_154_EVAL is considered equivalent to RESTART_APP.
-	case "RESTART_APP", "IGNORE", "XID_154_Eval":
+	case "RESTART_APP", "IGNORE", "XID_154_EVAL":
 		return pb.RecommendedAction_NONE
 	case "WORKFLOW_XID_48", "RESET_GPU", "RESET_FABRIC":
 		return pb.RecommendedAction_COMPONENT_RESET


### PR DESCRIPTION
## Summary

<!-- Brief description of your changes -->

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made health-monitor action recognition more robust by normalizing incoming action text (trimming and case-insensitive matching), reducing misclassification due to casing or stray whitespace and improving consistent routing of system health messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->