### PR TITLE
Make metrics-access network policy configurable

### DIFF
--- a/distros/kubernetes/nvsentinel/templates/networkpolicy.yaml
+++ b/distros/kubernetes/nvsentinel/templates/networkpolicy.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- if .Values.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -39,3 +40,4 @@ spec:
         - protocol: TCP
           port: {{ .Values.global.inclusterFileServer.cleanupMetricsPort }}
         {{- end }}
+{{- end }}

--- a/distros/kubernetes/nvsentinel/values.yaml
+++ b/distros/kubernetes/nvsentinel/values.yaml
@@ -97,6 +97,13 @@ global:
   preflight:
     enabled: false
 
+# Network policy configuration
+# The metrics-access network policy restricts ingress to metrics ports only.
+# This can block other services (e.g., cert-manager webhook) when deployed
+# in the same namespace. Set enabled=false to disable the network policy.
+networkPolicy:
+  enabled: true
+
 platformConnector:
   image:
     repository: ghcr.io/nvidia/nvsentinel/platform-connectors


### PR DESCRIPTION
## Summary

Add `networkPolicy.enabled` flag to allow users to disable the metrics-access network policy.

## Problem

The current `metrics-access` network policy only allows ingress on ports:
- 2112 (metrics)
- 9216 (MongoDB metrics)

This blocks all other ingress traffic, which causes issues when NVSentinel is deployed in the same namespace as other services. For example:

- **cert-manager webhook** (port 443) is blocked, causing `startupapicheck` to fail
- Any service requiring ingress on non-metrics ports will be affected

Error example from cert-manager startupapicheck:
```
failed calling webhook "webhook.cert-manager.io": Post "https://cert-manager-webhook.eidos-stack.svc:443/mutate": context deadline exceeded
```

## Solution

Add a configurable flag `networkPolicy.enabled` (default: `true`) that allows users to disable the network policy when needed:

```yaml
networkPolicy:
  enabled: false
```

This maintains backward compatibility (enabled by default) while giving users control over the network policy.

## Changes

- `templates/networkpolicy.yaml`: Wrap with `{{- if .Values.networkPolicy.enabled }}`
- `values.yaml`: Add `networkPolicy.enabled: true` with documentation

## Test plan

- [ ] Deploy with `networkPolicy.enabled: true` (default) - verify policy is created
- [ ] Deploy with `networkPolicy.enabled: false` - verify policy is not created
- [ ] Deploy alongside cert-manager in same namespace with policy disabled - verify webhook works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network policies are now optional and configurable, allowing operators to enable or disable them based on deployment requirements
  * Network policies are enabled by default to restrict access to metrics ports, with an option to disable in environments where conflicts may arise with other services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->