### PR TITLE
fix: add delay to nebius IsNodeReady check

### DIFF
--- a/janitor-provider/pkg/csp/nebius/nebius.go
+++ b/janitor-provider/pkg/csp/nebius/nebius.go
@@ -32,6 +32,7 @@ import (
 	"log/slog"
 	"os"
 	"regexp"
+	"time"
 
 	"github.com/nebius/gosdk"
 	"github.com/nebius/gosdk/auth"
@@ -168,6 +169,15 @@ func (c *Client) SendRebootSignal(ctx context.Context, node corev1.Node) (model.
 // - STARTING -> wait for start to complete
 // - RUNNING -> node is ready
 func (c *Client) IsNodeReady(ctx context.Context, node corev1.Node, requestID string) (bool, error) {
+	// don't check too early, wait 30 seconds before checking, return not ready if too early
+	storedTime, err := time.Parse(time.RFC3339, requestID)
+	if err != nil {
+		return false, err
+	}
+
+	if time.Since(storedTime) < 30*time.Second {
+		return false, nil
+	}
 	// requestID contains the instance ID from SendRebootSignal
 	instanceID := requestID
 


### PR DESCRIPTION
## Summary

Taking from other CSP implementations [ref](https://github.com/NVIDIA/NVSentinel/blob/main/janitor-provider/pkg/csp/aws/aws.go#L138-L145) [ref](https://github.com/NVIDIA/NVSentinel/blob/main/janitor-provider/pkg/csp/azure/azure.go#L110-L118), this adds a delay to isNodeReady for Nebius to allow time for the API responses to catch up to the latest state of the instance.

solves #726 

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [x] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Node readiness checks now include an initial 30-second delay before instance status polling begins.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->