### PR TITLE
fix: tests failures in hea

### DIFF
--- a/tests/helpers/health_events_analyzer.go
+++ b/tests/helpers/health_events_analyzer.go
@@ -177,9 +177,13 @@ func clearHealthEventsAnalyzerConditions(ctx context.Context, t *testing.T, node
 func TriggerMultipleRemediationsCycle(ctx context.Context, t *testing.T, client klient.Client, nodeName string) {
 	xidsToInject := []string{ERRORCODE_79, ERRORCODE_48}
 
+	t.Logf("Delete any existing RebootNode CR for node %s", nodeName)
+
+	err := DeleteAllRebootNodeCRs(ctx, t, client)
+	require.NoError(t, err, "failed to delete all RebootNode CRs")
+
 	// inject 2 fatal errors and let the remediation cycle finish
 	t.Logf("Injecting fatal errors to node %s", nodeName)
-
 	for _, xid := range xidsToInject {
 		waitForRemediationToComplete(ctx, t, client, nodeName, xid)
 	}
@@ -194,9 +198,6 @@ func waitForRemediationToComplete(ctx context.Context, t *testing.T, client klie
 	rebootNodeCR := WaitForRebootNodeCR(ctx, t, client, nodeName)
 	require.NotNil(t, rebootNodeCR, "RebootNode CR should be created for XID error")
 
-	err := DeleteRebootNodeCR(ctx, client, rebootNodeCR)
-	require.NoError(t, err, "failed to delete RebootNode CR")
-
 	SendHealthyEvent(ctx, t, nodeName)
 
 	t.Logf("Waiting for node %s to be fully uncordoned and cleaned up", nodeName)
@@ -207,15 +208,18 @@ func waitForRemediationToComplete(ctx context.Context, t *testing.T, client klie
 		}
 
 		if node.Spec.Unschedulable {
+			t.Logf("Node %s is still cordoned", nodeName)
 			return false
 		}
 
 		if node.Annotations != nil {
 			if _, exists := node.Annotations["quarantineHealthEvent"]; exists {
+				t.Logf("Node %s has quarantineHealthEvent annotation", nodeName)
 				return false
 			}
 
 			if _, exists := node.Annotations["latestFaultRemediationState"]; exists {
+				t.Logf("Node %s has latestFaultRemediationState annotation", nodeName)
 				return false
 			}
 		}
@@ -224,6 +228,9 @@ func waitForRemediationToComplete(ctx context.Context, t *testing.T, client klie
 
 		return true
 	}, EventuallyWaitTimeout, WaitInterval, "node should be fully cleaned up before next remediation cycle")
+
+	err := DeleteRebootNodeCR(ctx, client, rebootNodeCR)
+	require.NoError(t, err, "failed to delete RebootNode CR")
 }
 
 func TeardownHealthEventsAnalyzer(ctx context.Context, t *testing.T,

--- a/tests/helpers/health_events_analyzer.go
+++ b/tests/helpers/health_events_analyzer.go
@@ -177,13 +177,14 @@ func clearHealthEventsAnalyzerConditions(ctx context.Context, t *testing.T, node
 func TriggerMultipleRemediationsCycle(ctx context.Context, t *testing.T, client klient.Client, nodeName string) {
 	xidsToInject := []string{ERRORCODE_79, ERRORCODE_48}
 
-	t.Logf("Delete any existing RebootNode CR for node %s", nodeName)
+	t.Log("Delete any existing RebootNode CR")
 
 	err := DeleteAllRebootNodeCRs(ctx, t, client)
 	require.NoError(t, err, "failed to delete all RebootNode CRs")
 
 	// inject 2 fatal errors and let the remediation cycle finish
 	t.Logf("Injecting fatal errors to node %s", nodeName)
+
 	for _, xid := range xidsToInject {
 		waitForRemediationToComplete(ctx, t, client, nodeName, xid)
 	}

--- a/tests/helpers/health_events_analyzer.go
+++ b/tests/helpers/health_events_analyzer.go
@@ -77,7 +77,6 @@ func SetupHealthEventsAnalyzerTest(ctx context.Context,
 
 		backupData, err := BackupConfigMap(ctx, client, "health-events-analyzer-config", NVSentinelNamespace)
 		require.NoError(t, err)
-
 		t.Log("Backup created in memory")
 
 		testCtx.ConfigMapBackup = backupData

--- a/tests/helpers/health_events_analyzer.go
+++ b/tests/helpers/health_events_analyzer.go
@@ -77,6 +77,7 @@ func SetupHealthEventsAnalyzerTest(ctx context.Context,
 
 		backupData, err := BackupConfigMap(ctx, client, "health-events-analyzer-config", NVSentinelNamespace)
 		require.NoError(t, err)
+
 		t.Log("Backup created in memory")
 
 		testCtx.ConfigMapBackup = backupData


### PR DESCRIPTION
## Summary

<!-- Brief description of your changes -->

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review

## Summary
When `TestMultipleRemediationsCompleted` and `TestHealthEventsAnalyzerProcessingStrategyRuleOverride` was using same node, then `TestHealthEventsAnalyzerProcessingStrategyRuleOverride` was finding CRs created from first test because of which test setup was messing up.  `TestHealthEventsAnalyzerProcessingStrategyRuleOverride` was finding old CR and was assuming that remediation has been finished but it was not.

Now, with the current fix we are deleting all existing CRs using function `DeleteAllRebootNodeCRs`  before triggering multiple remediations cycle to avoid any conflict of finding old CR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test setup now consistently uses the test context's node name instead of locally acquired node selection.
  * Remediation-cycle cleanup improved: existing reboot records cleared before triggering events and final cleanup performed after node cleanup.
  * Enhanced diagnostic logging during remediation waits (node cordon status and relevant health annotations) for clearer test failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->