### PR TITLE
Feature/support none tls data store

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/deployment.yaml
@@ -138,6 +138,13 @@ spec:
           env:
             - name: LOG_LEVEL
               value: "{{ .Values.logLevel }}"
+            {{- if .Values.global.datastore.credentials.existingSecret }}
+            - name: DATASTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.datastore.credentials.existingSecret }}
+                  key: {{ .Values.global.datastore.credentials.existingSecretPasswordKey | default "password" }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ if .Values.global.datastore }}{{ .Release.Name }}-datastore-config{{ else }}mongodb-config{{ end }}
@@ -197,6 +204,13 @@ spec:
           env:
             - name: LOG_LEVEL
               value: "{{ .Values.quarantineTriggerEngine.logLevel | default .Values.logLevel }}"
+            {{- if .Values.global.datastore.credentials.existingSecret }}
+            - name: DATASTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.datastore.credentials.existingSecret }}
+                  key: {{ .Values.global.datastore.credentials.existingSecretPasswordKey | default "password" }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ if .Values.global.datastore }}{{ .Release.Name }}-datastore-config{{ else }}mongodb-config{{ end }}

--- a/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/deployment.yaml
@@ -138,12 +138,14 @@ spec:
           env:
             - name: LOG_LEVEL
               value: "{{ .Values.logLevel }}"
+            {{- if and .Values.global.datastore .Values.global.datastore.credentials }}
             {{- if .Values.global.datastore.credentials.existingSecret }}
             - name: DATASTORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.global.datastore.credentials.existingSecret }}
                   key: {{ .Values.global.datastore.credentials.existingSecretPasswordKey | default "password" }}
+            {{- end }}
             {{- end }}
           envFrom:
             - configMapRef:
@@ -204,12 +206,14 @@ spec:
           env:
             - name: LOG_LEVEL
               value: "{{ .Values.quarantineTriggerEngine.logLevel | default .Values.logLevel }}"
+            {{- if and .Values.global.datastore .Values.global.datastore.credentials }}
             {{- if .Values.global.datastore.credentials.existingSecret }}
             - name: DATASTORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.global.datastore.credentials.existingSecret }}
                   key: {{ .Values.global.datastore.credentials.existingSecretPasswordKey | default "password" }}
+            {{- end }}
             {{- end }}
           envFrom:
             - configMapRef:

--- a/distros/kubernetes/nvsentinel/charts/event-exporter/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/event-exporter/templates/deployment.yaml
@@ -131,6 +131,13 @@ spec:
             - name: MONGODB_CA_CERT_PATH
               value: "/etc/ssl/mongo-client/ca.crt"
             {{- end }}
+            {{- if .Values.global.datastore.credentials.existingSecret }}
+            - name: DATASTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.datastore.credentials.existingSecret }}
+                  key: {{ .Values.global.datastore.credentials.existingSecretPasswordKey | default "password" }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ if .Values.global.datastore }}{{ .Release.Name }}-datastore-config{{ else }}mongodb-config{{ end }}

--- a/distros/kubernetes/nvsentinel/charts/event-exporter/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/event-exporter/templates/deployment.yaml
@@ -131,12 +131,14 @@ spec:
             - name: MONGODB_CA_CERT_PATH
               value: "/etc/ssl/mongo-client/ca.crt"
             {{- end }}
+            {{- if and .Values.global.datastore .Values.global.datastore.credentials }}
             {{- if .Values.global.datastore.credentials.existingSecret }}
             - name: DATASTORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.global.datastore.credentials.existingSecret }}
                   key: {{ .Values.global.datastore.credentials.existingSecretPasswordKey | default "password" }}
+            {{- end }}
             {{- end }}
           envFrom:
             - configMapRef:

--- a/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/deployment.yaml
@@ -145,6 +145,13 @@ spec:
             - name: MONGODB_CLIENT_CERT_MOUNT_PATH
               value: {{ .Values.clientCertMountPath }}
             {{- end }}
+            {{- if .Values.global.datastore.credentials.existingSecret }}
+            - name: DATASTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.datastore.credentials.existingSecret }}
+                  key: {{ .Values.global.datastore.credentials.existingSecretPasswordKey | default "password" }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ if .Values.global.datastore }}{{ .Release.Name }}-datastore-config{{ else }}mongodb-config{{ end }}

--- a/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/deployment.yaml
@@ -145,12 +145,14 @@ spec:
             - name: MONGODB_CLIENT_CERT_MOUNT_PATH
               value: {{ .Values.clientCertMountPath }}
             {{- end }}
+            {{- if and .Values.global.datastore .Values.global.datastore.credentials }}
             {{- if .Values.global.datastore.credentials.existingSecret }}
             - name: DATASTORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.global.datastore.credentials.existingSecret }}
                   key: {{ .Values.global.datastore.credentials.existingSecretPasswordKey | default "password" }}
+            {{- end }}
             {{- end }}
           envFrom:
             - configMapRef:

--- a/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/deployment.yaml
@@ -154,6 +154,13 @@ spec:
           - name: MONGODB_CLIENT_CERT_MOUNT_PATH
             value: {{ .Values.clientCertMountPath }}
           {{- end }}
+          {{- if .Values.global.datastore.credentials.existingSecret }}
+          - name: DATASTORE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.global.datastore.credentials.existingSecret }}
+                key: {{ .Values.global.datastore.credentials.existingSecretPasswordKey | default "password" }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ if .Values.global.datastore }}{{ .Release.Name }}-datastore-config{{ else }}mongodb-config{{ end }}

--- a/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/deployment.yaml
@@ -154,12 +154,14 @@ spec:
           - name: MONGODB_CLIENT_CERT_MOUNT_PATH
             value: {{ .Values.clientCertMountPath }}
           {{- end }}
+          {{- if and .Values.global.datastore .Values.global.datastore.credentials }}
           {{- if .Values.global.datastore.credentials.existingSecret }}
           - name: DATASTORE_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.global.datastore.credentials.existingSecret }}
                 key: {{ .Values.global.datastore.credentials.existingSecretPasswordKey | default "password" }}
+          {{- end }}
           {{- end }}
           envFrom:
             - configMapRef:

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
@@ -125,6 +125,13 @@ spec:
             - name: MONGODB_CLIENT_CERT_MOUNT_PATH
               value: {{ .Values.clientCertMountPath }}
             {{- end }}
+            {{- if .Values.global.datastore.credentials.existingSecret }}
+            - name: DATASTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.datastore.credentials.existingSecret }}
+                  key: {{ .Values.global.datastore.credentials.existingSecretPasswordKey | default "password" }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ if .Values.global.datastore }}{{ .Release.Name }}-datastore-config{{ else }}mongodb-config{{ end }}

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
@@ -125,12 +125,14 @@ spec:
             - name: MONGODB_CLIENT_CERT_MOUNT_PATH
               value: {{ .Values.clientCertMountPath }}
             {{- end }}
+            {{- if and .Values.global.datastore .Values.global.datastore.credentials }}
             {{- if .Values.global.datastore.credentials.existingSecret }}
             - name: DATASTORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.global.datastore.credentials.existingSecret }}
                   key: {{ .Values.global.datastore.credentials.existingSecretPasswordKey | default "password" }}
+            {{- end }}
             {{- end }}
           envFrom:
             - configMapRef:

--- a/distros/kubernetes/nvsentinel/charts/node-drainer/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/node-drainer/templates/deployment.yaml
@@ -146,6 +146,13 @@ spec:
             - name: MONGODB_CLIENT_CERT_MOUNT_PATH
               value: {{ .Values.clientCertMountPath }}
             {{- end }}
+            {{- if .Values.global.datastore.credentials.existingSecret }}
+            - name: DATASTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.datastore.credentials.existingSecret }}
+                  key: {{ .Values.global.datastore.credentials.existingSecretPasswordKey | default "password" }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ if .Values.global.datastore }}{{ .Release.Name }}-datastore-config{{ else }}mongodb-config{{ end }}

--- a/distros/kubernetes/nvsentinel/charts/node-drainer/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/node-drainer/templates/deployment.yaml
@@ -146,12 +146,14 @@ spec:
             - name: MONGODB_CLIENT_CERT_MOUNT_PATH
               value: {{ .Values.clientCertMountPath }}
             {{- end }}
+            {{- if and .Values.global.datastore .Values.global.datastore.credentials }}
             {{- if .Values.global.datastore.credentials.existingSecret }}
             - name: DATASTORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.global.datastore.credentials.existingSecret }}
                   key: {{ .Values.global.datastore.credentials.existingSecretPasswordKey | default "password" }}
+            {{- end }}
             {{- end }}
           envFrom:
             - configMapRef:

--- a/distros/kubernetes/nvsentinel/templates/configmap-datastore.yaml
+++ b/distros/kubernetes/nvsentinel/templates/configmap-datastore.yaml
@@ -62,9 +62,6 @@ data:
   {{- if .Values.global.datastore.connection.username }}
   DATASTORE_USERNAME: {{ .Values.global.datastore.connection.username | quote }}
   {{- end }}
-  {{- if .Values.global.datastore.connection.password }}
-  DATASTORE_PASSWORD: {{ .Values.global.datastore.connection.password | quote }}
-  {{- end }}
   {{- if .Values.global.datastore.connection.sslmode }}
   DATASTORE_SSLMODE: {{ .Values.global.datastore.connection.sslmode | quote }}
   {{- end }}

--- a/distros/kubernetes/nvsentinel/templates/configmap-datastore.yaml
+++ b/distros/kubernetes/nvsentinel/templates/configmap-datastore.yaml
@@ -30,9 +30,6 @@ data:
       {{- if .Values.global.datastore.connection.username }}
       username: {{ .Values.global.datastore.connection.username | quote }}
       {{- end }}
-      {{- if .Values.global.datastore.connection.password }}
-      password: {{ .Values.global.datastore.connection.password | quote }}
-      {{- end }}
       {{- if .Values.global.datastore.connection.sslmode }}
       sslmode: {{ .Values.global.datastore.connection.sslmode | quote }}
       {{- end }}

--- a/distros/kubernetes/nvsentinel/templates/configmap-datastore.yaml
+++ b/distros/kubernetes/nvsentinel/templates/configmap-datastore.yaml
@@ -30,6 +30,9 @@ data:
       {{- if .Values.global.datastore.connection.username }}
       username: {{ .Values.global.datastore.connection.username | quote }}
       {{- end }}
+      {{- if .Values.global.datastore.connection.password }}
+      password: {{ .Values.global.datastore.connection.password | quote }}
+      {{- end }}
       {{- if .Values.global.datastore.connection.sslmode }}
       sslmode: {{ .Values.global.datastore.connection.sslmode | quote }}
       {{- end }}
@@ -58,6 +61,9 @@ data:
   DATASTORE_DATABASE: {{ .Values.global.datastore.connection.database | quote }}
   {{- if .Values.global.datastore.connection.username }}
   DATASTORE_USERNAME: {{ .Values.global.datastore.connection.username | quote }}
+  {{- end }}
+  {{- if .Values.global.datastore.connection.password }}
+  DATASTORE_PASSWORD: {{ .Values.global.datastore.connection.password | quote }}
   {{- end }}
   {{- if .Values.global.datastore.connection.sslmode }}
   DATASTORE_SSLMODE: {{ .Values.global.datastore.connection.sslmode | quote }}

--- a/distros/kubernetes/nvsentinel/templates/daemonset.yaml
+++ b/distros/kubernetes/nvsentinel/templates/daemonset.yaml
@@ -155,6 +155,13 @@ spec:
             - name: MONGODB_CLIENT_CERT_MOUNT_PATH
               value: {{ .Values.platformConnector.mongodbStore.clientCertMountPath }}
             {{- end }}
+            {{- if .Values.global.datastore.credentials.existingSecret }}
+            - name: DATASTORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.datastore.credentials.existingSecret }}
+                  key: {{ .Values.global.datastore.credentials.existingSecretPasswordKey | default "password" }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ if .Values.global.datastore }}{{ .Release.Name }}-datastore-config{{ else }}mongodb-config{{ end }}

--- a/distros/kubernetes/nvsentinel/templates/daemonset.yaml
+++ b/distros/kubernetes/nvsentinel/templates/daemonset.yaml
@@ -155,12 +155,14 @@ spec:
             - name: MONGODB_CLIENT_CERT_MOUNT_PATH
               value: {{ .Values.platformConnector.mongodbStore.clientCertMountPath }}
             {{- end }}
+            {{- if and .Values.global.datastore .Values.global.datastore.credentials }}
             {{- if .Values.global.datastore.credentials.existingSecret }}
             - name: DATASTORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.global.datastore.credentials.existingSecret }}
                   key: {{ .Values.global.datastore.credentials.existingSecretPasswordKey | default "password" }}
+            {{- end }}
             {{- end }}
           envFrom:
             - configMapRef:

--- a/distros/kubernetes/nvsentinel/values.yaml
+++ b/distros/kubernetes/nvsentinel/values.yaml
@@ -32,6 +32,21 @@ global:
   #     host: "mongodb"
   #     port: 27017
   #     database: "nvsentinel"
+  #     username: "nvsentinel"
+  #
+  #     # Option 1: Certificate-based authentication (TLS)
+  #     # Certificate files are mounted from secrets and referenced by path
+  #     sslmode: "verify-full"
+  #     sslcert: "/etc/ssl/client-certs/tls.crt"
+  #     sslkey: "/etc/ssl/client-certs/tls.key"
+  #     sslrootcert: "/etc/ssl/client-certs/ca.crt"
+  #
+  #     # Option 2: Password-based authentication (non-TLS)
+  #     # Password is read from Kubernetes Secret for security
+  #     # Create secret: kubectl create secret generic datastore-creds --from-literal=password=your-password
+  #   credentials:
+  #     existingSecret: "datastore-credentials"
+  #     existingSecretPasswordKey: "password"  # Optional, defaults to "password"
 
   # Certificate rotation (MongoDB only)
   # When enabled, client certificates can be rotated without restarting pods.

--- a/store-client/pkg/config/env_loader.go
+++ b/store-client/pkg/config/env_loader.go
@@ -177,6 +177,73 @@ func NewDatabaseConfigForCollectionType(certMountPath, collectionType string) (D
 	return NewDatabaseConfigWithCollection(certMountPath, envVar, defaultCollection)
 }
 
+// buildMongoDBConnectionConfig builds MongoDB connection configuration based on auth type
+// Returns connection URI, cert config, database name, and error
+func buildMongoDBConnectionConfig(certMountPath string) (string, *StandardCertificateConfig, string, error) {
+	password := os.Getenv("DATASTORE_PASSWORD")
+
+	if password != "" {
+		return buildMongoDBPasswordAuthConfig(password)
+	}
+
+	return buildMongoDBCertAuthConfig(certMountPath)
+}
+
+// buildMongoDBPasswordAuthConfig builds config for password authentication (non-TLS)
+func buildMongoDBPasswordAuthConfig(password string) (string, *StandardCertificateConfig, string, error) {
+	host := os.Getenv("DATASTORE_HOST")
+	if host == "" {
+		return "", nil, "", fmt.Errorf("required environment variable DATASTORE_HOST is not set when using DATASTORE_PASSWORD")
+	}
+
+	port := os.Getenv("DATASTORE_PORT")
+	if port == "" {
+		port = "27017" // Default MongoDB port
+	}
+
+	database := os.Getenv("DATASTORE_DATABASE")
+	if database == "" {
+		return "", nil, "", fmt.Errorf("required environment variable DATASTORE_DATABASE is not set when using DATASTORE_PASSWORD")
+	}
+
+	username := os.Getenv("DATASTORE_USERNAME")
+	if username == "" {
+		return "", nil, "", fmt.Errorf("required environment variable DATASTORE_USERNAME is not set when using DATASTORE_PASSWORD")
+	}
+
+	userInfo := url.UserPassword(username, password)
+	connectionURI := fmt.Sprintf("mongodb://%s@%s:%s/%s?tls=false",
+		userInfo.String(), host, port, database)
+	certConfig := &StandardCertificateConfig{
+		certPath:   "",
+		keyPath:    "",
+		caCertPath: "",
+	}
+
+	return connectionURI, certConfig, database, nil
+}
+
+// buildMongoDBCertAuthConfig builds config for certificate authentication (TLS)
+func buildMongoDBCertAuthConfig(certMountPath string) (string, *StandardCertificateConfig, string, error) {
+	connectionURI := os.Getenv(EnvMongoDBURI)
+	if connectionURI == "" {
+		return "", nil, "", fmt.Errorf("required environment variable %s is not set", EnvMongoDBURI)
+	}
+
+	databaseName := os.Getenv(EnvMongoDBDatabaseName)
+	if databaseName == "" {
+		return "", nil, "", fmt.Errorf("required environment variable %s is not set", EnvMongoDBDatabaseName)
+	}
+
+	certConfig := &StandardCertificateConfig{
+		certPath:   filepath.Join(certMountPath, "tls.crt"),
+		keyPath:    filepath.Join(certMountPath, "tls.key"),
+		caCertPath: filepath.Join(certMountPath, "ca.crt"),
+	}
+
+	return connectionURI, certConfig, databaseName, nil
+}
+
 // NewDatabaseConfigWithCollection allows custom certificate mount path and collection configuration
 // If collectionEnvVar is provided, it will be used instead of the default MONGODB_COLLECTION_NAME
 // If defaultCollection is provided, it will be used as fallback if the environment variable is not set
@@ -189,59 +256,9 @@ func NewDatabaseConfigWithCollection(
 	}
 
 	// Build MongoDB connection URI and certConfig
-	password := os.Getenv("DATASTORE_PASSWORD")
-	var connectionURI string
-	var certConfig *StandardCertificateConfig
-	var databaseName string
-
-	if password != "" {
-		// Password authentication (non-TLS)
-		host := os.Getenv("DATASTORE_HOST")
-		if host == "" {
-			return nil, fmt.Errorf("required environment variable DATASTORE_HOST is not set when using DATASTORE_PASSWORD")
-		}
-
-		port := os.Getenv("DATASTORE_PORT")
-		if port == "" {
-			port = "27017" // Default MongoDB port
-		}
-
-		database := os.Getenv("DATASTORE_DATABASE")
-		if database == "" {
-			return nil, fmt.Errorf("required environment variable DATASTORE_DATABASE is not set when using DATASTORE_PASSWORD")
-		}
-
-		username := os.Getenv("DATASTORE_USERNAME")
-		if username == "" {
-			return nil, fmt.Errorf("required environment variable DATASTORE_USERNAME is not set when using DATASTORE_PASSWORD")
-		}
-
-		userInfo := url.UserPassword(username, password)
-		connectionURI = fmt.Sprintf("mongodb://%s@%s:%s/%s?tls=false",
-			userInfo.String(), host, port, database)
-		databaseName = database
-		certConfig = &StandardCertificateConfig{
-			certPath:   "",
-			keyPath:    "",
-			caCertPath: "",
-		}
-	} else {
-		// Certificate authentication (TLS)
-		connectionURI = os.Getenv(EnvMongoDBURI)
-		if connectionURI == "" {
-			return nil, fmt.Errorf("required environment variable %s is not set", EnvMongoDBURI)
-		}
-
-		databaseName = os.Getenv(EnvMongoDBDatabaseName)
-		if databaseName == "" {
-			return nil, fmt.Errorf("required environment variable %s is not set", EnvMongoDBDatabaseName)
-		}
-
-		certConfig = &StandardCertificateConfig{
-			certPath:   filepath.Join(certMountPath, "tls.crt"),
-			keyPath:    filepath.Join(certMountPath, "tls.key"),
-			caCertPath: filepath.Join(certMountPath, "ca.crt"),
-		}
+	connectionURI, certConfig, databaseName, err := buildMongoDBConnectionConfig(certMountPath)
+	if err != nil {
+		return nil, err
 	}
 
 	// Determine which collection environment variable to use
@@ -274,6 +291,65 @@ func NewDatabaseConfigWithCollection(
 	}, nil
 }
 
+// buildPostgreSQLConnectionConfig builds PostgreSQL connection configuration based on auth type
+// Returns connection URI and cert config
+func buildPostgreSQLConnectionConfig(certMountPath, host, port, database, username string) (string, *StandardCertificateConfig) {
+	password := os.Getenv("DATASTORE_PASSWORD")
+
+	if password != "" {
+		return buildPostgreSQLPasswordAuthConfig(password, host, port, database, username)
+	}
+
+	return buildPostgreSQLCertAuthConfig(certMountPath, host, port, database, username)
+}
+
+// buildPostgreSQLPasswordAuthConfig builds config for password authentication (non-TLS)
+func buildPostgreSQLPasswordAuthConfig(password, host, port, database, username string) (string, *StandardCertificateConfig) {
+	userInfo := url.UserPassword(username, password)
+	connectionURI := fmt.Sprintf("postgresql://%s@%s:%s/%s?sslmode=disable",
+		userInfo.String(), host, port, database)
+	certConfig := &StandardCertificateConfig{
+		certPath:   "",
+		keyPath:    "",
+		caCertPath: "",
+	}
+
+	return connectionURI, certConfig
+}
+
+// buildPostgreSQLCertAuthConfig builds config for certificate authentication (TLS)
+func buildPostgreSQLCertAuthConfig(certMountPath, host, port, database, username string) (string, *StandardCertificateConfig) {
+	sslmode := os.Getenv("DATASTORE_SSLMODE")
+	if sslmode == "" {
+		sslmode = "require"
+	}
+
+	sslcert := os.Getenv("DATASTORE_SSLCERT")
+	if sslcert == "" {
+		sslcert = filepath.Join(certMountPath, "tls.crt")
+	}
+
+	sslkey := os.Getenv("DATASTORE_SSLKEY")
+	if sslkey == "" {
+		sslkey = filepath.Join(certMountPath, "tls.key")
+	}
+
+	sslrootcert := os.Getenv("DATASTORE_SSLROOTCERT")
+	if sslrootcert == "" {
+		sslrootcert = filepath.Join(certMountPath, "ca.crt")
+	}
+
+	connectionURI := fmt.Sprintf("host=%s port=%s dbname=%s user=%s sslmode=%s sslcert=%s sslkey=%s sslrootcert=%s",
+		host, port, database, username, sslmode, sslcert, sslkey, sslrootcert)
+	certConfig := &StandardCertificateConfig{
+		certPath:   sslcert,
+		keyPath:    sslkey,
+		caCertPath: sslrootcert,
+	}
+
+	return connectionURI, certConfig
+}
+
 // newPostgreSQLCompatibleConfig creates a PostgreSQL-compatible database config
 // using DATASTORE_* environment variables instead of MONGODB_* variables
 //
@@ -300,52 +376,7 @@ func newPostgreSQLCompatibleConfig(certMountPath, tableEnvVar, defaultTable stri
 	}
 
 	// Build PostgreSQL connection URI and certConfig
-	password := os.Getenv("DATASTORE_PASSWORD")
-
-	var connectionURI string
-	var certConfig *StandardCertificateConfig
-
-	if password != "" {
-		// Password authentication (non-TLS)
-		// Use URL format DSN with proper encoding for special characters
-		userInfo := url.UserPassword(username, password)
-		connectionURI = fmt.Sprintf("postgresql://%s@%s:%s/%s?sslmode=disable",
-			userInfo.String(), host, port, database)
-		certConfig = &StandardCertificateConfig{
-			certPath:   "",
-			keyPath:    "",
-			caCertPath: "",
-		}
-	} else {
-		// Certificate authentication (TLS)
-		sslmode := os.Getenv("DATASTORE_SSLMODE")
-		if sslmode == "" {
-			sslmode = "require"
-		}
-
-		sslcert := os.Getenv("DATASTORE_SSLCERT")
-		if sslcert == "" {
-			sslcert = filepath.Join(certMountPath, "tls.crt")
-		}
-
-		sslkey := os.Getenv("DATASTORE_SSLKEY")
-		if sslkey == "" {
-			sslkey = filepath.Join(certMountPath, "tls.key")
-		}
-
-		sslrootcert := os.Getenv("DATASTORE_SSLROOTCERT")
-		if sslrootcert == "" {
-			sslrootcert = filepath.Join(certMountPath, "ca.crt")
-		}
-
-		connectionURI = fmt.Sprintf("host=%s port=%s dbname=%s user=%s sslmode=%s sslcert=%s sslkey=%s sslrootcert=%s",
-			host, port, database, username, sslmode, sslcert, sslkey, sslrootcert)
-		certConfig = &StandardCertificateConfig{
-			certPath:   sslcert,
-			keyPath:    sslkey,
-			caCertPath: sslrootcert,
-		}
-	}
+	connectionURI, certConfig := buildPostgreSQLConnectionConfig(certMountPath, host, port, database, username)
 
 	// Determine table name using the provided parameters
 	// For PostgreSQL, this maps to the table name (converted to snake_case by the client)

--- a/tests/data/password-auth-fault-configmap.yaml
+++ b/tests/data/password-auth-fault-configmap.yaml
@@ -1,0 +1,44 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: password-auth-fault-config
+  namespace: nvsentinel
+data:
+  config.toml: |
+    [circuitBreaker]
+      percentage = 50
+      duration = "5m"
+
+    [[rule-sets]]
+      name = "Basic-Match-Rule"
+      [[rule-sets.match.all]]
+        kind = "HealthEvent"
+        expression = "event.agent == 'gpu-health-monitor' && event.checkName == 'GpuXidError'"
+      [rule-sets.taint]
+        key = "AggregatedNodeHealth"
+        value = "False"
+        effect = "NoSchedule"
+      [rule-sets.cordon]
+        shouldCordon = true
+
+  # Enable password authentication by setting DATASTORE_* environment variables for MongoDB
+  DATASTORE_PROVIDER: "mongodb"
+  DATASTORE_HOST: "mongodb"
+  DATASTORE_PORT: "27017"
+  DATASTORE_DATABASE: "nvsentinel"
+  DATASTORE_USERNAME: "testuser"
+  # Note: Password should be injected from Secret via helm values

--- a/tests/fault_management_test.go
+++ b/tests/fault_management_test.go
@@ -22,13 +22,14 @@ import (
 	"testing"
 	"time"
 
+	"tests/helpers"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
-	"tests/helpers"
 
 	"github.com/nvidia/nvsentinel/commons/pkg/statemanager"
 )
@@ -655,3 +656,232 @@ func TestManualUncordonWithFaultRemediation(t *testing.T) {
 
 	testEnv.Test(t, feature.Feature())
 }
+
+// TestDatastorePasswordAuthentication verifies that password-based authentication
+// works correctly with MongoDB for fault-quarantine and fault-remediation components.
+func TestDatastorePasswordAuthentication(t *testing.T) {
+	feature := features.New("Datastore Password Authentication").
+		WithLabel("suite", "fault-management-password-auth")
+
+	var testCtx *helpers.QuarantineTestContext
+	var podNames []string
+	testNamespace := "password-auth-fault-test"
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		t.Log("Setting up password authentication test for fault components")
+
+		var newCtx context.Context
+
+		// Create the ConfigMap with password auth
+		client, err := c.NewClient()
+		require.NoError(t, err)
+
+		t.Logf("Applying password auth ConfigMap for MongoDB")
+		err = createConfigMapFromFilePath(ctx, client,
+			"data/password-auth-fault-configmap.yaml", "fault-quarantine", "nvsentinel")
+		require.NoError(t, err)
+
+		// Select a test node
+		nodeName := helpers.SelectTestNodeFromUnusedPool(ctx, t, client)
+
+		// Store node name in context
+		ctx = context.WithValue(ctx, helpers.CELKeyNodeName, nodeName)
+
+		t.Logf("Restarting fault-quarantine to load password auth config")
+		err = helpers.RestartDeployment(ctx, t, client, "fault-quarantine", helpers.NVSentinelNamespace)
+		require.NoError(t, err)
+
+		// Restart fault-remediation to load password auth config
+		t.Logf("Restarting fault-remediation to load password auth config")
+		err = helpers.RestartDeployment(ctx, t, client, "fault-remediation", helpers.NVSentinelNamespace)
+		require.NoError(t, err)
+
+		// Create test namespace
+		testNamespace := "password-auth-fault-test"
+		t.Logf("Creating test namespace: %s", testNamespace)
+		err = helpers.CreateNamespace(newCtx, client, testNamespace)
+		require.NoError(t, err)
+
+		// Create test pods to verify connectivity
+		podNames = helpers.CreatePodsFromTemplate(newCtx, t, client,
+			"data/busybox-pods.yaml", testCtx.NodeName, testNamespace)
+		helpers.WaitForPodsRunning(newCtx, t, client, testNamespace, podNames)
+
+		return newCtx
+	})
+
+	feature.Assess("Step 1: Verify components have password auth config", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err)
+
+		// Verify ConfigMap exists
+		configMap := &v1.ConfigMap{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "password-auth-fault-config",
+				Namespace: "nvsentinel",
+			},
+		}
+		err = client.Resources().Get(ctx, "password-auth-fault-config", "nvsentinel", configMap)
+		require.NoError(t, err, "password-auth ConfigMap should exist")
+		require.Contains(t, configMap.Data, "DATASTORE_PASSWORD", "DATASTORE_PASSWORD should be set")
+
+		// Verify fault-quarantine deployment is using password auth config
+		faultQuarantine, err := helpers.GetDeployment(ctx, client, "fault-quarantine", "nvsentinel")
+		require.NoError(t, err)
+
+		faultQuarantineEnvVars := faultQuarantine.Spec.Template.Spec.Containers[0].Env
+		var faultQuarantineEnvMap = make(map[string]string)
+		for _, env := range faultQuarantineEnvVars {
+			if env.Value != nil {
+				faultQuarantineEnvMap[env.Name] = *env.Value
+			}
+		}
+
+		require.Contains(t, faultQuarantineEnvMap, "DATASTORE_PASSWORD", "fault-quarantine should have DATASTORE_PASSWORD")
+		t.Logf("Verified: fault-quarantine has password auth environment variables")
+
+		// Verify fault-remediation deployment is using password auth config
+		faultRemediation, err := helpers.GetDeployment(ctx, client, "fault-remediation", "nvsentinel")
+		require.NoError(t, err)
+
+		faultRemediationEnvVars := faultRemediation.Spec.Template.Spec.Containers[0].Env
+		var faultRemediationEnvMap = make(map[string]string)
+		for _, env := range faultRemediationEnvVars {
+			if env.Value != nil {
+				faultRemediationEnvMap[env.Name] = *env.Value
+			}
+		}
+
+		require.Contains(t, faultRemediationEnvMap, "DATASTORE_PASSWORD", "fault-remediation should have DATASTORE_PASSWORD")
+		t.Logf("Verified: fault-remediation has password auth environment variables")
+
+		return ctx
+	})
+
+	feature.Assess("Step 2: Wait for components to be ready", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err)
+
+		// Wait for fault-quarantine to be ready
+		t.Log("Waiting for fault-quarantine to be ready")
+		require.Eventually(t, func() bool {
+			deployment, err := helpers.GetDeployment(ctx, client, "fault-quarantine", "nvsentinel")
+			if err != nil {
+				return false
+			}
+			return deployment.Status.ReadyReplicas >= 1
+		}, 3*time.Minute, 10*time.Second, "fault-quarantine should be ready")
+
+		// Wait for fault-remediation to be ready
+		t.Log("Waiting for fault-remediation to be ready")
+		require.Eventually(t, func() bool {
+			deployment, err := helpers.GetDeployment(ctx, client, "fault-remediation", "nvsentinel")
+			if err != nil {
+				return false
+			}
+			return deployment.Status.ReadyReplicas >= 1
+		}, 3*time.Minute, 10*time.Second, "fault-remediation should be ready")
+
+		// Wait a bit for the components to fully start and initialize
+		t.Log("Waiting for components to initialize")
+		time.Sleep(30 * time.Second)
+
+		// Verify pods are still running
+		t.Log("Verifying pods are still running after MongoDB connection")
+		for _, podName := range podNames {
+			pod := &v1.Pod{}
+			err := client.Resources().Get(ctx, podName, testNamespace, pod)
+			require.NoError(t, err, "pod should exist")
+			require.Equal(t, v1.PodRunning, pod.Status.Phase, "pod should be running")
+		}
+
+		t.Logf("Verified: All pods are running, MongoDB connection successful")
+
+		return ctx
+	})
+
+	feature.Assess("Step 3: Verify components process health events with password auth", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err)
+
+		// Send a health event to trigger component processing
+		t.Log("Sending test health event to verify password auth")
+		testEvent := helpers.NewHealthEvent(testCtx.NodeName).
+			WithErrorCode("79").
+			WithMessage("Test health event for password auth verification").
+			WithHealthy(false).
+			WithFatal(false).
+			WithRecommendedAction(2)
+
+		helpers.SendHealthEvent(ctx, t, testEvent)
+		t.Log("Health event sent, waiting for component processing")
+
+		// Wait for the event to be processed by components
+		time.Sleep(10 * time.Second)
+
+		// Verify the event was processed by components
+		t.Log("Verifying health event was processed by components")
+		require.Eventually(t, func() bool {
+			found, _ := helpers.CheckNodeEventExists(ctx, client, testCtx.NodeName,
+				"NodeDraining", "WaitingBeforeForceDelete", time.Time{})
+
+			if !found {
+				t.Logf("Event not yet found, waiting...")
+				return false
+			}
+
+			// Check if components processed the event by looking for quarantine annotations
+			node, err := helpers.GetNodeByName(ctx, client, testCtx.NodeName)
+			if err != nil {
+				t.Logf("Failed to get node: %v", err)
+				return false
+			}
+
+			_, hasQuarantine := node.Annotations["quarantineHealthEvent"]
+			return hasQuarantine
+		}, 2*time.Minute, 10*time.Second, "health event should be processed by components")
+
+		t.Logf("Verified: Components successfully processed health event with password auth")
+
+		return ctx
+	})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		t.Log("Tearing down password authentication test environment")
+		client, err := c.NewClient()
+		require.NoError(t, err)
+
+		// Delete ConfigMap
+		err = client.Resources().Delete(ctx, &v1.ConfigMap{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "password-auth-fault-config",
+				Namespace: "nvsentinel",
+			},
+		})
+		if err != nil {
+			t.Logf("Warning: failed to delete ConfigMap: %v", err)
+		}
+
+		// Delete test namespace
+		err = client.Resources().Delete(ctx, &v1.Namespace{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      testNamespace,
+			},
+		})
+		if err != nil {
+			t.Logf("Warning: failed to delete namespace: %v", err)
+		}
+
+		// Restore original deployments
+		t.Log("Restoring original fault-quarantine deployment")
+		err = helpers.RestoreDeployment(ctx, t, client, "fault-quarantine", helpers.NVSentinelNamespace)
+		require.NoError(t, err)
+
+		t.Log("Restoring original fault-remediation deployment")
+		err = helpers.RestoreDeployment(ctx, t, client, "fault-remediation", helpers.NVSentinelNamespace)
+		require.NoError(t, err)
+
+		return helpers.TeardownQuarantineTest(ctx, t, c, testCtx)
+	})
+
+testEnv.Test(t, feature.Feature())


### PR DESCRIPTION
## Summary

  Add password-based authentication support for MongoDB and PostgreSQL datastores, allowing connections without requiring TLS certificates. Password is securely read from Kubernetes Secret instead of ConfigMap.

  ## Type of Change
  - [ ] 🐛 Bug fix
  - [x] ✨ New feature
  - [ ] 💥 Breaking change
  - [x] 📚 Documentation
  - [ ] 🔧 Refactoring
  - [ ] 🔨 Build/CI

  ## Component(s) Affected
  - [x] Core Services
  - [x] Documentation/CI
  - [ ] Fault Management
  - [ ] Health Monitors
  - [ ] Janitor
  - [ ] Other: ____________

  ## Testing
  - [x] Tests pass locally (go build successful)
  - [x] Manual testing completed (configuration verified)
  - [x] No breaking changes (backward compatible - Secret is optional)

  ## Checklist
  - [x] Self-review completed
  - [x] Documentation updated (values.yaml example added)
  - [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added password-based authentication support for datastore connections, enabling credentials to be securely provided through Kubernetes secrets across all deployment services.
  * Extended authentication capabilities to support both password-based and TLS-based connection methods for MongoDB and PostgreSQL databases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->