### PR TITLE
fix: initialize variable in UAT GPU reset test

### DIFF
--- a/tests/uat/tests.sh
+++ b/tests/uat/tests.sh
@@ -221,7 +221,7 @@ wait_for_gpu_reset() {
     local current_ts=$3
     local timeout=${UAT_RESET_TIMEOUT:-600}
     local elapsed=0
-    local matching_crd
+    local matching_crd=""
 
     log "Waiting for GPU reset for $uuid on $node (matching GPUReset CRD)..."
 


### PR DESCRIPTION
## Summary
The GPU reset UAT test is failing with an unbound variable error:
```
[2026-02-20 21:27:34] ==========================================================
[2026-02-20 21:27:34] Test 3: XID monitoring via syslog triggers COMPONENT_RESET
[2026-02-20 21:27:34] ==========================================================
[2026-02-20 21:27:36] Selected GPU node: gke-nvs-d22239375013-gpu-pool-b3e391b0-q7qs (has healthy syslog-health-monitor)
[2026-02-20 21:27:37] Fetching GPU UUID and PCI from nvidia-smi in driver pod to construct syslog message
[2026-02-20 21:27:38] Resetting GPU UUID GPU-6ee9343a-2536-af14-e50e-74ee241a795d on PCI 0000:04:00
[2026-02-20 21:27:38] Injecting XID 119 message on GPU GPU-6ee9343a-2536-af14-e50e-74ee241a795d via logger on pod: nvidia-driver-daemonset-cldkv
[2026-02-20 21:27:38] Waiting for node condition 'SysLogsXIDError' to appear on node gke-nvs-d22239375013-gpu-pool-b3e391b0-q7qs...
[2026-02-20 21:27:42] Node condition 'SysLogsXIDError' found ✓
  Status=True Reason=SysLogsXIDErrorIsNotHealthy
[2026-02-20 21:27:42] Waiting for node gke-nvs-d22239375013-gpu-pool-b3e391b0-q7qs to be quarantined (cordoned)...
[2026-02-20 21:27:43] Node gke-nvs-d22239375013-gpu-pool-b3e391b0-q7qs is quarantined (cordoned) ✓
[2026-02-20 21:27:43] Waiting for node to GPU reset and recover...
[2026-02-20 21:27:43] Waiting for GPU reset for GPU-6ee9343a-2536-af14-e50e-74ee241a795d on gke-nvs-d22239375013-gpu-pool-b3e391b0-q7qs (matching GPUReset CRD)...
tests/uat/tests.sh: line 252: matching_crd: unbound variable
```
The behavior for "set -u" depends on the shell. Using the following script as an example:
```
#!/bin/bash

set -euo pipefail

foo() {
    local foo="hello"
    echo "$foo"

    local bar
    echo "$bar"
}

foo
```
MacOS output:
```
% ./script.sh 
hello

% echo $?
0
```
Ubuntu output:
```
# ./script.sh
hello
./script.sh: line 10: bar: unbound variable

# echo $?
1
```
Explicitly setting bar="" works:
```
#!/bin/bash

set -euo pipefail

foo() {
    local foo="hello"
    echo "$foo"

    local bar=""
    echo "$bar"
}

foo
```
Execution:
```
# ./script.sh
hello

# echo $?
0
```



## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Fixed variable initialization in test utilities to prevent potential errors in strict shell mode, improving test reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->