### PR TITLE
fix: add disk cleanup logic before sbom generation

### DIFF
--- a/.github/actions/publish-container/action.yml
+++ b/.github/actions/publish-container/action.yml
@@ -96,6 +96,22 @@ runs:
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
         fi
+
+    - name: Free disk space for SBOM generation
+      shell: bash
+      run: |
+        echo "=== Disk usage BEFORE cleanup ==="
+        df -h
+        # Remove pre-installed tools (if they exist on this runner)
+        sudo rm -rf /usr/local/lib/android || true
+        sudo rm -rf /usr/share/dotnet || true
+        sudo rm -rf /opt/ghc || true
+        # Thorough Docker cleanup - build cache no longer needed after push
+        docker buildx prune -f --all || true
+        docker system prune -af --volumes || true
+        rm -rf /tmp/.buildx-cache || true
+        echo "=== Disk usage AFTER cleanup ==="
+        df -h
     
     - name: Generate SBOM and Attest
       uses: ./.github/actions/sbom-and-attest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,6 @@ on:
       - 'v*'
     branches:
       - main
-      - pull-request/827
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ on:
       - 'v*'
     branches:
       - main
+      - pull-request/827
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## Summary

<!-- Brief description of your changes -->

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD reliability by adding an automated disk-space cleanup step before SBOM generation; it frees resources, prunes caches, and is resilient to individual cleanup failures so the pipeline can continue.
  * Expanded workflow triggers so the pipeline also runs for an additional pull-request branch pattern, enabling verification for that branch as well.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->