### PR TITLE
fix: Clean up nolint directives marked as TODO - Part 4

### DIFF
--- a/labeler/pkg/labeler/labeler_test.go
+++ b/labeler/pkg/labeler/labeler_test.go
@@ -766,7 +766,7 @@ func TestKataLabelOverride(t *testing.T) {
 	}
 }
 
-func TestNewLabeler_InvalidLabelSelectors(t *testing.T) {
+func TestNewLabeler_InvalidLabelSelectors_ReturnsError(t *testing.T) {
 	clientset := fake.NewSimpleClientset()
 
 	t.Run("invalid pod label selector", func(t *testing.T) {

--- a/metadata-collector/pkg/mapper/httpsclient.go
+++ b/metadata-collector/pkg/mapper/httpsclient.go
@@ -128,6 +128,14 @@ func (client *kubeletHTTPSClient) ListPods() ([]corev1.Pod, error) {
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
+			snippet := make([]byte, 512)
+			n, _ := resp.Body.Read(snippet)
+
+			if n > 0 {
+				return fmt.Errorf("got a non-200 response code from /pods endpoint: %d, body: %s",
+					resp.StatusCode, string(snippet[:n]))
+			}
+
 			return fmt.Errorf("got a non-200 response code from /pods endpoint: %d", resp.StatusCode)
 		}
 

--- a/node-drainer/pkg/initializer/init.go
+++ b/node-drainer/pkg/initializer/init.go
@@ -70,7 +70,7 @@ func InitializeAll(ctx context.Context, params InitializationParams) (*Component
 
 	configs, err := loadConfigurations(params)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to load configurations: %w", err)
 	}
 
 	pipeline := config.NewQuarantinePipeline()
@@ -87,14 +87,14 @@ func InitializeAll(ctx context.Context, params InitializationParams) (*Component
 
 	clientSet, restConfig, err := initializeKubernetesClient(params.KubeconfigPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize kubernetes client: %w", err)
 	}
 
 	slog.Info("Successfully initialized kubernetes client")
 
 	dynamicClient, restMapper, err := initializeDynamicClientAndMapper(restConfig)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize dynamic client and mapper: %w", err)
 	}
 
 	informersInstance, err := initializeInformers(clientSet, &configs.tomlCfg.NotReadyTimeoutMinutes, params.DryRun)
@@ -128,7 +128,7 @@ func InitializeAll(ctx context.Context, params InitializationParams) (*Component
 
 	dsComponents, err := initializeDatastoreComponents(ctx, ds, clientTokenConfig.ClientName, pipeline)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize datastore components: %w", err)
 	}
 
 	defer closeOnError(&closeOnErr, dsComponents.databaseClient.Close, "database client")

--- a/node-drainer/pkg/initializer/init.go
+++ b/node-drainer/pkg/initializer/init.go
@@ -157,9 +157,11 @@ func InitializeAll(ctx context.Context, params InitializationParams) (*Component
 	}, nil
 }
 
+const cleanupTimeout = 5 * time.Second
+
 func closeOnError(shouldClose *bool, closer func(context.Context) error, resource string) {
 	if *shouldClose {
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
 		defer cancel()
 
 		if cerr := closer(cleanupCtx); cerr != nil {

--- a/node-drainer/pkg/initializer/init.go
+++ b/node-drainer/pkg/initializer/init.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package initializer bootstraps all node-drainer runtime dependencies
+// (Kubernetes clients, datastore, informers, reconciler) and returns
+// them as a single Components struct ready for use by main.
 package initializer
 
 import (
@@ -42,6 +45,7 @@ import (
 	_ "github.com/nvidia/nvsentinel/store-client/pkg/datastore/providers"
 )
 
+// InitializationParams holds the configuration paths and flags needed to bootstrap the node-drainer.
 type InitializationParams struct {
 	DatabaseClientCertMountPath string
 	KubeconfigPath              string
@@ -50,6 +54,7 @@ type InitializationParams struct {
 	DryRun                      bool
 }
 
+// Components holds the initialized runtime dependencies returned by InitializeAll.
 type Components struct {
 	Informers      *informers.Informers
 	EventWatcher   client.ChangeStreamWatcher
@@ -59,37 +64,22 @@ type Components struct {
 	DataStore      datastore.DataStore
 }
 
-//nolint:cyclop // Complexity slightly over limit (11 vs 10) but function is clear and linear
+// InitializeAll creates all node-drainer runtime dependencies from the given params and returns them as Components.
 func InitializeAll(ctx context.Context, params InitializationParams) (*Components, error) {
 	slog.Info("Starting node drainer initialization")
 
-	// Load token configuration - preserves ClientName="node-drainer" for resume token lookups
-	tokenConfig, err := sdkconfig.TokenConfigFromEnv("node-drainer")
+	configs, err := loadConfigurations(params)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load token configuration: %w", err)
+		return nil, err
 	}
 
-	// Load datastore configuration using the new unified system
-	dsConfig, err := datastore.LoadDatastoreConfig()
-	if err != nil {
-		return nil, fmt.Errorf("failed to load datastore config: %w", err)
-	}
-
-	// Convert to legacy DatabaseConfig interface for compatibility with existing factory
-	// Pass the certificate mount path to the adapter to handle path resolution at runtime
-	databaseConfig := adapter.ConvertDataStoreConfigToLegacyWithCertPath(dsConfig, params.DatabaseClientCertMountPath)
 	pipeline := config.NewQuarantinePipeline()
-
-	tomlCfg, err := config.LoadTomlConfig(params.TomlConfigPath)
-	if err != nil {
-		return nil, fmt.Errorf("error while loading the toml config: %w", err)
-	}
 
 	if params.DryRun {
 		slog.Info("Running in dry-run mode")
 	}
 
-	if tomlCfg.PartialDrainEnabled {
+	if configs.tomlCfg.PartialDrainEnabled {
 		slog.Info("Running with partial drain enabled")
 	} else {
 		slog.Info("Running with partial drain disabled")
@@ -97,50 +87,148 @@ func InitializeAll(ctx context.Context, params InitializationParams) (*Component
 
 	clientSet, restConfig, err := initializeKubernetesClient(params.KubeconfigPath)
 	if err != nil {
-		return nil, fmt.Errorf("error while initializing kubernetes client: %w", err)
+		return nil, err
 	}
 
 	slog.Info("Successfully initialized kubernetes client")
 
-	dynamicClient, err := dynamic.NewForConfig(restConfig)
+	dynamicClient, restMapper, err := initializeDynamicClientAndMapper(restConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
+		return nil, err
 	}
 
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create discovery client: %w", err)
-	}
-
-	cachedClient := memory.NewMemCacheClient(discoveryClient)
-	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(cachedClient)
-
-	informersInstance, err := initializeInformers(clientSet, &tomlCfg.NotReadyTimeoutMinutes, params.DryRun)
+	informersInstance, err := initializeInformers(clientSet, &configs.tomlCfg.NotReadyTimeoutMinutes, params.DryRun)
 	if err != nil {
 		return nil, fmt.Errorf("error while initializing informers: %w", err)
 	}
 
 	stateManager := initializeStateManager(clientSet)
 
-	// Convert store-client TokenConfig to client.TokenConfig type
 	// IMPORTANT: Preserves ClientName="node-drainer" for resume token lookups
 	clientTokenConfig := client.TokenConfig{
-		ClientName:      tokenConfig.ClientName,
-		TokenDatabase:   tokenConfig.TokenDatabase,
-		TokenCollection: tokenConfig.TokenCollection,
+		ClientName:      configs.tokenConfig.ClientName,
+		TokenDatabase:   configs.tokenConfig.TokenDatabase,
+		TokenCollection: configs.tokenConfig.TokenCollection,
 	}
 
-	reconcilerCfg := createReconcilerConfig(*tomlCfg, databaseConfig, clientTokenConfig, pipeline, stateManager)
+	reconcilerCfg := createReconcilerConfig(
+		*configs.tomlCfg, configs.databaseConfig, clientTokenConfig, stateManager,
+	)
 
-	// Create NEW database-agnostic datastore
-	ds, err := datastore.NewDataStore(ctx, *dsConfig)
+	ds, err := datastore.NewDataStore(ctx, *configs.dsConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create datastore: %w", err)
 	}
 
-	slog.Debug("Created datastore", "provider", dsConfig.Provider)
+	closeOnErr := true
 
-	// Get database client and change stream watcher from datastore
+	defer closeOnError(&closeOnErr, ds.Close, "datastore")
+
+	slog.Debug("Created datastore", "provider", configs.dsConfig.Provider)
+
+	dsComponents, err := initializeDatastoreComponents(ctx, ds, clientTokenConfig.ClientName, pipeline)
+	if err != nil {
+		return nil, err
+	}
+
+	defer closeOnError(&closeOnErr, dsComponents.databaseClient.Close, "database client")
+
+	reconcilerInstance, err := initializeReconciler(
+		reconcilerCfg, params.DryRun, clientSet, informersInstance,
+		dsComponents.databaseClient, ds.HealthEventStore(), dynamicClient, restMapper,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize reconciler: %w", err)
+	}
+
+	queueManager := reconcilerInstance.GetQueueManager()
+
+	slog.Info("Initialization completed successfully")
+
+	closeOnErr = false
+
+	return &Components{
+		Informers:      informersInstance,
+		EventWatcher:   dsComponents.eventWatcher,
+		QueueManager:   queueManager,
+		Reconciler:     reconcilerInstance,
+		DatabaseClient: dsComponents.databaseClient,
+		DataStore:      ds,
+	}, nil
+}
+
+func closeOnError(shouldClose *bool, closer func(context.Context) error, resource string) {
+	if *shouldClose {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if cerr := closer(cleanupCtx); cerr != nil {
+			slog.Warn("Failed to close resource during error cleanup", "resource", resource, "error", cerr)
+		}
+	}
+}
+
+type initConfigs struct {
+	tokenConfig    sdkconfig.TokenConfig
+	dsConfig       *datastore.DataStoreConfig
+	databaseConfig sdkconfig.DatabaseConfig
+	tomlCfg        *config.TomlConfig
+}
+
+func loadConfigurations(params InitializationParams) (*initConfigs, error) {
+	tokenConfig, err := sdkconfig.TokenConfigFromEnv("node-drainer")
+	if err != nil {
+		return nil, fmt.Errorf("failed to load token configuration: %w", err)
+	}
+
+	dsConfig, err := datastore.LoadDatastoreConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load datastore config: %w", err)
+	}
+
+	// Convert to legacy DatabaseConfig interface for compatibility with existing factory.
+	// Pass the certificate mount path to the adapter to handle path resolution at runtime.
+	databaseConfig := adapter.ConvertDataStoreConfigToLegacyWithCertPath(dsConfig, params.DatabaseClientCertMountPath)
+
+	tomlCfg, err := config.LoadTomlConfig(params.TomlConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("error while loading the toml config: %w", err)
+	}
+
+	return &initConfigs{
+		tokenConfig:    tokenConfig,
+		dsConfig:       dsConfig,
+		databaseConfig: databaseConfig,
+		tomlCfg:        tomlCfg,
+	}, nil
+}
+
+func initializeDynamicClientAndMapper(
+	restConfig *rest.Config,
+) (dynamic.Interface, *restmapper.DeferredDiscoveryRESTMapper, error) {
+	dynamicClient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create dynamic client: %w", err)
+	}
+
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(restConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create discovery client: %w", err)
+	}
+
+	cachedClient := memory.NewMemCacheClient(discoveryClient)
+	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(cachedClient)
+
+	return dynamicClient, restMapper, nil
+}
+
+type datastoreComponents struct {
+	databaseClient client.DatabaseClient
+	eventWatcher   client.ChangeStreamWatcher
+}
+
+func initializeDatastoreComponents(ctx context.Context, ds datastore.DataStore,
+	clientName string, pipeline any) (*datastoreComponents, error) {
 	datastoreAdapter, ok := ds.(interface {
 		GetDatabaseClient() client.DatabaseClient
 		CreateChangeStreamWatcher(
@@ -153,19 +241,8 @@ func InitializeAll(ctx context.Context, params InitializationParams) (*Component
 
 	databaseClient := datastoreAdapter.GetDatabaseClient()
 
-	// Reconciler creates its own queue manager and needs the database client
-	reconciler, err := initializeReconciler(
-		reconcilerCfg, params.DryRun, clientSet, informersInstance,
-		databaseClient, ds.HealthEventStore(), dynamicClient, restMapper,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize reconciler: %w", err)
-	}
-
-	queueManager := reconciler.GetQueueManager()
-
 	changeStreamWatcher, err := datastoreAdapter.CreateChangeStreamWatcher(
-		ctx, "node-drainer", pipeline)
+		ctx, clientName, pipeline)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create change stream watcher: %w", err)
 	}
@@ -180,17 +257,9 @@ func InitializeAll(ctx context.Context, params InitializationParams) (*Component
 		return nil, fmt.Errorf("watcher does not support unwrapping to client.ChangeStreamWatcher")
 	}
 
-	eventWatcher := unwrapable.Unwrap()
-
-	slog.Info("Initialization completed successfully")
-
-	return &Components{
-		Informers:      informersInstance,
-		EventWatcher:   eventWatcher,
-		QueueManager:   queueManager,
-		Reconciler:     reconciler,
-		DatabaseClient: databaseClient,
-		DataStore:      ds,
+	return &datastoreComponents{
+		databaseClient: databaseClient,
+		eventWatcher:   unwrapable.Unwrap(),
 	}, nil
 }
 
@@ -225,7 +294,6 @@ func createReconcilerConfig(
 	tomlCfg config.TomlConfig,
 	databaseConfig sdkconfig.DatabaseConfig,
 	tokenConfig client.TokenConfig,
-	pipeline interface{}, // Still passed for potential future use, but not stored in config
 	stateManager statemanager.StateManager,
 ) config.ReconcilerConfig {
 	return config.ReconcilerConfig{

--- a/node-drainer/pkg/reconciler/reconciler_integration_test.go
+++ b/node-drainer/pkg/reconciler/reconciler_integration_test.go
@@ -1763,6 +1763,14 @@ func TestReconciler_MultipleEventsOnNodeCancelledByUnQuarantine(t *testing.T) {
 	assert.Nil(t, pod2.DeletionTimestamp, "pod-2 should not be deleted")
 }
 
+func TestReconciler_HandleCancellation_UnknownStatus_LogsWarning(t *testing.T) {
+	setup := setupDirectTest(t, nil, false)
+
+	require.NotPanics(t, func() {
+		setup.reconciler.HandleCancellation("evt-1", "node-1", model.Status("SomeUnknownStatus"))
+	})
+}
+
 func TestReconciler_CustomDrainHappyPath(t *testing.T) {
 	customDrainCfg := config.CustomDrainConfig{
 		Enabled:               true,

--- a/platform-connectors/pkg/connectors/kubernetes/k8s_connector_envtest_test.go
+++ b/platform-connectors/pkg/connectors/kubernetes/k8s_connector_envtest_test.go
@@ -286,7 +286,7 @@ func TestK8sConnector_WithEnvtest_AddMessages(t *testing.T) {
 		},
 	}
 
-	err = connector.updateNodeConditions(ctx, healthEvents)
+	_, err = connector.updateNodeConditions(ctx, healthEvents)
 	require.NoError(t, err)
 
 	node, err = cli.CoreV1().Nodes().Get(ctx, "test-node", metav1.GetOptions{})
@@ -344,7 +344,7 @@ func TestK8sConnector_WithEnvtest_RemoveMessages(t *testing.T) {
 		},
 	}
 
-	err = connector.updateNodeConditions(ctx, healthEvents)
+	_, err = connector.updateNodeConditions(ctx, healthEvents)
 	require.NoError(t, err)
 
 	node, err = cli.CoreV1().Nodes().Get(ctx, "test-node", metav1.GetOptions{})
@@ -477,7 +477,7 @@ func TestK8sConnector_WithEnvtest_TransitionTimeUpdates(t *testing.T) {
 		},
 	}
 
-	err = connector.updateNodeConditions(ctx, healthEvents)
+	_, err = connector.updateNodeConditions(ctx, healthEvents)
 	require.NoError(t, err)
 
 	node, err = cli.CoreV1().Nodes().Get(ctx, "test-node", metav1.GetOptions{})

--- a/preflight-checks/nccl-loopback/pkg/benchmark/benchmark.go
+++ b/preflight-checks/nccl-loopback/pkg/benchmark/benchmark.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package benchmark provides runners for executing NCCL loopback benchmarks
+// and parsing their output.
 package benchmark
 
 import (
@@ -49,7 +51,7 @@ type Runner struct {
 	binaryPath string
 }
 
-// NewRunner creates a new benchmark runner.
+// NewRunner creates a new benchmark runner with the given binary path.
 func NewRunner(binaryPath string) *Runner {
 	return &Runner{binaryPath: binaryPath}
 }
@@ -67,8 +69,7 @@ func (r *Runner) Run(ctx context.Context, numGPUs, testSizeMB int) (*Result, err
 
 	sizeArg := fmt.Sprintf("%dM", testSizeMB)
 
-	//nolint:gosec // Validated binary path
-	cmd := exec.CommandContext(ctx, r.binaryPath,
+	cmd := exec.CommandContext(ctx, r.binaryPath, //nolint:gosec // G204 - binary path validated in NewRunner
 		"-b", sizeArg,
 		"-e", sizeArg,
 		"-g", strconv.Itoa(numGPUs),

--- a/preflight-checks/nccl-loopback/pkg/benchmark/benchmark.go
+++ b/preflight-checks/nccl-loopback/pkg/benchmark/benchmark.go
@@ -69,7 +69,8 @@ func (r *Runner) Run(ctx context.Context, numGPUs, testSizeMB int) (*Result, err
 
 	sizeArg := fmt.Sprintf("%dM", testSizeMB)
 
-	cmd := exec.CommandContext(ctx, r.binaryPath, //nolint:gosec // G204 - binary path validated in NewRunner
+	// G204: binaryPath validated via config.FromEnv (parseBinaryPath → validateExecutable)
+	cmd := exec.CommandContext(ctx, r.binaryPath, //nolint:gosec
 		"-b", sizeArg,
 		"-e", sizeArg,
 		"-g", strconv.Itoa(numGPUs),

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/nvidia/nvsentinel/commons v0.0.0
 	github.com/nvidia/nvsentinel/data-models v0.0.0
+	github.com/nvidia/nvsentinel/fault-remediation v0.0.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.67.5
 	github.com/stretchr/testify v1.11.1
@@ -53,7 +54,6 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.18.2 // indirect
 	github.com/moby/spdystream v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
@@ -80,7 +80,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.34.3 // indirect
 	k8s.io/component-base v0.34.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20251125145642-4e65d59e963e // indirect
@@ -95,3 +94,5 @@ replace github.com/nvidia/nvsentinel/data-models => ../data-models
 replace github.com/nvidia/nvsentinel/store-client => ../store-client
 
 replace github.com/nvidia/nvsentinel/commons => ../commons
+
+replace github.com/nvidia/nvsentinel/fault-remediation => ../fault-remediation

--- a/tests/helpers/fault_remediation.go
+++ b/tests/helpers/fault_remediation.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 
 	"github.com/nvidia/nvsentinel/commons/pkg/statemanager"
+	"github.com/nvidia/nvsentinel/fault-remediation/pkg/annotation"
 )
 
 type RemediationTestContextKey int
@@ -146,8 +147,8 @@ func cleanNodeMetadata(node *v1.Node) bool {
 	}
 
 	if node.Annotations != nil {
-		if _, exists := node.Annotations["latestFaultRemediationState"]; exists {
-			delete(node.Annotations, "latestFaultRemediationState")
+		if _, exists := node.Annotations[annotation.AnnotationKey]; exists {
+			delete(node.Annotations, annotation.AnnotationKey)
 
 			modified = true
 		}

--- a/tests/helpers/fault_remediation.go
+++ b/tests/helpers/fault_remediation.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/util/retry"
@@ -77,7 +78,6 @@ func SetupFaultRemediationTest(
 	return ctx, testCtx
 }
 
-//nolint:cyclop // Test teardown function with multiple cleanup steps
 func TeardownFaultRemediation(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 	t.Helper()
 
@@ -108,25 +108,7 @@ func TeardownFaultRemediation(ctx context.Context, t *testing.T, c *envconf.Conf
 			return getErr
 		}
 
-		modified := false
-
-		if node.Labels != nil {
-			if _, exists := node.Labels[statemanager.NVSentinelStateLabelKey]; exists {
-				delete(node.Labels, statemanager.NVSentinelStateLabelKey)
-
-				modified = true
-			}
-		}
-
-		if node.Annotations != nil {
-			if _, exists := node.Annotations["latestFaultRemediationState"]; exists {
-				delete(node.Annotations, "latestFaultRemediationState")
-
-				modified = true
-			}
-		}
-
-		if modified {
+		if cleanNodeMetadata(node) {
 			return client.Resources().Update(ctx, node)
 		}
 
@@ -150,6 +132,28 @@ func TeardownFaultRemediation(ctx context.Context, t *testing.T, c *envconf.Conf
 	}
 
 	return ctx
+}
+
+func cleanNodeMetadata(node *v1.Node) bool {
+	modified := false
+
+	if node.Labels != nil {
+		if _, exists := node.Labels[statemanager.NVSentinelStateLabelKey]; exists {
+			delete(node.Labels, statemanager.NVSentinelStateLabelKey)
+
+			modified = true
+		}
+	}
+
+	if node.Annotations != nil {
+		if _, exists := node.Annotations["latestFaultRemediationState"]; exists {
+			delete(node.Annotations, "latestFaultRemediationState")
+
+			modified = true
+		}
+	}
+
+	return modified
 }
 
 // GetRebootNodeCRsForNode returns all RebootNode CR names for a specific node

--- a/tests/helpers/kube.go
+++ b/tests/helpers/kube.go
@@ -1156,7 +1156,7 @@ func WaitForDeploymentRollout(
 
 		selector := buildMatchLabelSelector(t, deployment)
 		if selector == "" {
-			t.Logf("Deployment %s/%s has no match labels for selector", deployment.Namespace, deployment.Name)
+			t.Logf("Deployment %s/%s has empty or invalid selector", deployment.Namespace, deployment.Name)
 			return false
 		}
 

--- a/tests/helpers/kube.go
+++ b/tests/helpers/kube.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -164,21 +165,64 @@ intended sequence rather than starting without the label value. This is required
 between the end of the TestScaleHealthEvents where a node may have the remediation-succeeded when the test completes.
 This workaround can be removed after KACE-1703 is completed.
 */
-//nolint:cyclop,gocognit // Test helper with complex state machine logic
 func StartNodeLabelWatcher(ctx context.Context, t *testing.T, c klient.Client, nodeName string,
 	labelValueSequence []string, waitForLabelRemoval bool, success chan bool) error {
-	currentLabelIndex := 0
-	prevLabelValue := ""
+	state := newLabelWatcherState(ctx, t, c, nodeName, labelValueSequence, waitForLabelRemoval)
+
+	t.Logf("[LabelWatcher] Starting watcher for node %s, expecting sequence: %v (starting at index %d)",
+		nodeName, labelValueSequence, state.currentLabelIndex)
+
+	// Safe to send directly via sendNodeLabelResult (not s.sendResult) because the
+	// watch has not started yet, so there is no concurrent handleUpdate that could race.
+	if state.currentLabelIndex == len(labelValueSequence) && !waitForLabelRemoval {
+		t.Logf("[LabelWatcher] Node %s already at final label state, sending SUCCESS immediately", nodeName)
+
+		go sendNodeLabelResult(ctx, success, true)
+
+		return nil
+	}
+
+	return c.Resources().Watch(&v1.NodeList{}, resources.WithFieldSelector(
+		labels.FormatLabels(map[string]string{"metadata.name": nodeName}))).
+		WithUpdateFunc(func(updated interface{}) {
+			state.handleUpdate(t, ctx, updated, success)
+		}).Start(ctx)
+}
+
+type labelWatcherState struct {
+	// Lock to prevent concurrent access to currentLabelIndex/prevLabelValue.
+	// Sends to the success channel will be blocked on the test runner reading the result
+	// in TestFatalHealthEventEndToEnd. The UpdateFunc thread which has acquired the lock
+	// will be waiting for the main thread to read from the success channel. This is the
+	// desired behavior because we only want to have 1 UpdateFunc thread write true/false.
+	mu                  sync.Mutex
+	currentLabelIndex   int
+	prevLabelValue      string
+	labelValueSequence  []string
+	nodeName            string
+	waitForLabelRemoval bool
+	resultSent          bool
+}
+
+func newLabelWatcherState(ctx context.Context, t *testing.T, c klient.Client,
+	nodeName string, labelValueSequence []string, waitForLabelRemoval bool) *labelWatcherState {
+	state := &labelWatcherState{
+		labelValueSequence:  labelValueSequence,
+		nodeName:            nodeName,
+		waitForLabelRemoval: waitForLabelRemoval,
+	}
 
 	node, err := GetNodeByName(ctx, c, nodeName)
-	if err == nil {
+	if err != nil {
+		t.Logf("[LabelWatcher] Failed to get node %s for initial state: %v, starting from index 0", nodeName, err)
+	} else {
 		if currentValue, exists := node.Labels[statemanager.NVSentinelStateLabelKey]; exists {
 			for i, expected := range labelValueSequence {
 				if currentValue == expected {
 					t.Logf("[LabelWatcher] Node %s already has label=%s (index %d), adjusting start position",
 						nodeName, currentValue, i)
-					currentLabelIndex = i + 1 // Start watching for the NEXT label
-					prevLabelValue = currentValue
+					state.currentLabelIndex = i + 1
+					state.prevLabelValue = currentValue
 
 					break
 				}
@@ -186,116 +230,136 @@ func StartNodeLabelWatcher(ctx context.Context, t *testing.T, c klient.Client, n
 		}
 	}
 
-	// Lock to prevent concurrent access to currentLabelIndex/prevLabelValue/foundInvalidSequence.
-	// Note that sends to the success channel will be blocked on the test runner reading the result of this label sequence
-	// in TestFatalHealthEventEndToEnd. The UpdateFunc thread which has acquired the lock will be waiting for the main
-	// thead to read from the success channel. This is the desired behavior because we only want to have 1 UpdateFunc
-	// thread write true/false.
-	var lock sync.Mutex
+	return state
+}
 
-	t.Logf("[LabelWatcher] Starting watcher for node %s, expecting sequence: %v (starting at index %d)",
-		nodeName, labelValueSequence, currentLabelIndex)
+func (s *labelWatcherState) handleUpdate(t *testing.T, ctx context.Context, updated interface{}, success chan bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-	return c.Resources().Watch(&v1.NodeList{}, resources.WithFieldSelector(
-		labels.FormatLabels(map[string]string{"metadata.name": nodeName}))).
-		WithUpdateFunc(func(updated interface{}) {
-			lock.Lock()
-			defer lock.Unlock()
+	node, ok := updated.(*v1.Node)
+	if !ok || node == nil {
+		t.Logf("[LabelWatcher] unexpected update type %T for node %s, skipping", updated, s.nodeName)
+		return
+	}
 
-			node := updated.(*v1.Node)
+	actualValue, exists := node.Labels[statemanager.NVSentinelStateLabelKey]
 
-			actualValue, exists := node.Labels[statemanager.NVSentinelStateLabelKey]
-			if exists && currentLabelIndex < len(labelValueSequence) { //nolint:nestif // Complex label state tracking logic
-				expectedValue := labelValueSequence[currentLabelIndex]
-				t.Logf("[LabelWatcher] Node %s update: %s=%s (progress: %d/%d, expected: %s, prev: %s)",
-					nodeName, statemanager.NVSentinelStateLabelKey, actualValue,
-					currentLabelIndex, len(labelValueSequence), expectedValue, prevLabelValue)
-				//nolint:gocritic // Complex boolean logic appropriate for state transitions
-				if currentLabelIndex < len(labelValueSequence) && actualValue == labelValueSequence[currentLabelIndex] {
-					t.Logf("[LabelWatcher] ✓ MATCHED expected label [%d]: %s", currentLabelIndex, actualValue)
-					prevLabelValue = labelValueSequence[currentLabelIndex]
+	if exists && s.currentLabelIndex < len(s.labelValueSequence) {
+		s.handleLabelPresent(t, ctx, actualValue, success)
+	} else if !exists {
+		s.handleLabelAbsent(t, ctx, success)
+	}
+	// Label exists but sequence already complete: deliberate no-op.
+	// The watcher is either waiting for label removal (handled by
+	// handleLabelAbsent on a future update) or has already sent a result.
+}
 
-					currentLabelIndex++
-					if currentLabelIndex == len(labelValueSequence) {
-						if !waitForLabelRemoval {
-							t.Logf("[LabelWatcher] ✓ All labels observed, not waiting for removal. Sending SUCCESS to channel")
-							sendNodeLabelResult(ctx, success, true)
-						}
+func (s *labelWatcherState) handleLabelPresent(t *testing.T, ctx context.Context,
+	actualValue string, success chan bool) {
+	expectedValue := s.labelValueSequence[s.currentLabelIndex]
+	t.Logf("[LabelWatcher] Node %s update: %s=%s (progress: %d/%d, expected: %s, prev: %s)",
+		s.nodeName, statemanager.NVSentinelStateLabelKey, actualValue,
+		s.currentLabelIndex, len(s.labelValueSequence), expectedValue, s.prevLabelValue)
 
-						t.Logf("[LabelWatcher] ✓ All %d labels matched! Waiting for label removal...", len(labelValueSequence))
-					}
-				} else if actualValue != labelValueSequence[currentLabelIndex] && prevLabelValue != actualValue {
-					// Check if the actual label appears later in the sequence (skipped intermediate states)
-					// This can happen with fast state transitions, especially with PostgreSQL LISTEN/NOTIFY
-					foundLaterInSequence := false
-					skippedIndex := -1
+	switch {
+	case actualValue == expectedValue:
+		s.handleMatchedLabel(t, ctx, actualValue, success)
+	case actualValue != s.prevLabelValue:
+		s.handleOutOfSequenceLabel(t, ctx, actualValue, success)
+	default:
+		t.Logf("[LabelWatcher] Ignoring duplicate update for label: %s", actualValue)
+	}
+}
 
-					for i := currentLabelIndex + 1; i < len(labelValueSequence); i++ {
-						if actualValue == labelValueSequence[i] {
-							foundLaterInSequence = true
-							skippedIndex = i
+func (s *labelWatcherState) handleMatchedLabel(t *testing.T, ctx context.Context,
+	actualValue string, success chan bool) {
+	t.Logf("[LabelWatcher] ✓ MATCHED expected label [%d]: %s", s.currentLabelIndex, actualValue)
+	s.prevLabelValue = s.labelValueSequence[s.currentLabelIndex]
+	s.currentLabelIndex++
 
-							break
-						}
-					}
+	if s.currentLabelIndex == len(s.labelValueSequence) {
+		if !s.waitForLabelRemoval {
+			t.Logf("[LabelWatcher] ✓ All labels observed, not waiting for removal. Sending SUCCESS to channel")
+			s.sendResult(ctx, success, true)
+		} else {
+			t.Logf("[LabelWatcher] ✓ All %d labels matched! Waiting for label removal...", len(s.labelValueSequence))
+		}
+	}
+}
 
-					if foundLaterInSequence {
-						// We skipped intermediate states - log warning but continue
-						skippedLabels := labelValueSequence[currentLabelIndex:skippedIndex]
-						t.Logf(
-							"[LabelWatcher] ⚠ SKIPPED intermediate labels: %v (jumped from '%s' to '%s')",
-							skippedLabels, prevLabelValue, actualValue,
-						)
-						t.Logf("[LabelWatcher] ⚠ This is expected with fast state transitions (PostgreSQL LISTEN/NOTIFY)")
+func (s *labelWatcherState) handleOutOfSequenceLabel(t *testing.T, ctx context.Context,
+	actualValue string, success chan bool) {
+	// Check if the actual label appears later in the sequence (skipped intermediate states).
+	// This can happen with fast state transitions, especially with PostgreSQL LISTEN/NOTIFY.
+	skippedIndex := -1
 
-						// Update state to the current label
-						prevLabelValue = actualValue
-						currentLabelIndex = skippedIndex + 1
+	for i := s.currentLabelIndex + 1; i < len(s.labelValueSequence); i++ {
+		if actualValue == s.labelValueSequence[i] {
+			skippedIndex = i
 
-						if currentLabelIndex == len(labelValueSequence) {
-							t.Logf("[LabelWatcher] ✓ Reached final state despite skipped labels! Waiting for label removal...")
-						}
-					} else if currentLabelIndex == 0 {
-						// First label doesn't match and isn't in sequence - missed early labels
-						t.Logf(
-							"[LabelWatcher] ✗ MISSED early labels: First label received is '%s', "+
-								"but expected to start with '%s' (index 0)",
-							actualValue, labelValueSequence[0],
-						)
-						t.Logf("[LabelWatcher] Sending FAILURE to channel (missed early labels)")
-						sendNodeLabelResult(ctx, success, false)
-					} else {
-						// Completely unexpected transition (not in sequence at all)
-						t.Logf("[LabelWatcher] ✗ UNEXPECTED label transition: got '%s', expected '%s' (prev: '%s')",
-							actualValue, labelValueSequence[currentLabelIndex], prevLabelValue)
-						t.Logf("[LabelWatcher] ✗ Label '%s' is not in expected sequence", actualValue)
-						t.Logf("[LabelWatcher] Sending FAILURE to channel")
-						sendNodeLabelResult(ctx, success, false)
-					}
-				} else if actualValue == prevLabelValue {
-					t.Logf("[LabelWatcher] Ignoring duplicate update for label: %s", actualValue)
-				}
+			break
+		}
+	}
+
+	switch {
+	case skippedIndex >= 0:
+		skippedLabels := s.labelValueSequence[s.currentLabelIndex:skippedIndex]
+		t.Logf("[LabelWatcher] ⚠ SKIPPED intermediate labels: %v (jumped from '%s' to '%s')",
+			skippedLabels, s.prevLabelValue, actualValue)
+		t.Logf("[LabelWatcher] ⚠ This is expected with fast state transitions (PostgreSQL LISTEN/NOTIFY)")
+
+		s.prevLabelValue = actualValue
+		s.currentLabelIndex = skippedIndex + 1
+
+		if s.currentLabelIndex == len(s.labelValueSequence) {
+			if !s.waitForLabelRemoval {
+				t.Logf("[LabelWatcher] ✓ Reached final state despite skipped labels. Sending SUCCESS to channel")
+				s.sendResult(ctx, success, true)
 			} else {
-				t.Logf("[LabelWatcher] Node %s update: %s label doesn't exist (progress: %d/%d)",
-					nodeName, statemanager.NVSentinelStateLabelKey, currentLabelIndex, len(labelValueSequence))
-
-				switch {
-				case currentLabelIndex == len(labelValueSequence):
-					t.Logf("[LabelWatcher] ✓ All labels observed and now removed. Sending SUCCESS to channel")
-					sendNodeLabelResult(ctx, success, true)
-				case currentLabelIndex != 0:
-					t.Logf("[LabelWatcher] ✗ Label removed prematurely (only saw %d/%d labels). Sending FAILURE to channel",
-						currentLabelIndex, len(labelValueSequence))
-					sendNodeLabelResult(ctx, success, false)
-				default:
-					t.Logf("[LabelWatcher] Waiting for first label to appear...")
-				}
+				t.Logf("[LabelWatcher] ✓ Reached final state despite skipped labels! Waiting for label removal...")
 			}
-			// Do nothing if the label exists and the actualValue equals the previous label value, if the first label
-			// observed doesn't match yet, or if we already found all the expected labels and we're waiting for the
-			// label to be removed. Additionally, do nothing if the label doesn't exist and we still haven't seen the
-			// label added.
-		}).Start(ctx)
+		}
+	case s.currentLabelIndex == 0:
+		t.Logf("[LabelWatcher] ✗ MISSED early labels: First label received is '%s', "+
+			"but expected to start with '%s' (index 0)",
+			actualValue, s.labelValueSequence[0])
+		t.Logf("[LabelWatcher] Sending FAILURE to channel (missed early labels)")
+		s.sendResult(ctx, success, false)
+	default:
+		t.Logf("[LabelWatcher] ✗ UNEXPECTED label transition: got '%s', expected '%s' (prev: '%s')",
+			actualValue, s.labelValueSequence[s.currentLabelIndex], s.prevLabelValue)
+		t.Logf("[LabelWatcher] ✗ Label '%s' is not in expected sequence", actualValue)
+		t.Logf("[LabelWatcher] Sending FAILURE to channel")
+		s.sendResult(ctx, success, false)
+	}
+}
+
+func (s *labelWatcherState) handleLabelAbsent(t *testing.T, ctx context.Context, success chan bool) {
+	t.Logf("[LabelWatcher] Node %s update: %s label doesn't exist (progress: %d/%d)",
+		s.nodeName, statemanager.NVSentinelStateLabelKey, s.currentLabelIndex, len(s.labelValueSequence))
+
+	switch {
+	case s.currentLabelIndex == len(s.labelValueSequence):
+		t.Logf("[LabelWatcher] ✓ All labels observed and now removed. Sending SUCCESS to channel")
+		s.sendResult(ctx, success, true)
+	case s.currentLabelIndex != 0:
+		t.Logf("[LabelWatcher] ✗ Label removed prematurely (only saw %d/%d labels). Sending FAILURE to channel",
+			s.currentLabelIndex, len(s.labelValueSequence))
+		s.sendResult(ctx, success, false)
+	default:
+		t.Logf("[LabelWatcher] Waiting for first label to appear...")
+	}
+}
+
+func (s *labelWatcherState) sendResult(ctx context.Context, success chan bool, result bool) {
+	if s.resultSent {
+		return
+	}
+
+	s.resultSent = true
+
+	sendNodeLabelResult(ctx, success, result)
 }
 
 func sendNodeLabelResult(ctx context.Context, success chan bool, result bool) {
@@ -1065,7 +1129,8 @@ func ScaleDeployment(ctx context.Context, t *testing.T, c klient.Client, name, n
 	})
 }
 
-//nolint:cyclop,gocognit // Test helper with complex deployment rollout logic
+// WaitForDeploymentRollout blocks until the named Deployment's rollout is complete
+// (all replicas ready and the current ReplicaSet has ready pods) or ctx is cancelled.
 func WaitForDeploymentRollout(
 	ctx context.Context, t *testing.T, c klient.Client, name, namespace string,
 ) {
@@ -1079,125 +1144,28 @@ func WaitForDeploymentRollout(
 			return false
 		}
 
-		// Check all conditions for a successful rollout (same as kubectl rollout status)
-		if deployment.Spec.Replicas == nil {
-			t.Logf("Deployment spec replicas is nil")
+		expectedReplicas, replicasReady := checkDeploymentReplicaStatus(t, deployment)
+		if !replicasReady {
 			return false
 		}
 
-		expectedReplicas := *deployment.Spec.Replicas
+		if expectedReplicas == 0 {
+			t.Logf("Rollout complete: deployment %s/%s scaled to zero", deployment.Namespace, deployment.Name)
+			return true
+		}
 
-		if deployment.Status.UpdatedReplicas != expectedReplicas {
-			t.Logf("Waiting: UpdatedReplicas=%d, Expected=%d", deployment.Status.UpdatedReplicas, expectedReplicas)
+		selector := buildMatchLabelSelector(t, deployment)
+		if selector == "" {
+			t.Logf("Deployment %s/%s has no match labels for selector", deployment.Namespace, deployment.Name)
 			return false
 		}
 
-		if deployment.Status.ReadyReplicas != expectedReplicas {
-			t.Logf("Waiting: ReadyReplicas=%d, Expected=%d", deployment.Status.ReadyReplicas, expectedReplicas)
+		currentRS, foundReplicaSet := findCurrentReplicaSet(ctx, t, c, selector, deployment, namespace)
+		if !foundReplicaSet {
 			return false
 		}
 
-		if deployment.Status.AvailableReplicas != expectedReplicas {
-			t.Logf("Waiting: AvailableReplicas=%d, Expected=%d", deployment.Status.AvailableReplicas, expectedReplicas)
-			return false
-		}
-
-		if deployment.Status.ObservedGeneration < deployment.Generation {
-			t.Logf("Waiting: ObservedGeneration=%d, Generation=%d", deployment.Status.ObservedGeneration, deployment.Generation)
-			return false
-		}
-
-		// Find the current ReplicaSet (highest revision) to verify we're checking the right pods
-		rsList := &appsv1.ReplicaSetList{}
-		rsLabelSelector := ""
-
-		rsLabels := []string{}
-		for k, v := range deployment.Spec.Selector.MatchLabels {
-			rsLabels = append(rsLabels, fmt.Sprintf("%s=%s", k, v))
-		}
-
-		rsLabelSelector = strings.Join(rsLabels, ",")
-
-		if err := c.Resources(namespace).List(ctx, rsList, resources.WithLabelSelector(rsLabelSelector)); err != nil {
-			t.Logf("Error listing ReplicaSets: %v", err)
-			return false
-		}
-
-		// Find the ReplicaSet with highest revision (current one)
-		var currentRS *appsv1.ReplicaSet
-
-		highestRevision := int64(-1)
-
-		for i := range rsList.Items {
-			rs := &rsList.Items[i]
-			if rs.Annotations == nil {
-				continue
-			}
-
-			revisionStr := rs.Annotations["deployment.kubernetes.io/revision"]
-			if revisionStr == "" {
-				continue
-			}
-
-			revision := int64(0)
-			if _, err := fmt.Sscanf(revisionStr, "%d", &revision); err != nil {
-				// Skip this replica set if revision parsing fails
-				continue
-			}
-
-			if revision > highestRevision {
-				highestRevision = revision
-				currentRS = rs
-			}
-		}
-
-		if currentRS == nil {
-			t.Logf("Could not find current ReplicaSet")
-			return false
-		}
-
-		currentPodTemplateHash := currentRS.Labels["pod-template-hash"]
-		t.Logf("Current ReplicaSet: %s (revision: %d, hash: %s)", currentRS.Name, highestRevision, currentPodTemplateHash)
-
-		// Now verify at least one pod from the current ReplicaSet is ready
-		labelSelector := ""
-
-		labels := []string{}
-		for k, v := range deployment.Spec.Selector.MatchLabels {
-			labels = append(labels, fmt.Sprintf("%s=%s", k, v))
-		}
-
-		labelSelector = strings.Join(labels, ",")
-
-		pods := &v1.PodList{}
-		if err := c.Resources(namespace).List(ctx, pods, resources.WithLabelSelector(labelSelector)); err != nil {
-			t.Logf("Error listing pods: %v", err)
-			return false
-		}
-
-		readyPodFound := false
-
-		for _, pod := range pods.Items {
-			if pod.DeletionTimestamp != nil {
-				continue
-			}
-
-			podHash := pod.Labels["pod-template-hash"]
-			if podHash != currentPodTemplateHash {
-				t.Logf("Skipping pod %s from old ReplicaSet (hash: %s)", pod.Name, podHash)
-				continue
-			}
-
-			if pod.Status.Phase == v1.PodRunning && IsPodReady(pod) {
-				t.Logf("Found ready pod from current ReplicaSet: %s", pod.Name)
-
-				readyPodFound = true
-
-				break
-			}
-		}
-
-		if !readyPodFound {
+		if !hasReadyPodFromReplicaSet(ctx, t, c, selector, namespace, currentRS) {
 			return false
 		}
 
@@ -1207,6 +1175,161 @@ func WaitForDeploymentRollout(
 	}, EventuallyWaitTimeout, WaitInterval, "deployment %s/%s rollout should complete", namespace, name)
 
 	t.Logf("Deployment %s/%s rollout completed successfully", namespace, name)
+}
+
+func checkDeploymentReplicaStatus(t *testing.T, deployment *appsv1.Deployment) (int32, bool) {
+	t.Helper()
+
+	if deployment.Spec.Replicas == nil {
+		t.Logf("Deployment %s/%s has nil Spec.Replicas, will retry", deployment.Namespace, deployment.Name)
+		return 0, false
+	}
+
+	expectedReplicas := *deployment.Spec.Replicas
+
+	if deployment.Status.UpdatedReplicas != expectedReplicas {
+		t.Logf("Waiting: UpdatedReplicas=%d, Expected=%d", deployment.Status.UpdatedReplicas, expectedReplicas)
+		return 0, false
+	}
+
+	if deployment.Status.ReadyReplicas != expectedReplicas {
+		t.Logf("Waiting: ReadyReplicas=%d, Expected=%d", deployment.Status.ReadyReplicas, expectedReplicas)
+		return 0, false
+	}
+
+	if deployment.Status.AvailableReplicas != expectedReplicas {
+		t.Logf("Waiting: AvailableReplicas=%d, Expected=%d", deployment.Status.AvailableReplicas, expectedReplicas)
+		return 0, false
+	}
+
+	if deployment.Status.ObservedGeneration < deployment.Generation {
+		t.Logf("Waiting: ObservedGeneration=%d, Generation=%d", deployment.Status.ObservedGeneration, deployment.Generation)
+		return 0, false
+	}
+
+	return expectedReplicas, true
+}
+
+func findCurrentReplicaSet(ctx context.Context, t *testing.T, c klient.Client,
+	selector string, deployment *appsv1.Deployment, namespace string) (*appsv1.ReplicaSet, bool) {
+	t.Helper()
+
+	rsList := &appsv1.ReplicaSetList{}
+	if err := c.Resources(namespace).List(ctx, rsList,
+		resources.WithLabelSelector(selector)); err != nil {
+		t.Logf("Error listing ReplicaSets: %v", err)
+		return nil, false
+	}
+
+	currentRS, highestRevision := highestRevisionRS(rsList, deployment)
+
+	if currentRS == nil {
+		t.Logf("Could not find current ReplicaSet")
+		return nil, false
+	}
+
+	hashLabel, ok := currentRS.Labels["pod-template-hash"]
+	if !ok || hashLabel == "" {
+		t.Logf("Current ReplicaSet %s missing pod-template-hash label", currentRS.Name)
+		return nil, false
+	}
+
+	t.Logf("Current ReplicaSet: %s (revision: %d, hash: %s)",
+		currentRS.Name, highestRevision, hashLabel)
+
+	return currentRS, true
+}
+
+func highestRevisionRS(rsList *appsv1.ReplicaSetList, owner *appsv1.Deployment) (*appsv1.ReplicaSet, int64) {
+	var currentRS *appsv1.ReplicaSet
+
+	highest := int64(-1)
+
+	for i := range rsList.Items {
+		rs := &rsList.Items[i]
+
+		if !metav1.IsControlledBy(rs, owner) {
+			continue
+		}
+
+		if rs.Annotations == nil {
+			continue
+		}
+
+		revisionStr := rs.Annotations["deployment.kubernetes.io/revision"]
+		if revisionStr == "" {
+			continue
+		}
+
+		revision, err := strconv.ParseInt(revisionStr, 10, 64)
+		if err != nil {
+			continue
+		}
+
+		if revision > highest {
+			highest = revision
+			currentRS = rs
+		}
+	}
+
+	return currentRS, highest
+}
+
+// buildMatchLabelSelector converts the deployment's label selector to a string.
+// Returns "" if the selector is nil or invalid.
+func buildMatchLabelSelector(t *testing.T, deployment *appsv1.Deployment) string {
+	t.Helper()
+
+	if deployment.Spec.Selector == nil {
+		return ""
+	}
+
+	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		t.Logf("Deployment %s/%s has invalid label selector: %v",
+			deployment.Namespace, deployment.Name, err)
+
+		return ""
+	}
+
+	return selector.String()
+}
+
+func hasReadyPodFromReplicaSet(ctx context.Context, t *testing.T, c klient.Client,
+	selector, namespace string, currentRS *appsv1.ReplicaSet) bool {
+	t.Helper()
+
+	currentPodTemplateHash, ok := currentRS.Labels["pod-template-hash"]
+	if !ok || currentPodTemplateHash == "" {
+		t.Logf("Current ReplicaSet %s missing pod-template-hash label", currentRS.Name)
+		return false
+	}
+
+	pods := &v1.PodList{}
+	if err := c.Resources(namespace).List(ctx, pods,
+		resources.WithLabelSelector(selector)); err != nil {
+		t.Logf("Error listing pods: %v", err)
+		return false
+	}
+
+	for _, pod := range pods.Items {
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+
+		podHash, exists := pod.Labels["pod-template-hash"]
+		if !exists || podHash != currentPodTemplateHash {
+			t.Logf("Skipping pod %s from old ReplicaSet (hash: %s)", pod.Name, pod.Labels["pod-template-hash"])
+			continue
+		}
+
+		if pod.Status.Phase == v1.PodRunning && IsPodReady(pod) {
+			t.Logf("Found ready pod from current ReplicaSet: %s", pod.Name)
+			return true
+		}
+	}
+
+	return false
 }
 
 // RestartDeployment triggers a rolling restart of the specified deployment by updating

--- a/tests/helpers/kube.go
+++ b/tests/helpers/kube.go
@@ -167,6 +167,10 @@ This workaround can be removed after KACE-1703 is completed.
 */
 func StartNodeLabelWatcher(ctx context.Context, t *testing.T, c klient.Client, nodeName string,
 	labelValueSequence []string, waitForLabelRemoval bool, success chan bool) error {
+	if len(labelValueSequence) == 0 {
+		return fmt.Errorf("labelValueSequence must not be empty")
+	}
+
 	state := newLabelWatcherState(ctx, t, c, nodeName, labelValueSequence, waitForLabelRemoval)
 
 	t.Logf("[LabelWatcher] Starting watcher for node %s, expecting sequence: %v (starting at index %d)",

--- a/tests/helpers/kube.go
+++ b/tests/helpers/kube.go
@@ -1323,7 +1323,7 @@ func hasReadyPodFromReplicaSet(ctx context.Context, t *testing.T, c klient.Clien
 
 		podHash, exists := pod.Labels["pod-template-hash"]
 		if !exists || podHash != currentPodTemplateHash {
-			t.Logf("Skipping pod %s from old ReplicaSet (hash: %s)", pod.Name, pod.Labels["pod-template-hash"])
+			t.Logf("Skipping pod %s from old ReplicaSet (hash: %s)", pod.Name, podHash)
 			continue
 		}
 

--- a/tests/helpers/label_watcher_test.go
+++ b/tests/helpers/label_watcher_test.go
@@ -1,0 +1,321 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestHandleOutOfSequenceLabel_SkipToFinalNoRemoval(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	state := &labelWatcherState{
+		labelValueSequence:  []string{"a", "b", "c"},
+		nodeName:            "test-node",
+		waitForLabelRemoval: false,
+		currentLabelIndex:   1,
+		prevLabelValue:      "a",
+	}
+
+	success := make(chan bool, 1)
+
+	state.handleOutOfSequenceLabel(t, ctx, "c", success)
+
+	select {
+	case result := <-success:
+		if !result {
+			t.Fatal("expected SUCCESS (true), got FAILURE (false)")
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for result — success was never sent")
+	}
+
+	if state.currentLabelIndex != 3 {
+		t.Errorf("expected currentLabelIndex=3, got %d", state.currentLabelIndex)
+	}
+
+	if state.prevLabelValue != "c" {
+		t.Errorf("expected prevLabelValue='c', got '%s'", state.prevLabelValue)
+	}
+
+	if !state.resultSent {
+		t.Error("expected resultSent=true")
+	}
+}
+
+func TestHandleOutOfSequenceLabel_SkipToFinalWithRemoval(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	state := &labelWatcherState{
+		labelValueSequence:  []string{"a", "b", "c"},
+		nodeName:            "test-node",
+		waitForLabelRemoval: true,
+		currentLabelIndex:   1,
+		prevLabelValue:      "a",
+	}
+
+	success := make(chan bool, 1)
+
+	state.handleOutOfSequenceLabel(t, ctx, "c", success)
+
+	select {
+	case <-success:
+		t.Fatal("expected no result sent when waitForLabelRemoval=true, but got one")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	if state.currentLabelIndex != 3 {
+		t.Errorf("expected currentLabelIndex=3, got %d", state.currentLabelIndex)
+	}
+
+	if state.prevLabelValue != "c" {
+		t.Errorf("expected prevLabelValue='c', got '%s'", state.prevLabelValue)
+	}
+
+	if state.resultSent {
+		t.Error("expected resultSent=false when waiting for removal")
+	}
+}
+
+func TestHandleMatchedLabel_FinalNoRemoval(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	state := &labelWatcherState{
+		labelValueSequence:  []string{"a", "b"},
+		nodeName:            "test-node",
+		waitForLabelRemoval: false,
+		currentLabelIndex:   1,
+		prevLabelValue:      "a",
+	}
+
+	success := make(chan bool, 1)
+
+	state.handleMatchedLabel(t, ctx, "b", success)
+
+	select {
+	case result := <-success:
+		if !result {
+			t.Fatal("expected SUCCESS (true), got FAILURE (false)")
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for result — success was never sent")
+	}
+
+	if state.currentLabelIndex != 2 {
+		t.Errorf("expected currentLabelIndex=2, got %d", state.currentLabelIndex)
+	}
+
+	if state.prevLabelValue != "b" {
+		t.Errorf("expected prevLabelValue='b', got '%s'", state.prevLabelValue)
+	}
+
+	if !state.resultSent {
+		t.Error("expected resultSent=true")
+	}
+}
+
+func TestHandleOutOfSequenceLabel_MissedEarlyLabels(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	state := &labelWatcherState{
+		labelValueSequence:  []string{"a", "b", "c"},
+		nodeName:            "test-node",
+		waitForLabelRemoval: false,
+		currentLabelIndex:   0,
+		prevLabelValue:      "",
+	}
+
+	success := make(chan bool, 1)
+
+	state.handleOutOfSequenceLabel(t, ctx, "unknown-value", success)
+
+	select {
+	case result := <-success:
+		if result {
+			t.Fatal("expected FAILURE (false), got SUCCESS (true)")
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for result — failure was never sent")
+	}
+
+	if state.currentLabelIndex != 0 {
+		t.Errorf("expected currentLabelIndex=0 (unchanged), got %d", state.currentLabelIndex)
+	}
+
+	if !state.resultSent {
+		t.Error("expected resultSent=true")
+	}
+}
+
+func TestHandleOutOfSequenceLabel_UnexpectedLabel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	state := &labelWatcherState{
+		labelValueSequence:  []string{"a", "b", "c"},
+		nodeName:            "test-node",
+		waitForLabelRemoval: false,
+		currentLabelIndex:   1,
+		prevLabelValue:      "a",
+	}
+
+	success := make(chan bool, 1)
+
+	state.handleOutOfSequenceLabel(t, ctx, "unknown-value", success)
+
+	select {
+	case result := <-success:
+		if result {
+			t.Fatal("expected FAILURE (false), got SUCCESS (true)")
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for result — failure was never sent")
+	}
+
+	if state.currentLabelIndex != 1 {
+		t.Errorf("expected currentLabelIndex=1 (unchanged), got %d", state.currentLabelIndex)
+	}
+
+	if !state.resultSent {
+		t.Error("expected resultSent=true")
+	}
+}
+
+func TestHandleLabelAbsent_PrematureRemoval(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	state := &labelWatcherState{
+		labelValueSequence:  []string{"a", "b", "c"},
+		nodeName:            "test-node",
+		waitForLabelRemoval: true,
+		currentLabelIndex:   1,
+		prevLabelValue:      "a",
+	}
+
+	success := make(chan bool, 1)
+
+	state.handleLabelAbsent(t, ctx, success)
+
+	select {
+	case result := <-success:
+		if result {
+			t.Fatal("expected FAILURE (false) for premature removal, got SUCCESS (true)")
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for result — failure was never sent")
+	}
+
+	if !state.resultSent {
+		t.Error("expected resultSent=true")
+	}
+}
+
+func TestHandleLabelPresent_DuplicateUpdateIgnored(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	state := &labelWatcherState{
+		labelValueSequence:  []string{"a", "b"},
+		nodeName:            "test-node",
+		waitForLabelRemoval: false,
+		currentLabelIndex:   1,
+		prevLabelValue:      "a",
+	}
+
+	success := make(chan bool, 1)
+
+	state.handleLabelPresent(t, ctx, "a", success)
+
+	select {
+	case <-success:
+		t.Fatal("expected no result sent for duplicate update, but got one")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	if state.currentLabelIndex != 1 {
+		t.Errorf("expected currentLabelIndex=1 (unchanged), got %d", state.currentLabelIndex)
+	}
+
+	if state.prevLabelValue != "a" {
+		t.Errorf("expected prevLabelValue='a' (unchanged), got '%s'", state.prevLabelValue)
+	}
+
+	if state.resultSent {
+		t.Error("expected resultSent=false")
+	}
+}
+
+func TestHandleLabelAbsent_SuccessfulRemoval(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	state := &labelWatcherState{
+		labelValueSequence:  []string{"a", "b"},
+		nodeName:            "test-node",
+		waitForLabelRemoval: true,
+		currentLabelIndex:   2,
+		prevLabelValue:      "b",
+	}
+
+	success := make(chan bool, 1)
+
+	state.handleLabelAbsent(t, ctx, success)
+
+	select {
+	case result := <-success:
+		if !result {
+			t.Fatal("expected SUCCESS (true) for completed removal, got FAILURE (false)")
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for result — success was never sent")
+	}
+
+	if !state.resultSent {
+		t.Error("expected resultSent=true")
+	}
+}
+
+func TestResultSentGuard_PreventsDuplicateSend(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	state := &labelWatcherState{
+		labelValueSequence:  []string{"a"},
+		nodeName:            "test-node",
+		waitForLabelRemoval: false,
+		currentLabelIndex:   0,
+		prevLabelValue:      "",
+	}
+
+	success := make(chan bool, 2)
+
+	state.handleMatchedLabel(t, ctx, "a", success)
+	state.handleLabelAbsent(t, ctx, success)
+
+	if len(success) != 1 {
+		t.Errorf("expected exactly 1 result on channel, got %d", len(success))
+	}
+
+	if !state.resultSent {
+		t.Error("expected resultSent=true")
+	}
+}


### PR DESCRIPTION
## Summary

Refactors nolint directives by lowering complexity and improving structure. No intended behavior change.

Modules updated in this PR:
- labeler
- metadata-collector
- node-drainer
- platform-connectors
- preflight-checks
- tests

<!-- Brief description of your changes -->

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [x] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced TLS1.2 for kubelet connections; improved HTTP response/resource handling and richer error messages.

* **New Features**
  * Added public initialization parameters and a Components result to simplify configurable startup.

* **Improvements**
  * Modularized informer/indexing setup; batched per-node condition processing with safer timestamps and aggregated messages; clearer drain/quarantine and cancellation handling; safer init teardown on failure.

* **Tests**
  * Added extensive label-watcher tests, kata-label and reconciler test additions; updated connector and node-condition tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->