### PR TITLE
feat: allow using all fields in the health event for templating

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/fault-remediation/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-remediation/values.yaml
@@ -90,11 +90,11 @@ maintenance:
       apiVersion: janitor.dgxc.nvidia.com/v1alpha1
       kind: RebootNode
       metadata:
-        name: maintenance-{{ .NodeName }}-{{ .HealthEventID }}
+        name: maintenance-{{ .HealthEvent.NodeName }}-{{ .HealthEventID }}
         labels:
           app.kubernetes.io/managed-by: nvsentinel
       spec:
-        nodeName: {{ .NodeName }}
+        nodeName: {{ .HealthEvent.NodeName }}
         force: false
     # Additional template examples:
     # "namespaced-restart.yaml": |

--- a/distros/kubernetes/nvsentinel/values-tilt.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt.yaml
@@ -266,9 +266,9 @@ fault-remediation:
         apiVersion: {{ .ApiGroup }}/{{ .Version }}
         kind: RebootNode
         metadata:
-          name: maintenance-{{ .NodeName }}-{{ .HealthEventID }}
+          name: maintenance-{{ .HealthEvent.NodeName }}-{{ .HealthEventID }}
         spec:
-          nodeName: {{ .NodeName }}
+          nodeName: {{ .HealthEvent.NodeName }}
 
   logCollector:
     enabled: true

--- a/fault-remediation/pkg/common/equivalence_groups.go
+++ b/fault-remediation/pkg/common/equivalence_groups.go
@@ -21,12 +21,23 @@ import (
 // RemediationEquivalenceGroups defines groups of remediation actions that are considered
 // to have the same operational effect. This is used to prevent multiple, similar remediations
 // (like various forms of reboots) from occurring in rapid succession.
-// TODO: Fix this multiple mappings as part of https://jirasw.nvidia.com/browse/KACE-1736
 var RemediationEquivalenceGroups = map[string][]protos.RecommendedAction{
 	"restart": {
 		protos.RecommendedAction_COMPONENT_RESET,
 		protos.RecommendedAction_RESTART_VM,
 		protos.RecommendedAction_RESTART_BM,
+	},
+	"fieldiag": {
+		protos.RecommendedAction_RUN_FIELDDIAG,
+	},
+	"dcgmeud": {
+		protos.RecommendedAction_RUN_DCGMEUD,
+	},
+	"support": {
+		protos.RecommendedAction_CONTACT_SUPPORT,
+	},
+	"replace": {
+		protos.RecommendedAction_REPLACE_VM,
 	},
 }
 

--- a/fault-remediation/pkg/common/equivalence_groups_test.go
+++ b/fault-remediation/pkg/common/equivalence_groups_test.go
@@ -44,9 +44,9 @@ func TestGetRemediationGroupForAction(t *testing.T) {
 			expectedGroup: "restart",
 		},
 		{
-			name:          "CONTACT_SUPPORT returns empty string (not in any group)",
+			name:          "CONTACT_SUPPORT returns support",
 			action:        protos.RecommendedAction_CONTACT_SUPPORT,
-			expectedGroup: "",
+			expectedGroup: "support",
 		},
 		{
 			name:          "NONE returns empty string (not in any group)",

--- a/fault-remediation/pkg/reconciler/reconciler.go
+++ b/fault-remediation/pkg/reconciler/reconciler.go
@@ -150,7 +150,8 @@ func (r *FaultRemediationReconciler) shouldSkipEvent(ctx context.Context,
 		return true
 	}
 
-	if common.GetRemediationGroupForAction(action) != "" {
+	_, exists := r.config.RemediationClient.GetConfig().RemediationActions[action.String()]
+	if common.GetRemediationGroupForAction(action) != "" && exists {
 		return false
 	}
 

--- a/fault-remediation/pkg/reconciler/remediation.go
+++ b/fault-remediation/pkg/reconciler/remediation.go
@@ -80,6 +80,8 @@ type TemplateData struct {
 	RecommendedAction     protos.RecommendedAction
 	RecommendedActionName string
 
+	HealthEvent *protos.HealthEvent
+
 	// CRD routing metadata (populated from MaintenanceResource)
 	ApiGroup  string
 	Version   string
@@ -270,6 +272,8 @@ func (c *FaultRemediationClient) CreateMaintenanceResource(
 		HealthEventID:         healthEventID,
 		RecommendedAction:     healthEvent.RecommendedAction,
 		RecommendedActionName: recommendedActionName,
+
+		HealthEvent: healthEvent,
 
 		ApiGroup:  maintenanceResource.ApiGroup,
 		Version:   maintenanceResource.Version,

--- a/fault-remediation/pkg/reconciler/remediation_test.go
+++ b/fault-remediation/pkg/reconciler/remediation_test.go
@@ -444,9 +444,9 @@ func TestCreateRebootNodeResource(t *testing.T) {
 			tmpl, err := tmpl.Parse(`apiVersion: {{.ApiGroup}}/{{.Version}}
 kind: RebootNode
 metadata:
-  name: maintenance-{{.NodeName}}-{{.HealthEventID}}
+  name: maintenance-{{.HealthEvent.NodeName}}-{{.HealthEventID}}
 spec:
-  nodeName: {{.NodeName}}`)
+  nodeName: {{.HealthEvent.NodeName}}`)
 			assert.NoError(t, err)
 
 			// Create K8sClient with mock


### PR DESCRIPTION
## Summary

Some more complex CRDs remediation systems ask for information about in the remediation CR, hence pass in the complete health event to the templating system to allow generation of the required CRs

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure maintenance remediation resources consistently use the node name from the related health event so nodes are targeted correctly.
  * Tighten action validation so unsupported or unconfigured remediation actions are skipped and logged.

* **New Features**
  * Added several remediation equivalence groups to broaden available remediation actions.

* **Tests**
  * Updated tests to reflect the new group mappings and template behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->