### PR TITLE
feat: enhanced gpu-health-monitor to make it compatible with dcgm version 4.4.2

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/configmap.yaml
@@ -48,5 +48,6 @@ data:
     DCGM_HEALTH_WATCH_NVSWITCH_NONFATAL=NonFatal
     DCGM_HEALTH_WATCH_PCIE=Fatal
     DCGM_HEALTH_WATCH_PMU=Fatal
+    DCGM_HEALTH_WATCH_ALL=Fatal
 
 {{ (.Files.Glob "files/dcgmerrorsmapping.csv").AsConfig | indent 2 }}

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -188,12 +188,20 @@ These metrics track the internal ring buffer workqueue performance:
 
 These metrics track GPU health events detected via DCGM (Data Center GPU Manager):
 
-| Metric Name | Type | Labels | Description |
-|------------|------|--------|-------------|
-| `dcgm_health_events_publish_time_to_grpc_channel` | Histogram | `operation_name` | Amount of time spent in publishing DCGM health events on the gRPC channel |
-| `health_events_insertion_to_uds_succeed` | Counter | - | Total number of successful insertions of health events to UDS |
-| `health_events_insertion_to_uds_error` | Counter | - | Total number of failed insertions of health events to UDS |
-| `dcgm_health_active_events` | Gauge | `event_type`, `gpu_id`, `severity` | Total number of active health events at any given time by severity. Severity values: `fatal`, `non_fatal` |
+| Metric Name                                       | Type      | Labels                             | Description                                                                                               |
+|---------------------------------------------------|-----------|------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| `dcgm_health_events_publish_time_to_grpc_channel` | Histogram | `operation_name`                   | Amount of time spent in publishing DCGM health events on the gRPC channel                                 |
+| `health_events_insertion_to_uds_succeed`          | Counter   | -                                  | Total number of successful insertions of health events to UDS                                             |
+| `health_events_insertion_to_uds_error`            | Counter   | -                                  | Total number of failed insertions of health events to UDS                                                 |
+| `dcgm_health_active_events`                       | Gauge     | `event_type`, `gpu_id`, `severity` | Total number of active health events at any given time by severity. Severity values: `fatal`, `non_fatal` |
+| `dcgm_api_latency`                                | Histogram | `operation_name`                   | Amount of time spent calling DCGM APIs                                                                    |
+| `dcgm_reconcile_time`                             | Histogram | -                                  | Amount of time spent running a single DCGM reconcile loop                                                 |
+| `number_of_health_watches`                        | Gauge     | -                                  | Number of DCGM health watches available                                                                   |
+| `number_of_fields`                                | Gauge     | -                                  | Number of available DCGM fields to monitor                                                                |
+| `callback_failures`                               | Counter   | `class_name`, `func_name`          | Number of times a callback function has thrown an exception                                               |
+| `callback_success`                                | Counter   | `class_name`, `func_name`          | Number of times a callback function has successfully completed                                            |
+| `dcgm_api_failures`                               | Counter   | `error_name`                       | Number of DCGM API errors                                                                                 |
+| `dcgm_health_check_unknown_system_skipped`        | Counter   | -                                  | Number of DCGM health check incidents skipped due to unrecognized system value                            |
 
 ---
 

--- a/health-monitors/gpu-health-monitor/Dockerfile
+++ b/health-monitors/gpu-health-monitor/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DCGM_VERSION="4.2.0-1-ubuntu22.04"
+ARG DCGM_VERSION="4.4.2-1-ubuntu22.04"
 ARG VERSION="0.1.0"
 # GIT_COMMIT and BUILD_DATE are passed by CI (make/docker.mk) for OCI annotations
 ARG GIT_COMMIT="none"

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/dcgm.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/dcgm.py
@@ -196,7 +196,7 @@ class DCGMWatcher:
                         f"Unknown health watch system value {incident.system} "
                         f"for entity {incident.entityInfo.entityId}, skipping incident"
                     )
-                    metrics.health_check_unknown_system_skipped.inc()
+                    metrics.dcgm_health_check_unknown_system_skipped.inc()
                     continue
 
                 health_status[watch_name].status = types.HealthStatus(int(incident.health))

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/dcgm.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/dcgm.py
@@ -54,7 +54,6 @@ class DCGMWatcher:
         for var in dir(dcgm_structs):
             if (
                 var.startswith("DCGM_HEALTH_WATCH")
-                and not var.endswith("ALL")
                 and not "_COUNT_" in var
                 and not "DCGM_GROUP_MAX_ENTITIES" in var
                 and not "DCGM_HEALTH_WATCH_MAX_INCIDENTS" in var
@@ -176,12 +175,36 @@ class DCGMWatcher:
             # Temporary dict to accumulate multiple failures per GPU
             gpu_failures_accumulator = {}
 
+            log.debug(
+                f"Health check returned: overallHealth={health_details.overallHealth}, "
+                f"incidentCount={health_details.incidentCount}"
+            )
+
             for i in range(health_details.incidentCount):
                 incident = health_details.incidents[i]
-                watch_name = self._health_watches[incident.system]
+                log.debug(
+                    f"Incident[{i}]: system={incident.system} (known={incident.system in self._health_watches}), "
+                    f"health={incident.health}, error.code={incident.error.code}, "
+                    f"entityGroupId={incident.entityInfo.entityGroupId}, "
+                    f"entityId={incident.entityInfo.entityId}, "
+                    f"error.msg={incident.error.msg}"
+                )
+
+                watch_name = self._health_watches.get(incident.system)
+                if watch_name is None:
+                    log.warning(
+                        f"Unknown health watch system value {incident.system} "
+                        f"for entity {incident.entityInfo.entityId}, skipping incident"
+                    )
+                    metrics.health_check_unknown_system_skipped.inc()
+                    continue
+
                 health_status[watch_name].status = types.HealthStatus(int(incident.health))
                 gpu_id = incident.entityInfo.entityId
-                error_code = self._error_codes[incident.error.code]
+                fallback_error_code = self._error_codes.get(dcgm_errors.DCGM_FR_UNKNOWN, "DCGM_FR_UNKNOWN")
+                error_code = self._error_codes.get(incident.error.code, fallback_error_code)
+                if error_code == fallback_error_code:
+                    log.warning(f"Unknown DCGM error code {incident.error.code} for entity {gpu_id}")
                 error_msg = incident.error.msg
 
                 log.debug(f"incident.error.code is {incident.error.code} and error msg is {error_msg}")

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/metrics.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/metrics.py
@@ -35,7 +35,7 @@ dcgm_api_failures = Counter(
     "Number of times an error has occurred",
     labelnames=["error_name"],
 )
-health_check_unknown_system_skipped = Counter(
-    "health_check_unknown_system_skipped",
-    "Number of health check incidents skipped due to unrecognized system value",
+dcgm_health_check_unknown_system_skipped = Counter(
+    "dcgm_health_check_unknown_system_skipped",
+    "Number of DCGM health check incidents skipped due to unrecognized system value",
 )

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/metrics.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/metrics.py
@@ -35,3 +35,7 @@ dcgm_api_failures = Counter(
     "Number of times an error has occurred",
     labelnames=["error_name"],
 )
+health_check_unknown_system_skipped = Counter(
+    "health_check_unknown_system_skipped",
+    "Number of health check incidents skipped due to unrecognized system value",
+)

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/conftest.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/conftest.py
@@ -39,7 +39,7 @@ class MockDCGMModule:
     DCGM_HEALTH_WATCH_DRIVER = 10
     DCGM_HEALTH_WATCH_NVSWITCH = 11
     DCGM_HEALTH_WATCH_CPUSET = 12
-    DCGM_HEALTH_WATCH_ALL = 65535
+    DCGM_HEALTH_WATCH_ALL = 4294967295  # This is 0xFFFFFFFF in hex.
     DCGM_HEALTH_WATCH_MAX_INCIDENTS = 128
 
     # Health result constants
@@ -155,12 +155,13 @@ class MockDCGMErrors:
     """Mock DCGM errors module for testing."""
 
     # Sample error codes used in tests
+    DCGM_FR_UNKNOWN = 0
     DCGM_FR_PCI_REPLAY_RATE = 1
     DCGM_FR_NVLINK_DOWN = 2
     DCGM_FR_THERMAL_VIOLATIONS = 3
 
-    # Add more error codes as needed by tests
-    for i in range(4, 113):  # Mock 112 error codes total as expected by tests (3 manual + 109 generated = 112)
+    # Add more error codes as needed by tests (4 manual + 109 generated = 113 total)
+    for i in range(4, 113):
         locals()[f"DCGM_FR_ERROR_{i}"] = i
 
 

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_platform_connector/test_platform_connector.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_platform_connector/test_platform_connector.py
@@ -126,6 +126,7 @@ class TestPlatformConnectors(unittest.TestCase):
         dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_PMU"] = "Fatal"
         dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_CPUSET"] = "NonFatal"
         dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_NVSWITCH"] = "Fatal"
+        dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_ALL"] = "Fatal"
 
         temp_file_path = metadata_file()
 
@@ -264,6 +265,7 @@ class TestPlatformConnectors(unittest.TestCase):
         dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_PMU"] = "Fatal"
         dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_CPUSET"] = "NonFatal"
         dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_NVSWITCH"] = "Fatal"
+        dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_ALL"] = "Fatal"
 
         temp_file_path = metadata_file()
 
@@ -384,6 +386,7 @@ class TestPlatformConnectors(unittest.TestCase):
         dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_PMU"] = "Fatal"
         dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_CPUSET"] = "NonFatal"
         dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_NVSWITCH"] = "Fatal"
+        dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_ALL"] = "Fatal"
 
         platform_connector_test = platform_connector.PlatformConnectorEventProcessor(
             socket_path,
@@ -519,6 +522,7 @@ class TestPlatformConnectors(unittest.TestCase):
         dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_PMU"] = "Fatal"
         dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_CPUSET"] = "NonFatal"
         dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_NVSWITCH"] = "Fatal"
+        dcgm_health_conditions_categorization_mapping_config["DCGM_HEALTH_WATCH_ALL"] = "Fatal"
 
         temp_file_path = metadata_file()
 
@@ -775,6 +779,7 @@ class TestPlatformConnectors(unittest.TestCase):
                 "DCGM_HEALTH_WATCH_PMU": "Fatal",
                 "DCGM_HEALTH_WATCH_CPUSET": "NonFatal",
                 "DCGM_HEALTH_WATCH_NVSWITCH": "Fatal",
+                "DCGM_HEALTH_WATCH_ALL": "Fatal",
             }
 
             platform_connector_processor = platform_connector.PlatformConnectorEventProcessor(

--- a/preflight-checks/dcgm-diag/Dockerfile
+++ b/preflight-checks/dcgm-diag/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DCGM_VERSION="4.2.3-1-ubuntu22.04"
+ARG DCGM_VERSION="4.4.2-1-ubuntu22.04"
 ARG VERSION="0.1.0"
 ARG GIT_COMMIT="none"
 ARG BUILD_DATE=$(date -u +%FT%TZ)

--- a/tilt/dcgm-fake/Dockerfile
+++ b/tilt/dcgm-fake/Dockerfile
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM nvcr.io/nvidia/cloud-native/dcgm:4.2.0-1-ubuntu22.04
+# Match DCGM_VERSION used in gpu-health-monitor and preflight dcgm-diag Dockerfiles
+ARG DCGM_VERSION=4.4.2-1-ubuntu22.04
+FROM nvcr.io/nvidia/cloud-native/dcgm:${DCGM_VERSION}
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
@@ -21,7 +23,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         ca-certificates && \
     apt-get update && apt list -a datacenter-gpu-manager-4-dev && \
     apt-get install -y --no-install-recommends \
-        datacenter-gpu-manager-4-dev=1:4.2.0 && \
+        datacenter-gpu-manager-4-dev=1:4.4.2-1 && \
     rm -rf /var/lib/apt/lists/*
 
 COPY gpu-spec.yaml /gpu-spec.yaml


### PR DESCRIPTION
Jira: https://github.com/NVIDIA/NVSentinel/issues/896

## Summary
Upgrades gpu-health-monitor, preflight dcgm-diag, and fake-dcgm to DCGM 4.4.2, and adds support for DCGM_HEALTH_WATCH_ALL — the watch type DCGM uses to report destructive XIDs (e.g., XID 95). Previously, DCGM_HEALTH_WATCH_ALL incidents were silently excluded  even in case of destructive XIDs.


RCA:-
XID 95 (destructive) on GPU
        │
        ▼
DCGM reports: system=0xFFFFFFFF (DCGM_HEALTH_WATCH_ALL), error.code=81
        │
        ▼
Old code: filter excluded "ALL" + direct dict access
        │
        ▼
KeyError → health check loop crashes → no health events sent
        │
        ▼
GPU failure goes undetected by NVSentinel

Fix Details:-
1. Removed DCGM_HEALTH_WATCH_ALL exclusion filter — _get_available_health_watches() had not var.endswith("ALL") which excluded DCGM_HEALTH_WATCH_ALL (0xFFFFFFFF). DCGM uses this watch type to report destructive XIDs in production. Removing the filter allows these critical incidents to be processed.

2. Replaced unsafe direct dict access with .get() fallback — self._health_watches[incident.system] and self._error_codes[incident.error.code] would crash with KeyError on any unrecognized value. Now uses .get() with graceful handling: unknown systems are logged and skipped; unknown error codes fall back to DCGM_FR_UNKNOWN.

3. Added DCGM_HEALTH_WATCH_ALL=Fatal to configmap — Ensures incidents reported under WATCH_ALL are categorized as Fatal and flow through to platform-connectors for remediation.

4. Bumped DCGM version from 4.2.x to 4.4.2 across all Dockerfiles (gpu-health-monitor, dcgm-diag, dcgm-fake).

Testing:-
1. With DCGM version 4.4.2, for destructive xid like XID95, the below GpuAllWatch will come
`
  GpuAllWatch                                       True    Tue, 24 Feb 2026 12:36:16 +0530   Tue, 24 Feb 2026 12:36:16 +0530   GpuAllWatchIsNotHealthy                                      ErrorCode:DCGM_FR_UNCONTAINED_ERROR GPU:1 GPU had an uncontained error (XID 95) Drain the GPU and reset it or reboot the node. Recommended Action=RESTART_VM;`


2. Checked backward compatibility as well with gpu-health-monitor dcgm version 4.4.2 and gpu-operator dcgm version 4.2.3-1-ubuntu22.04, no health event will come as this is not supported with 4.2.3.1 dcgm version.


## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [x] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded GPU health monitoring to include an additional aggregate watch category and more detailed health/watch coverage.

* **Bug Fixes**
  * Improved resilience: unknown error codes and unrecognized system incidents are now handled gracefully with fallback behavior and better aggregation of per-GPU messages.

* **Chores**
  * Updated DCGM base images used by health monitors and preflight checks.

* **Documentation**
  * Expanded metrics documentation with new timing, API, reconcile, and health counters (including an unknown-system counter).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->