### PR TITLE
feat: add GPU reset support to gpu-health-monitor

### DIFF
--- a/health-monitors/csp-health-monitor/pkg/csp/aws/aws.go
+++ b/health-monitors/csp-health-monitor/pkg/csp/aws/aws.go
@@ -779,7 +779,7 @@ func (c *AWSClient) mapToValidAction(desc string) pb.RecommendedAction {
 
 			switch {
 			case strings.Contains(section, "reset") && strings.Contains(section, "component"):
-				return pb.RecommendedAction_COMPONENT_RESET
+				return pb.RecommendedAction_RESTART_VM
 
 			case strings.Contains(section, "stop and start") || strings.Contains(section, "reboot"):
 				return pb.RecommendedAction_RESTART_VM

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_platform_connector/test_platform_connector.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_platform_connector/test_platform_connector.py
@@ -17,6 +17,9 @@ from threading import Event
 import grpc
 import time
 import unittest
+import json
+import os
+import tempfile
 from typing import Any
 from concurrent import futures
 from gpu_health_monitor.dcgm_watcher import types as dcgmtypes
@@ -30,6 +33,34 @@ from google.protobuf.timestamp_pb2 import Timestamp
 
 socket_path = "/tmp/nvsentinel.sock"
 node_name = "node1"
+
+
+def sample_metadata():
+    """Sample GPU metadata for testing."""
+    return {
+        "version": "1.0",
+        "timestamp": "2025-11-07T10:00:00Z",
+        "node_name": "test-node",
+        "chassis_serial": "CHASSIS-12345",
+        "gpus": [
+            {
+                "gpu_id": 0,
+                "uuid": "GPU-00000000-0000-0000-0000-000000000000",
+                "pci_address": "0000:17:00.0",
+                "serial_number": "SN-GPU-0",
+                "device_name": "NVIDIA A100",
+                "nvlinks": [],
+            }
+        ],
+        "nvswitches": [],
+    }
+
+
+def metadata_file():
+    """Create a temporary metadata file for testing."""
+    f = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json")
+    json.dump(sample_metadata(), f)
+    return f.name
 
 
 class PlatformConnectorServicer(platformconnector_pb2_grpc.PlatformConnectorServicer):
@@ -96,6 +127,8 @@ class TestPlatformConnectors(unittest.TestCase):
         dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_CPUSET"] = "NonFatal"
         dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_NVSWITCH"] = "Fatal"
 
+        temp_file_path = metadata_file()
+
         platform_connector_test = platform_connector.PlatformConnectorEventProcessor(
             socket_path,
             node_name,
@@ -103,7 +136,7 @@ class TestPlatformConnectors(unittest.TestCase):
             dcgm_errors_info_dict,
             "statefile",
             dcgm_health_conditions_categorization_mapping_config,
-            "/tmp/test_metadata.json",
+            temp_file_path,
             platformconnector_pb2.STORE_ONLY,
         )
         dcgm_health_events = watcher._get_health_status_dict()
@@ -184,6 +217,7 @@ class TestPlatformConnectors(unittest.TestCase):
         assert platform_connector_test.entity_cache[dcgm_health_event_key].isHealthy == True
 
         server.stop(0)
+        os.unlink(temp_file_path)
 
     def test_health_event_multiple_failures_same_gpu(self):
         """Test that multiple NvLink failures for the same GPU are properly published to gRPC."""
@@ -231,6 +265,8 @@ class TestPlatformConnectors(unittest.TestCase):
         dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_CPUSET"] = "NonFatal"
         dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_NVSWITCH"] = "Fatal"
 
+        temp_file_path = metadata_file()
+
         platform_connector_test = platform_connector.PlatformConnectorEventProcessor(
             socket_path,
             node_name,
@@ -238,7 +274,7 @@ class TestPlatformConnectors(unittest.TestCase):
             dcgm_errors_info_dict,
             "statefile",
             dcgm_health_conditions_categorization_mapping_config,
-            "/tmp/test_metadata.json",
+            temp_file_path,
             platformconnector_pb2.STORE_ONLY,
         )
 
@@ -301,6 +337,7 @@ class TestPlatformConnectors(unittest.TestCase):
         assert nvlink_failure_event.processingStrategy == platformconnector_pb2.STORE_ONLY
 
         server.stop(0)
+        os.unlink(temp_file_path)
 
     def test_health_event_multiple_gpus_multiple_failures_each(self):
         """Test that multiple NvLink failures across multiple GPUs are properly published to gRPC."""
@@ -436,6 +473,154 @@ class TestPlatformConnectors(unittest.TestCase):
         assert gpu1_event.processingStrategy == platformconnector_pb2.STORE_ONLY
 
         server.stop(0)
+
+    def test_health_event_multiple_recommended_action_override(self):
+        """Test that only events with PCI and GPU_UUID are published with the COMPONENT_RESET action"""
+        healthEventProcessor = PlatformConnectorServicer()
+        server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+        platformconnector_pb2_grpc.add_PlatformConnectorServicer_to_server(healthEventProcessor, server)
+        server.add_insecure_port(f"unix://{socket_path}")
+        server.start()
+
+        watcher = dcgm.DCGMWatcher(
+            addr="localhost:5555",
+            poll_interval_seconds=10,
+            callbacks=[],
+            dcgm_k8s_service_enabled=False,
+        )
+
+        gpu_serials = {
+            0: "1650924060039",
+            1: "1650924060040",
+            2: "1650924060041",
+            3: "1650924060042",
+            4: "1650924060043",
+            5: "1650924060044",
+            6: "1650924060045",
+            7: "1650924060046",
+        }
+
+        exit = Event()
+        dcgm_errors_info_dict = {}
+        dcgm_errors_info_dict["DCGM_FR_NVLINK_DOWN"] = "COMPONENT_RESET"
+
+        dcgm_health_conditions_categorization_mapping_config = {}
+        dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_NVLINK"] = "Fatal"
+        dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_PCIE"] = "Fatal"
+        dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_MEM"] = "Fatal"
+        dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_INFOROM"] = "Fatal"
+        dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_MCU"] = "Fatal"
+        dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_DRIVER"] = "Fatal"
+        dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_NVSWITCH_FATAL"] = "Fatal"
+        dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_NVSWITCH_NONFATAL"] = "NonFatal"
+        dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_SM"] = "Fatal"
+        dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_THERMAL"] = "NonFatal"
+        dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_POWER"] = "NonFatal"
+        dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_PMU"] = "Fatal"
+        dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_CPUSET"] = "NonFatal"
+        dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_NVSWITCH"] = "Fatal"
+
+        temp_file_path = metadata_file()
+
+        platform_connector_test = platform_connector.PlatformConnectorEventProcessor(
+            socket_path,
+            node_name,
+            exit,
+            dcgm_errors_info_dict,
+            "statefile",
+            dcgm_health_conditions_categorization_mapping_config,
+            temp_file_path,
+            platformconnector_pb2.STORE_ONLY,
+        )
+
+        # Simulate multiple NvLink failures for GPU 0 and GPU 1
+        dcgm_health_events = watcher._get_health_status_dict()
+
+        gpu0_message = (
+            "GPU 0's NvLink link 8 is currently down Check DCGM and system logs for errors. Reset GPU. Restart DCGM. Rerun diagnostics.; "
+            "GPU 0's NvLink link 9 is currently down Check DCGM and system logs for errors. Reset GPU. Restart DCGM. Rerun diagnostics.; "
+            "GPU 0's NvLink link 14 is currently down Check DCGM and system logs for errors. Reset GPU. Restart DCGM. Rerun diagnostics.; "
+            "GPU 0's NvLink link 15 is currently down Check DCGM and system logs for errors. Reset GPU. Restart DCGM. Rerun diagnostics."
+        )
+
+        gpu1_message = (
+            "GPU 1's NvLink link 8 is currently down Check DCGM and system logs for errors. Reset GPU. Restart DCGM. Rerun diagnostics.; "
+            "GPU 1's NvLink link 9 is currently down Check DCGM and system logs for errors. Reset GPU. Restart DCGM. Rerun diagnostics.; "
+            "GPU 1's NvLink link 12 is currently down Check DCGM and system logs for errors. Reset GPU. Restart DCGM. Rerun diagnostics.; "
+            "GPU 1's NvLink link 13 is currently down Check DCGM and system logs for errors. Reset GPU. Restart DCGM. Rerun diagnostics."
+        )
+
+        dcgm_health_events["DCGM_HEALTH_WATCH_NVLINK"] = dcgmtypes.HealthDetails(
+            status=dcgmtypes.HealthStatus.FAIL,
+            entity_failures={
+                0: dcgm.types.ErrorDetails(
+                    code="DCGM_FR_NVLINK_DOWN",
+                    message=gpu0_message,
+                ),
+                1: dcgm.types.ErrorDetails(
+                    code="DCGM_FR_NVLINK_DOWN",
+                    message=gpu1_message,
+                ),
+            },
+        )
+
+        gpu_ids = [0, 1, 2, 3, 4, 5, 6, 7]
+        platform_connector_test.health_event_occurred(dcgm_health_events, gpu_ids)
+
+        health_events = healthEventProcessor.health_events
+
+        # Find NvLink failure events for both GPUs
+        gpu0_event = None
+        gpu1_event = None
+        for event in health_events:
+            if event.checkName == "GpuNvlinkWatch" and not event.isHealthy:
+                if event.entitiesImpacted[0].entityValue == "0":
+                    gpu0_event = event
+                elif event.entitiesImpacted[0].entityValue == "1":
+                    gpu1_event = event
+
+        # Verify GPU 0 event
+        assert gpu0_event is not None, "NvLink failure event for GPU 0 not found"
+        assert gpu0_event.errorCode[0] == "DCGM_FR_NVLINK_DOWN"
+        assert gpu0_event.isFatal == True
+        assert gpu0_event.isHealthy == False
+
+        # Verify all 4 NvLink failures for GPU 0
+        assert "link 8" in gpu0_event.message
+        assert "link 9" in gpu0_event.message
+        assert "link 14" in gpu0_event.message
+        assert "link 15" in gpu0_event.message
+        assert gpu0_event.message.count(";") == 3
+        assert gpu0_event.message == gpu0_message
+        assert gpu0_event.processingStrategy == platformconnector_pb2.STORE_ONLY
+        # Metadata collector includes PCI and GPU_UUID only for GPU 0.
+        # Since the PCI and GPU_UUID are present in entitiesImpacted, the
+        # recommendedAction will not be overridden from COMPONENT_RESET.
+        assert gpu0_event.recommendedAction == platformconnector_pb2.COMPONENT_RESET
+        assert len(gpu0_event.entitiesImpacted) == 3
+
+        # Verify GPU 1 event
+        assert gpu1_event is not None, "NvLink failure event for GPU 1 not found"
+        assert gpu1_event.errorCode[0] == "DCGM_FR_NVLINK_DOWN"
+        assert gpu1_event.isFatal == True
+        assert gpu1_event.isHealthy == False
+        # Since the PCI and GPU_UUID are not present in entitiesImpacted for
+        # GPU 1, the recommendedAction will be overridden from COMPONENT_RESET
+        # to RESTART_VM.
+        assert gpu1_event.recommendedAction == platformconnector_pb2.RESTART_VM
+        assert len(gpu1_event.entitiesImpacted) == 1
+
+        # Verify all 4 NvLink failures for GPU 1
+        assert "link 8" in gpu1_event.message
+        assert "link 9" in gpu1_event.message
+        assert "link 12" in gpu1_event.message
+        assert "link 13" in gpu1_event.message
+        assert gpu1_event.message.count(";") == 3
+        assert gpu1_event.message == gpu1_message
+        assert gpu1_event.processingStrategy == platformconnector_pb2.STORE_ONLY
+
+        server.stop(0)
+        os.unlink(temp_file_path)
 
     def test_dcgm_connectivity_failed(self):
         """Test that GpuDcgmConnectivityFailure health event is sent when DCGM connectivity fails."""


### PR DESCRIPTION
## Summary
Related design doc for GPU reset: https://github.com/NVIDIA/NVSentinel/blob/main/docs/designs/020-nvsentinel-gpu-reset.md.

This PR adds GPU reset support to the gpu-health-monitor. The corresponding changes to the syslog-health-monitor was previously implemented in https://github.com/NVIDIA/NVSentinel/pull/669. This PR enforces that any unhealthy HealthEvent which includes the COMPONENT_RESET remediation must include the GPU_UUID and PCI as impacted entities. Sending an event with COMPONENT_RESET that is missing the GPU_UUID impacted entity will result in a failed partial drain in node-drainer (as well as a failed remediation in fault-remediation). As a result, we are checking that the GPU_UUID (along with the PCI) can be read from the MetadataReader and are falling back to the RESTART_VM action if it is not present on the event.

Note that entity-specific HealthEvents require an exact match for the set of impacted entities between the initial unhealthy event and the eventual healthy event which clears the event in fault-quarantine. To ensure that there's a consistent view of impacted entities between healthy and unhealthy events, we will only send unhealthy HealthEvents for COMPONENT_RESET which include the GPU index, PCI, and GPU_UUID (and the corresponding HealthyEvent will include all of these as long as there's no failure extracting the PCI or GPU_UUID from the MetadataReader).

## Unhealthy events
If the MetadataReader is working when we send unhealthy events, we will include these impacted entities and support these actions:
- ImpactedEntities: GPU index, GPU_UUID, PCI
- RecommendedAction: any

If the MetadataReader is not working when we send unhealthy events, we will include these impacted entities and support these actions:
- ImpactedEntities: GPU index
- RecommendedAction: COMPONENT_RESET will be overridden to RESTART_VM, otherwise don't modify the original recommended action from dcgmerrorsmapping.csv

## Healthy events
We will send healthy events with whatever impacted entities are available. If the MetadataReader is working when we send healthy events:
- ImpactedEntities: GPU index, GPU_UUID, PCI

If the MetadataReader is not working when we send healthy events:
- ImpactedEntities: GPU index

## Comparing to syslog-health-monitor
Similarities between gpu-health-monitor + syslog-health-monitor:

1. The list of ImpactedEntities should include all available information. While GPUResets can be accomplished without the PCI or GPU index, we do not want to remove entities to simplify our unhealthy/healthy event generation. In summary, the gpu-health-monitor will include whatever is available out of GPU index, GPU_UUID, and PCI and the syslog-health-monitor will include GPU_UUID and PCI in both unhealthy and healthy events.
2. We will not send COMPONENT_RESET events that will result in a failed drain (or failed remediation) if the event is missing the GPU_UUID (and PCI). If this condition is detected, both health-monitors will override the recommended action to RESTART_VM.


Differences between gpu-health-monitor + syslog-health-monitor:
1. The gpu-health-monitor includes an additional impacted entity for the GPU index in healthy + unhealthy events.
2. If the GPU_UUID + PCI are available when an unhealthy event is generated but are not available later when a healthy event needs generated, both health-monitors will fail to clear the condition for COMPONENT_RESETS. However, the gpu-health-monitor will still send a healthy HealthEvent after DCGM reports a healthy condition (even if it only includes the GPU index) since we do not know what the recommended action might be for any previous unhealthy events which may need to be cleared for non-COMPONENT_RESET actions. This is different from the syslog-health-monitor when sending healthy events for COMPONENT_RESET because it generates the event from a GPU reset syslog line. There's no point in sending the HealthEvent when it's missing the GPU_UUID + PCI because we can be certain that it is only targeting a previous COMPONENT_RESET request + the impacted entities won't match.


## Type of Change
- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [X] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * AWS health monitoring now recommends VM restart when reset guidance references both component and reset.
  * GPU monitoring downgrades component-reset recommendations to VM restart when GPU metadata (PCI/UUID) is missing.

* **Tests**
  * Added test coverage verifying recommendation overrides across multi-GPU scenarios and varying metadata availability, using temporary metadata fixtures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->