### PR TITLE
feat: add GPU reset image

### DIFF
--- a/.github/workflows/container-build-test.yml
+++ b/.github/workflows/container-build-test.yml
@@ -65,6 +65,9 @@ jobs:
             make_command: 'make -C log-collector docker-build-log-collector'
           - component: file-server-cleanup
             make_command: 'make -C log-collector docker-build-file-server-cleanup'
+          # GPU Reset (Docker-based)
+          - component: gpu-reset
+            make_command: 'make -C gpu-reset docker-build'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -58,6 +58,10 @@ jobs:
             make_command: 'make -C log-collector lint-log-collector'
             step_name: 'Run lint'
             replace_imports: 'false'
+          - component: gpu-reset
+            make_command: 'make -C gpu-reset lint'
+            step_name: 'Run lint'
+            replace_imports: 'false'
           - component: file-server-cleanup
             make_command: 'make -C log-collector lint-file-server-cleanup'
             step_name: 'Run lint'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,6 +117,9 @@ jobs:
           - component: file-server-cleanup
             make_command: 'make -C log-collector docker-publish-file-server-cleanup'
             container_name: 'nvsentinel/file-server-cleanup'
+          - component: gpu-reset
+            make_command: 'make -C gpu-reset docker-publish'
+            container_name: 'nvsentinel/gpu-reset'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ PYTHON_MODULES := \
 
 # Container-only modules
 CONTAINER_MODULES := \
-	log-collector
+	log-collector \
+    gpu-reset
 
 # Special modules requiring private repo access
 PRIVATE_MODULES := \
@@ -267,7 +268,7 @@ install-go-ci: ## Install Go $(GO_VERSION) for CI environments (Linux/macOS, amd
 
 # Lint and test all modules (delegates to sub-Makefiles)
 .PHONY: lint-test-all
-lint-test-all: protos-lint license-headers-lint gomod-lint health-monitors-lint-test-all go-lint-test-all python-lint-test-all kubernetes-distro-lint log-collector-lint ## Lint and test all modules
+lint-test-all: protos-lint license-headers-lint gomod-lint health-monitors-lint-test-all go-lint-test-all python-lint-test-all kubernetes-distro-lint log-collector-lint gpu-reset-lint ## Lint and test all modules
 
 # Health monitors lint-test (delegate to health-monitors/Makefile)
 .PHONY: health-monitors-lint-test-all
@@ -501,6 +502,12 @@ helm-lint:
 log-collector-lint: ## Lint shell scripts in log collector
 	@echo "Linting log collector shell scripts..."
 	$(MAKE) -C log-collector lint
+
+# GPU reset lint (shell script)
+.PHONY: gpu-reset-lint
+gpu-reset-lint: ## Lint shell scripts in GPU reset
+	@echo "Linting GPU reset shell scripts..."
+	$(MAKE) -C gpu-reset lint
 
 # Build targets (delegate to sub-Makefiles for better organization)
 .PHONY: build-all

--- a/gpu-reset/Dockerfile
+++ b/gpu-reset/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM nvidia/cuda:13.1.0-runtime-ubuntu24.04
+
+COPY gpu-reset/gpu_reset.sh /usr/local/bin/gpu_reset.sh
+
+RUN chmod +x /usr/local/bin/gpu_reset.sh
+
+ENTRYPOINT ["/usr/local/bin/gpu_reset.sh"]

--- a/gpu-reset/Makefile
+++ b/gpu-reset/Makefile
@@ -1,0 +1,53 @@
+# GPU reset Makefile
+# Individual module build and test targets (requires private repo access)
+#
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# =============================================================================
+# MODULE-SPECIFIC CONFIGURATION
+# =============================================================================
+
+HAS_DOCKER := 1
+
+# =============================================================================
+# INCLUDE SHARED DEFINITIONS
+# =============================================================================
+
+include ../make/common.mk
+include ../make/go.mk
+include ../make/docker.mk
+
+# =============================================================================
+# DEFAULT TARGET
+# =============================================================================
+
+.PHONY: all
+all: lint
+
+.PHONY: lint
+lint:
+	@echo "Linting GPU reset shell scripts..."
+	shellcheck gpu_reset.sh
+
+# =============================================================================
+# MODULE HELP
+# =============================================================================
+
+.PHONY: help
+help:
+	@echo "GPU reset Makefile - Using nvsentinel make/*.mk standards"
+	@echo ""
+	@echo "Main targets: all, lint"
+	@echo "Docker targets: docker, docker-build, docker-publish"

--- a/gpu-reset/Tiltfile
+++ b/gpu-reset/Tiltfile
@@ -1,0 +1,20 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+docker_build(
+    "ghcr.io/nvidia/nvsentinel/gpu-reset",
+    context="../..",
+    dockerfile="./Dockerfile",
+    build_args={"BUILD_TAGS": "fake"}
+)

--- a/gpu-reset/gpu_reset.sh
+++ b/gpu-reset/gpu_reset.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -eou pipefail
+
+# Performs a robust NVIDIA GPU reset workflow. This includes
+# safely managing persistence mode (PM), executing the reset,
+# restoring PM, and running a post-reset health check.
+#
+# USAGE:
+#   1. Reset all GPUs (default if NVIDIA_GPU_RESETS is unset or empty):
+#      ./gpu_reset.sh
+#
+#   2. Reset specific GPUs:
+#      NVIDIA_GPU_RESETS="GPU-123,GPU-456" ./gpu_reset.sh
+#
+# NOTES:
+#   - Requires root
+#   - Requires 'nvidia-smi'
+
+START_TIME=$(date +%s.%N)
+
+log() {
+  printf "(%s) %s\n" "$(date '+%Y-%m-%d %H:%M:%S')" "$*"
+}
+
+RESET_STATUS=0
+FINAL_EXIT_STATUS=0
+PM_STATES_FILE=$(mktemp)
+RESET_OUTPUT_FILE=$(mktemp)
+HEALTH_CHECK_OUTPUT_FILE=$(mktemp)
+trap 'rm -f -- "$PM_STATES_FILE" "$RESET_OUTPUT_FILE" "$HEALTH_CHECK_OUTPUT_FILE"' EXIT
+
+log "INFO: Starting GPU reset workflow..."
+
+#------------------
+# DETERMINE TARGETS
+#------------------
+
+log "INFO: Determining target devices..."
+IDS="${NVIDIA_GPU_RESETS:-}"
+
+if [ -z "$IDS" ]; then
+  IDS=$(nvidia-smi --query-gpu=uuid --format=csv,noheader | sed 's/^[[:space:]]*//' | tr '\n' ',' | sed 's/,$//')
+
+  if [ -z "$IDS" ]; then
+    log "ERROR: No specific devices provided, and no GPUs found on the node."
+    exit 1
+  fi
+
+  log "INFO: No specific devices provided. All GPUs will be reset."
+fi
+
+TARGET_UUIDS="$IDS"
+log "INFO: Targets:"
+echo "${TARGET_UUIDS}" | tr ',' '\n' | sed 's/^/  /'
+
+#-------------------------------------------
+# PRE-RESET PERSISTENCE MODE (PM) MANAGEMENT
+#-------------------------------------------
+
+log "INFO: Running pre-reset persistence mode (PM) management..."
+
+ORIGINAL_IFS=$IFS
+IFS=','
+for UUID in $TARGET_UUIDS; do
+  # Trim leading/trailing whitespace from UUID
+  UUID=$(echo "$UUID" | xargs)
+
+  if [ -z "$UUID" ]; then
+    continue
+  fi
+
+  if ! nvidia-smi -i "$UUID" >/dev/null 2>&1; then
+    log "WARN: Device not found or inaccessible: ${UUID}"
+    continue
+  fi
+
+  PM_STATUS=$(nvidia-smi -i "$UUID" --query-gpu=persistence_mode --format=csv,noheader | tr -d ' \r\n')
+
+  # Store original status for re-enabling
+  echo "${UUID}:${PM_STATUS}" >> "${PM_STATES_FILE}"
+
+  if [ "${PM_STATUS}" = "Enabled" ]; then
+    nvidia-smi -i "${UUID}" -pm 0 | grep -v "All done." | sed -e 's/\.$//' -e 's/^/  /'
+  fi
+done
+IFS=$ORIGINAL_IFS
+
+log "INFO: Pre-reset persistence mode (PM) management complete."
+
+#----------------
+# RESET EXECUTION
+#----------------
+
+log "INFO: Resetting GPUs..."
+
+if nvidia-smi --gpu-reset -i "${TARGET_UUIDS}" > "$RESET_OUTPUT_FILE" 2>&1; then
+  cat "$RESET_OUTPUT_FILE" | grep -v "All done." | sed -e 's/\.$//' -e 's/^/  /'
+  log "INFO: GPU reset complete."
+else
+  RESET_STATUS=$?
+  FINAL_EXIT_STATUS=$RESET_STATUS
+  log "ERROR: Reset failed. See details below:"
+  cat "$RESET_OUTPUT_FILE" | grep -v "All done." | sed 's/\.$//' | grep .
+fi
+
+#--------------------------------------------
+# POST-RESET PERSISTENCE MODE (PM) MANAGEMENT
+#--------------------------------------------
+
+log "INFO: Running post-reset persistence mode (PM) management..."
+
+while IFS= read -r line; do
+  ID=$(echo "$line" | cut -d: -f1)
+  ORIGINAL_STATUS=$(echo "$line" | cut -d: -f2)
+
+  if [ "${ORIGINAL_STATUS}" = "Enabled" ]; then
+    nvidia-smi -i "${ID}" -pm 1 | grep -v "All done." | sed -e 's/\.$//' -e 's/^/  /'
+  fi
+done < "${PM_STATES_FILE}"
+
+log "INFO: Post-reset persistence mode (PM) management complete."
+
+#------------------------
+# POST-RESET HEALTH CHECK
+#------------------------
+
+if [ "$FINAL_EXIT_STATUS" -eq 0 ]; then
+  log "INFO: Running post-reset health check..."
+
+  if nvidia-smi -q -i "$TARGET_UUIDS" > "$HEALTH_CHECK_OUTPUT_FILE" 2>&1; then
+    log "INFO: Post-reset health check passed."
+  else
+    log "ERROR: Post-reset health check failed. See details below:"
+    sed 's/^/  /' "$HEALTH_CHECK_OUTPUT_FILE"
+    FINAL_EXIT_STATUS=1
+  fi
+else
+  log "WARN: Post-reset health check skipped."
+fi
+
+#------------------------
+# SUMMARY
+#------------------------
+
+END_TIME=$(date +%s.%N)
+DURATION_RAW=$(awk "BEGIN {print ${END_TIME} - ${START_TIME}}")
+DURATION=$(printf "%.3f" "$DURATION_RAW")
+
+if [ "$FINAL_EXIT_STATUS" -ne 0 ]; then
+  log "FAILED: GPU reset workflow failed in ${DURATION}s."
+else
+  log "SUCCESS: GPU reset workflow completed in ${DURATION}s."
+
+  # Write "GPU reset executed" message to notify syslog-health-monitor of GPU reset success
+  ORIGINAL_IFS=$IFS
+  IFS=','
+  for UUID in $TARGET_UUIDS; do
+    # Trim leading/trailing whitespace from UUID
+    UUID=$(echo "$UUID" | xargs)
+
+    if [ -z "$UUID" ]; then
+      continue
+    fi
+
+    log "Writing reset success for ${UUID} to syslog"
+    logger -p daemon.err "GPU reset executed: ${UUID}"
+
+  done
+  IFS=$ORIGINAL_IFS
+fi
+
+exit "$FINAL_EXIT_STATUS"

--- a/scripts/build-image-list.sh
+++ b/scripts/build-image-list.sh
@@ -50,6 +50,7 @@ declare -a dynamic_images=(
   "${CONTAINER_REGISTRY}/${CONTAINER_ORG}/nvsentinel/file-server-cleanup:${SAFE_REF_NAME}"
   "${CONTAINER_REGISTRY}/${CONTAINER_ORG}/nvsentinel/gpu-health-monitor:${SAFE_REF_NAME}-dcgm-3.x"
   "${CONTAINER_REGISTRY}/${CONTAINER_ORG}/nvsentinel/gpu-health-monitor:${SAFE_REF_NAME}-dcgm-4.x"
+  "${CONTAINER_REGISTRY}/${CONTAINER_ORG}/nvsentinel/gpu-reset:${SAFE_REF_NAME}"
   "${CONTAINER_REGISTRY}/${CONTAINER_ORG}/nvsentinel/health-events-analyzer:${SAFE_REF_NAME}"
   "${CONTAINER_REGISTRY}/${CONTAINER_ORG}/nvsentinel/janitor:${SAFE_REF_NAME}"
   "${CONTAINER_REGISTRY}/${CONTAINER_ORG}/nvsentinel/janitor-provider:${SAFE_REF_NAME}"

--- a/scripts/check-image-attestations.sh
+++ b/scripts/check-image-attestations.sh
@@ -76,6 +76,7 @@ DOCKER_IMAGES=(
     "nvsentinel/syslog-health-monitor"
     "nvsentinel/log-collector"
     "nvsentinel/file-server-cleanup"
+    "nvsentinel/gpu-reset"
 )
 
 # Counters

--- a/tilt/Tiltfile
+++ b/tilt/Tiltfile
@@ -129,6 +129,7 @@ include('../health-monitors/kubernetes-object-monitor/Tiltfile')
 include('../health-monitors/syslog-health-monitor/Tiltfile')
 include('../labeler/Tiltfile')
 include('../log-collector/Tiltfile')
+include('../gpu-reset/Tiltfile')
 values_files = [
     '../distros/kubernetes/nvsentinel/values.yaml',
     '../distros/kubernetes/nvsentinel/values-tilt.yaml',


### PR DESCRIPTION
## Summary
Related design doc for GPU reset: https://github.com/NVIDIA/NVSentinel/blob/main/docs/designs/020-nvsentinel-gpu-reset.md.

This PR adds a GPUReset container image which will be leveraged as part of the GPUReset CRD in Janitor. When reconciling a GPUReset CRD, Janitor will create a job which uses this "ghcr.io/nvidia/nvsentinel/gpu-reset" container image. The GPUReset controller implementation will be added in a follow-up PR.

## Testing
This container image was tested as part of the WIP PR which enables GPUReset testing in NVSentinel: https://github.com/NVIDIA/NVSentinel/pull/768. Specifically, the UAT tests in that PR leverage a GPUReset image using the same bash script.

Example GPUReset CRD:
```
 apiVersion: v1
items:
- apiVersion: janitor.dgxc.nvidia.com/v1alpha1
  kind: GPUReset
  metadata:
    creationTimestamp: "2026-01-27T21:30:24Z"
    finalizers:
    - janitor.dgxc.nvidia.com/finalizer
    generation: 1
    name: gpureset-sample
    resourceVersion: "257575"
    uid: eb4bf110-16c8-40b8-a28f-e8025a9cf1f5
  spec:
    nodeName: node-1
    selector:
      uuids:
      - GPU-c8a5645c-cdb5-6d33-46f0-99725e85cc62
```
Example pod resulting from this CRD:
```
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: "2026-01-29T03:21:23Z"
  finalizers:
  - batch.kubernetes.io/job-tracking
  generateName: gpureset-sample-reset-job-
  labels:
    batch.kubernetes.io/controller-uid: ba3d7ce8-985e-4bda-8d4c-4584e50db6b4
    batch.kubernetes.io/job-name: gpureset-sample-reset-job
    controller-uid: ba3d7ce8-985e-4bda-8d4c-4584e50db6b4
    job-name: gpureset-sample-reset-job
  name: gpureset-sample-reset-job-9q5xj
  namespace: dgxc-janitor-system
  ownerReferences:
  - apiVersion: batch/v1
    blockOwnerDeletion: true
    controller: true
    kind: Job
    name: gpureset-sample-reset-job
    uid: ba3d7ce8-985e-4bda-8d4c-4584e50db6b4
  resourceVersion: "103126660"
  uid: 8fb2cf19-5c3e-4f97-9b9b-1d046b0a00a3
spec:
  containers:
  - env:
    - name: NVIDIA_GPU_RESETS
      value: GPU-c8a5645c-cdb5-6d33-46f0-99725e85cc62
    image: ghcr.io/nvidia/nvsentinel/gpu-reset:main-123
 nodeName: node-1
```

## Type of Change
- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [X] Janitor
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GPU reset component with an executable reset tool and container image.
* **CI / Release**
  * Integrated the GPU reset component into build, lint, test, and publish workflows so it’s built, linted, tested, and published automatically.
* **Tooling**
  * Included the GPU reset image in image lists and attestation checks and added local dev tooling support for Tilt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->