### PR TITLE
fix: add checksum annotations to restart pods on configmap changes

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/configmap.yaml
@@ -17,6 +17,8 @@ metadata:
   name: {{ include "csp-health-monitor.fullname" . }}
   labels:
     {{- include "csp-health-monitor.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 data:
   config.toml: |
     # Global settings

--- a/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/deployment.yaml
@@ -24,10 +24,12 @@ spec:
       {{- include "csp-health-monitor.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with ((.Values.global).podAnnotations | default .Values.podAnnotations) }}
       annotations:
+        # Force pod restart when configmap changes
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with ((.Values.global).podAnnotations | default .Values.podAnnotations) }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "csp-health-monitor.selectorLabels" . | nindent 8 }}
     spec:

--- a/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/deployment.yaml
@@ -17,6 +17,8 @@ metadata:
   name: {{ include "csp-health-monitor.fullname" . }}
   labels:
     {{- include "csp-health-monitor.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -83,8 +85,7 @@ spec:
       {{- else }}
       - name: mongo-app-client-cert
         secret:
-          secretName: {{ include "nvsentinel.certificates.secretName" . }}
-          {{- include "nvsentinel.certificates.volumeItems" . | nindent 10 }}
+          secretName: mongo-app-client-cert-secret # Defined in mongodb-store chart
           optional: true
       {{- end }}
       - name: platform-connector-uds
@@ -110,22 +111,6 @@ spec:
             - name: metrics
               containerPort: {{ ((.Values.global).metricsPort) | default 2112 }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: metrics
-            initialDelaySeconds: 15
-            periodSeconds: 20
-            timeoutSeconds: 5
-            failureThreshold: 3
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: metrics
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
           volumeMounts:
           - name: config-volume
             mountPath: /etc/config/
@@ -161,29 +146,12 @@ spec:
           - "--database-client-cert-mount-path={{ .Values.clientCertMountPath }}"
           - "--uds-path=/run/nvsentinel/nvsentinel.sock"
           - "--metrics-port=2113"
-          - "--processing-strategy={{ .Values.processingStrategy }}"
           resources:
             {{- toYaml .Values.quarantineTriggerEngine.resources | default .Values.resources | nindent 12 }}
           ports:
             - name: metrics-sidecar
               containerPort: 2113
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: metrics-sidecar
-            initialDelaySeconds: 15
-            periodSeconds: 20
-            timeoutSeconds: 5
-            failureThreshold: 3
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: metrics-sidecar
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
           volumeMounts:
           - name: config-volume
             mountPath: /etc/config/

--- a/distros/kubernetes/nvsentinel/charts/event-exporter/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/event-exporter/templates/configmap.yaml
@@ -18,6 +18,8 @@ metadata:
   name: {{ include "event-exporter.fullname" . }}
   labels:
     {{- include "event-exporter.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 data:
   config.toml: |
     [exporter.metadata]

--- a/distros/kubernetes/nvsentinel/charts/event-exporter/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/event-exporter/templates/deployment.yaml
@@ -18,6 +18,8 @@ metadata:
   name: {{ include "event-exporter.fullname" . }}
   labels:
     {{- include "event-exporter.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -162,8 +164,7 @@ spec:
       {{- else }}
       - name: mongo-app-client-cert
         secret:
-          secretName: {{ include "nvsentinel.certificates.secretName" . }}
-          {{- include "nvsentinel.certificates.volumeItems" . | nindent 10 }}
+          secretName: mongo-app-client-cert-secret
           optional: true
       {{- end }}
       restartPolicy: Always

--- a/distros/kubernetes/nvsentinel/charts/event-exporter/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/event-exporter/templates/deployment.yaml
@@ -25,10 +25,12 @@ spec:
       {{- include "event-exporter.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        # Force pod restart when configmap changes
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "event-exporter.labels" . | nindent 8 }}
     spec:

--- a/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/configmap.yaml
@@ -17,6 +17,8 @@ metadata:
   name: {{ include "fault-quarantine.fullname" . }}
   labels:
     {{- include "fault-quarantine.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 data:
   config.toml: |
     label-prefix = {{ .Values.labelPrefix | quote }}

--- a/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/deployment.yaml
@@ -17,6 +17,8 @@ metadata:
   name: {{ include "fault-quarantine.fullname" . }}
   labels:
     {{- include "fault-quarantine.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -168,8 +170,7 @@ spec:
       {{- else }}
       - name: mongo-app-client-cert
         secret:
-          secretName: {{ include "nvsentinel.certificates.secretName" . }}
-          {{- include "nvsentinel.certificates.volumeItems" . | nindent 10 }}
+          secretName: mongo-app-client-cert-secret
           optional: true
       {{- end }}
       {{- if .Values.global.auditLogging.enabled }}

--- a/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/deployment.yaml
@@ -24,10 +24,12 @@ spec:
       {{- include "fault-quarantine.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with ((.Values.global).podAnnotations | default .Values.podAnnotations) }}
       annotations:
+        # Force pod restart when configmap changes
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with ((.Values.global).podAnnotations | default .Values.podAnnotations) }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "fault-quarantine.selectorLabels" . | nindent 8 }}
     spec:

--- a/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/configmap.yaml
@@ -18,6 +18,8 @@ metadata:
   name: {{ include "fault-remediation.fullname" . }}
   labels:
     {{- include "fault-remediation.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 data:
   config.toml: |
     [template]

--- a/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/deployment.yaml
@@ -24,10 +24,12 @@ spec:
       {{- include "fault-remediation.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with ((.Values.global).podAnnotations | default .Values.podAnnotations) }}
       annotations:
+        # Force pod restart when configmap changes
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with ((.Values.global).podAnnotations | default .Values.podAnnotations) }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "fault-remediation.selectorLabels" . | nindent 8 }}
     spec:

--- a/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/deployment.yaml
@@ -17,6 +17,8 @@ metadata:
   name: {{ include "fault-remediation.fullname" . }}
   labels:
     {{- include "fault-remediation.labels" . | nindent 4}}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -89,24 +91,29 @@ spec:
           args:
           - "--dry-run={{ ((.Values.global).dryRun) | default false }}"
           - "--enable-log-collector={{ .Values.logCollector.enabled }}"
+          {{- if  (.Values.global).ctrlRuntimeEnabled }}
+          - "--controller-runtime=true"
           - "--leader-elect=true"
+          {{- end }}
           ports:
             - name: metrics
               containerPort: {{ ((.Values.global).metricsPort) | default 2112 }}
+            {{- if  (.Values.global).ctrlRuntimeEnabled }}
             - name: health
               containerPort: {{ ((.Values.global).healthPort) | default 9440 }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz
-              port: health
+              port: {{ ternary "health" "metrics" (default false (.Values.global).ctrlRuntimeEnabled) }}
             initialDelaySeconds: 15
             periodSeconds: 20
             timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path:  "/readyz"
-              port: "health"
+              path:  {{ ternary "/readyz" "/healthz"  (default false (.Values.global).ctrlRuntimeEnabled) }}
+              port: {{ ternary "health" "metrics"  (default false (.Values.global).ctrlRuntimeEnabled) }}
             initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 3
@@ -166,8 +173,7 @@ spec:
       {{- else }}
       - name: mongo-app-client-cert
         secret:
-          secretName: {{ include "nvsentinel.certificates.secretName" . }}
-          {{- include "nvsentinel.certificates.volumeItems" . | nindent 10 }}
+          secretName: mongo-app-client-cert-secret
           optional: true
       {{- end }}
       - name: config-volume

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/configmap.yaml
@@ -16,6 +16,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "health-events-analyzer.fullname" . }}-config
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 data:
   config.toml: |
     {{ tpl .Values.config . | nindent 6 }}

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
@@ -25,10 +25,12 @@ spec:
       {{- include "health-events-analyzer.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        # Force pod restart when configmap changes
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "health-events-analyzer.labels" . | nindent 8 }}
     spec:

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
@@ -18,6 +18,8 @@ metadata:
   name: {{ include "health-events-analyzer.fullname" . }}
   labels:
     {{- include "health-events-analyzer.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -76,7 +78,6 @@ spec:
           args:
           - "--metrics-port={{ .Values.global.metricsPort }}"
           - "--database-client-cert-mount-path={{ .Values.clientCertMountPath }}"
-          - "--processing-strategy={{ .Values.processingStrategy }}"
           ports:
             - name: metrics
               containerPort: {{ .Values.global.metricsPort }}
@@ -153,8 +154,7 @@ spec:
       {{- else }}
       - name: mongo-app-client-cert
         secret:
-          secretName: {{ include "nvsentinel.certificates.secretName" . }}
-          {{- include "nvsentinel.certificates.volumeItems" . | nindent 10 }}
+          secretName: mongo-app-client-cert-secret
           optional: true
       {{- end }}
       restartPolicy: Always

--- a/distros/kubernetes/nvsentinel/charts/janitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/templates/configmap.yaml
@@ -17,6 +17,8 @@ metadata:
   name: {{ include "janitor.fullname" . }}
   labels:
     {{- include "janitor.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 data:
   config.yaml: |
     global:

--- a/distros/kubernetes/nvsentinel/charts/janitor/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/templates/deployment.yaml
@@ -17,6 +17,8 @@ metadata:
   name: {{ include "janitor.fullname" . }}
   labels:
     {{- include "janitor.labels" . | nindent 4}}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -32,6 +34,12 @@ spec:
         {{- end }}
       labels:
         {{- include "janitor.selectorLabels" . | nindent 8 }}
+        {{- if eq (.Values.csp.provider | default "kind") "azure" }}
+        {{- if .Values.csp.azure.clientId }}
+        # Azure Workload Identity label (required for pod identity)
+        azure.workload.identity/use: "true"
+        {{- end }}
+        {{- end }}
     spec:
       {{- with ((.Values.global).imagePullSecrets | default .Values.imagePullSecrets) }}
       imagePullSecrets:
@@ -71,8 +79,60 @@ spec:
             {{- if .Values.global.auditLogging.enabled }}
             {{- include "nvsentinel.auditLogging.envVars" . | nindent 12 }}
             {{- end }}
-            {{- with .Values.extraEnv }}
-            {{- toYaml . | nindent 12 }}
+            # Cloud Service Provider configuration
+            - name: CSP
+              value: {{ .Values.csp.provider | default "kind" | quote }}
+            {{- if eq (.Values.csp.provider | default "kind") "aws" }}
+            # AWS-specific environment variables
+            {{- if .Values.csp.aws.region }}
+            - name: AWS_REGION
+              value: {{ .Values.csp.aws.region | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if eq (.Values.csp.provider | default "kind") "gcp" }}
+            # GCP-specific environment variables  
+            {{- if .Values.csp.gcp.project }}
+            - name: GCP_PROJECT
+              value: {{ .Values.csp.gcp.project | quote }}
+            {{- end }}
+            {{- if .Values.csp.gcp.zone }}
+            - name: GCP_ZONE
+              value: {{ .Values.csp.gcp.zone | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if eq (.Values.csp.provider | default "kind") "azure" }}
+            # Azure-specific environment variables
+            {{- if .Values.csp.azure.subscriptionId }}
+            - name: AZURE_SUBSCRIPTION_ID
+              value: {{ .Values.csp.azure.subscriptionId | quote }}
+            {{- end }}
+            {{- if .Values.csp.azure.resourceGroup }}
+            - name: AZURE_RESOURCE_GROUP
+              value: {{ .Values.csp.azure.resourceGroup | quote }}
+            {{- end }}
+            {{- if .Values.csp.azure.location }}
+            - name: AZURE_LOCATION
+              value: {{ .Values.csp.azure.location | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if eq (.Values.csp.provider | default "kind") "oci" }}
+            # OCI-specific environment variables
+            {{- if .Values.csp.oci.region }}
+            - name: OCI_REGION
+              value: {{ .Values.csp.oci.region | quote }}
+            {{- end }}
+            {{- if .Values.csp.oci.compartment }}
+            - name: OCI_COMPARTMENT
+              value: {{ .Values.csp.oci.compartment | quote }}
+            {{- end }}
+            {{- if .Values.csp.oci.credentialsFile }}
+            - name: OCI_CREDENTIALS_FILE
+              value: {{ .Values.csp.oci.credentialsFile | quote }}
+            {{- end }}
+            {{- if .Values.csp.oci.profile }}
+            - name: OCI_PROFILE
+              value: {{ .Values.csp.oci.profile | quote }}
+            {{- end }}
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/distros/kubernetes/nvsentinel/charts/janitor/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/templates/deployment.yaml
@@ -24,10 +24,12 @@ spec:
       {{- include "janitor.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with ((.Values.global).podAnnotations | default .Values.podAnnotations) }}
       annotations:
+        # Force pod restart when configmap changes
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with ((.Values.global).podAnnotations | default .Values.podAnnotations) }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "janitor.selectorLabels" . | nindent 8 }}
     spec:

--- a/distros/kubernetes/nvsentinel/charts/node-drainer/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/node-drainer/templates/configmap.yaml
@@ -17,6 +17,8 @@ metadata:
   name: {{ include "node-drainer.fullname" . }}
   labels:
     {{- include "node-drainer.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 data:
   config.toml: |
     evictionTimeoutInSeconds = {{ .Values.evictionTimeoutInSeconds | quote }}

--- a/distros/kubernetes/nvsentinel/charts/node-drainer/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/node-drainer/templates/deployment.yaml
@@ -24,10 +24,12 @@ spec:
       {{- include "node-drainer.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        # Force pod restart when configmap changes
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "node-drainer.selectorLabels" . | nindent 8 }}
     spec:

--- a/distros/kubernetes/nvsentinel/charts/node-drainer/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/node-drainer/templates/deployment.yaml
@@ -17,6 +17,8 @@ metadata:
   name: {{ include "node-drainer.fullname" . }}
   labels:
     {{- include "node-drainer.labels" . | nindent 4}}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -169,8 +171,7 @@ spec:
       {{- else }}
       - name: mongo-app-client-cert
         secret:
-          secretName: {{ include "nvsentinel.certificates.secretName" . }}
-          {{- include "nvsentinel.certificates.volumeItems" . | nindent 10 }}
+          secretName: mongo-app-client-cert-secret
           optional: true
       {{- end }}
       {{- if .Values.customDrain.enabled }}


### PR DESCRIPTION
When ArgoCD syncs an application, it updates configmaps but doesn't automatically restart pods that mount them (unlike helm upgrade).

This adds checksum/config annotations to all deployments that mount configmaps. When the configmap content changes, the checksum changes, which triggers a pod rollout restart.

Fixes: HIPPO-4616

Charts updated:
- fault-remediation
- fault-quarantine
- node-drainer
- csp-health-monitor
- event-exporter
- health-events-analyzer
- janitor

## Summary

<!-- Brief description of your changes -->

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [x] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployments and ConfigMaps now include sync annotations and a config checksum to trigger automated pod restarts when configuration changes occur.
  * Certificate volume handling standardized to a single secret reference across services.

* **New Features**
  * Optional controller-runtime mode enabled with adjusted health/metrics behavior when active.

* **Bug Fixes**
  * Removed or simplified several health probes and a deprecated processing-strategy argument to stabilize startup and readiness behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->