### PR TITLE
feat: add GPU reset support to fault-remediation

### DIFF
--- a/fault-remediation/pkg/annotation/annotation_interface.go
+++ b/fault-remediation/pkg/annotation/annotation_interface.go
@@ -45,5 +45,6 @@ type EquivalenceGroupState struct {
 	CreatedAt     time.Time `json:"createdAt"`
 
 	// Action that created the CR (e.g., "RESTART_BM")
+	// Required to look up the corresponding MaintenanceResource from the TomlConfig
 	ActionName string `json:"actionName"`
 }

--- a/fault-remediation/pkg/common/equivalence_groups.go
+++ b/fault-remediation/pkg/common/equivalence_groups.go
@@ -15,67 +15,143 @@
 package common
 
 import (
+	"fmt"
+	"log/slog"
+
 	"github.com/nvidia/nvsentinel/data-models/pkg/protos"
+	"github.com/nvidia/nvsentinel/fault-remediation/pkg/annotation"
+	"github.com/nvidia/nvsentinel/fault-remediation/pkg/config"
 )
 
-// RemediationEquivalenceGroups defines groups of remediation actions that are considered
-// to have the same operational effect. This is used to prevent multiple, similar remediations
-// (like various forms of reboots) from occurring in rapid succession.
-var RemediationEquivalenceGroups = map[string][]protos.RecommendedAction{
-	"restart": {
-		protos.RecommendedAction_COMPONENT_RESET,
-		protos.RecommendedAction_RESTART_VM,
-		protos.RecommendedAction_RESTART_BM,
-	},
-	"fieldiag": {
-		protos.RecommendedAction_RUN_FIELDDIAG,
-	},
-	"dcgmeud": {
-		protos.RecommendedAction_RUN_DCGMEUD,
-	},
-	"support": {
-		protos.RecommendedAction_CONTACT_SUPPORT,
-	},
-	"replace": {
-		protos.RecommendedAction_REPLACE_VM,
-	},
+type EquivalenceGroupConfig struct {
+	EffectiveEquivalenceGroup    string
+	ImpactedEntityScopeValue     string
+	SupersedingEquivalenceGroups []string
 }
 
-// GetRemediationGroupForAction returns the equivalence group key for a given action.
-// If the action is not part of any group, it returns an empty string.
-func GetRemediationGroupForAction(action protos.RecommendedAction) string {
-	for group, actions := range RemediationEquivalenceGroups {
-		for _, a := range actions {
-			if a == action {
-				return group
+/*
+This functions returns the EffectiveEquivalenceGroup, ImpactedEntityScopeValue and SupersedingEquivalenceGroups
+for the given HealthEvent. The EquivalenceGroup depends on the recommended action and set of impacted entities included
+in the event. The recommended action maps to a given MaintenanceResource defined in the TomlConfig. Example:
+
+		RESTART_VM:
+		  apiGroup: "janitor.dgxc.nvidia.com"
+		  version: "v1alpha1"
+		  kind: "RebootNode"
+		  equivalenceGroup: "restart"
+
+		COMPONENT_RESET:
+		  apiGroup: "janitor.dgxc.nvidia.com"
+		  version: "v1alpha1"
+		  kind: "GPUReset"
+		  equivalenceGroup: "reset"
+		  supersedingEquivalenceGroups: ["restart"]
+	      impactedEntityScope: "GPU_UUID"
+
+For a HealthEvent which includes the RESTART_VM recommended action, we will set EffectiveEquivalenceGroup=restart.
+For a HealthEvent which includes the COMPONENT_RESET recommended action that includes an impacted entity as
+GPU_UUID=GPU-123, we will define the EffectiveEquivalenceGroup=reset-GPU-123, ImpactedEntityScopeValue=GPU-123, and
+SupersedingEquivalenceGroups=["restart"]. Note that we will fail the remediation if a COMPONENT_RESET event is missing
+an impacted entity for GPU_UUID. Additionally, we only allow a TomlConfig to define an ImpactedEntityScope if this
+entity has been enabled for partial draining (defined in pod_device_annotation.go).
+
+In the second example for COMPONENT_RESET, we will consider the HealthEvent as being a member in both the reset-GPU-123
+and restart EquivalenceGroups. Additionally, the ImpactedEntityScope will be passed to the corresponding maintenance
+custom resource template.
+*/
+func GetGroupConfigForEvent(remediationActions map[string]config.MaintenanceResource,
+	healthEvent *protos.HealthEvent) (*EquivalenceGroupConfig, error) {
+	actionName := healthEvent.RecommendedAction.String()
+
+	actionConfig, exists := remediationActions[actionName]
+	if !exists {
+		slog.Warn("Action not found in remediation configuration",
+			"action", actionName,
+			"node", healthEvent.NodeName)
+
+		return nil, nil
+	}
+
+	var equivalenceGroupName string
+
+	var impactedEntityScopeValue string
+
+	if len(actionConfig.ImpactedEntityScope) != 0 {
+		for _, entity := range healthEvent.GetEntitiesImpacted() {
+			if entity.EntityType == actionConfig.ImpactedEntityScope {
+				equivalenceGroupName = fmt.Sprintf("%s-%s", actionConfig.EquivalenceGroup, entity.EntityValue)
+				impactedEntityScopeValue = entity.EntityValue
 			}
 		}
+
+		if len(equivalenceGroupName) == 0 {
+			return nil, fmt.Errorf("HealthEvent is missing impacted entity for %s required by action %s",
+				actionConfig.ImpactedEntityScope, actionName)
+		}
+	} else {
+		equivalenceGroupName = actionConfig.EquivalenceGroup
 	}
 
-	return ""
+	return &EquivalenceGroupConfig{
+		EffectiveEquivalenceGroup:    equivalenceGroupName,
+		ImpactedEntityScopeValue:     impactedEntityScopeValue,
+		SupersedingEquivalenceGroups: actionConfig.SupersedingEquivalenceGroups,
+	}, nil
 }
 
-// GetActionsForGroup returns all actions that belong to a given equivalence group.
-func GetActionsForGroup(group string) []protos.RecommendedAction {
-	if actions, ok := RemediationEquivalenceGroups[group]; ok {
-		return actions
+/*
+This function will filter the RemediationStateAnnotation to only include the EquivalenceGroups which match the current
+event. Specifically, we will only return the EquivalenceGroupState on the annotation for groups which match the
+EffectiveEquivalenceGroup or any SupersedingEquivalenceGroups for the given HealthEvent. For example, if the current
+HealthEvent has EffectiveEquivalenceGroup=reset-GPU-123 and SupersedingEquivalenceGroups=["restart"] and then
+RemediationStateAnnotation state annotation on the node is
+
+	"restart": {
+	  "maintenanceCR": "maintenance-123",
+	  "createdAt": "2025-11-13T17:18:32.163469826Z"
+	  "actionName", "RESTART_VM",
+	},
+	"reset-GPU-123": {
+	  "maintenanceCR": "maintenance-456",
+	  "createdAt": "2025-11-13T17:18:32.163469826Z"
+	  "actionName", "COMPONENT_RESET",
+	},
+	"reset-GPU-456": {
+	  "maintenanceCR": "maintenance-789",
+	  "createdAt": "2025-11-13T17:18:32.163469826Z"
+	  "actionName", "COMPONENT_RESET",
 	}
 
-	return nil
-}
+We will return the following EquivalenceGroupStates which match our current event:
 
-// IsActionInGroup checks if an action belongs to a specific equivalence group
-func IsActionInGroup(action protos.RecommendedAction, group string) bool {
-	actions, ok := RemediationEquivalenceGroups[group]
-	if !ok {
-		return false
+	"restart": {
+	  "maintenanceCR": "maintenance-123",
+	  "createdAt": "2025-11-13T17:18:32.163469826Z"
+	  "actionName", "RESTART_VM",
+	},
+	"reset-GPU-123": {
+	  "maintenanceCR": "maintenance-456",
+	  "createdAt": "2025-11-13T17:18:32.163469826Z"
+	  "actionName", "COMPONENT_RESET",
 	}
 
-	for _, a := range actions {
-		if a == action {
-			return true
+We will validate that both maintenance-123 and maintenance-456 are not in-progress prior to creating a new maintenance
+custom resource for the EffectiveEquivalenceGroup reset-GPU-123.
+*/
+func FilterEquivalenceGroupStates(groupConfig *EquivalenceGroupConfig,
+	remediationState *annotation.RemediationStateAnnotation) map[string]annotation.EquivalenceGroupState {
+	allGroups := []string{groupConfig.EffectiveEquivalenceGroup}
+	if len(groupConfig.SupersedingEquivalenceGroups) != 0 {
+		allGroups = append(allGroups, groupConfig.SupersedingEquivalenceGroups...)
+	}
+
+	matchingGroupStates := make(map[string]annotation.EquivalenceGroupState)
+
+	for _, currentGroup := range allGroups {
+		if equivalenceGroupState, ok := remediationState.EquivalenceGroups[currentGroup]; ok {
+			matchingGroupStates[currentGroup] = equivalenceGroupState
 		}
 	}
 
-	return false
+	return matchingGroupStates
 }

--- a/fault-remediation/pkg/common/equivalence_groups_test.go
+++ b/fault-remediation/pkg/common/equivalence_groups_test.go
@@ -20,178 +20,186 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/nvidia/nvsentinel/data-models/pkg/protos"
+	"github.com/nvidia/nvsentinel/fault-remediation/pkg/annotation"
+	"github.com/nvidia/nvsentinel/fault-remediation/pkg/config"
 )
 
-func TestGetRemediationGroupForAction(t *testing.T) {
-	tests := []struct {
-		name          string
-		action        protos.RecommendedAction
-		expectedGroup string
-	}{
-		{
-			name:          "COMPONENT_RESET returns restart group",
-			action:        protos.RecommendedAction_COMPONENT_RESET,
-			expectedGroup: "restart",
+func TestGetGroupConfigForEvent(t *testing.T) {
+	remediationActions := map[string]config.MaintenanceResource{
+		"RESTART_BM": {
+			ApiGroup:                     "janitor.dgxc.nvidia.com",
+			Version:                      "v1alpha1",
+			Kind:                         "RebootNode",
+			TemplateFileName:             "rebootnode-template.yaml",
+			CompleteConditionType:        "NodeReady",
+			EquivalenceGroup:             "restart",
+			ImpactedEntityScope:          "",
+			SupersedingEquivalenceGroups: nil,
 		},
-		{
-			name:          "RESTART_VM returns restart group",
-			action:        protos.RecommendedAction_RESTART_VM,
-			expectedGroup: "restart",
-		},
-		{
-			name:          "RESTART_BM returns restart group",
-			action:        protos.RecommendedAction_RESTART_BM,
-			expectedGroup: "restart",
-		},
-		{
-			name:          "CONTACT_SUPPORT returns support",
-			action:        protos.RecommendedAction_CONTACT_SUPPORT,
-			expectedGroup: "support",
-		},
-		{
-			name:          "NONE returns empty string (not in any group)",
-			action:        protos.RecommendedAction_NONE,
-			expectedGroup: "",
-		},
-		{
-			name:          "UNKNOWN returns empty string (not in any group)",
-			action:        protos.RecommendedAction_UNKNOWN,
-			expectedGroup: "",
+		"COMPONENT_RESET": {
+			ApiGroup:                     "janitor.dgxc.nvidia.com",
+			Version:                      "v1alpha1",
+			Kind:                         "RebootNode",
+			TemplateFileName:             "rebootnode-template.yaml",
+			CompleteConditionType:        "NodeReady",
+			EquivalenceGroup:             "reset",
+			ImpactedEntityScope:          "GPU_UUID",
+			SupersedingEquivalenceGroups: []string{"restart"},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			group := GetRemediationGroupForAction(tt.action)
-			assert.Equal(t, tt.expectedGroup, group)
-		})
-	}
-}
-
-func TestGetActionsForGroup(t *testing.T) {
 	tests := []struct {
-		name            string
-		group           string
-		expectedActions []protos.RecommendedAction
+		name                string
+		healthEvent         *protos.HealthEvent
+		expectError         bool
+		expectedGroupConfig *EquivalenceGroupConfig
 	}{
 		{
-			name:  "restart group returns all restart-related actions",
-			group: "restart",
-			expectedActions: []protos.RecommendedAction{
-				protos.RecommendedAction_COMPONENT_RESET,
-				protos.RecommendedAction_RESTART_VM,
-				protos.RecommendedAction_RESTART_BM,
+			name: "Non-supported recommended action",
+			healthEvent: &protos.HealthEvent{
+				RecommendedAction: protos.RecommendedAction(1000),
+			},
+			expectError:         false,
+			expectedGroupConfig: nil,
+		},
+		{
+			name: "EquivalenceGroup without ImpactedEntityScope",
+			healthEvent: &protos.HealthEvent{
+				RecommendedAction: protos.RecommendedAction_RESTART_BM,
+			},
+			expectError: false,
+			expectedGroupConfig: &EquivalenceGroupConfig{
+				EffectiveEquivalenceGroup: "restart",
 			},
 		},
 		{
-			name:            "non-existent group returns nil",
-			group:           "non-existent",
-			expectedActions: nil,
+			name: "EquivalenceGroup with valid ImpactedEntityScope",
+			healthEvent: &protos.HealthEvent{
+				RecommendedAction: protos.RecommendedAction_COMPONENT_RESET,
+				EntitiesImpacted: []*protos.Entity{
+					{
+						EntityType:  "GPU_UUID",
+						EntityValue: "GPU-123",
+					},
+				},
+			},
+			expectError: false,
+			expectedGroupConfig: &EquivalenceGroupConfig{
+				EffectiveEquivalenceGroup:    "reset-GPU-123",
+				ImpactedEntityScopeValue:     "GPU-123",
+				SupersedingEquivalenceGroups: []string{"restart"},
+			},
 		},
 		{
-			name:            "empty string returns nil",
-			group:           "",
-			expectedActions: nil,
+			name: "EquivalenceGroup where HealthEvent is missing ImpactedEntityScope",
+			healthEvent: &protos.HealthEvent{
+				RecommendedAction: protos.RecommendedAction_COMPONENT_RESET,
+			},
+			expectError:         true,
+			expectedGroupConfig: nil,
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actions := GetActionsForGroup(tt.group)
-			if tt.expectedActions == nil {
-				assert.Nil(t, actions)
+			groupConfig, err := GetGroupConfigForEvent(remediationActions, tt.healthEvent)
+			if tt.expectError {
+				assert.Error(t, err)
 			} else {
-				assert.ElementsMatch(t, tt.expectedActions, actions)
+				assert.NoError(t, err)
 			}
+			assert.Equal(t, tt.expectedGroupConfig, groupConfig)
 		})
 	}
 }
 
-func TestIsActionInGroup(t *testing.T) {
+func TestFilterEquivalenceGroupStates(t *testing.T) {
+	remediationState := &annotation.RemediationStateAnnotation{
+		EquivalenceGroups: map[string]annotation.EquivalenceGroupState{
+			"restart": {
+				MaintenanceCR: "reboot-node",
+				ActionName:    protos.RecommendedAction_RESTART_VM.String(),
+			},
+		},
+	}
+	remediationStateWithMultipleGroups := &annotation.RemediationStateAnnotation{
+		EquivalenceGroups: map[string]annotation.EquivalenceGroupState{
+			"restart": {
+				MaintenanceCR: "reboot-node",
+				ActionName:    protos.RecommendedAction_RESTART_VM.String(),
+			},
+			"GPU-123-reset": {
+				MaintenanceCR: "gpu-reset",
+				ActionName:    protos.RecommendedAction_COMPONENT_RESET.String(),
+			},
+			"GPU-456-reset": {
+				MaintenanceCR: "gpu-reset",
+				ActionName:    protos.RecommendedAction_COMPONENT_RESET.String(),
+			},
+		},
+	}
 	tests := []struct {
-		name     string
-		action   protos.RecommendedAction
-		group    string
-		expected bool
+		name               string
+		remediationState   *annotation.RemediationStateAnnotation
+		groupConfig        *EquivalenceGroupConfig
+		expectedGroupState map[string]annotation.EquivalenceGroupState
 	}{
 		{
-			name:     "COMPONENT_RESET is in restart group",
-			action:   protos.RecommendedAction_COMPONENT_RESET,
-			group:    "restart",
-			expected: true,
+			name: "Primary equivalence group exists on annotation",
+			groupConfig: &EquivalenceGroupConfig{
+				EffectiveEquivalenceGroup: "restart",
+			},
+			remediationState: remediationState,
+			expectedGroupState: map[string]annotation.EquivalenceGroupState{
+				"restart": remediationState.EquivalenceGroups["restart"],
+			},
 		},
 		{
-			name:     "RESTART_VM is in restart group",
-			action:   protos.RecommendedAction_RESTART_VM,
-			group:    "restart",
-			expected: true,
+			name: "Primary equivalence group is missing on annotation",
+			groupConfig: &EquivalenceGroupConfig{
+				EffectiveEquivalenceGroup: "stop",
+			},
+			remediationState:   remediationState,
+			expectedGroupState: map[string]annotation.EquivalenceGroupState{},
 		},
 		{
-			name:     "RESTART_BM is in restart group",
-			action:   protos.RecommendedAction_RESTART_BM,
-			group:    "restart",
-			expected: true,
+			name: "Multiple groups on annotation: primary and superseding match",
+			groupConfig: &EquivalenceGroupConfig{
+				EffectiveEquivalenceGroup:    "GPU-123-reset",
+				SupersedingEquivalenceGroups: []string{"restart"},
+			},
+			remediationState: remediationStateWithMultipleGroups,
+			expectedGroupState: map[string]annotation.EquivalenceGroupState{
+				"restart":       remediationStateWithMultipleGroups.EquivalenceGroups["restart"],
+				"GPU-123-reset": remediationStateWithMultipleGroups.EquivalenceGroups["GPU-123-reset"],
+			},
 		},
 		{
-			name:     "CONTACT_SUPPORT is not in restart group",
-			action:   protos.RecommendedAction_CONTACT_SUPPORT,
-			group:    "restart",
-			expected: false,
+			name: "Multiple groups on annotation: superseding matches",
+			groupConfig: &EquivalenceGroupConfig{
+				EffectiveEquivalenceGroup:    "GPU-789-reset",
+				SupersedingEquivalenceGroups: []string{"restart"},
+			},
+			remediationState: remediationStateWithMultipleGroups,
+			expectedGroupState: map[string]annotation.EquivalenceGroupState{
+				"restart": remediationStateWithMultipleGroups.EquivalenceGroups["restart"],
+			},
 		},
 		{
-			name:     "NONE is not in restart group",
-			action:   protos.RecommendedAction_NONE,
-			group:    "restart",
-			expected: false,
-		},
-		{
-			name:     "RESTART_VM is not in non-existent group",
-			action:   protos.RecommendedAction_RESTART_VM,
-			group:    "non-existent",
-			expected: false,
-		},
-		{
-			name:     "any action in empty group returns false",
-			action:   protos.RecommendedAction_RESTART_VM,
-			group:    "",
-			expected: false,
+			name: "Multiple groups on annotation: primary matches",
+			groupConfig: &EquivalenceGroupConfig{
+				EffectiveEquivalenceGroup:    "GPU-123-reset",
+				SupersedingEquivalenceGroups: []string{"stop"},
+			},
+			remediationState: remediationStateWithMultipleGroups,
+			expectedGroupState: map[string]annotation.EquivalenceGroupState{
+				"GPU-123-reset": remediationStateWithMultipleGroups.EquivalenceGroups["GPU-123-reset"],
+			},
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := IsActionInGroup(tt.action, tt.group)
-			assert.Equal(t, tt.expected, result)
+			groupState := FilterEquivalenceGroupStates(tt.groupConfig, tt.remediationState)
+			assert.Equal(t, tt.expectedGroupState, groupState)
 		})
-	}
-}
-
-func TestEquivalenceGroupsConsistency(t *testing.T) {
-	restartActions := GetActionsForGroup("restart")
-	assert.NotNil(t, restartActions, "restart group should exist")
-	assert.NotEmpty(t, restartActions, "restart group should not be empty")
-
-	for _, action := range restartActions {
-		group := GetRemediationGroupForAction(action)
-		assert.Equal(t, "restart", group, "action %v should map to restart group", action)
-
-		inGroup := IsActionInGroup(action, "restart")
-		assert.True(t, inGroup, "action %v should be in restart group", action)
-	}
-}
-
-func TestRemediationEquivalenceGroupsStructure(t *testing.T) {
-	assert.NotEmpty(t, RemediationEquivalenceGroups, "RemediationEquivalenceGroups should not be empty")
-
-	restartGroup, exists := RemediationEquivalenceGroups["restart"]
-	assert.True(t, exists, "restart group should exist in RemediationEquivalenceGroups")
-	assert.NotEmpty(t, restartGroup, "restart group should contain actions")
-
-	for groupName, actions := range RemediationEquivalenceGroups {
-		seen := make(map[protos.RecommendedAction]bool)
-		for _, action := range actions {
-			assert.False(t, seen[action], "duplicate action %v found in group %s", action, groupName)
-			seen[action] = true
-		}
 	}
 }

--- a/fault-remediation/pkg/reconciler/templates/gpureset-template.yaml
+++ b/fault-remediation/pkg/reconciler/templates/gpureset-template.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: {{.ApiGroup}}/{{.Version}}
+kind: GPUReset
+metadata:
+  name: maintenance-{{.NodeName}}-{{.HealthEventID}}
+spec:
+  nodeName: {{.NodeName}}
+  selector:
+    uuids:
+      - {{.ImpactedEntityScopeValue}}
+

--- a/fault-remediation/pkg/reconciler/testdata/janitor.dgxc.nvidia.com_gpuresets.yaml
+++ b/fault-remediation/pkg/reconciler/testdata/janitor.dgxc.nvidia.com_gpuresets.yaml
@@ -1,0 +1,1 @@
+../../../../distros/kubernetes/nvsentinel/charts/janitor/crds/janitor.dgxc.nvidia.com_gpuresets.yaml

--- a/fault-remediation/pkg/remediation/fault_remediation_client_interface.go
+++ b/fault-remediation/pkg/remediation/fault_remediation_client_interface.go
@@ -21,13 +21,15 @@ import (
 
 	"github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	"github.com/nvidia/nvsentinel/fault-remediation/pkg/annotation"
+	"github.com/nvidia/nvsentinel/fault-remediation/pkg/common"
 	"github.com/nvidia/nvsentinel/fault-remediation/pkg/config"
 	"github.com/nvidia/nvsentinel/fault-remediation/pkg/crstatus"
 	"github.com/nvidia/nvsentinel/fault-remediation/pkg/events"
 )
 
 type FaultRemediationClientInterface interface {
-	CreateMaintenanceResource(ctx context.Context, healthEventData *events.HealthEventData) (string, error)
+	CreateMaintenanceResource(ctx context.Context, healthEventData *events.HealthEventData,
+		groupConfig *common.EquivalenceGroupConfig) (string, error)
 	RunLogCollectorJob(ctx context.Context, nodeName string, eventId string) (ctrl.Result, error)
 	GetAnnotationManager() annotation.NodeAnnotationManagerInterface
 	GetStatusChecker() crstatus.CRStatusCheckerInterface
@@ -37,10 +39,11 @@ type FaultRemediationClientInterface interface {
 // TemplateData holds the data to be inserted into the template
 type TemplateData struct {
 	// Node and event data
-	NodeName              string
-	HealthEventID         string
-	RecommendedAction     protos.RecommendedAction
-	RecommendedActionName string
+	NodeName                 string
+	ImpactedEntityScopeValue string
+	HealthEventID            string
+	RecommendedAction        protos.RecommendedAction
+	RecommendedActionName    string
 
 	HealthEvent *protos.HealthEvent
 

--- a/fault-remediation/pkg/remediation/remediation_test.go
+++ b/fault-remediation/pkg/remediation/remediation_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/nvidia/nvsentinel/data-models/pkg/model"
 	"github.com/nvidia/nvsentinel/data-models/pkg/protos"
+	"github.com/nvidia/nvsentinel/fault-remediation/pkg/common"
 	"github.com/nvidia/nvsentinel/fault-remediation/pkg/config"
 	"github.com/nvidia/nvsentinel/fault-remediation/pkg/events"
 	"github.com/stretchr/testify/assert"
@@ -310,9 +311,12 @@ spec:
 					},
 				},
 			}
+			groupConfig, err := common.GetGroupConfigForEvent(remediationConfig.RemediationActions,
+				healthEventDoc.HealthEvent)
+			assert.NoError(t, err)
 
 			// Test CreateMaintenanceResource
-			crName, err := remediationClient.CreateMaintenanceResource(context.Background(), healthEventDoc)
+			crName, err := remediationClient.CreateMaintenanceResource(context.Background(), healthEventDoc, groupConfig)
 			if tt.expectedError {
 				assert.Error(t, err)
 			} else {

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -21,7 +21,7 @@
 
 # E2E Tests module configuration
 IS_GO_MODULE := 1
-TEST_EXTRA_FLAGS := -timeout 35m -count 1 -failfast
+TEST_EXTRA_FLAGS := -timeout 45m -count 1 -failfast
 
 # Database-aware test tags:
 # - USE_POSTGRESQL=1: excludes mongodb-only tests (e.g., health_events_analyzer_test.go)


### PR DESCRIPTION
## Summary

Related design doc for GPU reset: https://github.com/NVIDIA/NVSentinel/blob/main/docs/designs/020-nvsentinel-gpu-reset.md.

This PR adds GPU reset support to fault-remediation. This PR is not enabling this functionality and a follow-up PR will be made to map the COMPONENT_RESET remediation action to the GPUReset custom resource. This PR adds additional functionality to EquivalenceGroups in fault-remediation (extending the functionality added in https://github.com/NVIDIA/NVSentinel/pull/603). Specifically, we are adding fields for supersedingEquivalenceGroups and impactedEntityScope to the maintenance resource definition. Here's an example: 
```
		RESTART_VM:
		  apiGroup: "janitor.dgxc.nvidia.com"
		  version: "v1alpha1"
		  kind: "RebootNode"
		  equivalenceGroup: "restart"

		COMPONENT_RESET:
		  apiGroup: "janitor.dgxc.nvidia.com"
		  version: "v1alpha1"
		  kind: "GPUReset"
		  equivalenceGroup: "reset"
		  supersedingEquivalenceGroups: ["restart"]
	      impactedEntityScope: "GPU_UUID"
```
Recall that an 	EquivalenceGroup defines which actions are considered equivalent for deduplication and actions in the same group will deduplicate against each other regardless of CRD type if the given CRD is in a non-terminal state. For GPUReset, we have 2 additional requirements:
1. Equivalence groups for COMPONENT_RESET should be constructed based on impacted entities not universal to the node. We need this to consider each GPU needing reset on a given node in its own equivalence group.
2. We want to count COMPONENT_RESET to be a part of the RESTART_VM equivalence group but not the inverse. We need this to prevent a GPU reset occurring after a reboot completes and uncordons the node.

To accomplish these, any equivalenceGroups specified in supersedingEquivalenceGroups will allow a given remediation action to have membership in multiple groups. Additionally, the impactedEntityScope will used to construct a unique equivalence group by appending the value for this entity to the equivalenceGroup name. 

Example 1:  HealthEvent which includes the RESTART_VM recommended action:
- EquivalenceGroup=restart

Example 2: HealthEvent which includes the COMPONENT_RESET recommended action that includes an impacted entity as GPU_UUID=GPU-123
- EquivalenceGroup=reset-GPU-123
- SupersedingEquivalenceGroups=["restart"]

Note that we will fail the remediation if a COMPONENT_RESET event is missing an impacted entity for GPU_UUID. We only allow a TomlConfig to define an ImpactedEntityScope if this entity has been enabled for partial draining (defined in pod_device_annotation.go). In addition to be using to construct the equivalenceGroup name, the ImpactedEntityScope will be passed to the corresponding maintenance custom resource template. Here's an example for GPUReset:
```
apiVersion: {{.ApiGroup}}/{{.Version}}
kind: GPUReset
metadata:
  name: maintenance-{{.NodeName}}-{{.HealthEventID}}
spec:
  nodeName: {{.NodeName}}
  selector:
    uuids:
      - {{.ImpactedEntityScopeValue}}
```

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [X] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPUReset remediation support with a new template
  * Equivalence groups, superseding-group relationships, and impacted-entity scoping for per-group deduplication and targeted remediation

* **Documentation**
  * Configuration docs and examples updated for action-centric templates and new template variables (health event data, impacted-entity scope)

* **Tests**
  * Expanded unit and e2e tests covering equivalence-group behavior, superseding groups, and GPU-reset flows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->