### PR TITLE
fix: set RuntimeClassName to nvidia in GPU reset pod

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/janitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/templates/configmap.yaml
@@ -76,6 +76,7 @@ data:
       {{- end }}
       {{- if .Values.config.controllers.gpuReset.resetJob }}
       resetJob:
+        runtimeClassName: "{{ .Values.config.controllers.gpuReset.resetJob.runtimeClassName }}"
         imageConfig:
           image: "{{ .Values.config.controllers.gpuReset.resetJob.image.repository }}:{{ .Values.config.controllers.gpuReset.resetJob.image.tag | default ((.Values.global).image).tag | default .Chart.AppVersion }}"
           {{- with (.Values.config.controllers.gpuReset.resetJob.image.imagePullSecrets | default  (.Values.global).imagePullSecrets) }}

--- a/distros/kubernetes/nvsentinel/charts/janitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/values.yaml
@@ -147,6 +147,7 @@ config:
       serviceManager:
         name: "gpu-operator"
       resetJob:
+        runtimeClassName: "nvidia"
         # imagePullSecrets can be specified under image.imagePullSecrets, otherwise we will
         # fall back to global.imagePullSecrets.
         image:

--- a/distros/kubernetes/nvsentinel/values-tilt.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt.yaml
@@ -3740,6 +3740,7 @@ janitor:
               enabledValue: "true"
               disabledValue: "false"
         resetJob:
+          runtimeClassName: ""
           image:
             repository: "public.ecr.aws/docker/library/alpine"
             tag: "latest"

--- a/janitor/pkg/config/config.go
+++ b/janitor/pkg/config/config.go
@@ -94,8 +94,9 @@ type GPUResetControllerConfig struct {
 }
 
 type ResetJobConfig struct {
-	ImageConfig ImageConfig          `mapstructure:"imageConfig" json:"imageConfig"`
-	Resources   ResourceRequirements `mapstructure:"resources" json:"resources"`
+	ImageConfig      ImageConfig          `mapstructure:"imageConfig" json:"imageConfig"`
+	Resources        ResourceRequirements `mapstructure:"resources" json:"resources"`
+	RuntimeClassName string               `mapstructure:"runtimeClassName" json:"runtimeClassName"`
 }
 
 type ResourceRequirements struct {
@@ -159,7 +160,7 @@ func LoadConfig(configPath string, namespace string) (*Config, error) {
 
 		jobTemplate, err := getDefaultGPUResetJobTemplate(namespace,
 			config.GPUReset.ResetJob.ImageConfig.Image, config.GPUReset.ResetJob.ImageConfig.ImagePullSecrets,
-			config.GPUReset.ResetJob.Resources)
+			config.GPUReset.ResetJob.Resources, config.GPUReset.ResetJob.RuntimeClassName)
 		if err != nil {
 			return nil, err
 		}

--- a/janitor/pkg/config/default.go
+++ b/janitor/pkg/config/default.go
@@ -137,7 +137,7 @@ func getImagePullSecrets(imagePullSecrets []ImagePullSecret) []corev1.LocalObjec
 
 // getDefaultGPUResetJobTemplate returns the default JobTemplateSpec for GPU reset jobs.
 func getDefaultGPUResetJobTemplate(namespace string, image string, secrets []ImagePullSecret,
-	resources ResourceRequirements) (*batchv1.JobTemplateSpec, error) {
+	resources ResourceRequirements, runtimeClassName string) (*batchv1.JobTemplateSpec, error) {
 	imagePullSecrets := getImagePullSecrets(secrets)
 
 	containerResources, err := getResources(resources)
@@ -145,7 +145,7 @@ func getDefaultGPUResetJobTemplate(namespace string, image string, secrets []Ima
 		return nil, err
 	}
 
-	return &batchv1.JobTemplateSpec{
+	job := &batchv1.JobTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 		},
@@ -203,5 +203,10 @@ func getDefaultGPUResetJobTemplate(namespace string, image string, secrets []Ima
 				},
 			},
 		},
-	}, nil
+	}
+	if len(runtimeClassName) > 0 {
+		job.Spec.Template.Spec.RuntimeClassName = &runtimeClassName
+	}
+
+	return job, nil
 }


### PR DESCRIPTION
## Summary

Set the RuntimeClassName to "nvidia" in the GPU reset pod. Currently, the GPU reset pod is failing with the following nvidia-smi error:
```
(2026-02-19 04:58:13) ERROR: Reset failed. See details below:
/usr/local/bin/gpu_reset.sh: line 109: nvidia-smi: command not found
```
The gpu-operator installed on the GKE cluster in the UAT test is setting NVIDIA_RUNTIME_SET_AS_DEFAULT to false in the nvidia-container-toolkit-daemonset pod. This is resulting in our nvidia/cuda image not getting all GPU devices injected into the container even though NVIDIA_VISIBLE_DEVICES=all. As a result, we have to set the RuntimeClassName explicitly to "nvidia" for the job to work regardless of what the default runtime is.


The GPUReset job mounts all GPU devices on the given node into its nvidia/cuda container by relying on the value NVIDIA_VISIBLE_DEVICES=all. The runtime configured by nvidia-container-toolkit run the container. The following configurations exist:

1. The default runtime on the node is set to nvidia and pods do not need to set the runtimeClass field
2. The default runtime on the node is containerd and pods have to explicitly set the runtimeClass=nvidia. Depending on GPU Operator settings, the value for NVIDIA_RUNTIME_SET_AS_DEFAULT setting in the nvidia-container-toolkit pod may be true or false.
3. If the node is using CRIO instead of containerd, we should rely on the default runtime on the node: https://github.com/NVIDIA/gpu-operator/issues/1298.

For the GPU reset pod, we can cover cases 1-3 with the following approach:

1. If the node isn't using CRIO, always set runtimeClass=nvidia in the pod spec.
2. If the nod is using CRIO, do not set runtimeClass to any value in the pod spec. This is currently only OCI.

## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [X] Janitor
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Kubernetes runtime class support for GPU reset jobs. Users can now specify a custom runtime class through configuration values to control the runtime environment for GPU reset operations, with "nvidia" selected as the default option for optimal GPU compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->