### PR TITLE
fix: fix auth mechanism in mongodb metrics URL

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/mongodb-store/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/mongodb-store/values.yaml
@@ -237,7 +237,7 @@ mongodb:
     args:
       - |
         export HOSTNAME=$(hostname)
-        /bin/mongodb_exporter --collector.diagnosticdata --collector.replicasetstatus --compatible-mode --mongodb.direct-connect --mongodb.global-conn-pool --web.listen-address ":9216" --mongodb.uri "mongodb://$MONGODB_ROOT_USER:$(echo $MONGODB_ROOT_PASSWORD | sed -r "s/@/%40/g;s/:/%3A/g")@${HOSTNAME}.mongodb-headless.nvsentinel.svc.cluster.local:27017/admin?tls=true&tlsCertificateKeyFile=/certs/mongodb.pem&tlsCAFile=/certs/mongodb-ca-cert&connectTimeoutMS=30000&serverSelectionTimeoutMS=30000"
+        /bin/mongodb_exporter --collector.diagnosticdata --collector.replicasetstatus --compatible-mode --mongodb.direct-connect --mongodb.global-conn-pool --web.listen-address ":9216" --mongodb.uri "mongodb://$MONGODB_ROOT_USER:$(echo $MONGODB_ROOT_PASSWORD | sed -r "s/@/%40/g;s/:/%3A/g")@${HOSTNAME}.mongodb-headless.nvsentinel.svc.cluster.local:27017/admin?tls=true&tlsCertificateKeyFile=/certs/mongodb.pem&tlsCAFile=/certs/mongodb-ca-cert&authMechanism=SCRAM-SHA-256&connectTimeoutMS=30000&serverSelectionTimeoutMS=30000"
 
 # =============================================================================
 # Percona MongoDB Operator Configuration (used when usePerconaOperator=true)

--- a/distros/kubernetes/nvsentinel/templates/daemonset.yaml
+++ b/distros/kubernetes/nvsentinel/templates/daemonset.yaml
@@ -89,11 +89,17 @@ spec:
           ports:
             - name: metrics
               containerPort: {{ .Values.global.metricsPort }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /healthz
               port: metrics
-            initialDelaySeconds: 15
             periodSeconds: 20
             timeoutSeconds: 5
             failureThreshold: 3
@@ -101,7 +107,6 @@ spec:
             httpGet:
               path: /healthz
               port: metrics
-            initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3


### PR DESCRIPTION
## Summary

<!-- Brief description of your changes -->

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


# Description:

## The Problem

1. **MongoDB Server Configuration**: The Bitnami MongoDB is configured with:
   ```
   --setParameter authenticationMechanisms=MONGODB-X509,SCRAM-SHA-256
   ```
   This means MongoDB **only accepts** `SCRAM-SHA-256` (and X.509). **SCRAM-SHA-1 is disabled**.

2. **MongoDB Driver Default Behavior**: When the metrics exporter connects without specifying an `authMechanism`, the MongoDB Go driver defaults to trying `SCRAM-SHA-1` first (for backward compatibility with older MongoDB versions).

3. **Result**: The driver tries SCRAM-SHA-1 -> MongoDB rejects it -> Error:
   ```
   unable to authenticate using mechanism "SCRAM-SHA-1": (MechanismUnavailable) 
   Received authentication for mechanism SCRAM-SHA-1 which is not enabled
   ```

## The Fix

Adding `authMechanism=SCRAM-SHA-256` to the connection string:
```
mongodb://...?...&authMechanism=SCRAM-SHA-256
```

This **explicitly tells the driver** to use SCRAM-SHA-256 instead of its default mechanism selection. The driver no longer tries SCRAM-SHA-1 first, so it successfully authenticates on the first attempt.

# Testing:

Deployed with the fix and tested on a dev cluster:

<img width="3157" height="1547" alt="image" src="https://github.com/user-attachments/assets/1d8764c3-e007-4c57-a0a1-c52d33868df2" />

<img width="3762" height="1060" alt="image" src="https://github.com/user-attachments/assets/46cd6556-e1fe-4e0b-ba2f-00950dd98353" />


## Fix for platform connector rollout timeout in tests
The `platform-connectors` service blocks its entire startup sequence while waiting for a successful MongoDB connection (which can take up to **5 minutes** by default). 

However, the Kubernetes **liveness probe** was configured with a much shorter window:
1. It started checking after 15 seconds.
2. it would kill the container after 3 failed attempts (totaling about **55 seconds**).

Because the service hadn't finished connecting to the database, it hadn't started its health endpoint yet. Kubernetes saw the "Connection Refused" on the health port, assumed the app was dead, and killed it, creating a "death spiral" where the pod could never finish starting up.

## The Fix: Startup Probe
I added a **Startup Probe** to the Helm chart. This is the Kubernetes-native way to handle slow-starting applications:

1.  **Grace Period**: It gives the container a dedicated **5-minute window** (30 retries * 10 seconds) to finish its database initialization.
2.  **Protection**: While the startup probe is running, Kubernetes **disables the liveness and readiness probes**. This prevents the "death spiral" by ensuring the container is never killed for being slow during startup.
3.  **Efficiency**: As soon as the database connects and the health endpoint becomes active, the startup probe succeeds, and Kubernetes immediately switches to normal liveness monitoring with fast failure detection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Explicitly specify MongoDB authentication mechanism in Kubernetes deployment to improve connection reliability.
  * Improve pod health handling by adding a startup probe and adjusting liveness/readiness probe timing to detect startup issues more proactively.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->