### PR TITLE
fix: only update gpu-health-monitor event cache after healthevent is send to platform-connector

### DIFF
--- a/docs/designs/025-processing-strategy-for-health-checks.md
+++ b/docs/designs/025-processing-strategy-for-health-checks.md
@@ -314,7 +314,7 @@ class PlatformConnectorEventProcessor:
         # ... existing fields ...
         self._processing_strategy = processing_strategy  # NEW: Store strategy
     
-    def health_event_occurred(self, health_details, gpu_ids, serials):
+    def health_event_occurred(self, health_details, gpu_ids):
         # Creates HealthEvents in multiple places - add processingStrategy to ALL:
         
         health_event = platformconnector_pb2.HealthEvent(

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/dcgm.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/dcgm.py
@@ -269,7 +269,6 @@ class DCGMWatcher:
         dcgm_handle = None
         dcgm_group = None
         gpu_ids = []
-        gpu_serials = {}
 
         # Initial DCGM handle and monitoring setup
         while not exit.is_set():
@@ -285,7 +284,6 @@ class DCGMWatcher:
                         dcgm_handle = None
                         dcgm_group = None
                         gpu_ids = []
-                        gpu_serials = {}
                 else:
                     log.debug("Running health check")
                     health_status, connectivity_success = self._perform_health_check(dcgm_group)
@@ -296,12 +294,11 @@ class DCGMWatcher:
                         dcgm_handle = None
                         dcgm_group = None
                         gpu_ids = []
-                        gpu_serials = {}
                     else:
                         log.debug("Publish DCGM health checks")
                         self._fire_callback_funcs(
                             types.CallbackInterface.health_event_occurred.__name__,
-                            [health_status, gpu_ids, gpu_serials],
+                            [health_status, gpu_ids],
                         )
 
             log.debug("Waiting till next cycle")

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/types.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/types.py
@@ -42,7 +42,9 @@ class FieldDetails:
 
 class CallbackInterface(abc.ABC):
     @abc.abstractmethod
-    def health_event_occurred(self, health_details: dict[str, HealthDetails], gpu_ids: list[int]):
+    def health_event_occurred(
+        self, health_details: dict[str, HealthDetails], gpu_ids: list[int], serials: dict[int, str]
+    ):
         pass
 
     @abc.abstractmethod

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/types.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/types.py
@@ -42,9 +42,7 @@ class FieldDetails:
 
 class CallbackInterface(abc.ABC):
     @abc.abstractmethod
-    def health_event_occurred(
-        self, health_details: dict[str, HealthDetails], gpu_ids: list[int], serials: dict[int, str]
-    ):
+    def health_event_occurred(self, health_details: dict[str, HealthDetails], gpu_ids: list[int]):
         pass
 
     @abc.abstractmethod

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/platform_connector/platform_connector.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/platform_connector/platform_connector.py
@@ -88,16 +88,13 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
     def _build_cache_key(self, check_name: str, entity_type: str, entity_value: str) -> str:
         return f"{check_name}|{entity_type}|{entity_value}"
 
-    def clear_dcgm_connectivity_failure(self, timestamp: Timestamp):
+    def clear_dcgm_connectivity_failure(self, timestamp: Timestamp) -> None:
         """Clear DCGM connectivity failure events if connectivity has been restored."""
         health_events = []
         check_name = "GpuDcgmConnectivityFailure"
 
         key = self._build_cache_key(check_name, "DCGM", "ALL")
         if key not in self.entity_cache or not self.entity_cache[key].isHealthy:
-            self.entity_cache[key] = CachedEntityState(isFatal=False, isHealthy=True)
-            log.info(f"Updated cache for key {key} with connectivity failure")
-
             event_metadata = {}
             chassis_serial = self._metadata_reader.get_chassis_serial()
             if chassis_serial:
@@ -121,19 +118,21 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
             )
             health_events.append(health_event)
 
-            # Clear metric for connectivity failure
-            metrics.dcgm_health_active_events.labels(event_type=check_name, gpu_id="", severity="fatal").set(0)
-
         if len(health_events):
             try:
-                self.send_health_event_with_retries(health_events)
+                if self.send_health_event_with_retries(health_events):
+                    # Only update cache after successful send
+                    self.entity_cache[key] = CachedEntityState(isFatal=False, isHealthy=True)
+                    log.info(f"Updated cache for key {key} after successful send")
+                    # Clear metric for connectivity failure
+                    metrics.dcgm_health_active_events.labels(event_type=check_name, gpu_id="", severity="fatal").set(0)
             except Exception as e:
                 log.error(f"Exception while sending DCGM connectivity restored events: {e}")
                 raise
 
     def health_event_occurred(
         self, health_details: dict[str, dcgmtypes.HealthDetails], gpu_ids: list, serials: dict[int, str]
-    ):
+    ) -> None:
         with metrics.dcgm_health_events_publish_time_to_grpc_channel.labels(
             "dcgm_health_events_to_grpc_channel"
         ).time():
@@ -145,6 +144,10 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
             self.clear_dcgm_connectivity_failure(timestamp)
 
             health_events = []
+            # Collect pending cache and metric updates to apply only after successful send
+            pending_cache_updates: dict[str, CachedEntityState] = {}
+            pending_metric_updates: list[tuple[str, str, str, int]] = []  # (event_type, gpu_id, severity, value)
+
             for watch_name, details in health_details.items():
                 check_name = self._convert_dcgm_watch_name_to_check_name(watch_name)
                 message = (
@@ -194,8 +197,8 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
                             or self.entity_cache[key].isFatal != isFatal
                             or self.entity_cache[key].isHealthy != isHealthy
                         ):
-                            self.entity_cache[key] = CachedEntityState(isFatal=isFatal, isHealthy=isHealthy)
-                            log.info(f"Updated cache for key {key} with value {self.entity_cache[key]}")
+                            # Defer cache update until after successful send
+                            pending_cache_updates[key] = CachedEntityState(isFatal=isFatal, isHealthy=isHealthy)
                             recommended_action = self.get_recommended_action_from_dcgm_error_map(failure_details.code)
 
                             event_metadata = {}
@@ -226,9 +229,8 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
                                 if self.dcgm_health_conditions_categorization_mapping_config[watch_name] == "NonFatal"
                                 else "fatal"
                             )
-                            metrics.dcgm_health_active_events.labels(
-                                event_type=check_name, gpu_id=gpu_id, severity=severity
-                            ).set(1)
+                            # Defer metric update until after successful send
+                            pending_metric_updates.append((check_name, gpu_id, severity, 1))
                     else:
 
                         entity = platformconnector_pb2.Entity(entityType=self._component_class, entityValue=str(gpu_id))
@@ -253,15 +255,21 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
                             or self.entity_cache[key].isFatal
                             or not self.entity_cache[key].isHealthy
                         ):
-
-                            self.entity_cache[key] = CachedEntityState(isFatal=False, isHealthy=True)
-                            log.info(f"Updated cache for key {key} with value {self.entity_cache[key]}")
                             # Don't send health events for non-fatal health conditions when they are healthy
                             # they will get published as node conditions which we don't want to do to have
                             # consistency in the health events publishing logic
                             if self.dcgm_health_conditions_categorization_mapping_config[watch_name] == "NonFatal":
                                 log.debug(f"Skipping non-fatal health event for watch {watch_name}")
+                                # For non-fatal events that are not sent, update cache immediately
+                                # (no race condition since nothing is being sent)
+                                self.entity_cache[key] = CachedEntityState(isFatal=False, isHealthy=True)
+                                log.info(f"Updated cache for key {key} with value {self.entity_cache[key]}")
+                                metrics.dcgm_health_active_events.labels(
+                                    event_type=check_name, gpu_id=gpu_id, severity="non_fatal"
+                                ).set(0)
                             else:
+                                # Defer cache update until after successful send
+                                pending_cache_updates[key] = CachedEntityState(isFatal=False, isHealthy=True)
                                 event_metadata = {}
                                 chassis_serial = self._metadata_reader.get_chassis_serial()
                                 if chassis_serial:
@@ -285,21 +293,22 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
                                         processingStrategy=self._processing_strategy,
                                     )
                                 )
-                            severity = (
-                                "non_fatal"
-                                if self.dcgm_health_conditions_categorization_mapping_config[watch_name] == "NonFatal"
-                                else "fatal"
-                            )
-                            metrics.dcgm_health_active_events.labels(
-                                event_type=check_name, gpu_id=gpu_id, severity=severity
-                            ).set(0)
+                                # Defer metric update until after successful send
+                                pending_metric_updates.append((check_name, gpu_id, "fatal", 0))
             log.debug(f"dcgm health event is {health_events}")
             if len(health_events):
                 try:
-                    self.send_health_event_with_retries(health_events)
+                    if self.send_health_event_with_retries(health_events):
+                        # Only update cache and metrics after successful send
+                        for key, state in pending_cache_updates.items():
+                            self.entity_cache[key] = state
+                            log.info(f"Updated cache for key {key} with value {state} after successful send")
+                        for event_type, gpu_id, severity, value in pending_metric_updates:
+                            metrics.dcgm_health_active_events.labels(
+                                event_type=event_type, gpu_id=gpu_id, severity=severity
+                            ).set(value)
                 except Exception as e:
                     log.error(f"Exception while sending health events: {e}")
-                    self.entity_cache = {}
 
     def get_recommended_action_from_dcgm_error_map(self, error_code):
         if error_code in self.dcgm_errors_info_dict:
@@ -309,7 +318,13 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
 
         return platformconnector_pb2.RecommendedAction.CONTACT_SUPPORT
 
-    def send_health_event_with_retries(self, health_events: list[platformconnector_pb2.HealthEvent]):
+    def send_health_event_with_retries(self, health_events: list[platformconnector_pb2.HealthEvent]) -> bool:
+        """Send health events to the platform connector with retries.
+
+        Returns:
+            True if the send was successful, False if all retries were exhausted.
+            Cache updates should only be performed by the caller when this returns True.
+        """
         delay = INITIAL_DELAY
         for _ in range(MAX_RETRIES):
             with grpc.insecure_channel(f"unix://{self._socket_path}") as chan:
@@ -324,25 +339,12 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
                     delay *= 1.5
                     continue
         metrics.health_events_insertion_to_uds_error.inc()
-        # Remove failed health events from entity cache
-        for health_event in health_events:
-            if health_event.checkName == "GpuDcgmConnectivityFailure":
-                # Explicitly handle DCGM connectivity events
-                cache_key = self._build_cache_key(health_event.checkName, "DCGM", "ALL")
-                if cache_key in self.entity_cache:
-                    del self.entity_cache[cache_key]
-                    log.info(f"Removed DCGM connectivity event from cache after send failure: {cache_key}")
-            elif len(health_event.entitiesImpacted) > 0:
-                for entity in health_event.entitiesImpacted:
-                    cache_key = self._build_cache_key(health_event.checkName, entity.entityType, entity.entityValue)
-                    if cache_key in self.entity_cache:
-                        del self.entity_cache[cache_key]
-            else:
-                # Ideally should not come here, but just in case added a warning.
-                log.warning(f"Unknown system-level event with empty entities detected: {health_event.checkName}")
+        log.warning(
+            f"Failed to send health event after {MAX_RETRIES} retries. Events will be retried on next health check cycle."
+        )
         return False
 
-    def dcgm_connectivity_failed(self):
+    def dcgm_connectivity_failed(self) -> None:
         """Handle DCGM connectivity failure event."""
         with metrics.dcgm_health_events_publish_time_to_grpc_channel.labels(
             "dcgm_connectivity_failure_to_grpc_channel"
@@ -355,9 +357,6 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
             check_name = "GpuDcgmConnectivityFailure"
             key = self._build_cache_key(check_name, "DCGM", "ALL")
             if key not in self.entity_cache or self.entity_cache[key].isHealthy:
-                self.entity_cache[key] = CachedEntityState(isFatal=True, isHealthy=False)
-                log.info(f"Updated cache for key {key} with connectivity failure")
-
                 event_metadata = {}
                 chassis_serial = self._metadata_reader.get_chassis_serial()
                 if chassis_serial:
@@ -380,11 +379,16 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
                     processingStrategy=self._processing_strategy,
                 )
                 health_events.append(health_event)
-                metrics.dcgm_health_active_events.labels(event_type=check_name, gpu_id="", severity="fatal").set(1)
 
             if len(health_events):
                 try:
-                    self.send_health_event_with_retries(health_events)
+                    if self.send_health_event_with_retries(health_events):
+                        # Only update cache after successful send
+                        self.entity_cache[key] = CachedEntityState(isFatal=True, isHealthy=False)
+                        log.info(f"Updated cache for key {key} after successful send")
+                        metrics.dcgm_health_active_events.labels(
+                            event_type=check_name, gpu_id="", severity="fatal"
+                        ).set(1)
                 except Exception as e:
                     log.error(f"Exception while sending DCGM connectivity failure events: {e}")
                     raise

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/platform_connector/platform_connector.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/platform_connector/platform_connector.py
@@ -124,7 +124,6 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
                     # Only update cache after successful send
                     self.entity_cache[key] = CachedEntityState(isFatal=False, isHealthy=True)
                     log.info(f"Updated cache for key {key} after successful send")
-                    # Clear metric for connectivity failure
                     metrics.dcgm_health_active_events.labels(event_type=check_name, gpu_id="", severity="fatal").set(0)
             except Exception as e:
                 log.error(f"Exception while sending DCGM connectivity restored events: {e}")

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/platform_connector/platform_connector.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/platform_connector/platform_connector.py
@@ -146,7 +146,7 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
             health_events = []
             # Collect pending cache and metric updates to apply only after successful send
             pending_cache_updates: dict[str, CachedEntityState] = {}
-            pending_metric_updates: list[tuple[str, str, str, int]] = []  # (event_type, gpu_id, severity, value)
+            pending_metric_updates: list[tuple[str, int, str, int]] = []  # (event_type, gpu_id, severity, value)
 
             for watch_name, details in health_details.items():
                 check_name = self._convert_dcgm_watch_name_to_check_name(watch_name)

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/platform_connector/platform_connector.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/platform_connector/platform_connector.py
@@ -130,9 +130,7 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
                 log.error(f"Exception while sending DCGM connectivity restored events: {e}")
                 raise
 
-    def health_event_occurred(
-        self, health_details: dict[str, dcgmtypes.HealthDetails], gpu_ids: list, serials: dict[int, str]
-    ) -> None:
+    def health_event_occurred(self, health_details: dict[str, dcgmtypes.HealthDetails], gpu_ids: list) -> None:
         with metrics.dcgm_health_events_publish_time_to_grpc_channel.labels(
             "dcgm_health_events_to_grpc_channel"
         ).time():

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_dcgm_watcher/test_dcgm.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_dcgm_watcher/test_dcgm.py
@@ -28,11 +28,8 @@ class FakeEventProcessorInTest(dcgm.types.CallbackInterface):
         self.fields_changes = None
         self.connectivity_failed_called = False
 
-    def health_event_occurred(
-        self, health_details: dict[str, dcgm.types.HealthDetails], gpu_ids: list[int], serials: dict[int, str]
-    ):
+    def health_event_occurred(self, health_details: dict[str, dcgm.types.HealthDetails], gpu_ids: list[int]):
         self.health_details = health_details
-        self.serials = serials
 
     def dcgm_connectivity_failed(self):
         self.connectivity_failed_called = True

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_platform_connector/test_platform_connector.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_platform_connector/test_platform_connector.py
@@ -122,7 +122,7 @@ class TestPlatformConnectors(unittest.TestCase):
                 fatal_dcgm_health_events_length += 1
 
         gpu_ids = [0, 1, 2, 3, 4, 5, 6, 7]
-        platform_connector_test.health_event_occurred(dcgm_health_events, gpu_ids, gpu_serials)
+        platform_connector_test.health_event_occurred(dcgm_health_events, gpu_ids)
         health_events = healthEventProcessor.health_events
         for event in health_events:
             if event.checkName == "GpuInforomWatch" and event.isHealthy == False:
@@ -153,7 +153,7 @@ class TestPlatformConnectors(unittest.TestCase):
         )
         before_insertion_cache_value = platform_connector_test.entity_cache[dcgm_health_event_key]
         cache_length = len(platform_connector_test.entity_cache)
-        platform_connector_test.health_event_occurred(dcgm_health_events, gpu_ids, gpu_serials)
+        platform_connector_test.health_event_occurred(dcgm_health_events, gpu_ids)
         health_events = healthEventProcessor.health_events
         assert len(platform_connector_test.entity_cache) == cache_length
         assert (
@@ -171,7 +171,7 @@ class TestPlatformConnectors(unittest.TestCase):
 
         check_name = platform_connector_test._convert_dcgm_watch_name_to_check_name("DCGM_HEALTH_WATCH_INFOROM")
         cache_length = len(platform_connector_test.entity_cache)
-        platform_connector_test.health_event_occurred(dcgm_health_events, gpu_ids, gpu_serials)
+        platform_connector_test.health_event_occurred(dcgm_health_events, gpu_ids)
 
         # Verify healthy event was added to cache with correct message format
         dcgm_health_event_key = platform_connector_test._build_cache_key(
@@ -263,7 +263,7 @@ class TestPlatformConnectors(unittest.TestCase):
         )
 
         gpu_ids = [0, 1, 2, 3, 4, 5, 6, 7]
-        platform_connector_test.health_event_occurred(dcgm_health_events, gpu_ids, gpu_serials)
+        platform_connector_test.health_event_occurred(dcgm_health_events, gpu_ids)
 
         health_events = healthEventProcessor.health_events
 
@@ -391,7 +391,7 @@ class TestPlatformConnectors(unittest.TestCase):
         )
 
         gpu_ids = [0, 1, 2, 3, 4, 5, 6, 7]
-        platform_connector_test.health_event_occurred(dcgm_health_events, gpu_ids, gpu_serials)
+        platform_connector_test.health_event_occurred(dcgm_health_events, gpu_ids)
 
         health_events = healthEventProcessor.health_events
 
@@ -635,7 +635,7 @@ class TestPlatformConnectors(unittest.TestCase):
                 },
             )
             gpu_ids = [0]
-            platform_connector_processor.health_event_occurred(dcgm_health_events, gpu_ids, gpu_serials)
+            platform_connector_processor.health_event_occurred(dcgm_health_events, gpu_ids)
             gpu_health_cache_key = platform_connector_processor._build_cache_key("GpuInforomWatch", "GPU", "0")
             assert (
                 gpu_health_cache_key not in platform_connector_processor.entity_cache
@@ -690,7 +690,7 @@ class TestPlatformConnectors(unittest.TestCase):
             assert dcgm_restored_event.isHealthy == True
 
             # GPU Health Event - send succeeds, cache should be updated
-            platform_connector_processor.health_event_occurred(dcgm_health_events, gpu_ids, gpu_serials)
+            platform_connector_processor.health_event_occurred(dcgm_health_events, gpu_ids)
             time.sleep(1)
             assert (
                 gpu_health_cache_key in platform_connector_processor.entity_cache

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_platform_connector/test_platform_connector.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_platform_connector/test_platform_connector.py
@@ -550,7 +550,7 @@ class TestPlatformConnectors(unittest.TestCase):
 
         server.stop(0)
 
-    def test_event_retry_and_cache_cleanup_when_platform_connector_down(self):
+    def test_event_retry_and_cache_cleanup_when_platform_connector_down(self) -> None:
         """Test when platform connector goes down and comes back up."""
         import tempfile
         import os
@@ -606,15 +606,14 @@ class TestPlatformConnectors(unittest.TestCase):
             # Verify cache is empty initially
             assert len(platform_connector_processor.entity_cache) == 0
 
-            # Test 1: DCGM Connectivity Failure (system-level event, no entities)
-            # This tests the cache cleanup path: if checkName == "GpuDcgmConnectivityFailure"
+            # Platform-connector is DOWN - send will fail, cache should NOT be updated
             platform_connector_processor.dcgm_connectivity_failed()
             dcgm_failure_cache_key = platform_connector_processor._build_cache_key(
                 "GpuDcgmConnectivityFailure", "DCGM", "ALL"
             )
             assert (
                 dcgm_failure_cache_key not in platform_connector_processor.entity_cache
-            ), "DCGM failure cache entry should be removed after send failure"
+            ), "Cache should NOT be updated when send fails"
 
             # Test 2: DCGM Connectivity Restored
             timestamp = Timestamp()
@@ -622,10 +621,9 @@ class TestPlatformConnectors(unittest.TestCase):
             platform_connector_processor.clear_dcgm_connectivity_failure(timestamp)
             assert (
                 dcgm_failure_cache_key not in platform_connector_processor.entity_cache
-            ), "DCGM restored cache entry should be removed after send failure"
+            ), "Cache should NOT be updated when send fails"
 
-            # Test 3: GPU Health Event (entity-specific event)
-            # This tests the cache cleanup path: elif len(entitiesImpacted) > 0
+            # GPU Health Event - send will fail, cache should NOT be updated
             dcgm_health_events = watcher._get_health_status_dict()
             dcgm_health_events["DCGM_HEALTH_WATCH_INFOROM"] = dcgmtypes.HealthDetails(
                 status=dcgmtypes.HealthStatus.FAIL,
@@ -641,7 +639,7 @@ class TestPlatformConnectors(unittest.TestCase):
             gpu_health_cache_key = platform_connector_processor._build_cache_key("GpuInforomWatch", "GPU", "0")
             assert (
                 gpu_health_cache_key not in platform_connector_processor.entity_cache
-            ), "GPU health cache entry should be removed after send failure"
+            ), "Cache should NOT be updated when send fails"
 
             # Platform connector comes UP - Start server
             healthEventProcessor = PlatformConnectorServicer()
@@ -650,12 +648,12 @@ class TestPlatformConnectors(unittest.TestCase):
             server.add_insecure_port(f"unix://{socket_path}")
             server.start()
 
-            # Retry DCGM Connectivity Failure
+            # DCGM Connectivity Failure - send succeeds, cache should be updated
             platform_connector_processor.dcgm_connectivity_failed()
             time.sleep(1)
             assert (
                 dcgm_failure_cache_key in platform_connector_processor.entity_cache
-            ), "DCGM failure cache entry should be present after successful send"
+            ), "Cache should be updated after successful send"
             assert platform_connector_processor.entity_cache[dcgm_failure_cache_key].isFatal == True
             assert platform_connector_processor.entity_cache[dcgm_failure_cache_key].isHealthy == False
 
@@ -671,14 +669,14 @@ class TestPlatformConnectors(unittest.TestCase):
             assert dcgm_failure_event.errorCode == ["DCGM_CONNECTIVITY_ERROR"]
             assert dcgm_failure_event.entitiesImpacted == []
 
-            # Retry DCGM Connectivity Restored
+            # DCGM Connectivity Restored - send succeeds, cache should be updated
             timestamp = Timestamp()
             timestamp.GetCurrentTime()
             platform_connector_processor.clear_dcgm_connectivity_failure(timestamp)
             time.sleep(1)
-            assert (
-                platform_connector_processor.entity_cache[dcgm_failure_cache_key].isHealthy == True
-            ), "DCGM failure cache entry should be updated to healthy"
+            assert platform_connector_processor.entity_cache[
+                dcgm_failure_cache_key
+            ].isHealthy, "Cache should be updated after successful send"
 
             # Verify DCGM restored event was sent
             health_events = healthEventProcessor.health_events
@@ -691,12 +689,12 @@ class TestPlatformConnectors(unittest.TestCase):
             assert dcgm_restored_event.isFatal == False
             assert dcgm_restored_event.isHealthy == True
 
-            # Retry GPU Health Event
+            # GPU Health Event - send succeeds, cache should be updated
             platform_connector_processor.health_event_occurred(dcgm_health_events, gpu_ids, gpu_serials)
             time.sleep(1)
             assert (
                 gpu_health_cache_key in platform_connector_processor.entity_cache
-            ), "GPU health cache entry should be present after successful send"
+            ), "Cache should be updated after successful send"
             assert platform_connector_processor.entity_cache[gpu_health_cache_key].isFatal == True
             assert platform_connector_processor.entity_cache[gpu_health_cache_key].isHealthy == False
 


### PR DESCRIPTION

## Summary

This issue is a timing issue and will mostly occur in cases when both dcgm and platform-connector is not up during startup but gpu-health-monitor is up. below is the scenario.

1. Platform-connector goes DOWN
2. DCGM fails → cache set to "unhealthy" → send starts retrying (with exponential backoff)
3. DCGM restored → cache set to "healthy" → send starts retrying
4. Platform-connector comes back UP
5. "Healthy" send succeeds FIRST → node condition = healthy
6. "Unhealthy" send succeeds AFTER → node condition = unhealthy (STALE!)
7. Future polls: cache="healthy", DCGM=healthy → no event sent
8. Node condition stuck at "unhealthy"



<!-- Brief description of your changes -->
As part of the fix, the idea is to update health-events cache only once the event is sent else there is no point in updating cache unless the event is sent.

**1. Cache reflects only successfully delivered events**
Before: Cache updated immediately, regardless of send success/failure
After: Cache updated only when platform-connector acknowledges receipt
Result: Cache accurately represents what platform-connector knows

**2. Failed sends are automatically retried on next poll**
Before: Cache updated on failure → next poll sees "no change needed" → skips sending
After: Cache NOT updated on failure → next poll sees "state mismatch" → retries sending
Result: Events keep retrying until successfully delivered

**3. Out-of-order delivery doesn't corrupt cache state**
Before: Both "unhealthy" and "healthy" events update cache during their retry loops → race condition
After: Only the event that succeeds first updates the cache → consistent state
Result: Cache always matches the most recently acknowledged event

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [x] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable processing strategy that is propagated with health events.

* **Bug Fixes**
  * Cache and metric updates are deferred and applied only after health-event delivery succeeds, preventing incorrect removals and race conditions.
  * Improved retry and error handling for failed sends; failures now log clearer warnings and avoid premature cache mutations.
  * Certain non-fatal scenarios still allow immediate updates to avoid races.

* **Behavior Change**
  * Health callbacks no longer include GPU serials in their payload.

* **Tests**
  * Tests updated to assert cache remains unchanged on failed sends and is updated after successful deliveries.

* **Documentation**
  * Clarified send/commit semantics and update contract.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->