### PR TITLE
feat: Make IAM role name configurable in CSP health monitor for EKS

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/serviceaccount.yaml
+++ b/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/serviceaccount.yaml
@@ -22,7 +22,11 @@ metadata:
       {{- if and (eq .Values.cspName "gcp") .Values.configToml.gcp .Values.configToml.gcp.targetProjectId .Values.configToml.gcp.gcpServiceAccountName }}
     iam.gke.io/gcp-service-account: {{ .Values.configToml.gcp.gcpServiceAccountName }}@{{ .Values.configToml.gcp.targetProjectId }}.iam.gserviceaccount.com
       {{- end }}
-      {{- if and (eq .Values.cspName "aws") .Values.configToml.aws .Values.configToml.aws.accountId .Values.configToml.clusterName }}
+      {{- if and (eq .Values.cspName "aws") .Values.configToml.aws .Values.configToml.aws.accountId }}
+        {{- if .Values.configToml.aws.iamRoleName }}
+    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.configToml.aws.accountId }}:role/{{ .Values.configToml.aws.iamRoleName }}
+        {{- else if .Values.configToml.clusterName }}
     eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.configToml.aws.accountId }}:role/{{ .Values.configToml.clusterName }}-nvsentinel-health-monitor-assume-role-policy
+        {{- end }}
       {{- end }}
     {{- end }}

--- a/distros/kubernetes/nvsentinel/charts/csp-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/csp-health-monitor/values.yaml
@@ -88,3 +88,7 @@ configToml:
     pollingIntervalSeconds: 60 # Used by main monitor (AWS poller)
     # AWS region of the tenant cluster.
     region: "" # Used by main monitor
+    # Custom IAM role name for IRSA (IAM Roles for Service Accounts).
+    # If empty, defaults to "<clusterName>-nvsentinel-health-monitor-assume-role-policy".
+    # Set this if your cluster name exceeds 19 characters (AWS IAM role names max 64 chars).
+    iamRoleName: ""

--- a/docs/csp-health-monitor-iam.md
+++ b/docs/csp-health-monitor-iam.md
@@ -138,9 +138,23 @@ csp-health-monitor:
       accountId: "<ACCOUNT_ID>"
       region: "<AWS_REGION>"
       pollingIntervalSeconds: 60
+      # Optional: override the default IAM role name
+      # iamRoleName: "my-custom-nvsentinel-role"
 ```
 
-> **Important**: The IAM role name must match `<CLUSTER_NAME>-nvsentinel-health-monitor-assume-role-policy`.
+> **Important (EKS)**: By default, the IAM role name is constructed as `<CLUSTER_NAME>-nvsentinel-health-monitor-assume-role-policy`. AWS IAM role names have a **64-character limit**, and the default suffix is 45 characters, leaving only **19 characters** for the cluster name. If your cluster name exceeds 19 characters, set `aws.iamRoleName` to a custom role name and create the IAM role with that name instead:
+>
+> ```bash
+> aws iam create-role \
+>     --role-name my-custom-nvsentinel-role \
+>     --assume-role-policy-document file://trust-policy.json
+> ```
+>
+> Then in Helm values:
+> ```yaml
+> aws:
+>   iamRoleName: "my-custom-nvsentinel-role"
+> ```
 
 ## Additional Resources
 

--- a/docs/runbooks/csp-health-monitor-iam.md
+++ b/docs/runbooks/csp-health-monitor-iam.md
@@ -84,9 +84,12 @@ Error while fetching maintenance events: operation error Health: DescribeEvents,
 1. **Check IAM policy is attached to role:**
 
 ```bash
+# Use your custom role name if aws.iamRoleName is set, otherwise use the default pattern
 aws iam list-attached-role-policies \
-    --role-name <CLUSTER_NAME>-nvsentinel-health-monitor-assume-role-policy
+    --role-name <IAM_ROLE_NAME>
 ```
+
+> **Note**: The role name is either the value of `aws.iamRoleName` (if set) or the default `<CLUSTER_NAME>-nvsentinel-health-monitor-assume-role-policy`.
 
 Expected output should show `CSPHealthMonitorPolicy` attached.
 
@@ -94,7 +97,7 @@ Expected output should show `CSPHealthMonitorPolicy` attached.
 
 ```bash
 aws iam get-role \
-    --role-name <CLUSTER_NAME>-nvsentinel-health-monitor-assume-role-policy \
+    --role-name <IAM_ROLE_NAME> \
     --query 'Role.AssumeRolePolicyDocument'
 ```
 
@@ -106,7 +109,7 @@ Expected: Trust policy should reference the correct EKS OIDC provider and `syste
 kubectl get serviceaccount csp-health-monitor -n nvsentinel -o jsonpath='{.metadata.annotations.eks\.amazonaws\.com/role-arn}'
 ```
 
-Expected output: `arn:aws:iam::<ACCOUNT_ID>:role/<CLUSTER_NAME>-nvsentinel-health-monitor-assume-role-policy`
+Expected output: `arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE_NAME>`
 
 ### Resolution
 
@@ -116,11 +119,11 @@ If IAM policy is not attached:
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 
 aws iam attach-role-policy \
-    --role-name <CLUSTER_NAME>-nvsentinel-health-monitor-assume-role-policy \
+    --role-name <IAM_ROLE_NAME> \
     --policy-arn arn:aws:iam::${ACCOUNT_ID}:policy/CSPHealthMonitorPolicy
 ```
 
-If the role ARN doesn't match Helm values, update `configToml.clusterName` and redeploy.
+If the role ARN doesn't match Helm values, ensure `aws.iamRoleName` (or `configToml.clusterName` if using the default pattern) is correct, and redeploy.
 
 ### Test Permissions Manually
 


### PR DESCRIPTION
## Summary

<!-- Brief description of your changes -->

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [x] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review

## Testing
Completed manual testing in a dev AWS cluster. Verified that the change is working as expected with the set `iamRoleName` in the `values.yaml`:

```
$ kubectl get serviceaccount csp-health-monitor -n nvsentinel -o yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::381491907752:role/ta135790-dgxc-csp-health-monitor-role
    meta.helm.sh/release-name: nvsentinel
    meta.helm.sh/release-namespace: nvsentinel
  creationTimestamp: "2026-02-18T06:58:47Z"
  labels:
    app.kubernetes.io/instance: nvsentinel
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: csp-health-monitor
    app.kubernetes.io/version: 1.16.0
    helm.sh/chart: csp-health-monitor-0.1.0
  name: csp-health-monitor
  namespace: nvsentinel
  resourceVersion: "181030424"
  uid: 0a8b2685-b88e-4310-a949-4244396aa6be
kdabhadkar@NV-60MP224:~/workspace_go/src/bcp-dot-next-deployment/bcp-release$ kubectl get pods -n nvsentinel -l app.kubernetes.io/name=csp-health-monitor
NAME                                 READY   STATUS    RESTARTS       AGE
csp-health-monitor-96d485777-4p64l   2/2     Running   4 (105s ago)   2m57s
kdabhadkar@NV-60MP224:~/workspace_go/src/bcp-dot-next-deployment/bcp-release$ kubectl logs -n nvsentinel -l app.kubernetes.io/name=csp-health-monitor -c csp-health-monitor --tail=50
2026/02/18 07:00:13 INFO Registered datastore provider provider=mongodb
2026/02/18 07:00:13 INFO Registering MongoDB builder factory
{"time":"2026-02-18T07:00:13.047067436Z","level":"INFO","source":{"function":"main.main","file":"github.com/nvidia/nvsentinel/health-monitors/csp-health-monitor/cmd/csp-health-monitor/main.go","line":62},"msg":"Starting csp-health-monitor","module":"csp-health-monitor","version":"v0.7.0","version":"v0.7.0","commit":"3f98a4562f6ab5396359adfd7ccbce3285619bd5","date":"2026-01-20T13:10:26Z"}
{"time":"2026-02-18T07:00:13.04743659Z","level":"INFO","source":{"function":"github.com/nvidia/nvsentinel/commons/pkg/server.NewServer","file":"github.com/nvidia/nvsentinel/commons@v0.0.0/pkg/server/server.go","line":390},"msg":"server initialized","module":"csp-health-monitor","version":"v0.7.0","port":2112,"read_timeout":10000000000,"write_timeout":10000000000}
{"time":"2026-02-18T07:00:13.047473615Z","level":"INFO","source":{"function":"main.run","file":"github.com/nvidia/nvsentinel/health-monitors/csp-health-monitor/cmd/csp-health-monitor/main.go","line":208},"msg":"CSP Health Monitor (Main Container) components started successfully.","module":"csp-health-monitor","version":"v0.7.0"}
{"time":"2026-02-18T07:00:13.047478979Z","level":"INFO","source":{"function":"main.run.func1","file":"github.com/nvidia/nvsentinel/health-monitors/csp-health-monitor/cmd/csp-health-monitor/main.go","line":154},"msg":"Starting metrics server","module":"csp-health-monitor","version":"v0.7.0","port":2112}
{"time":"2026-02-18T07:00:13.04751034Z","level":"INFO","source":{"function":"main.run.func2","file":"github.com/nvidia/nvsentinel/health-monitors/csp-health-monitor/cmd/csp-health-monitor/main.go","line":164},"msg":"Initializing datastore connection...","module":"csp-health-monitor","version":"v0.7.0"}
{"time":"2026-02-18T07:00:13.047542431Z","level":"INFO","source":{"function":"github.com/nvidia/nvsentinel/store-client/pkg/datastore/providers/mongodb/watcher.pollTillCACertIsMountedSuccessfully","file":"github.com/nvidia/nvsentinel/store-client@v0.0.0/pkg/datastore/providers/mongodb/watcher/watch_store.go","line":724},"msg":"Trying to read CA cert","module":"csp-health-monitor","version":"v0.7.0","path":"/etc/ssl/client-certs/ca.crt"}
{"time":"2026-02-18T07:00:13.047589782Z","level":"INFO","source":{"function":"github.com/nvidia/nvsentinel/store-client/pkg/datastore/providers/mongodb/watcher.pollTillCACertIsMountedSuccessfully","file":"github.com/nvidia/nvsentinel/store-client@v0.0.0/pkg/datastore/providers/mongodb/watcher/watch_store.go","line":735},"msg":"Successfully read CA cert","module":"csp-health-monitor","version":"v0.7.0"}
{"time":"2026-02-18T07:00:13.047688412Z","level":"INFO","source":{"function":"github.com/nvidia/nvsentinel/commons/pkg/server.(*server).Serve","file":"github.com/nvidia/nvsentinel/commons@v0.0.0/pkg/server/server.go","line":502},"msg":"starting server","module":"csp-health-monitor","version":"v0.7.0","addr":":2112"}
{"time":"2026-02-18T07:00:13.048002762Z","level":"INFO","source":{"function":"github.com/nvidia/nvsentinel/store-client/pkg/datastore/providers/mongodb/watcher.confirmConnectivityWithDBAndCollection","file":"github.com/nvidia/nvsentinel/store-client@v0.0.0/pkg/datastore/providers/mongodb/watcher/watch_store.go","line":492},"msg":"Trying to ping database to confirm connectivity","module":"csp-health-monitor","version":"v0.7.0","database":"HealthEventsDatabase"}
{"time":"2026-02-18T07:00:32.552719096Z","level":"INFO","source":{"function":"github.com/nvidia/nvsentinel/store-client/pkg/datastore/providers/mongodb/watcher.confirmConnectivityWithDBAndCollection","file":"github.com/nvidia/nvsentinel/store-client@v0.0.0/pkg/datastore/providers/mongodb/watcher/watch_store.go","line":503},"msg":"Successfully pinged database to confirm connectivity","module":"csp-health-monitor","version":"v0.7.0","database":"HealthEventsDatabase"}
{"time":"2026-02-18T07:00:32.553017473Z","level":"INFO","source":{"function":"github.com/nvidia/nvsentinel/store-client/pkg/datastore/providers/mongodb/watcher.confirmConnectivityWithDBAndCollection","file":"github.com/nvidia/nvsentinel/store-client@v0.0.0/pkg/datastore/providers/mongodb/watcher/watch_store.go","line":521},"msg":"Confirmed that the collection exists in the database","module":"csp-health-monitor","version":"v0.7.0","collection":"MaintenanceEvents","database":"HealthEventsDatabase"}
{"time":"2026-02-18T07:00:32.553041254Z","level":"INFO","source":{"function":"github.com/nvidia/nvsentinel/health-monitors/csp-health-monitor/pkg/datastore.NewStore","file":"github.com/nvidia/nvsentinel/health-monitors/csp-health-monitor/pkg/datastore/datastore.go","line":91},"msg":"Database client initialized successfully using store-client","module":"csp-health-monitor","version":"v0.7.0","collection":"MaintenanceEvents"}
{"time":"2026-02-18T07:00:32.55305677Z","level":"INFO","source":{"function":"main.run.func2","file":"github.com/nvidia/nvsentinel/health-monitors/csp-health-monitor/cmd/csp-health-monitor/main.go","line":171},"msg":"Datastore initialized successfully.","module":"csp-health-monitor","version":"v0.7.0"}
{"time":"2026-02-18T07:00:32.553069456Z","level":"INFO","source":{"function":"main.run.func2","file":"github.com/nvidia/nvsentinel/health-monitors/csp-health-monitor/cmd/csp-health-monitor/main.go","line":180},"msg":"Event processor initialized successfully.","module":"csp-health-monitor","version":"v0.7.0"}
{"time":"2026-02-18T07:00:32.553075427Z","level":"INFO","source":{"function":"main.initActiveMonitor","file":"github.com/nvidia/nvsentinel/health-monitors/csp-health-monitor/cmd/csp-health-monitor/main.go","line":245},"msg":"AWS configuration is enabled.","module":"csp-health-monitor","version":"v0.7.0"}
{"time":"2026-02-18T07:00:32.553262663Z","level":"INFO","source":{"function":"github.com/nvidia/nvsentinel/health-monitors/csp-health-monitor/pkg/csp/aws.NewClient","file":"github.com/nvidia/nvsentinel/health-monitors/csp-health-monitor/pkg/csp/aws/aws.go","line":142},"msg":"Successfully initialized AWS Health client","module":"csp-health-monitor","version":"v0.7.0","region":"us-east-1"}

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for custom AWS IAM role names in CSP Health Monitor Helm chart configuration.
  * Default role naming remains unchanged, with automatic fallback when custom names are not provided.

* **Documentation**
  * Updated configuration guides with new IAM role name option.
  * Added examples and IAM requirements for AWS deployments.
  * Included guidance for handling long cluster names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->