### PR TITLE
fix: flaky labeler tests

### DIFF
--- a/labeler/pkg/labeler/labeler_test.go
+++ b/labeler/pkg/labeler/labeler_test.go
@@ -1120,6 +1120,16 @@ func TestStaleLabelsRemoval(t *testing.T) {
 					driverObjs, _ := labeler.podInformer.GetIndexer().ByIndex(NodeDriverIndex, tt.existingNode.Name)
 					return len(dcgmObjs) > 0 || len(driverObjs) > 0
 				}, 10*time.Second, 100*time.Millisecond, "pods not indexed in custom indexes")
+
+				// Restore original labels - reconcileAllNodes() may have removed them
+				// before pods were indexed during the initial sync race
+				node, err := cli.CoreV1().Nodes().Get(ctx, tt.existingNode.Name, metav1.GetOptions{})
+				require.NoError(t, err, "failed to get node")
+				for k, v := range tt.existingNode.Labels {
+					node.Labels[k] = v
+				}
+				_, err = cli.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+				require.NoError(t, err, "failed to restore node labels")
 			}
 
 			err = labeler.handleNodeEvent(tt.existingNode)

--- a/labeler/pkg/labeler/labeler_test.go
+++ b/labeler/pkg/labeler/labeler_test.go
@@ -1113,6 +1113,15 @@ func TestStaleLabelsRemoval(t *testing.T) {
 				return labeler.allInformersSynced()
 			}, 10*time.Second, 100*time.Millisecond, "labeler informers did not sync")
 
+			// Wait for pods to be indexed in custom indexes before testing
+			if len(tt.existingPods) > 0 {
+				require.Eventually(t, func() bool {
+					dcgmObjs, _ := labeler.podInformer.GetIndexer().ByIndex(NodeDCGMIndex, tt.existingNode.Name)
+					driverObjs, _ := labeler.podInformer.GetIndexer().ByIndex(NodeDriverIndex, tt.existingNode.Name)
+					return len(dcgmObjs) > 0 || len(driverObjs) > 0
+				}, 10*time.Second, 100*time.Millisecond, "pods not indexed in custom indexes")
+			}
+
 			err = labeler.handleNodeEvent(tt.existingNode)
 			require.NoError(t, err, "failed to handle node event")
 


### PR DESCRIPTION
## Summary

<!-- Brief description of your changes -->

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test synchronization to wait for custom indexes to be populated before proceeding, and restored node labels after indexing to prevent race conditions during node event handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->