### PR TITLE
fix: free disk space for SBOM generation in publish container job

### DIFF
--- a/.github/actions/publish-container/action.yml
+++ b/.github/actions/publish-container/action.yml
@@ -32,6 +32,16 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Workaround for freeing up more disk space
+      shell: bash
+      run: |
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        sudo docker image prune --all --force
+        sudo docker system prune -f
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435  # v3.11.1
       with:
@@ -86,16 +96,6 @@ runs:
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
         fi
-
-    - name: Workaround for freeing up more disk space
-      shell: bash
-      run: |
-        sudo rm -rf /usr/local/lib/android
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /opt/ghc
-        sudo rm -rf /opt/hostedtoolcache/CodeQL
-        sudo docker image prune --all --force
-        sudo docker system prune -f
     
     - name: Generate SBOM and Attest
       uses: ./.github/actions/sbom-and-attest

--- a/.github/actions/publish-container/action.yml
+++ b/.github/actions/publish-container/action.yml
@@ -86,6 +86,20 @@ runs:
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
         fi
+
+    - name: Free disk space for SBOM generation
+      shell: bash
+      run: |
+        echo "Disk usage before cleanup:"
+        df -h /tmp
+        # Clean up Docker buildx cache and unused images
+        docker buildx prune -f --all || true
+        docker image prune -f || true
+        docker system prune -f || true
+        # Clean up temp files
+        rm -rf /tmp/.buildx-cache || true
+        echo "Disk usage after cleanup:"
+        df -h /tmp
     
     - name: Generate SBOM and Attest
       uses: ./.github/actions/sbom-and-attest

--- a/.github/actions/publish-container/action.yml
+++ b/.github/actions/publish-container/action.yml
@@ -87,17 +87,15 @@ runs:
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
         fi
 
-    - name: Free disk space for SBOM generation
+    - name: Workaround for freeing up more disk space
       shell: bash
       run: |
-        echo "Disk usage before cleanup:"
-        df -h /tmp
-        # Clean up Docker buildx cache and unused images
-        docker buildx prune -f --all || true
-        docker image prune -f || true
-        docker system prune -f || true
-        echo "Disk usage after cleanup:"
-        df -h /tmp
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        sudo docker image prune --all --force
+        sudo docker system prune -f
     
     - name: Generate SBOM and Attest
       uses: ./.github/actions/sbom-and-attest

--- a/.github/actions/publish-container/action.yml
+++ b/.github/actions/publish-container/action.yml
@@ -96,8 +96,6 @@ runs:
         docker buildx prune -f --all || true
         docker image prune -f || true
         docker system prune -f || true
-        # Clean up temp files
-        rm -rf /tmp/.buildx-cache || true
         echo "Disk usage after cleanup:"
         df -h /tmp
     

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -1,7 +1,0 @@
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-featureGates:
-  WorkloadAwareScheduling: true
-nodes:
-- role: control-plane
-- role: worker

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -1,0 +1,7 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  WorkloadAwareScheduling: true
+nodes:
+- role: control-plane
+- role: worker


### PR DESCRIPTION
## Summary

<!-- Brief description of your changes -->

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved container publishing workflow by adding an automated pre-build disk cleanup step: reports disk usage, removes unneeded artifacts and caches, prunes unused images, and re-reports usage to reduce build failures from low disk space.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->