### PR TITLE
fix: remove stale labels from labeler

### DIFF
--- a/labeler/pkg/labeler/labeler.go
+++ b/labeler/pkg/labeler/labeler.go
@@ -314,10 +314,31 @@ func (l *Labeler) Run(ctx context.Context) error {
 
 	slog.Info("Labeler caches synced")
 
+	// Reconcile all nodes now that all informers have synced.
+	// This ensures stale labels are cleaned up for nodes that were processed
+	// during initial sync before pod data was available.
+	l.reconcileAllNodes()
+
 	<-ctx.Done()
 	slog.Info("Labeler stopped")
 
 	return nil
+}
+
+func (l *Labeler) reconcileAllNodes() {
+	nodes := l.nodeInformer.GetStore().List()
+	for _, obj := range nodes {
+		node, ok := obj.(*v1.Node)
+		if !ok {
+			continue
+		}
+
+		if err := l.updateNodeLabels(node.Name); err != nil {
+			slog.Error("Failed to reconcile node labels", "node", node.Name, "error", err)
+		}
+	}
+
+	slog.Info("Completed initial node label reconciliation", "nodeCount", len(nodes))
 }
 
 // getDCGMVersionForNode returns the expected DCGM version for a specific node

--- a/labeler/pkg/labeler/labeler.go
+++ b/labeler/pkg/labeler/labeler.go
@@ -66,7 +66,16 @@ type Labeler struct {
 	driverAppLabel       string
 	gkeInstallerAppLabel string
 	kataLabels           []string // Instance-specific kata labels
-	initialSyncComplete  bool     // True after all informers have synced
+}
+
+func (l *Labeler) allInformersSynced() bool {
+	for _, synced := range l.informersSynced {
+		if !synced() {
+			return false
+		}
+	}
+
+	return true
 }
 
 // NewLabeler creates a new Labeler instance
@@ -309,8 +318,6 @@ func (l *Labeler) Run(ctx context.Context) error {
 	if ok := cache.WaitForCacheSync(ctx.Done(), l.informersSynced...); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
-
-	l.initialSyncComplete = true
 
 	slog.Info("Labeler caches synced")
 
@@ -612,10 +619,10 @@ func (l *Labeler) reconcileNodeLabelsInPlace(node *v1.Node, driverLabel, dcgmVer
 		slog.Info("Setting Kata enabled label on node", "node", node.Name, "kata", expectedKataLabel)
 	}
 
-	// Only remove stale labels after initial sync is complete.
+	// Only remove stale labels after all informers have synced.
 	// During startup, node events may fire before pod informer has indexed all pods,
 	// which would incorrectly identify valid labels as stale.
-	if !l.initialSyncComplete {
+	if !l.allInformersSynced() {
 		return needsUpdate
 	}
 

--- a/labeler/pkg/labeler/labeler.go
+++ b/labeler/pkg/labeler/labeler.go
@@ -66,6 +66,7 @@ type Labeler struct {
 	driverAppLabel       string
 	gkeInstallerAppLabel string
 	kataLabels           []string // Instance-specific kata labels
+	initialSyncComplete  bool     // True after all informers have synced
 }
 
 // NewLabeler creates a new Labeler instance
@@ -308,6 +309,8 @@ func (l *Labeler) Run(ctx context.Context) error {
 	if ok := cache.WaitForCacheSync(ctx.Done(), l.informersSynced...); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
+
+	l.initialSyncComplete = true
 
 	slog.Info("Labeler caches synced")
 
@@ -586,6 +589,13 @@ func (l *Labeler) reconcileNodeLabelsInPlace(node *v1.Node, driverLabel, dcgmVer
 		needsUpdate = true
 		node.Labels[KataEnabledLabel] = expectedKataLabel
 		slog.Info("Setting Kata enabled label on node", "node", node.Name, "kata", expectedKataLabel)
+	}
+
+	// Only remove stale labels after initial sync is complete.
+	// During startup, node events may fire before pod informer has indexed all pods,
+	// which would incorrectly identify valid labels as stale.
+	if !l.initialSyncComplete {
+		return needsUpdate
 	}
 
 	if driverLabel == "" && node.Labels[DriverInstalledLabel] != "" {

--- a/labeler/pkg/labeler/labeler.go
+++ b/labeler/pkg/labeler/labeler.go
@@ -530,28 +530,27 @@ func (l *Labeler) updateNodeLabelsForPod(nodeName, expectedDCGMVersion, expected
 	return nil
 }
 
-// handleNodeEvent processes node events to update kata detection label
 func (l *Labeler) handleNodeEvent(obj any) error {
 	node, ok := obj.(*v1.Node)
 	if !ok {
 		return fmt.Errorf("node event: expected Node object, got %T", obj)
 	}
 
-	expectedKataLabel := l.getKataLabelForNode(node)
-
-	currentKataLabel := node.Labels[KataEnabledLabel]
-	if currentKataLabel == expectedKataLabel {
-		slog.Debug("Node already has correct kata label", "node", node.Name, "kata", expectedKataLabel)
-		return nil
-	}
-
-	// Only update kata label, leave DCGM/driver labels alone
-	return l.updateKataLabel(node.Name, expectedKataLabel)
+	return l.updateNodeLabels(node.Name)
 }
 
-// updateKataLabel updates only the kata label on a node
-func (l *Labeler) updateKataLabel(nodeName, expectedKataLabel string) error {
-	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+func (l *Labeler) updateNodeLabels(nodeName string) error {
+	driverLabel, err := l.getDriverLabelForNode(nodeName)
+	if err != nil {
+		return fmt.Errorf("failed to check driver pods for node %s: %w", nodeName, err)
+	}
+
+	dcgmVersion, err := l.getDCGMVersionForNode(nodeName)
+	if err != nil {
+		return fmt.Errorf("failed to check DCGM pods for node %s: %w", nodeName, err)
+	}
+
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		node, err := l.clientset.CoreV1().Nodes().Get(l.ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
 			return err
@@ -561,14 +560,31 @@ func (l *Labeler) updateKataLabel(nodeName, expectedKataLabel string) error {
 			node.Labels = make(map[string]string)
 		}
 
-		currentKataLabel := node.Labels[KataEnabledLabel]
-		if currentKataLabel == expectedKataLabel {
-			slog.Debug("Node already has correct kata label", "node", nodeName, "kata", expectedKataLabel)
-			return nil
+		needsUpdate := false
+
+		expectedKataLabel := l.getKataLabelForNode(node)
+		if node.Labels[KataEnabledLabel] != expectedKataLabel {
+			needsUpdate = true
+			node.Labels[KataEnabledLabel] = expectedKataLabel
+			slog.Info("Setting Kata enabled label on node", "node", nodeName, "kata", expectedKataLabel)
 		}
 
-		node.Labels[KataEnabledLabel] = expectedKataLabel
-		slog.Info("Setting Kata enabled label on node", "node", nodeName, "kata", expectedKataLabel)
+		if driverLabel == "" && node.Labels[DriverInstalledLabel] != "" {
+			needsUpdate = true
+			delete(node.Labels, DriverInstalledLabel)
+			slog.Info("Removing stale driver installed label from node", "node", nodeName)
+		}
+
+		if dcgmVersion == "" && node.Labels[DCGMVersionLabel] != "" {
+			needsUpdate = true
+			delete(node.Labels, DCGMVersionLabel)
+			slog.Info("Removing stale DCGM version label from node", "node", nodeName)
+		}
+
+		if !needsUpdate {
+			slog.Debug("Node labels are correct", "node", nodeName)
+			return nil
+		}
 
 		_, err = l.clientset.CoreV1().Nodes().Update(l.ctx, node, metav1.UpdateOptions{})
 
@@ -576,7 +592,7 @@ func (l *Labeler) updateKataLabel(nodeName, expectedKataLabel string) error {
 	})
 	if err != nil {
 		metrics.NodeUpdateFailures.Inc()
-		return fmt.Errorf("failed to update kata label for %s: %w", nodeName, err)
+		return fmt.Errorf("failed to update labels for node %s: %w", nodeName, err)
 	}
 
 	return nil

--- a/labeler/pkg/labeler/labeler.go
+++ b/labeler/pkg/labeler/labeler.go
@@ -560,27 +560,7 @@ func (l *Labeler) updateNodeLabels(nodeName string) error {
 			node.Labels = make(map[string]string)
 		}
 
-		needsUpdate := false
-
-		expectedKataLabel := l.getKataLabelForNode(node)
-		if node.Labels[KataEnabledLabel] != expectedKataLabel {
-			needsUpdate = true
-			node.Labels[KataEnabledLabel] = expectedKataLabel
-			slog.Info("Setting Kata enabled label on node", "node", nodeName, "kata", expectedKataLabel)
-		}
-
-		if driverLabel == "" && node.Labels[DriverInstalledLabel] != "" {
-			needsUpdate = true
-			delete(node.Labels, DriverInstalledLabel)
-			slog.Info("Removing stale driver installed label from node", "node", nodeName)
-		}
-
-		if dcgmVersion == "" && node.Labels[DCGMVersionLabel] != "" {
-			needsUpdate = true
-			delete(node.Labels, DCGMVersionLabel)
-			slog.Info("Removing stale DCGM version label from node", "node", nodeName)
-		}
-
+		needsUpdate := l.reconcileNodeLabelsInPlace(node, driverLabel, dcgmVersion)
 		if !needsUpdate {
 			slog.Debug("Node labels are correct", "node", nodeName)
 			return nil
@@ -596,6 +576,33 @@ func (l *Labeler) updateNodeLabels(nodeName string) error {
 	}
 
 	return nil
+}
+
+func (l *Labeler) reconcileNodeLabelsInPlace(node *v1.Node, driverLabel, dcgmVersion string) bool {
+	needsUpdate := false
+
+	expectedKataLabel := l.getKataLabelForNode(node)
+	if node.Labels[KataEnabledLabel] != expectedKataLabel {
+		needsUpdate = true
+		node.Labels[KataEnabledLabel] = expectedKataLabel
+		slog.Info("Setting Kata enabled label on node", "node", node.Name, "kata", expectedKataLabel)
+	}
+
+	if driverLabel == "" && node.Labels[DriverInstalledLabel] != "" {
+		needsUpdate = true
+
+		delete(node.Labels, DriverInstalledLabel)
+		slog.Info("Removing stale driver installed label from node", "node", node.Name)
+	}
+
+	if dcgmVersion == "" && node.Labels[DCGMVersionLabel] != "" {
+		needsUpdate = true
+
+		delete(node.Labels, DCGMVersionLabel)
+		slog.Info("Removing stale DCGM version label from node", "node", node.Name)
+	}
+
+	return needsUpdate
 }
 
 // handlePodDeleteEvent processes pod delete events by recalculating node labels

--- a/labeler/pkg/labeler/labeler_test.go
+++ b/labeler/pkg/labeler/labeler_test.go
@@ -1110,8 +1110,8 @@ func TestStaleLabelsRemoval(t *testing.T) {
 			}()
 
 			require.Eventually(t, func() bool {
-				return labeler.initialSyncComplete
-			}, 10*time.Second, 100*time.Millisecond, "labeler initial sync did not complete")
+				return labeler.allInformersSynced()
+			}, 10*time.Second, 100*time.Millisecond, "labeler informers did not sync")
 
 			err = labeler.handleNodeEvent(tt.existingNode)
 			require.NoError(t, err, "failed to handle node event")

--- a/labeler/pkg/labeler/labeler_test.go
+++ b/labeler/pkg/labeler/labeler_test.go
@@ -16,6 +16,7 @@ package labeler
 
 import (
 	"context"
+	"maps"
 	"testing"
 	"time"
 
@@ -984,13 +985,13 @@ func TestKataLabelDetection(t *testing.T) {
 
 func TestStaleLabelsRemoval(t *testing.T) {
 	tests := []struct {
-		name                   string
-		existingNode           *corev1.Node
-		existingPods           []*corev1.Pod
-		expectedDriverLabel    string
-		expectedDCGMLabel      string
-		shouldHaveDriverLabel  bool
-		shouldHaveDCGMLabel    bool
+		name                  string
+		existingNode          *corev1.Node
+		existingPods          []*corev1.Pod
+		expectedDriverLabel   string
+		expectedDCGMLabel     string
+		shouldHaveDriverLabel bool
+		shouldHaveDCGMLabel   bool
 	}{
 		{
 			name: "both stale labels removed when no pods exist",
@@ -1112,6 +1113,22 @@ func TestStaleLabelsRemoval(t *testing.T) {
 			require.Eventually(t, func() bool {
 				return cache.WaitForCacheSync(labelerCtx.Done(), labeler.informersSynced...)
 			}, 10*time.Second, 100*time.Millisecond, "informer cache did not sync")
+
+			if len(tt.existingPods) > 0 {
+				require.Eventually(t, func() bool {
+					dcgmObjs, _ := labeler.podInformer.GetIndexer().ByIndex(NodeDCGMIndex, tt.existingNode.Name)
+					driverObjs, _ := labeler.podInformer.GetIndexer().ByIndex(NodeDriverIndex, tt.existingNode.Name)
+					return len(dcgmObjs) > 0 || len(driverObjs) > 0
+				}, 10*time.Second, 100*time.Millisecond, "pods not indexed")
+
+				// Re-apply original labels since the informer may have already processed the node
+				// before pods were indexed, incorrectly removing the labels
+				node, err := cli.CoreV1().Nodes().Get(ctx, tt.existingNode.Name, metav1.GetOptions{})
+				require.NoError(t, err, "failed to get node")
+				maps.Copy(node.Labels, tt.existingNode.Labels)
+				_, err = cli.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+				require.NoError(t, err, "failed to restore node labels")
+			}
 
 			err = labeler.handleNodeEvent(tt.existingNode)
 			require.NoError(t, err, "failed to handle node event")

--- a/labeler/pkg/labeler/labeler_test.go
+++ b/labeler/pkg/labeler/labeler_test.go
@@ -981,3 +981,178 @@ func TestKataLabelDetection(t *testing.T) {
 		})
 	}
 }
+
+func TestStaleLabelsRemoval(t *testing.T) {
+	tests := []struct {
+		name                   string
+		existingNode           *corev1.Node
+		existingPods           []*corev1.Pod
+		expectedDriverLabel    string
+		expectedDCGMLabel      string
+		shouldHaveDriverLabel  bool
+		shouldHaveDCGMLabel    bool
+	}{
+		{
+			name: "both stale labels removed when no pods exist",
+			existingNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Labels: map[string]string{
+						DriverInstalledLabel: "true",
+						DCGMVersionLabel:     "3.x",
+					},
+				},
+			},
+			existingPods:          []*corev1.Pod{},
+			shouldHaveDriverLabel: false,
+			shouldHaveDCGMLabel:   false,
+		},
+		{
+			name: "driver label retained when driver pod exists",
+			existingNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Labels: map[string]string{
+						DriverInstalledLabel: "true",
+					},
+				},
+			},
+			existingPods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "driver-pod",
+						Labels: map[string]string{"app": "nvidia-driver-daemonset"},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "test-node",
+						Containers: []corev1.Container{
+							{Name: "driver", Image: "nvcr.io/nvidia/driver:550.x"},
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+			},
+			expectedDriverLabel:   "true",
+			shouldHaveDriverLabel: true,
+			shouldHaveDCGMLabel:   false,
+		},
+		{
+			name: "DCGM label retained when DCGM pod exists",
+			existingNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Labels: map[string]string{
+						DCGMVersionLabel: "4.x",
+					},
+				},
+			},
+			existingPods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "dcgm-pod",
+						Labels: map[string]string{"app": "nvidia-dcgm"},
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "test-node",
+						Containers: []corev1.Container{
+							{Name: "dcgm", Image: "nvcr.io/nvidia/dcgm:4.1.0"},
+						},
+					},
+				},
+			},
+			expectedDCGMLabel:     "4.x",
+			shouldHaveDriverLabel: false,
+			shouldHaveDCGMLabel:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			testEnv := envtest.Environment{}
+			cfg, err := testEnv.Start()
+			require.NoError(t, err, "failed to setup envtest")
+			defer func() { _ = testEnv.Stop() }()
+
+			cli, err := kubernetes.NewForConfig(cfg)
+			require.NoError(t, err, "failed to create kubernetes client")
+
+			ns, err := cli.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "gpu-operator"}}, metav1.CreateOptions{})
+			require.NoError(t, err, "failed to create namespace")
+
+			_, err = cli.CoreV1().Nodes().Create(ctx, tt.existingNode, metav1.CreateOptions{})
+			require.NoError(t, err, "failed to create node")
+
+			for _, pod := range tt.existingPods {
+				po, err := cli.CoreV1().Pods(ns.Name).Create(ctx, pod, metav1.CreateOptions{})
+				require.NoError(t, err, "failed to create pod")
+
+				po.Status = pod.Status
+				_, err = cli.CoreV1().Pods(ns.Name).UpdateStatus(ctx, po, metav1.UpdateOptions{})
+				require.NoError(t, err, "failed to update pod status")
+			}
+
+			labeler, err := NewLabeler(cli, time.Minute, "nvidia-dcgm", "nvidia-driver-daemonset", "nvidia-driver-installer", "")
+			require.NoError(t, err, "failed to create labeler")
+
+			labelerCtx, labelerCancel := context.WithCancel(ctx)
+			defer labelerCancel()
+
+			go func() {
+				_ = labeler.Run(labelerCtx)
+			}()
+
+			require.Eventually(t, func() bool {
+				return cache.WaitForCacheSync(labelerCtx.Done(), labeler.informersSynced...)
+			}, 10*time.Second, 100*time.Millisecond, "informer cache did not sync")
+
+			err = labeler.handleNodeEvent(tt.existingNode)
+			require.NoError(t, err, "failed to handle node event")
+
+			require.Eventually(t, func() bool {
+				node, err := cli.CoreV1().Nodes().Get(ctx, tt.existingNode.Name, metav1.GetOptions{})
+				if err != nil {
+					t.Logf("Failed to get node: %v", err)
+					return false
+				}
+
+				driverLabel, driverExists := node.Labels[DriverInstalledLabel]
+				dcgmLabel, dcgmExists := node.Labels[DCGMVersionLabel]
+
+				t.Logf("Node labels: driver=%q (exists=%v), dcgm=%q (exists=%v)",
+					driverLabel, driverExists, dcgmLabel, dcgmExists)
+
+				if tt.shouldHaveDriverLabel {
+					if !driverExists || driverLabel != tt.expectedDriverLabel {
+						return false
+					}
+				} else {
+					if driverExists {
+						t.Logf("Driver label should not exist but found: %s", driverLabel)
+						return false
+					}
+				}
+
+				if tt.shouldHaveDCGMLabel {
+					if !dcgmExists || dcgmLabel != tt.expectedDCGMLabel {
+						return false
+					}
+				} else {
+					if dcgmExists {
+						t.Logf("DCGM label should not exist but found: %s", dcgmLabel)
+						return false
+					}
+				}
+
+				return true
+			}, 15*time.Second, 500*time.Millisecond, "labels not set correctly on node %s", tt.existingNode.Name)
+		})
+	}
+}

--- a/labeler/pkg/labeler/labeler_test.go
+++ b/labeler/pkg/labeler/labeler_test.go
@@ -16,7 +16,6 @@ package labeler
 
 import (
 	"context"
-	"maps"
 	"testing"
 	"time"
 
@@ -1111,24 +1110,8 @@ func TestStaleLabelsRemoval(t *testing.T) {
 			}()
 
 			require.Eventually(t, func() bool {
-				return cache.WaitForCacheSync(labelerCtx.Done(), labeler.informersSynced...)
-			}, 10*time.Second, 100*time.Millisecond, "informer cache did not sync")
-
-			if len(tt.existingPods) > 0 {
-				require.Eventually(t, func() bool {
-					dcgmObjs, _ := labeler.podInformer.GetIndexer().ByIndex(NodeDCGMIndex, tt.existingNode.Name)
-					driverObjs, _ := labeler.podInformer.GetIndexer().ByIndex(NodeDriverIndex, tt.existingNode.Name)
-					return len(dcgmObjs) > 0 || len(driverObjs) > 0
-				}, 10*time.Second, 100*time.Millisecond, "pods not indexed")
-
-				// Re-apply original labels since the informer may have already processed the node
-				// before pods were indexed, incorrectly removing the labels
-				node, err := cli.CoreV1().Nodes().Get(ctx, tt.existingNode.Name, metav1.GetOptions{})
-				require.NoError(t, err, "failed to get node")
-				maps.Copy(node.Labels, tt.existingNode.Labels)
-				_, err = cli.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
-				require.NoError(t, err, "failed to restore node labels")
-			}
+				return labeler.initialSyncComplete
+			}, 10*time.Second, 100*time.Millisecond, "labeler initial sync did not complete")
 
 			err = labeler.handleNodeEvent(tt.existingNode)
 			require.NoError(t, err, "failed to handle node event")


### PR DESCRIPTION
## Summary

This change add logic of removing stale labels that are related to DCGM and driver installed from a node. We do this by performing additional reconcile cycle after all of the informers are synced


### Testing
1. Tested that regular functionality works by removing labels from the node and re-installing the labeler
2. Tested that problem described in https://github.com/NVIDIA/NVSentinel/issues/715 is solved by: 
     1. Scaling down labeler deployment to 0 replicas
     2. Changing node selector of driver daemonset pod so it doesn't schedule on any node
     3. Upscaling labeler to 1 replica
     4. Verified that the labeler removed stale labels, logs attached below

```
labeler {"time":"2026-01-23T04:47:09.426000762Z","level":"INFO","msg":"Starting labeler","module":"labeler","version":"01230953","version":"01230953","commit":"a2fd93a95923685a53cdbab1d8f4c99cc8024420","date":"2026-01-23T04:36:57Z"}
labeler {"time":"2026-01-23T04:47:09.426991217Z","level":"INFO","msg":"server initialized","module":"labeler","version":"01230953","port":2112,"read_timeout":10000000000,"write_timeout":10000000000}
labeler {"time":"2026-01-23T04:47:09.427020819Z","level":"INFO","msg":"Starting labeler module initialization","module":"labeler","version":"01230953"}
labeler W0123 04:47:09.427039       1 client_config.go:682] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
labeler {"time":"2026-01-23T04:47:09.42757945Z","level":"INFO","msg":"Successfully initialized kubernetes client","module":"labeler","version":"01230953"}
labeler {"time":"2026-01-23T04:47:09.427674656Z","level":"INFO","msg":"Labeler created, watching DCGM and driver pods, and nodes for kata detection","module":"labeler","version":"01230953"}
labeler {"time":"2026-01-23T04:47:09.427685856Z","level":"INFO","msg":"Initialization completed successfully","module":"labeler","version":"01230953"}
labeler {"time":"2026-01-23T04:47:09.427718058Z","level":"INFO","msg":"Waiting for Labeler caches to sync...","module":"labeler","version":"01230953"}
labeler {"time":"2026-01-23T04:47:09.427905069Z","level":"INFO","msg":"Starting metrics server","module":"labeler","version":"01230953","port":2112}
labeler {"time":"2026-01-23T04:47:09.428171884Z","level":"INFO","msg":"starting server","module":"labeler","version":"01230953","addr":":2112"}
labeler {"time":"2026-01-23T04:47:09.475440737Z","level":"INFO","msg":"Removing driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss00000b"}
labeler {"time":"2026-01-23T04:47:09.567838225Z","level":"INFO","msg":"Removing driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss000007"}
labeler {"time":"2026-01-23T04:47:09.674436509Z","level":"INFO","msg":"Removing driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss00000f"}
labeler {"time":"2026-01-23T04:47:09.693137059Z","level":"INFO","msg":"Removing stale driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss00000e"}
labeler {"time":"2026-01-23T04:47:09.729232285Z","level":"INFO","msg":"Labeler caches synced","module":"labeler","version":"01230953"}
labeler {"time":"2026-01-23T04:47:09.755694471Z","level":"INFO","msg":"Removing stale driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss00000f"}
labeler {"time":"2026-01-23T04:47:09.80805521Z","level":"INFO","msg":"Removing stale driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss00000j"}
labeler {"time":"2026-01-23T04:47:09.875495796Z","level":"INFO","msg":"Removing driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss000001"}
labeler {"time":"2026-01-23T04:47:10.676400659Z","level":"INFO","msg":"Removing stale driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss00000p"}
labeler {"time":"2026-01-23T04:47:10.87377764Z","level":"INFO","msg":"Removing stale driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss00000p"}
labeler {"time":"2026-01-23T04:47:11.075795681Z","level":"INFO","msg":"Removing driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss000003"}
labeler {"time":"2026-01-23T04:47:11.874001392Z","level":"INFO","msg":"Removing stale driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss000002"}
labeler {"time":"2026-01-23T04:47:12.274227361Z","level":"INFO","msg":"Removing driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss00000m"}
labeler {"time":"2026-01-23T04:47:13.098469034Z","level":"INFO","msg":"Removing stale driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss00000n"}
labeler {"time":"2026-01-23T04:47:13.47816535Z","level":"INFO","msg":"Removing driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss00000o"}
labeler {"time":"2026-01-23T04:47:14.902341403Z","level":"INFO","msg":"Removing stale driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss00000i"}
labeler {"time":"2026-01-23T04:47:15.673229742Z","level":"INFO","msg":"Removing stale driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss000006"}
labeler {"time":"2026-01-23T04:47:15.898828154Z","level":"INFO","msg":"Removing driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss00000g"}
labeler {"time":"2026-01-23T04:47:16.673118457Z","level":"INFO","msg":"Removing stale driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss000000"}
labeler {"time":"2026-01-23T04:47:17.473022494Z","level":"INFO","msg":"Removing stale driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss000004"}
labeler {"time":"2026-01-23T04:47:18.475591555Z","level":"INFO","msg":"Removing driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss000005"}
labeler {"time":"2026-01-23T04:47:18.676495331Z","level":"INFO","msg":"Removing stale driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss00000k"}
labeler {"time":"2026-01-23T04:47:19.875280082Z","level":"INFO","msg":"Removing stale driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss00000c"}
labeler {"time":"2026-01-23T04:47:20.874890262Z","level":"INFO","msg":"Removing driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss00000l"}
labeler {"time":"2026-01-23T04:47:21.076096156Z","level":"INFO","msg":"Removing stale driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss00000l"}
labeler {"time":"2026-01-23T04:47:22.1029427Z","level":"INFO","msg":"Setting DCGM version label on node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss00000j","version":"4.x"}
labeler {"time":"2026-01-23T04:47:22.87850689Z","level":"INFO","msg":"Removing stale driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss000008"}
labeler {"time":"2026-01-23T04:47:23.875440307Z","level":"INFO","msg":"Removing stale driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss00000a"}
labeler {"time":"2026-01-23T04:47:25.675096129Z","level":"INFO","msg":"Removing stale driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss000009"}
labeler {"time":"2026-01-23T04:47:25.874443312Z","level":"INFO","msg":"Removing stale driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss000009"}
labeler {"time":"2026-01-23T04:47:26.675102296Z","level":"INFO","msg":"Removing driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss00000d"}
labeler {"time":"2026-01-23T04:47:26.875904546Z","level":"INFO","msg":"Removing stale driver installed label from node","module":"labeler","version":"01230953","node":"aks-gpu-12493808-vmss00000d"}
labeler {"time":"2026-01-23T04:47:30.673696127Z","level":"INFO","msg":"Completed initial node label reconciliation","module":"labeler","version":"01230953","nodeCount":31}
```

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Centralized node-label reconciliation to consolidate checks and reduce redundant updates.
  * Run a full node reconciliation after initial cache sync to remove stale labels from early processing.
  * Defer label removals during startup until informers are fully synced.
  * Better handling of pod-delete cases to avoid stale label mistakes and improved contextual logging.

* **Tests**
  * Added tests validating stale label removal and correct label retention across driver/DCGM presence scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->