### PR TITLE
fix: add checksum and sync-wave annotations for ArgoCD configmap rest…

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/configmap.yaml
@@ -17,6 +17,8 @@ metadata:
   name: {{ include "csp-health-monitor.fullname" . }}
   labels:
     {{- include "csp-health-monitor.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 data:
   config.toml: |
     # Global settings

--- a/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/deployment.yaml
@@ -17,6 +17,8 @@ metadata:
   name: {{ include "csp-health-monitor.fullname" . }}
   labels:
     {{- include "csp-health-monitor.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -24,10 +26,12 @@ spec:
       {{- include "csp-health-monitor.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with ((.Values.global).podAnnotations | default .Values.podAnnotations) }}
       annotations:
+        # Force pod restart when configmap changes
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with ((.Values.global).podAnnotations | default .Values.podAnnotations) }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "csp-health-monitor.selectorLabels" . | nindent 8 }}
     spec:

--- a/distros/kubernetes/nvsentinel/charts/event-exporter/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/event-exporter/templates/configmap.yaml
@@ -18,6 +18,8 @@ metadata:
   name: {{ include "event-exporter.fullname" . }}
   labels:
     {{- include "event-exporter.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 data:
   config.toml: |
     [exporter.metadata]

--- a/distros/kubernetes/nvsentinel/charts/event-exporter/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/event-exporter/templates/deployment.yaml
@@ -18,6 +18,8 @@ metadata:
   name: {{ include "event-exporter.fullname" . }}
   labels:
     {{- include "event-exporter.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -25,10 +27,12 @@ spec:
       {{- include "event-exporter.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        # Force pod restart when configmap changes
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "event-exporter.labels" . | nindent 8 }}
     spec:

--- a/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/configmap.yaml
@@ -17,6 +17,8 @@ metadata:
   name: {{ include "fault-quarantine.fullname" . }}
   labels:
     {{- include "fault-quarantine.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 data:
   config.toml: |
     label-prefix = {{ .Values.labelPrefix | quote }}

--- a/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/deployment.yaml
@@ -17,6 +17,8 @@ metadata:
   name: {{ include "fault-quarantine.fullname" . }}
   labels:
     {{- include "fault-quarantine.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -24,10 +26,12 @@ spec:
       {{- include "fault-quarantine.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with ((.Values.global).podAnnotations | default .Values.podAnnotations) }}
       annotations:
+        # Force pod restart when configmap changes
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with ((.Values.global).podAnnotations | default .Values.podAnnotations) }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "fault-quarantine.selectorLabels" . | nindent 8 }}
     spec:

--- a/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/configmap.yaml
@@ -18,6 +18,8 @@ metadata:
   name: {{ include "fault-remediation.fullname" . }}
   labels:
     {{- include "fault-remediation.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 data:
   config.toml: |
     [template]

--- a/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/deployment.yaml
@@ -17,6 +17,8 @@ metadata:
   name: {{ include "fault-remediation.fullname" . }}
   labels:
     {{- include "fault-remediation.labels" . | nindent 4}}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -24,10 +26,12 @@ spec:
       {{- include "fault-remediation.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with ((.Values.global).podAnnotations | default .Values.podAnnotations) }}
       annotations:
+        # Force pod restart when configmap changes
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with ((.Values.global).podAnnotations | default .Values.podAnnotations) }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "fault-remediation.selectorLabels" . | nindent 8 }}
     spec:

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/configmap.yaml
@@ -16,6 +16,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "health-events-analyzer.fullname" . }}-config
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 data:
   config.toml: |
     {{ tpl .Values.config . | nindent 6 }}

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
@@ -18,6 +18,8 @@ metadata:
   name: {{ include "health-events-analyzer.fullname" . }}
   labels:
     {{- include "health-events-analyzer.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -25,10 +27,12 @@ spec:
       {{- include "health-events-analyzer.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        # Force pod restart when configmap changes
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "health-events-analyzer.labels" . | nindent 8 }}
     spec:

--- a/distros/kubernetes/nvsentinel/charts/incluster-file-server/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/incluster-file-server/templates/deployment.yaml
@@ -17,6 +17,8 @@ metadata:
   name: {{ include "incluster-file-server.fullname" . }}
   labels:
     {{- include "incluster-file-server.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: 1
   strategy:
@@ -185,6 +187,8 @@ metadata:
   name: {{ include "incluster-file-server.fullname" . }}-data
   labels:
     {{- include "incluster-file-server.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   accessModes:
 {{- range .Values.persistence.accessModes }}

--- a/distros/kubernetes/nvsentinel/charts/janitor-provider/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor-provider/templates/deployment.yaml
@@ -17,6 +17,8 @@ metadata:
   name: {{ include "provider.fullname" . }}
   labels:
     {{- include "provider.labels" . | nindent 4}}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/distros/kubernetes/nvsentinel/charts/janitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/templates/configmap.yaml
@@ -17,6 +17,8 @@ metadata:
   name: {{ include "janitor.fullname" . }}
   labels:
     {{- include "janitor.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 data:
   config.yaml: |
     global:

--- a/distros/kubernetes/nvsentinel/charts/janitor/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/templates/deployment.yaml
@@ -17,6 +17,8 @@ metadata:
   name: {{ include "janitor.fullname" . }}
   labels:
     {{- include "janitor.labels" . | nindent 4}}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -24,10 +26,12 @@ spec:
       {{- include "janitor.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with ((.Values.global).podAnnotations | default .Values.podAnnotations) }}
       annotations:
+        # Force pod restart when configmap changes
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with ((.Values.global).podAnnotations | default .Values.podAnnotations) }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "janitor.selectorLabels" . | nindent 8 }}
     spec:
@@ -133,4 +137,3 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-

--- a/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/configmap.yaml
@@ -18,6 +18,8 @@ metadata:
   name: {{ include "kubernetes-object-monitor.fullname" . }}
   labels:
     {{- include "kubernetes-object-monitor.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 data:
   config.toml: |
     {{- range .Values.policies }}

--- a/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/deployment.yaml
@@ -18,6 +18,8 @@ metadata:
   name: {{ include "kubernetes-object-monitor.fullname" . }}
   labels:
     {{- include "kubernetes-object-monitor.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/distros/kubernetes/nvsentinel/charts/labeler/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/labeler/templates/deployment.yaml
@@ -27,10 +27,7 @@ spec:
       {{- include "labeler.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      annotations:
-        # Force pod restart when configmap changes
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        &
+      {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/distros/kubernetes/nvsentinel/charts/labeler/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/labeler/templates/deployment.yaml
@@ -18,6 +18,8 @@ metadata:
   name: {{ include "labeler.fullname" . }}
   labels:
     {{- include "labeler.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -25,7 +27,10 @@ spec:
       {{- include "labeler.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      annotations:
+        # Force pod restart when configmap changes
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        &
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/distros/kubernetes/nvsentinel/charts/node-drainer/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/node-drainer/templates/configmap.yaml
@@ -17,6 +17,8 @@ metadata:
   name: {{ include "node-drainer.fullname" . }}
   labels:
     {{- include "node-drainer.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 data:
   config.toml: |
     evictionTimeoutInSeconds = {{ .Values.evictionTimeoutInSeconds | quote }}

--- a/distros/kubernetes/nvsentinel/charts/node-drainer/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/node-drainer/templates/deployment.yaml
@@ -17,6 +17,8 @@ metadata:
   name: {{ include "node-drainer.fullname" . }}
   labels:
     {{- include "node-drainer.labels" . | nindent 4}}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -24,10 +26,12 @@ spec:
       {{- include "node-drainer.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        # Force pod restart when configmap changes
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "node-drainer.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
Fixing ArgoCD doesn't restart deployments on configmap changes

- Add checksum/config annotation to deployments to restart pods when configmap changes
- Add sync-wave annotations: configmaps=-1, deployments=0 to ensure ordering
- Fixes HIPPO-4616: ArgoCD doesn't restart deployments on configmap changes

Affected charts:
- csp-health-monitor
- event-exporter
- fault-quarantine
- fault-remediation
- health-events-analyzer
- incluster-file-server
- janitor
- kubernetes-object-monitor
- labeler
- node-drainer

## Summary

<!-- Brief description of your changes -->

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [x] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment orchestration with synchronized rollout ordering across services.
  * Implemented automatic pod restart when configurations are updated, ensuring services run with the latest settings.
  * Improved reliability of configuration management across multiple services.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->