### PR TITLE
feat(helm): add support for custom certificate secrets

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/deployment.yaml
@@ -81,7 +81,8 @@ spec:
       {{- else }}
       - name: mongo-app-client-cert
         secret:
-          secretName: mongo-app-client-cert-secret # Defined in mongodb-store chart
+          secretName: {{ include "nvsentinel.certificates.secretName" . }}
+          {{- include "nvsentinel.certificates.volumeItems" . | nindent 10 }}
           optional: true
       {{- end }}
       - name: platform-connector-uds

--- a/distros/kubernetes/nvsentinel/charts/event-exporter/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/event-exporter/templates/deployment.yaml
@@ -160,7 +160,8 @@ spec:
       {{- else }}
       - name: mongo-app-client-cert
         secret:
-          secretName: mongo-app-client-cert-secret
+          secretName: {{ include "nvsentinel.certificates.secretName" . }}
+          {{- include "nvsentinel.certificates.volumeItems" . | nindent 10 }}
           optional: true
       {{- end }}
       restartPolicy: Always

--- a/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/deployment.yaml
@@ -166,7 +166,8 @@ spec:
       {{- else }}
       - name: mongo-app-client-cert
         secret:
-          secretName: mongo-app-client-cert-secret
+          secretName: {{ include "nvsentinel.certificates.secretName" . }}
+          {{- include "nvsentinel.certificates.volumeItems" . | nindent 10 }}
           optional: true
       {{- end }}
       {{- if .Values.global.auditLogging.enabled }}

--- a/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/deployment.yaml
@@ -164,7 +164,8 @@ spec:
       {{- else }}
       - name: mongo-app-client-cert
         secret:
-          secretName: mongo-app-client-cert-secret
+          secretName: {{ include "nvsentinel.certificates.secretName" . }}
+          {{- include "nvsentinel.certificates.volumeItems" . | nindent 10 }}
           optional: true
       {{- end }}
       - name: config-volume

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
@@ -151,7 +151,8 @@ spec:
       {{- else }}
       - name: mongo-app-client-cert
         secret:
-          secretName: mongo-app-client-cert-secret
+          secretName: {{ include "nvsentinel.certificates.secretName" . }}
+          {{- include "nvsentinel.certificates.volumeItems" . | nindent 10 }}
           optional: true
       {{- end }}
       restartPolicy: Always

--- a/distros/kubernetes/nvsentinel/charts/mongodb-store/templates/certmanager.yaml
+++ b/distros/kubernetes/nvsentinel/charts/mongodb-store/templates/certmanager.yaml
@@ -20,7 +20,7 @@ metadata:
   name: mongo-app-client-cert
   namespace: {{ $.Release.Namespace }}
 spec:
-  secretName: mongo-app-client-cert-secret
+  secretName: {{ include "nvsentinel.certificates.secretName" . }}
   duration: 8760h
   renewBefore: 360h
   commonName: mongo-user-client
@@ -68,7 +68,7 @@ metadata:
   name: mongo-app-client-cert
   namespace: {{ $.Release.Namespace }}
 spec:
-  secretName: mongo-app-client-cert-secret
+  secretName: {{ include "nvsentinel.certificates.secretName" . }}
   duration: 8760h
   renewBefore: 360h
   commonName: mongo-user-client

--- a/distros/kubernetes/nvsentinel/charts/mongodb-store/templates/jobs.yaml
+++ b/distros/kubernetes/nvsentinel/charts/mongodb-store/templates/jobs.yaml
@@ -146,7 +146,7 @@ spec:
           set -e
           
           NAMESPACE="{{ .Release.Namespace }}"
-          CLIENT_CERT_SECRET="mongo-app-client-cert-secret"
+          CLIENT_CERT_SECRET="{{ include "nvsentinel.certificates.secretName" . }}"
           ISSUER_SECRET="{{ $issuerSecret }}"
           
           echo "Validating client certificate CA..."
@@ -363,14 +363,8 @@ spec:
       volumes:
         - name: mongo-certificates
           secret:
-            secretName: mongo-app-client-cert-secret
-            items:
-              - key: tls.crt
-                path: tls.crt
-              - key: tls.key
-                path: tls.key
-              - key: ca.crt
-                path: ca.crt
+            secretName: {{ include "nvsentinel.certificates.secretName" . }}
+            {{- include "nvsentinel.certificates.volumeItems" . | nindent 12 }}
       # Job scheduling configuration with backward-compatible fallback
       # Prefers: job.nodeSelector -> Falls back to: mongodb.nodeSelector
       {{- $jobNodeSelector := .Values.mongodb.nodeSelector }}

--- a/distros/kubernetes/nvsentinel/charts/node-drainer/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/node-drainer/templates/deployment.yaml
@@ -167,7 +167,8 @@ spec:
       {{- else }}
       - name: mongo-app-client-cert
         secret:
-          secretName: mongo-app-client-cert-secret
+          secretName: {{ include "nvsentinel.certificates.secretName" . }}
+          {{- include "nvsentinel.certificates.volumeItems" . | nindent 10 }}
           optional: true
       {{- end }}
       {{- if .Values.customDrain.enabled }}

--- a/distros/kubernetes/nvsentinel/templates/_helpers.tpl
+++ b/distros/kubernetes/nvsentinel/templates/_helpers.tpl
@@ -103,3 +103,36 @@ Audit logging environment variables
 - name: AUDIT_LOG_COMPRESS
   value: "{{ .Values.global.auditLogging.compress }}"
 {{- end }}
+
+{{/*
+MongoDB client certificate secret name
+*/}}
+{{- define "nvsentinel.certificates.secretName" -}}
+{{- if and .Values.global.datastore .Values.global.datastore.certificates .Values.global.datastore.certificates.secretName -}}
+{{ .Values.global.datastore.certificates.secretName }}
+{{- else -}}
+mongo-app-client-cert-secret
+{{- end -}}
+{{- end -}}
+
+{{/*
+MongoDB client certificate volume items
+Maps configurable source keys to standard destination paths
+*/}}
+{{- define "nvsentinel.certificates.volumeItems" -}}
+{{- $certKey := "tls.crt" -}}
+{{- $keyKey := "tls.key" -}}
+{{- $caKey := "ca.crt" -}}
+{{- if and .Values.global.datastore .Values.global.datastore.certificates -}}
+  {{- $certKey = .Values.global.datastore.certificates.certKey | default "tls.crt" -}}
+  {{- $keyKey = .Values.global.datastore.certificates.keyKey | default "tls.key" -}}
+  {{- $caKey = .Values.global.datastore.certificates.caKey | default "ca.crt" -}}
+{{- end -}}
+items:
+  - key: {{ $certKey }}
+    path: tls.crt
+  - key: {{ $keyKey }}
+    path: tls.key
+  - key: {{ $caKey }}
+    path: ca.crt
+{{- end -}}

--- a/distros/kubernetes/nvsentinel/templates/daemonset.yaml
+++ b/distros/kubernetes/nvsentinel/templates/daemonset.yaml
@@ -177,7 +177,8 @@ spec:
         {{- else }}
         - name: mongo-app-client-cert
           secret:
-            secretName: mongo-app-client-cert-secret
+            secretName: {{ include "nvsentinel.certificates.secretName" . }}
+            {{- include "nvsentinel.certificates.volumeItems" . | nindent 12 }}
             optional: true
         {{- end }}
         {{- if .Values.global.auditLogging.enabled }}

--- a/distros/kubernetes/nvsentinel/values.yaml
+++ b/distros/kubernetes/nvsentinel/values.yaml
@@ -31,6 +31,11 @@ global:
   #     host: "mongodb"
   #     port: 27017
   #     database: "nvsentinel"
+  #   certificates:
+  #     secretName: "mongo-app-client-cert-secret"  # Secret containing client certificates
+  #     certKey: "tls.crt"      # Key for client certificate (default: tls.crt)
+  #     keyKey: "tls.key"       # Key for client private key (default: tls.key)
+  #     caKey: "ca.crt"         # Key for CA certificate (default: ca.crt)
 
   # Certificate rotation (MongoDB only)
   # When enabled, client certificates can be rotated without restarting pods.


### PR DESCRIPTION
## Summary

This pull request introduces a configurable approach for handling MongoDB client certificate secrets and their key mappings across all relevant Kubernetes Helm charts. The changes centralize the secret name and key mapping logic, allowing for easier customization and improved maintainability.

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [x] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [x] Other: helm chart

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored MongoDB client certificate configuration across all Kubernetes deployments to use dynamic templates
  * Administrators can now customize certificate secret names and key paths through configuration parameters
  * Provides improved flexibility and consistency in certificate management across all application components

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->