### PR TITLE
fix: add retry while injecting inforom error in E2E test

### DIFF
--- a/tests/gpu_health_monitor_test.go
+++ b/tests/gpu_health_monitor_test.go
@@ -695,9 +695,23 @@ func TestGpuHealthMonitorStoreOnlyEvents(t *testing.T) {
 			fmt.Sprintf("dcgmi test --host %s:%s --inject --gpuid 0 -f 84 -v 0",
 				dcgmServiceHost, dcgmServicePort)}
 
-		stdout, stderr, execErr := helpers.ExecInPod(ctx, restConfig, helpers.NVSentinelNamespace, podName, "", cmd)
-		require.NoError(t, execErr, "failed to inject Inforom error: %s", stderr)
-		require.Contains(t, stdout, "Successfully injected", "Inforom error injection failed")
+		var stdout, stderr string
+		var execErr error
+		// Retry the injection command as DCGM might need time to initialize after pod rollout
+		require.Eventually(t, func() bool {
+			stdout, stderr, execErr = helpers.ExecInPod(ctx, restConfig, helpers.NVSentinelNamespace, podName, "", cmd)
+			if execErr != nil {
+				t.Logf("DCGM error injection attempt failed %v, stderr: %s", execErr, stderr)
+				return false
+			}
+			if !strings.Contains(stdout, "Successfully injected") {
+				t.Logf("DCGM injection did not return success message: %s", stdout)
+				return false
+			}
+			return true
+		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval, "failed to inject Inforom error after retries: %s", stderr)
+
+		t.Logf("Successfully injected Inforom error")
 
 		return ctx
 	})

--- a/tests/gpu_health_monitor_test.go
+++ b/tests/gpu_health_monitor_test.go
@@ -697,11 +697,17 @@ func TestGpuHealthMonitorStoreOnlyEvents(t *testing.T) {
 
 		var stdout, stderr string
 		var execErr error
-		// Retry the injection command as DCGM might need time to initialize after pod rollout
+		// Retry the injection command only for exit code 235 (DCGM_ST_CONNECTION_NOT_VALID)
+		// as DCGM might need time to initialize after pod rollout
 		require.Eventually(t, func() bool {
 			stdout, stderr, execErr = helpers.ExecInPod(ctx, restConfig, helpers.NVSentinelNamespace, podName, "", cmd)
 			if execErr != nil {
-				t.Logf("DCGM error injection attempt failed %v, stderr: %s", execErr, stderr)
+				if strings.Contains(execErr.Error(), "exit code 235") {
+					t.Logf("DCGM error injection failed with exit code 235 (will retry): %v, stderr: %s", execErr, stderr)
+					return false
+				}
+
+				t.Fatalf("DCGM error injection failed with non-retryable error: %v, stderr: %s", execErr, stderr)
 				return false
 			}
 			if !strings.Contains(stdout, "Successfully injected") {

--- a/tests/gpu_health_monitor_test.go
+++ b/tests/gpu_health_monitor_test.go
@@ -706,17 +706,12 @@ func TestGpuHealthMonitorStoreOnlyEvents(t *testing.T) {
 					t.Logf("DCGM error injection failed with exit code 235 (will retry): %v, stderr: %s", execErr, stderr)
 					return false
 				}
-
-				t.Fatalf("DCGM error injection failed with non-retryable error: %v, stderr: %s", execErr, stderr)
-				return false
-			}
-			if !strings.Contains(stdout, "Successfully injected") {
-				t.Logf("DCGM injection did not return success message: %s", stdout)
-				return false
 			}
 			return true
 		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval, "failed to inject Inforom error after retries: %s", stderr)
 
+		require.NoError(t, execErr, "failed to inject Inforom error: %s", stderr)
+		require.Contains(t, stdout, "Successfully injected", "Inforom error injection failed")
 		t.Logf("Successfully injected Inforom error")
 
 		return ctx


### PR DESCRIPTION
## Summary

<!-- Brief description of your changes -->

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [x] Other:  E2E tests 

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review

Test TestGpuHealthMonitorStoreOnlyEvents was failing with error while injecting inforom error

Error:      	Received unexpected error:
        	            	command terminated with exit code 235

exit code 235 indicates connection error DCGM_ST_CONNECTION_NOT_VALID as mentioned in DCGM [doc](https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/dcgm-diagnostics.html#:~:text=bindings%20only%20error)-,235,-DCGM_ST_CONNECTION_NOT_VALID).

Adding retry block to handle this error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved GPU health monitor test reliability by adding retry logic to handle initialization delays after pod rollout.
  * Enhanced logging and output capture for clearer diagnostics, including handling of transient exit codes.
  * Applied the same retry and logging approach to initial error injection during setup, and added a final confirmation log on success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->