### PR TITLE
docs: Add comprehensive guides for cluster scale operations and maint…

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,45 @@ For detailed module configuration, see the **[Helm Chart Configuration Guide](di
 - **[Metadata Collector](docs/metadata-collector.md)**: Gathers GPU and NVSwitch topology information
 - **[Log Collection](docs/log-collection.md)**: Collects diagnostic logs and GPU reports for troubleshooting
 
+## 📚 Documentation
+
+### Runbooks and Operational Guides
+
+NVSentinel provides comprehensive documentation for common operational scenarios:
+
+**Essential Reading**:
+- **[Maintenance Operations Guide](docs/runbooks/maintenance-operations.md)** - Complete guide for all maintenance scenarios (start here!)
+- **[Cluster Scale Operations](docs/runbooks/cluster-scale-operations.md)** - Prevent circuit breaker trips during node scale-up and cluster bringup
+- **[Circuit Breaker Troubleshooting](docs/runbooks/circuit-breaker.md)** - Reset and troubleshoot circuit breaker trips
+- **[Driver Upgrades](docs/runbooks/driver-upgrades.md)** - Safely upgrade GPU drivers and GPU Operator
+
+**Additional Resources**:
+- [All Runbooks](docs/runbooks/) - Complete list of troubleshooting guides
+- [Architecture Decision Records (ADRs)](docs/designs/) - Design decisions and rationale
+- [Component Documentation](docs/) - Detailed docs for each NVSentinel component
+
+### Key Topics
+
+#### Preventing Circuit Breaker Issues
+
+The most common operational issue is the circuit breaker tripping during legitimate operations like:
+- Initial GPU node bringup (CPU → GPU cluster transitions)
+- Autoscaling events (Karpenter, Cluster Autoscaler)
+- GPU driver or operator upgrades
+- Node maintenance operations
+
+**Solution**: Label nodes to exclude them from NVSentinel management during transitional states:
+
+```bash
+# Before maintenance/scale-up
+kubectl label node <NODE_NAME> k8saas.nvidia.com/ManagedByNVSentinel=false
+
+# After nodes are healthy
+kubectl label node <NODE_NAME> k8saas.nvidia.com/ManagedByNVSentinel-
+```
+
+See the [Cluster Scale Operations](docs/runbooks/cluster-scale-operations.md) guide for detailed procedures.
+
 ## 📋 Requirements
 
 - **Kubernetes**: 1.25 or later

--- a/docs/designs/027-automated-node-labeling.md
+++ b/docs/designs/027-automated-node-labeling.md
@@ -1,0 +1,301 @@
+# ADR-027: Node Management — Automated Node Labeling for Scale Operations
+
+## Context
+
+NVSentinel's circuit breaker is designed to prevent too many nodes from being cordoned simultaneously when widespread health issues are detected. It monitors the percentage of nodes that become unhealthy within a time window (default: 50% within 5 minutes) and trips when the threshold is exceeded.
+
+However, during legitimate cluster scale operations (initial GPU node bringup, autoscaling, capacity expansion), newly provisioned nodes go through an initialization phase where GPU components (drivers, GPU Operator, DCGM) are not yet ready. From NVSentinel's perspective, these transitioning nodes appear unhealthy, triggering the circuit breaker despite no actual failures occurring.
+
+### Current Challenges
+
+1. **Services inside the cluster cannot distinguish between scale-up and failure**: A controller running in-cluster sees nodes coming online but doesn't know if they're new nodes or existing nodes recovering from maintenance/failure.
+
+2. **Circuit breaker trips during legitimate operations**:
+   - Small clusters (1-2 nodes): Adding even 1 node represents 50%+ of cluster
+   - Initial bringup: CPU-only cluster → add GPU nodes exceeds threshold
+   - Rapid autoscaling: Inference workloads triggering Karpenter to provision many nodes
+   - Multi-zone expansion: Multiple nodes coming online simultaneously
+
+3. **Manual workaround is error-prone**: Current solution requires operators to manually label nodes with `k8saas.nvidia.com/ManagedByNVSentinel=false` before scale operations, then remove the label after nodes are healthy. This is:
+   - Forgotten during time-pressured operations
+   - Not integrated into automated workflows
+   - Inconsistently applied across teams
+   - Similar to the manual labeling required during OSMO maintenance upgrades
+
+4. **Similar to previously solved GPU Operator timing issue**: This mirrors the GPU Operator race condition where the runtime controller checked for cluster-policy readiness before GPU resources were available. That was solved with preflight checks at the orchestration layer.
+
+### Options Considered
+
+**Option A: Higher-order orchestration** (e.g., runtime controller, GitOps)
+- Pros: Can see cluster spec and expected node count, knows scale operations are happening
+- Cons: Only works for centrally managed clusters, not for user-managed Karpenter/autoscaling
+
+**Option B: Webhook-based automatic labeling** (Kubernetes admission controller)
+- Pros: Automatic, works for all provisioning methods
+- Cons: Requires additional component, adds complexity
+
+**Option C: Node initialization controller** (DaemonSet + operator pattern)
+- Pros: Self-contained, works across provisioning methods
+- Cons: Adds another component, timing-dependent
+
+**Option D: Enhanced circuit breaker logic** (node age awareness)
+- Pros: No external changes needed
+- Cons: Circuit breaker still can't distinguish new vs. recovered nodes
+
+**Option E: Manual labeling with better documentation** (current state + docs)
+- Pros: Simple, no code changes, works today
+- Cons: Requires manual intervention, error-prone
+
+## Decision
+
+Implement a **phased approach** combining multiple solutions:
+
+### Phase 1: Enhanced Documentation (Immediate)
+Create comprehensive runbooks documenting:
+- When and why circuit breaker trips during scale operations
+- Step-by-step procedures for manual labeling
+- Examples for common scenarios (initial bringup, autoscaling, multi-zone)
+- Integration with infrastructure-as-code tools (Terraform, Pulumi)
+- Reference to similar maintenance procedures (OSMO upgrades, driver upgrades)
+
+### Phase 2: Orchestration Layer Integration (Medium-term)
+For centrally managed clusters using runtime controllers or GitOps:
+- Implement scale-operation awareness in higher-order controllers
+- Automatically apply `k8saas.nvidia.com/ManagedByNVSentinel=false` label during orchestrated operations
+- Monitor node health and automatically remove label when ready
+- Similar to how the runtime controller solved GPU Operator timing issues
+
+### Phase 3: Admission Controller (Long-term - Optional)
+For clusters where users directly provision nodes (Karpenter, manual kubectl):
+- Develop validating/mutating webhook admission controller
+- Automatically inject `k8saas.nvidia.com/ManagedByNVSentinel=false` label on new GPU nodes
+- Use node initialization signals to determine when to remove label
+- Make this optional/configurable per cluster
+
+## Implementation
+
+### Phase 1: Documentation (This ADR's Scope)
+
+#### New Runbook: `docs/runbooks/cluster-scale-operations.md`
+- Overview of the problem
+- Common scenarios (initial bringup, autoscaling, expansion)
+- Step-by-step procedures for:
+  - Manual labeling workflow
+  - Troubleshooting circuit breaker trips during scale operations
+  - Resetting circuit breaker with appropriate cursor mode
+- Integration examples:
+  - Terraform/Pulumi scripts
+  - Karpenter/Cluster Autoscaler configurations
+  - GitOps workflows
+- Automation approaches for different platforms
+
+#### Update Existing Documentation
+- `docs/runbooks/circuit-breaker.md`: Add section on scale operations
+- `docs/runbooks/driver-upgrades.md`: Cross-reference scale operations runbook
+- `README.md`: Link to scale operations guidance
+
+### Phase 2: Orchestration Integration (Future Implementation)
+
+#### For Runtime Controllers
+```go
+// Conceptual example - not actual implementation
+func (r *Reconciler) ScaleGPUNodePool(ctx context.Context, desired int) error {
+    // 1. Read expected node count from cluster spec
+    expectedNodes := desired
+    
+    // 2. Label existing nodes before scale operation
+    if err := r.labelNodesForScaleOperation(ctx); err != nil {
+        return err
+    }
+    
+    // 3. Trigger node pool scale-up
+    if err := r.scaleNodePool(ctx, desired); err != nil {
+        return err
+    }
+    
+    // 4. Wait for GPU Operator to be ready on new nodes
+    if err := r.waitForGPUOperator(ctx, expectedNodes); err != nil {
+        return err
+    }
+    
+    // 5. Wait for DCGM health on all nodes
+    if err := r.waitForDCGMHealthy(ctx, expectedNodes); err != nil {
+        return err
+    }
+    
+    // 6. Remove NVSentinel exclusion labels
+    if err := r.unlabelNodesAfterScaleOperation(ctx); err != nil {
+        return err
+    }
+    
+    return nil
+}
+```
+
+**Integration Points:**
+- Runtime controller's node pool management logic
+- Maintenance API (similar to OSMO upgrades)
+- Cluster lifecycle hooks
+
+### Phase 3: Admission Controller (Future - Optional)
+
+#### Architecture
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Kubernetes API Server                                       │
+│  ┌──────────────────────────────────────────────────────┐  │
+│  │ Node Creation Request                                 │  │
+│  └────────────────────┬─────────────────────────────────┘  │
+│                       │                                     │
+│                       ▼                                     │
+│  ┌──────────────────────────────────────────────────────┐  │
+│  │ Mutating Webhook: nvsentinel-node-labeler            │  │
+│  │ - Check if node has GPU labels                       │  │
+│  │ - Inject: k8saas.nvidia.com/ManagedByNVSentinel=false│  │
+│  │ - Inject: node-initializing=true                     │  │
+│  └────────────────────┬─────────────────────────────────┘  │
+│                       │                                     │
+│                       ▼                                     │
+│  ┌──────────────────────────────────────────────────────┐  │
+│  │ Node Created with Labels                             │  │
+│  └──────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+                       │
+                       ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Node Initialization Controller (DaemonSet)                  │
+│  ┌──────────────────────────────────────────────────────┐  │
+│  │ Watch for nodes with node-initializing=true          │  │
+│  │ - Wait for GPU Operator pods Ready                   │  │
+│  │ - Wait for DCGM connectivity                         │  │
+│  │ - Wait for driver loaded                             │  │
+│  │ - Remove both labels when healthy                    │  │
+│  └──────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Components:**
+1. **Mutating Webhook**: Injects labels on GPU node creation
+2. **Initialization Controller**: Monitors node health and removes labels
+3. **Configuration**: Per-cluster opt-in via Helm values
+
+## Rationale
+
+### Why Phased Approach?
+
+1. **Immediate Value**: Phase 1 provides immediate relief through better documentation - users know how to handle this issue today
+
+2. **Targeted Automation**: Phase 2 automates for the most common use case (centrally managed clusters) without adding complexity for all users
+
+3. **Optional Complexity**: Phase 3 handles the remaining cases (user-managed autoscaling) but as an opt-in feature
+
+4. **Proven Pattern**: Follows the same pattern used to solve GPU Operator timing issues - orchestration layer awareness
+
+### Why Not Automatic in All Cases?
+
+The core issue is **information asymmetry**: services inside the cluster don't have context about higher-order operations. There's no universal way for NVSentinel (running in-cluster) to know:
+- If a node is new (scale-up) vs. existing (break-fix recovery)
+- How many total nodes are expected
+- Whether a scale operation is in progress
+
+The best solution depends on **who controls the provisioning**:
+- **Centrally managed**: Higher-order controller has the context → automate there (Phase 2)
+- **User-managed**: Users control provisioning → provide tools/docs (Phase 1, Phase 3)
+
+## Consequences
+
+### Positive
+
+1. **Immediate improvement**: Documentation helps users today without code changes
+2. **Reduces operational burden**: Automation in orchestration layer eliminates manual steps for most users
+3. **Prevents circuit breaker trips**: Proper labeling prevents false-positive trips during legitimate operations
+4. **Follows established patterns**: Similar to GPU Operator timing fix and OSMO maintenance procedures
+5. **Flexible**: Users can choose manual, orchestrated, or automatic approaches based on their setup
+
+### Negative
+
+1. **Not fully automatic**: Still requires user awareness for ad-hoc scale operations
+2. **Multiple solutions**: Different approaches for different scenarios increases documentation complexity
+3. **Phase 2/3 require development**: Orchestration integration and admission controller need implementation effort
+4. **Admission controller overhead**: Phase 3 adds webhook latency to node creation
+
+### Mitigations
+
+1. **Clear documentation**: Comprehensive runbooks explain when and how to use each approach
+2. **Sensible defaults**: Most common case (orchestrated) gets automated first
+3. **Opt-in complexity**: Admission controller is optional, only for users who need it
+4. **Cross-references**: Link related docs (circuit breaker, driver upgrades, OSMO maintenance)
+
+## Alternatives Considered
+
+### Make Circuit Breaker "Smarter" (Node Age Awareness)
+
+**Approach**: Modify circuit breaker to ignore nodes younger than N minutes.
+
+**Rejected because**:
+- Still can't distinguish "new node being provisioned" from "existing node that just rebooted"
+- Would require storing node creation timestamps and tracking state
+- Could mask real issues with newly rebooted nodes
+- Adds complexity to circuit breaker logic that should remain simple
+
+### Disable Circuit Breaker by Default
+
+**Approach**: Make circuit breaker opt-in rather than opt-out.
+
+**Rejected because**:
+- Circuit breaker is a critical safety mechanism for production
+- Would increase risk of widespread cordoning during legitimate issues
+- Removes important protection for users who don't understand the implications
+- Better to solve the scale-up problem than remove the safety mechanism
+
+### Taint-Based Handoff (Similar to Skyhook → GPU Operator → NVSentinel)
+
+**Approach**: Use multi-layer taints where each system removes its taint when ready.
+
+**Rejected because**:
+- Requires changes to multiple systems (node provisioner, GPU Operator, NVSentinel)
+- More complex to debug when issues occur
+- Still doesn't solve the circuit breaker threshold issue (nodes are still "unhealthy")
+- Taint handoff is for scheduling, not health monitoring
+
+### Separate Circuit Breakers for New vs. Existing Nodes
+
+**Approach**: Track new vs. existing nodes separately with different thresholds.
+
+**Rejected because**:
+- No reliable way to determine "new" vs. "existing" from inside the cluster
+- Would require persistent state about all nodes
+- Adds significant complexity to circuit breaker logic
+- Doesn't solve the fundamental information asymmetry problem
+
+## Notes
+
+### Related Issues and Discussions
+
+- HIPPO-5214: Circuit breaker tripped during cluster bringup (EKS CPU → GPU flow)
+- Similar to GPU Operator cluster-policy timing bug (solved via runtime controller preflight checks)
+- OSMO maintenance process already uses this label-based approach successfully
+
+### Non-Goals
+
+- **Automatic detection of scale operations**: Not attempting to make NVSentinel "know" when scale operations happen - this requires higher-order context
+- **Replacing circuit breaker**: Circuit breaker remains essential safety mechanism
+- **Universal automation**: Different provisioning methods (Terraform, Karpenter, manual) may require different approaches
+
+### Future Considerations
+
+1. **Cloud provider integrations**: Could leverage cloud provider APIs (AWS ASG events, GCP MIG operations) to detect scale operations
+2. **Maintenance API enhancement**: Extend existing maintenance API to cover scale operations explicitly
+3. **Standardized node lifecycle hooks**: Kubernetes SIG-Node discussions around standardized init/ready signals
+4. **Metrics and alerting**: Add metrics for nodes with exclusion labels, alert if labels remain too long
+
+## References
+
+- [Runbook: Cluster Bringup and Node Scale Operations](../runbooks/cluster-scale-operations.md)
+- [Runbook: Circuit Breaker](../runbooks/circuit-breaker.md)
+- [Runbook: Driver Upgrades](../runbooks/driver-upgrades.md)
+- [ADR-022: Circuit Breaker Reset Mechanism](022-circuit-breaker-reset-mechanism.md)
+- HIPPO-5214: Circuit breaker tripped during EKS cluster bringup
+- GPU Operator timing issue discussion (internal)
+- OSMO maintenance procedures (internal)
+

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -4,13 +4,17 @@ This directory contains troubleshooting runbooks for NVSentinel operations.
 
 ## Available Runbooks
 
+### Maintenance Operations
+- [Maintenance Operations Guide](maintenance-operations.md) - **START HERE** - Comprehensive guide for all maintenance scenarios
+- [Cluster Scale Operations](cluster-scale-operations.md) - Prevent circuit breaker trips during node scale-up and initial bringup
+- [Driver Upgrades](driver-upgrades.md) - Safely upgrade GPU drivers without triggering circuit breaker
+
 ### Core System Issues
 - [Circuit Breaker Troubleshooting](circuit-breaker.md) - Reset a tripped circuit breaker after mass cordon events
 - [Cordoned Nodes](cordoned-nodes.md) - Investigate and remediate cordoned nodes
 - [Node Conditions](node-conditions.md) - Handle nodes with health conditions but not cordoned
 - [Stale Events](stale-events.md) - Clear accumulated events after system downtime
 - [Datastore Connection](datastore-connection.md) - Connect to MongoDB for health event queries
-- [Driver Upgrades](driver-upgrades.md) - Runbook for driver upgrade
 
 ### Platform Connector Issues
 - [Node Event Creation Failures](node-event-creation-failures.md) - Resolve failures when creating Kubernetes node events

--- a/docs/runbooks/circuit-breaker.md
+++ b/docs/runbooks/circuit-breaker.md
@@ -9,6 +9,41 @@ This runbook guides you through investigating and resetting a tripped circuit br
 - In-progress remediation continues, but no new actions are taken
 - Only reset after investigating and fixing the root cause
 
+## Common Scenarios
+
+### Cluster Scale Operations
+
+Circuit breakers often trip during **legitimate cluster operations** such as:
+
+- **Initial cluster bringup**: Creating a CPU-only cluster, then adding GPU node pools
+- **Autoscaling events**: Karpenter/Cluster Autoscaler rapidly provisioning nodes
+- **Capacity expansion**: Adding new node pools after receiving GPU quota
+- **Multi-zone expansion**: Adding nodes across multiple availability zones
+
+**Why**: New GPU nodes appear "unhealthy" during initialization (GPU driver, GPU Operator, DCGM not ready). On small clusters, even adding 1 node can exceed the threshold.
+
+**Prevention**: Label nodes before scale operations:
+
+```bash
+# Before adding nodes
+kubectl label node --all k8saas.nvidia.com/ManagedByNVSentinel=false
+
+# After nodes are healthy
+kubectl label node --all k8saas.nvidia.com/ManagedByNVSentinel-
+```
+
+See [Cluster Scale Operations](cluster-scale-operations.md) for detailed procedures.
+
+### GPU Driver Upgrades
+
+During driver/GPU Operator upgrades, DCGM becomes temporarily unavailable. Parallel upgrades can trip the breaker.
+
+See [Driver Upgrades](driver-upgrades.md) for procedures.
+
+### Node Maintenance
+
+OS maintenance (OSMO), node reboots, or infrastructure work affecting multiple nodes simultaneously.
+
 ## Procedure
 
 ### 1. Verify Status
@@ -110,3 +145,11 @@ kubectl get cm circuit-breaker -n nvsentinel -o jsonpath='{.data.status}'
 # Monitor nodes
 kubectl get nodes -w
 ```
+
+## Related Documentation
+
+- [Cluster Scale Operations](cluster-scale-operations.md) - Preventing circuit breaker trips during node scale-up
+- [Driver Upgrades](driver-upgrades.md) - Managing circuit breaker during GPU driver upgrades  
+- [ADR-022: Circuit Breaker Reset Mechanism](../designs/022-circuit-breaker-reset-mechanism.md) - Design details on cursor modes
+- [ADR-027: Automated Node Labeling](../designs/027-automated-node-labeling.md) - Future automation for scale operations
+

--- a/docs/runbooks/cluster-scale-operations.md
+++ b/docs/runbooks/cluster-scale-operations.md
@@ -1,0 +1,448 @@
+# Runbook: Cluster Bringup and Node Scale Operations
+
+## Overview
+
+This runbook provides procedures for safely scaling GPU nodes (both during initial cluster bringup and autoscaling operations) while preventing NVSentinel's circuit breaker from tripping due to nodes being in a transitional state.
+
+## Background
+
+### The Problem
+
+When GPU nodes are added to a cluster (whether during initial bringup or scale-up operations), they go through several initialization phases:
+1. Node joins the cluster
+2. GPU drivers are loaded
+3. GPU Operator components are deployed
+4. DCGM and other monitoring tools become available
+5. Node becomes fully healthy and ready
+
+During phases 1-4, NVSentinel's health checks may fail because:
+- DCGM is not yet available
+- GPU drivers are still initializing
+- GPU Operator pods are still being deployed
+
+### Why the Circuit Breaker Trips
+
+NVSentinel's circuit breaker monitors the **percentage** of nodes that become unhealthy within a time window (default: 50% within 5 minutes). When you scale up nodes:
+
+- **Small clusters** (1-2 nodes): Adding even 1 node represents 50%+ of the cluster
+- **Rapid scale-up**: Adding many nodes simultaneously can exceed the threshold
+- **Initial bringup**: Starting with CPU-only cluster, then adding GPU nodes creates a large percentage change
+
+When the threshold is exceeded, NVSentinel's circuit breaker trips to protect against what it perceives as a widespread cluster issue.
+
+### Circuit Breaker Behavior
+
+Once tripped:
+- No new node remediation actions will be performed
+- GPU nodes may remain cordoned even after they become healthy
+- Requires manual intervention to reset (see [circuit-breaker.md](circuit-breaker.md))
+
+## Common Scenarios
+
+### Scenario 1: Initial Cluster Bringup (CPU → GPU)
+
+**Use Case:** Creating a CPU-only cluster first, installing runtime components, then adding GPU node pools.
+
+**Why This Happens:** This workflow allows teams to set up cluster infrastructure before GPU capacity arrives, but NVSentinel doesn't distinguish between "new nodes being added" and "existing nodes failing."
+
+**Risk Level:** ⚠️ **HIGH** - Almost guaranteed to trip the circuit breaker on small clusters
+
+### Scenario 2: Autoscaling with Karpenter/Cluster Autoscaler
+
+**Use Case:** Automatic horizontal scaling in response to workload demands.
+
+**Why This Happens:** Large batch jobs or inference workloads can trigger rapid scale-up of many GPU nodes simultaneously.
+
+**Risk Level:** ⚠️ **MEDIUM** - Depends on scale-up speed and cluster size
+
+### Scenario 3: Manual Node Pool Addition
+
+**Use Case:** Adding capacity after receiving additional GPU quota.
+
+**Why This Happens:** Teams manually add node pools or resize existing ones.
+
+**Risk Level:** ⚠️ **MEDIUM** - Depends on the percentage of nodes being added
+
+### Scenario 4: Multi-Zone Expansion
+
+**Use Case:** Adding GPU nodes across multiple availability zones simultaneously.
+
+**Why This Happens:** High-availability requirements or capacity distribution.
+
+**Risk Level:** ⚠️ **HIGH** - Multiple nodes coming online simultaneously
+
+## Recommended Procedures
+
+### Option 1: Disable NVSentinel Management During Scale Operations (Recommended)
+
+This is the **safest and most reliable** approach for planned scale operations.
+
+#### Step 1: Label Nodes to Exclude from NVSentinel Management
+
+**Before adding new nodes**, apply the exclusion label to prevent NVSentinel from managing them during initialization:
+
+```bash
+# For existing nodes that will be part of the operation
+kubectl label node <NODE_NAME> k8saas.nvidia.com/ManagedByNVSentinel=false
+
+# For all nodes during initial bringup
+kubectl label node --all k8saas.nvidia.com/ManagedByNVSentinel=false
+```
+
+**Note:** If your infrastructure supports it, configure your node provisioning system to automatically apply this label during node creation.
+
+#### Step 2: Perform Scale-Up Operation
+
+Add your GPU nodes using your standard provisioning workflow:
+- Update EKS/GKE/AKS node pool configurations
+- Deploy via Terraform/Helm/kubectl
+- Trigger Karpenter/Cluster Autoscaler
+- Run your infrastructure automation
+
+#### Step 3: Validate GPU Node Health
+
+Wait for all GPU components to become healthy before proceeding:
+
+```bash
+# Check that GPU Operator pods are running on new nodes
+kubectl get po -n gpu-operator -o wide
+
+# Verify DCGM is accessible on new nodes
+kubectl get po -n gpu-operator | grep dcgm
+
+# Check node conditions
+kubectl get nodes -o wide
+
+# Validate that nodes are Ready and not cordoned
+kubectl get nodes | grep -v SchedulingDisabled
+```
+
+**Wait until:**
+- All GPU Operator pods are `Running` and `Ready`
+- Nodes show `Ready` status
+- No nodes are cordoned
+- DCGM metrics are being collected
+
+#### Step 4: Re-enable NVSentinel Management
+
+Once nodes are fully healthy, remove the exclusion label:
+
+```bash
+# For specific nodes
+kubectl label node <NODE_NAME> k8saas.nvidia.com/ManagedByNVSentinel-
+
+# For all nodes
+kubectl label node --all k8saas.nvidia.com/ManagedByNVSentinel-
+```
+
+#### Step 5: Monitor for Issues
+
+After re-enabling management, monitor for 15-30 minutes:
+
+```bash
+# Check circuit breaker status
+kubectl get cm circuit-breaker -n nvsentinel -o yaml
+
+# Watch for cordoned nodes
+kubectl get nodes | grep SchedulingDisabled
+
+# Check NVSentinel metrics
+kubectl logs -n nvsentinel -l app=fault-quarantine --tail=50
+```
+
+### Option 2: Disable Circuit Breaker for Non-Production Environments
+
+For **development, testing, or staging environments only**, you can disable the circuit breaker entirely.
+
+⚠️ **WARNING:** Do not disable the circuit breaker in production environments. It is a critical safety mechanism.
+
+#### Configuration
+
+In your Helm values:
+
+```yaml
+fault-quarantine:
+  circuitBreaker:
+    enabled: false
+```
+
+Then upgrade your NVSentinel installation:
+
+```bash
+helm upgrade nvsentinel <chart> -n nvsentinel -f values.yaml
+```
+
+**When to use this option:**
+- Small test/dev clusters (< 5 nodes)
+- Environments where cluster stability is not critical
+- Temporary testing scenarios
+
+**Do NOT use this option for:**
+- Production clusters
+- Clusters running critical workloads
+- Shared/multi-tenant environments
+
+### Option 3: Adjust Circuit Breaker Thresholds
+
+For large clusters with gradual scale-up patterns, you can adjust thresholds to reduce false positives.
+
+```yaml
+fault-quarantine:
+  circuitBreaker:
+    enabled: true
+    percentage: 70      # Increase from default 50%
+    duration: "10m"     # Increase from default 5m
+```
+
+**Considerations:**
+- Higher percentage = more nodes can be cordoned before tripping
+- Longer duration = slower response to legitimate widespread issues
+- This is a **band-aid solution** - Option 1 is still recommended
+
+**Recommended settings by cluster size:**
+- **1-10 nodes:** Use Option 1 (labeling) or Option 2 (disable for non-prod)
+- **10-50 nodes:** `percentage: 60-70%`, `duration: "10m"`
+- **50+ nodes:** Default settings usually work, but use Option 1 for large scale-ups
+
+## Advanced: Automating the Label Process
+
+### For Node Provisioning Systems
+
+If your infrastructure supports node initialization hooks, you can automate the labeling process:
+
+#### Example: Kubernetes Node Taints + Labels
+
+During node provisioning, apply a temporary taint and the NVSentinel exclusion label:
+
+```yaml
+# Node template configuration
+apiVersion: v1
+kind: Node
+metadata:
+  labels:
+    k8saas.nvidia.com/ManagedByNVSentinel: "false"
+  taints:
+  - key: "node.kubernetes.io/not-ready"
+    effect: "NoSchedule"
+```
+
+Then use a DaemonSet or init controller to:
+1. Wait for GPU Operator to be healthy
+2. Remove the exclusion label
+3. Remove the taint
+
+#### Example: Terraform/Pulumi
+
+```hcl
+# Terraform example
+resource "kubernetes_node_pool" "gpu_nodes" {
+  # ... other configuration ...
+  
+  node_labels = {
+    "k8saas.nvidia.com/ManagedByNVSentinel" = "false"
+  }
+}
+
+# Use a null_resource with local-exec to remove label after health checks
+resource "null_resource" "enable_nvsentinel" {
+  depends_on = [kubernetes_node_pool.gpu_nodes]
+  
+  provisioner "local-exec" {
+    command = <<-EOT
+      # Wait for nodes to be healthy
+      kubectl wait --for=condition=Ready nodes -l your-node-selector --timeout=10m
+      
+      # Remove exclusion label
+      kubectl label nodes -l your-node-selector k8saas.nvidia.com/ManagedByNVSentinel-
+    EOT
+  }
+}
+```
+
+### For GitOps/Runtime Controllers
+
+If you use a runtime controller or GitOps system, implement preflight checks similar to the GPU Operator timing fix:
+
+```go
+// Pseudocode example
+func ScaleUpGPUNodes(desiredCount int) error {
+    // 1. Label all existing nodes
+    LabelAllNodes("k8saas.nvidia.com/ManagedByNVSentinel", "false")
+    
+    // 2. Perform scale-up
+    ScaleNodePool(desiredCount)
+    
+    // 3. Wait for GPU Operator to be ready
+    WaitForGPUOperatorReady()
+    
+    // 4. Wait for DCGM to be accessible on all nodes
+    WaitForDCGMHealthy()
+    
+    // 5. Remove labels
+    RemoveLabelFromAllNodes("k8saas.nvidia.com/ManagedByNVSentinel")
+    
+    return nil
+}
+```
+
+## Comparison with GPU Operator Timing Issues
+
+This issue is analogous to the GPU Operator race condition that was previously addressed:
+
+| Issue | GPU Operator Timing Bug | NVSentinel Circuit Breaker Trip |
+|-------|------------------------|--------------------------------|
+| **Symptom** | Cluster Policy not ready when checked | Nodes cordoned during scale-up |
+| **Root Cause** | Controller checked before GPU resources ready | Too many nodes unhealthy at once |
+| **Solution** | Added preflight checks for GPU presence | Label nodes during scale operations |
+| **Location** | Runtime controller | Infrastructure/GitOps layer |
+
+Both issues stem from the same problem: **services running inside the cluster cannot distinguish between scale-up and failure scenarios**.
+
+## Troubleshooting
+
+### Circuit Breaker Tripped During Scale-Up
+
+**Symptoms:**
+- Circuit breaker status shows `TRIPPED`
+- New GPU nodes are cordoned
+- Nodes appear healthy but remain unavailable
+
+**Resolution:**
+
+1. Verify nodes are actually healthy:
+```bash
+kubectl get nodes
+kubectl describe node <NODE_NAME>
+kubectl get po -n gpu-operator -o wide
+```
+
+2. If nodes are healthy, reset the circuit breaker:
+```bash
+# Option A: Skip accumulated events (recommended for scale-up scenarios)
+kubectl patch configmap circuit-breaker -n nvsentinel \
+  -p '{"data":{"status":"CLOSED","cursor":"CREATE"}}'
+
+# Option B: Process accumulated events
+kubectl patch configmap circuit-breaker -n nvsentinel \
+  -p '{"data":{"status":"CLOSED","cursor":"RESUME"}}'
+
+# Restart fault-quarantine
+kubectl rollout restart deployment fault-quarantine -n nvsentinel
+```
+
+3. Uncordon nodes if necessary:
+```bash
+kubectl uncordon <NODE_NAME>
+```
+
+4. Apply the exclusion label to prevent future issues:
+```bash
+kubectl label node <NODE_NAME> k8saas.nvidia.com/ManagedByNVSentinel=false
+```
+
+5. Once stable, remove the label:
+```bash
+kubectl label node <NODE_NAME> k8saas.nvidia.com/ManagedByNVSentinel-
+```
+
+### Autoscaler Repeatedly Triggers Circuit Breaker
+
+**Problem:** Karpenter or Cluster Autoscaler rapidly scales up, causing repeated circuit breaker trips.
+
+**Solutions:**
+
+1. **Implement gradual scale-up** in your autoscaler configuration:
+```yaml
+# Karpenter example
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: gpu-provisioner
+spec:
+  limits:
+    resources:
+      nvidia.com/gpu: 100
+  # Add gradual scale-up constraints
+  consolidation:
+    enabled: true
+  ttlSecondsAfterEmpty: 300
+```
+
+2. **Use automation** to apply labels during autoscale events (see "Advanced: Automating the Label Process" above)
+
+3. **Adjust circuit breaker thresholds** for your workload patterns
+
+### Nodes Remain Cordoned After Scale-Up
+
+**Problem:** Even after circuit breaker is reset, nodes stay cordoned.
+
+**Diagnosis:**
+```bash
+# Check node conditions
+kubectl describe node <NODE_NAME> | grep -A 10 Conditions
+
+# Check node taints
+kubectl describe node <NODE_NAME> | grep Taints
+```
+
+**Resolution:**
+```bash
+# Manually uncordon if node is healthy
+kubectl uncordon <NODE_NAME>
+
+# Check NVSentinel logs for the reason
+kubectl logs -n nvsentinel -l app=fault-quarantine | grep <NODE_NAME>
+```
+
+## Best Practices
+
+1. **Plan scale operations**: Don't perform unplanned rapid scale-ups in production
+2. **Use automation**: Implement automatic labeling in your provisioning system
+3. **Monitor circuit breaker**: Set up alerts for circuit breaker status changes
+4. **Document procedures**: Ensure your team knows to apply labels during scale operations
+5. **Test in staging**: Validate your scale-up procedures in non-production environments first
+6. **Size appropriately**: Start with adequate cluster size to minimize the need for large scale-ups
+7. **Gradual scaling**: Configure autoscalers for gradual scale-up when possible
+8. **Post-scale validation**: Always verify node health before removing exclusion labels
+
+## Related Documentation
+
+- [Circuit Breaker](circuit-breaker.md) - Understanding circuit breaker behavior
+- [Driver Upgrades](driver-upgrades.md) - Similar procedure for GPU driver upgrades
+- [Cordoned Nodes](cordoned-nodes.md) - General guidance on cordoned nodes
+- [ADR-027: Automated Node Labeling for Scale Operations](../designs/027-automated-node-labeling.md) - Proposed automation solutions
+
+## Quick Reference
+
+### Label to exclude from NVSentinel
+```bash
+kubectl label node <NODE_NAME> k8saas.nvidia.com/ManagedByNVSentinel=false
+```
+
+### Remove exclusion label
+```bash
+kubectl label node <NODE_NAME> k8saas.nvidia.com/ManagedByNVSentinel-
+```
+
+### Check circuit breaker status
+```bash
+kubectl get cm circuit-breaker -n nvsentinel -o yaml
+```
+
+### Reset circuit breaker (skip accumulated events)
+```bash
+kubectl patch configmap circuit-breaker -n nvsentinel \
+  -p '{"data":{"status":"CLOSED","cursor":"CREATE"}}'
+kubectl rollout restart deployment fault-quarantine -n nvsentinel
+```
+
+### Check for cordoned nodes
+```bash
+kubectl get nodes | grep SchedulingDisabled
+```
+
+### Uncordon a node
+```bash
+kubectl uncordon <NODE_NAME>
+```
+

--- a/docs/runbooks/maintenance-operations.md
+++ b/docs/runbooks/maintenance-operations.md
@@ -1,0 +1,576 @@
+# NVSentinel Maintenance Operations Guide
+
+## Overview
+
+This guide provides comprehensive procedures for common maintenance operations that require temporarily disabling or adjusting NVSentinel's node management. These operations share a common pattern: they involve changes that make nodes temporarily appear unhealthy to NVSentinel, potentially triggering the circuit breaker.
+
+## Common Pattern: The `ManagedByNVSentinel` Label
+
+Most maintenance operations follow this pattern:
+
+```bash
+# 1. Disable NVSentinel management
+kubectl label node <NODE_NAME> k8saas.nvidia.com/ManagedByNVSentinel=false
+
+# 2. Perform your maintenance operation
+# ...
+
+# 3. Verify node health
+kubectl get nodes
+kubectl get po -n gpu-operator
+
+# 4. Re-enable NVSentinel management
+kubectl label node <NODE_NAME> k8saas.nvidia.com/ManagedByNVSentinel-
+```
+
+**Why this works**: The label tells NVSentinel to ignore the node, preventing it from:
+- Cordoning the node during transitional states
+- Contributing to circuit breaker thresholds
+- Triggering alerts for expected maintenance events
+
+## Operation-Specific Guides
+
+### 1. Cluster Scale Operations
+
+**Applies to:**
+- Initial cluster bringup (CPU → GPU)
+- Autoscaling events (Karpenter, Cluster Autoscaler)
+- Manual capacity expansion
+- Multi-zone node additions
+
+**Why needed**: New nodes go through initialization where GPU components aren't ready yet, appearing unhealthy to NVSentinel.
+
+**Detailed guide**: See [Cluster Scale Operations](cluster-scale-operations.md)
+
+**Quick reference**:
+```bash
+# Label ALL nodes before adding new GPU nodes
+kubectl label node --all k8saas.nvidia.com/ManagedByNVSentinel=false
+
+# Perform scale-up
+# Wait for GPU Operator and DCGM healthy
+
+# Remove labels
+kubectl label node --all k8saas.nvidia.com/ManagedByNVSentinel-
+```
+
+**Risk level**: 🔴 **HIGH** - Almost certain to trip circuit breaker on small clusters without labeling
+
+---
+
+### 2. GPU Driver Upgrades
+
+**Applies to:**
+- GPU driver version updates
+- GPU Operator upgrades
+- NVIDIA driver module changes
+
+**Why needed**: During upgrades, DCGM becomes temporarily unavailable, triggering health check failures.
+
+**Detailed guide**: See [Driver Upgrades](driver-upgrades.md)
+
+**Quick reference**:
+```bash
+# Label nodes to be upgraded
+kubectl label node --all k8saas.nvidia.com/ManagedByNVSentinel=false
+
+# Perform GPU driver/operator upgrade
+# Verify all gpu-operator pods are Running and Ready
+
+# Remove labels
+kubectl label node --all k8saas.nvidia.com/ManagedByNVSentinel-
+```
+
+**Risk level**: 🟡 **MEDIUM** - Will trip if upgrading many nodes in parallel
+
+---
+
+### 3. OSMO (OS Maintenance Operations)
+
+**Applies to:**
+- Operating system upgrades
+- Kernel updates
+- Security patches requiring node reboots
+- Node drain and replace operations
+
+**Why needed**: Node reboots cause all GPU services to restart, creating a period where nodes appear unhealthy.
+
+**Procedure**:
+```bash
+# Before starting OSMO maintenance
+kubectl label node <NODE_NAME> k8saas.nvidia.com/ManagedByNVSentinel=false
+
+# Follow your OSMO maintenance procedure:
+# - Drain node
+# - Apply updates
+# - Reboot
+# - Wait for node to rejoin cluster
+
+# Verify node health
+kubectl get nodes
+kubectl get po -n gpu-operator -o wide | grep <NODE_NAME>
+
+# After node is fully healthy, remove label
+kubectl label node <NODE_NAME> k8saas.nvidia.com/ManagedByNVSentinel-
+```
+
+**Risk level**: 🟡 **MEDIUM** - Depends on how many nodes are maintained in parallel
+
+---
+
+### 4. Node Hardware Maintenance
+
+**Applies to:**
+- GPU hardware replacement
+- Memory upgrades
+- Network card replacement
+- Power supply maintenance
+- Physical server relocation
+
+**Procedure**:
+```bash
+# Label and drain the node
+kubectl label node <NODE_NAME> k8saas.nvidia.com/ManagedByNVSentinel=false
+kubectl drain <NODE_NAME> --ignore-daemonsets --delete-emptydir-data
+
+# Cordon to prevent scheduling during maintenance
+kubectl cordon <NODE_NAME>
+
+# Perform physical hardware maintenance
+# ...
+
+# Uncordon and verify health
+kubectl uncordon <NODE_NAME>
+kubectl get nodes <NODE_NAME>
+kubectl get po -n gpu-operator -o wide | grep <NODE_NAME>
+
+# Wait for all GPU services to be healthy (DCGM, device plugin, etc.)
+
+# Remove label
+kubectl label node <NODE_NAME> k8saas.nvidia.com/ManagedByNVSentinel-
+```
+
+**Risk level**: 🟢 **LOW** - Usually affects single nodes, unlikely to trip circuit breaker
+
+---
+
+### 5. Infrastructure Maintenance (Network, Power, Cooling)
+
+**Applies to:**
+- Rack-level maintenance affecting multiple nodes
+- Network switch upgrades
+- Data center maintenance windows
+- Power infrastructure changes
+
+**Procedure**:
+```bash
+# Before maintenance window starts
+# Label ALL nodes that will be affected
+kubectl label node -l <rack-label>=<value> k8saas.nvidia.com/ManagedByNVSentinel=false
+
+# Optionally silence alerts for the maintenance window
+# (if you have alerting configured)
+
+# Perform infrastructure maintenance
+# ...
+
+# After maintenance, verify all nodes are healthy
+kubectl get nodes
+
+# Remove labels from all affected nodes
+kubectl label node -l <rack-label>=<value> k8saas.nvidia.com/ManagedByNVSentinel-
+```
+
+**Risk level**: 🔴 **HIGH** - Infrastructure maintenance often affects many nodes simultaneously
+
+---
+
+### 6. GPU Operator Component Updates
+
+**Applies to:**
+- Device plugin updates
+- DCGM exporter updates
+- GPU feature discovery updates
+- MIG manager updates
+
+**Procedure**:
+```bash
+# Label all GPU nodes
+kubectl label node -l nvidia.com/gpu.present=true k8saas.nvidia.com/ManagedByNVSentinel=false
+
+# Update GPU Operator components via Helm
+helm upgrade gpu-operator nvidia/gpu-operator -n gpu-operator -f values.yaml
+
+# Wait for rollout to complete
+kubectl rollout status daemonset -n gpu-operator nvidia-dcgm-exporter
+kubectl rollout status daemonset -n gpu-operator nvidia-device-plugin-daemonset
+
+# Verify all pods are healthy
+kubectl get po -n gpu-operator
+
+# Remove labels
+kubectl label node -l nvidia.com/gpu.present=true k8saas.nvidia.com/ManagedByNVSentinel-
+```
+
+**Risk level**: 🟡 **MEDIUM** - Depends on rollout strategy and cluster size
+
+---
+
+### 7. Troubleshooting and Testing
+
+**Applies to:**
+- Testing NVSentinel rules
+- Debugging health check issues
+- Investigating node problems
+- Simulating failures
+
+**Procedure**:
+```bash
+# Label test nodes to isolate from production monitoring
+kubectl label node <TEST_NODE> k8saas.nvidia.com/ManagedByNVSentinel=false
+
+# Perform your troubleshooting or testing
+# - Test health checks
+# - Inject faults
+# - Debug components
+
+# When testing complete, remove label
+kubectl label node <TEST_NODE> k8saas.nvidia.com/ManagedByNVSentinel-
+```
+
+**Risk level**: 🟢 **LOW** - Typically affects only test/debug nodes
+
+---
+
+## Best Practices
+
+### Before Maintenance
+
+1. **Plan ahead**: Review which operations require labeling
+2. **Label proactively**: Apply labels before starting maintenance, not after issues occur
+3. **Document scope**: Keep track of which nodes are labeled and why
+4. **Set alerts**: Configure notifications for circuit breaker events
+5. **Check circuit breaker**: Verify it's not already tripped before starting
+
+```bash
+# Check current circuit breaker status
+kubectl get cm circuit-breaker -n nvsentinel -o jsonpath='{.data.status}'
+```
+
+### During Maintenance
+
+1. **Use batch operations carefully**: Be aware of how many nodes are affected simultaneously
+2. **Monitor circuit breaker**: Watch for trips even with labels applied
+3. **Verify health progressively**: Check each node/batch before proceeding to the next
+4. **Keep labels during transition**: Don't remove labels until fully healthy
+
+```bash
+# Monitor nodes during maintenance
+watch kubectl get nodes -o wide
+
+# Check GPU Operator health
+watch kubectl get po -n gpu-operator
+```
+
+### After Maintenance
+
+1. **Verify complete health**: Ensure all components are ready before removing labels
+2. **Remove labels promptly**: Don't leave labels on longer than necessary
+3. **Monitor for issues**: Watch for 15-30 minutes after removing labels
+4. **Document results**: Note any issues encountered and how they were resolved
+
+```bash
+# Final health check before removing labels
+kubectl get nodes
+kubectl get po -n gpu-operator
+kubectl get cm circuit-breaker -n nvsentinel -o yaml
+
+# After removing labels, monitor
+kubectl get nodes -w
+```
+
+### Circuit Breaker Management
+
+If the circuit breaker trips despite following procedures:
+
+1. **Don't panic**: The circuit breaker is doing its job
+2. **Investigate**: Determine if it's a legitimate issue or expected transitional state
+3. **Reset appropriately**: Use `cursor: CREATE` for maintenance scenarios to skip accumulated events
+
+```bash
+# Reset circuit breaker after maintenance
+kubectl patch cm circuit-breaker -n nvsentinel \
+  -p '{"data":{"status":"CLOSED","cursor":"CREATE"}}'
+kubectl rollout restart deploy fault-quarantine -n nvsentinel
+```
+
+See [Circuit Breaker Runbook](circuit-breaker.md) for detailed reset procedures.
+
+## Automation Strategies
+
+### Infrastructure-as-Code Integration
+
+#### Terraform Example
+
+```hcl
+resource "kubernetes_labels" "maintenance_mode" {
+  api_version = "v1"
+  kind        = "Node"
+  
+  metadata {
+    name = var.node_name
+  }
+  
+  labels = {
+    "k8saas.nvidia.com/ManagedByNVSentinel" = "false"
+  }
+}
+
+# Perform maintenance operations
+# ...
+
+# Remove label using null_resource with local-exec
+resource "null_resource" "remove_maintenance_mode" {
+  depends_on = [
+    # Your maintenance resources
+  ]
+  
+  provisioner "local-exec" {
+    command = "kubectl label node ${var.node_name} k8saas.nvidia.com/ManagedByNVSentinel-"
+  }
+}
+```
+
+#### Ansible Playbook Example
+
+```yaml
+---
+- name: Node Maintenance with NVSentinel Management
+  hosts: localhost
+  tasks:
+    - name: Disable NVSentinel management
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Node
+          metadata:
+            name: "{{ node_name }}"
+            labels:
+              k8saas.nvidia.com/ManagedByNVSentinel: "false"
+    
+    - name: Perform maintenance
+      # Your maintenance tasks here
+      
+    - name: Wait for node health
+      kubernetes.core.k8s_info:
+        kind: Node
+        name: "{{ node_name }}"
+      register: node_info
+      until: node_info.resources[0].status.conditions | selectattr('type', 'equalto', 'Ready') | map(attribute='status') | first == 'True'
+      retries: 30
+      delay: 10
+    
+    - name: Re-enable NVSentinel management
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Node
+          metadata:
+            name: "{{ node_name }}"
+            labels:
+              k8saas.nvidia.com/ManagedByNVSentinel: null
+```
+
+### GitOps Integration
+
+For ArgoCD/Flux-managed clusters, create a maintenance ConfigMap that your runtime controller watches:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: maintenance-schedule
+  namespace: nvsentinel
+data:
+  mode: "scale-operation"  # or "driver-upgrade", "osmo-maintenance", etc.
+  nodes: "node-1,node-2,node-3"
+  start-time: "2026-02-07T10:00:00Z"
+  end-time: "2026-02-07T12:00:00Z"
+```
+
+Your controller can automatically apply/remove labels based on this schedule.
+
+## Troubleshooting Common Issues
+
+### Labels Not Taking Effect
+
+**Symptom**: Nodes are still being cordoned despite having the `ManagedByNVSentinel=false` label.
+
+**Possible causes**:
+1. Label was applied after NVSentinel already detected the issue
+2. There are multiple NVSentinel deployments (check namespace)
+3. Typo in label name or value
+
+**Solution**:
+```bash
+# Verify label is correctly applied
+kubectl get node <NODE_NAME> --show-labels | grep ManagedByNVSentinel
+
+# Check NVSentinel logs
+kubectl logs -n nvsentinel -l app=fault-quarantine | grep <NODE_NAME>
+
+# Restart fault-quarantine to pick up labels
+kubectl rollout restart deploy fault-quarantine -n nvsentinel
+```
+
+### Forgot to Apply Labels
+
+**Symptom**: Circuit breaker tripped during maintenance because labels weren't applied proactively.
+
+**Solution**:
+```bash
+# Apply labels now (even though late)
+kubectl label node --all k8saas.nvidia.com/ManagedByNVSentinel=false
+
+# Reset circuit breaker with CREATE cursor
+kubectl patch cm circuit-breaker -n nvsentinel \
+  -p '{"data":{"status":"CLOSED","cursor":"CREATE"}}'
+
+# Restart fault-quarantine
+kubectl rollout restart deploy fault-quarantine -n nvsentinel
+
+# Continue with maintenance
+# Remove labels after completion
+```
+
+### Labels Left On Too Long
+
+**Symptom**: Nodes have `ManagedByNVSentinel=false` from previous maintenance, not being monitored.
+
+**Solution**:
+```bash
+# Find nodes with the exclusion label
+kubectl get nodes -l k8saas.nvidia.com/ManagedByNVSentinel=false
+
+# Verify they're actually healthy
+kubectl describe node <NODE_NAME>
+
+# Remove labels from healthy nodes
+kubectl label node -l k8saas.nvidia.com/ManagedByNVSentinel=false k8saas.nvidia.com/ManagedByNVSentinel-
+```
+
+**Prevention**: Set up monitoring/alerting for nodes with this label:
+
+```promql
+# Alert if nodes have exclusion label for > 2 hours
+kube_node_labels{label_k8saas_nvidia_com_ManagedByNVSentinel="false"} == 1
+```
+
+## Decision Tree: Do I Need to Label?
+
+```
+START: Planning a cluster operation
+    |
+    ├─> Will this affect GPU nodes? 
+    |       NO → Proceed normally (no labeling needed)
+    |       YES ↓
+    |
+    ├─> Will GPU services (driver/DCGM) be temporarily unavailable?
+    |       NO → Proceed normally (no labeling needed)
+    |       YES ↓
+    |
+    ├─> How many nodes affected simultaneously?
+    |       Single node → Low risk, optional labeling
+    |       2-5 nodes → Medium risk, labeling recommended
+    |       5+ nodes or >30% of cluster → High risk, labeling required
+    |       ↓
+    |
+    └─> APPLY LABELS BEFORE STARTING OPERATION
+```
+
+## Quick Reference Commands
+
+```bash
+# === LABEL OPERATIONS ===
+
+# Label all nodes
+kubectl label node --all k8saas.nvidia.com/ManagedByNVSentinel=false
+
+# Label specific node
+kubectl label node <NODE_NAME> k8saas.nvidia.com/ManagedByNVSentinel=false
+
+# Label by selector
+kubectl label node -l <selector> k8saas.nvidia.com/ManagedByNVSentinel=false
+
+# Remove label from all nodes
+kubectl label node --all k8saas.nvidia.com/ManagedByNVSentinel-
+
+# Remove label from specific node
+kubectl label node <NODE_NAME> k8saas.nvidia.com/ManagedByNVSentinel-
+
+# List nodes with exclusion label
+kubectl get nodes -l k8saas.nvidia.com/ManagedByNVSentinel=false
+
+# === HEALTH CHECKS ===
+
+# Check all nodes
+kubectl get nodes -o wide
+
+# Check GPU Operator pods
+kubectl get po -n gpu-operator
+
+# Check DCGM health
+kubectl get po -n gpu-operator | grep dcgm
+
+# Check node details
+kubectl describe node <NODE_NAME>
+
+# === CIRCUIT BREAKER ===
+
+# Check circuit breaker status
+kubectl get cm circuit-breaker -n nvsentinel -o yaml
+
+# Reset with CREATE cursor (skip events)
+kubectl patch cm circuit-breaker -n nvsentinel \
+  -p '{"data":{"status":"CLOSED","cursor":"CREATE"}}'
+kubectl rollout restart deploy fault-quarantine -n nvsentinel
+
+# Reset with RESUME cursor (process events)
+kubectl patch cm circuit-breaker -n nvsentinel \
+  -p '{"data":{"status":"CLOSED","cursor":"RESUME"}}'
+kubectl rollout restart deploy fault-quarantine -n nvsentinel
+
+# === MONITORING ===
+
+# Watch nodes
+kubectl get nodes -w
+
+# Watch GPU Operator pods
+kubectl get po -n gpu-operator -w
+
+# Check fault-quarantine logs
+kubectl logs -n nvsentinel -l app=fault-quarantine --tail=100 -f
+
+# Check for cordoned nodes
+kubectl get nodes | grep SchedulingDisabled
+```
+
+## Related Documentation
+
+- [Cluster Scale Operations](cluster-scale-operations.md) - Detailed guide for scale-up scenarios
+- [Driver Upgrades](driver-upgrades.md) - Specific procedures for GPU driver maintenance
+- [Circuit Breaker](circuit-breaker.md) - Understanding and resetting the circuit breaker
+- [Cordoned Nodes](cordoned-nodes.md) - General troubleshooting for cordoned nodes
+- [ADR-027: Automated Node Labeling](../designs/027-automated-node-labeling.md) - Future automation plans
+
+## Feedback and Improvements
+
+This guide is continuously being improved based on real-world usage. If you encounter:
+- Scenarios not covered here
+- Procedures that don't work as expected
+- Suggestions for automation
+
+Please contribute back to the documentation or file an issue with your findings.
+


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation to address circuit breaker trips during legitimate cluster operations such as node scale-up, initial GPU bringup, autoscaling events, and maintenance scenarios.

## Problem Statement

Currently, NVSentinel's circuit breaker trips during legitimate operations when GPU nodes appear "unhealthy" during their initialization phase. This occurs because:

1. **Services inside the cluster cannot distinguish between scale-up and failure**: A controller running in-cluster sees nodes coming online but doesn't know if they're new nodes or existing nodes recovering from failure.

2. **Circuit breaker trips during common scenarios**:
   - Initial cluster bringup (CPU-only → add GPU nodes)
   - Autoscaling events (Karpenter, Cluster Autoscaler)
   - Manual capacity expansion
   - Multi-zone node additions
   - Driver/GPU Operator upgrades
   - Node maintenance operations (OSMO, hardware work)

3. **Current workaround is manual and error-prone**: Operators must remember to manually label nodes with `k8saas.nvidia.com/ManagedByNVSentinel=false` before operations, then remove the label after - this is often forgotten during time-pressured situations.

**Related: HIPPO-5214 (Circuit breaker tripped during EKS cluster bringup)**

## Solution

This PR provides comprehensive documentation following a phased approach:

### Phase 1: Enhanced Documentation (This PR)

Create detailed runbooks and guides that operators can use immediately:

1. **Cluster Scale Operations Runbook** - Step-by-step procedures for preventing circuit breaker trips during node scale-up and bringup
2. **Maintenance Operations Guide** - Comprehensive guide covering all maintenance scenarios with best practices
3. **ADR-027** - Architecture decision record proposing future automation paths

### Phase 2 & 3: Future Automation (Documented in ADR)

- **Phase 2**: Orchestration layer integration (runtime controllers, GitOps)
- **Phase 3**: Optional admission controller for user-managed autoscaling

## Changes

### New Documentation

- **`docs/runbooks/cluster-scale-operations.md`**: Detailed guide for scale operations
  - Why circuit breaker trips during scale-up
  - Step-by-step procedures with `ManagedByNVSentinel` label pattern
  - Common scenarios (initial bringup, autoscaling, multi-zone)
  - Integration examples (Terraform, Ansible, GitOps)
  - Troubleshooting and quick reference

- **`docs/runbooks/maintenance-operations.md`**: Comprehensive maintenance guide
  - 7 operation types covered (scale-up, driver upgrades, OSMO, hardware, infrastructure, GPU Operator updates, testing)
  - Best practices (before, during, after maintenance)
  - Automation strategies
  - Decision tree for when labeling is needed
  - Quick reference commands

- **`docs/designs/027-automated-node-labeling.md`**: ADR for automation
  - Root cause analysis (information asymmetry problem)
  - Phased approach with rationale
  - Implementation details with code examples
  - Alternatives considered and rejected

### Updated Documentation

- **`docs/runbooks/circuit-breaker.md`**: Added common scenarios section and cross-references
- **`docs/runbooks/README.md`**: Reorganized with Maintenance Operations section at top
- **`README.md`**: Added comprehensive Documentation section with quick reference

## Key Pattern Documented

The core pattern for all maintenance operations:

```bash
# 1. Before operation: Disable NVSentinel management
kubectl label node <NODE_NAME> k8saas.nvidia.com/ManagedByNVSentinel=false

# 2. Perform operation (scale-up, upgrade, maintenance, etc.)

# 3. Verify node health

# 4. After operation: Re-enable NVSentinel management
kubectl label node <NODE_NAME> k8saas.nvidia.com/ManagedByNVSentinel-
```

## Summary

<!-- Brief description of your changes -->

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [x] Other: bringup and scaling

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [x] Documentation updated (if needed)
- [ ] Ready for review
