### PR TITLE
Use cuda image from NVCR to avoid rate limits

### DIFF
--- a/gpu-reset/Dockerfile
+++ b/gpu-reset/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM nvr.io/nvidia/cuda:13.1.0-runtime-ubuntu24.04
+FROM nvcr.io/nvidia/cuda:13.1.0-runtime-ubuntu24.04
 
 COPY gpu-reset/gpu_reset.sh /usr/local/bin/gpu_reset.sh
 

--- a/gpu-reset/Dockerfile
+++ b/gpu-reset/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM nvidia/cuda:13.1.0-runtime-ubuntu24.04
+FROM nvr.io/nvidia/cuda:13.1.0-runtime-ubuntu24.04
 
 COPY gpu-reset/gpu_reset.sh /usr/local/bin/gpu_reset.sh
 


### PR DESCRIPTION
## Summary

Use nvcr.io for cuda image

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the base image source for gpu-reset container builds to pull from an alternate registry while maintaining version compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->