### PR TITLE
fix: slinky-drainer should only wait for ready pods

### DIFF
--- a/plugins/slinky-drainer/pkg/controller/drainrequest_controller.go
+++ b/plugins/slinky-drainer/pkg/controller/drainrequest_controller.go
@@ -44,7 +44,6 @@ const (
 	annotationKey                    = "nodeset.slinky.slurm.net/node-cordon-reason"
 	annotationPrefix                 = "[J] [NVSentinel]"
 	nvsentinelStateLabelKey          = "dgxc.nvidia.com/nvsentinel-state"
-	remediationSucceededValue        = "remediation-succeeded"
 	drainRequestFinalizer            = "nvsentinel.nvidia.com/slinky-drainer"
 )
 

--- a/plugins/slinky-drainer/pkg/controller/drainrequest_controller.go
+++ b/plugins/slinky-drainer/pkg/controller/drainrequest_controller.go
@@ -294,12 +294,26 @@ func (r *DrainRequestReconciler) checkPodsReadyForDrain(pods []corev1.Pod) (bool
 	var notReady []string
 
 	for _, pod := range pods {
+		if !isPodReady(&pod) {
+			continue
+		}
+
 		if !hasSlurmDrainCondition(&pod) {
 			notReady = append(notReady, pod.Name)
 		}
 	}
 
 	return len(notReady) == 0, notReady
+}
+
+func isPodReady(pod *corev1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady {
+			return cond.Status == corev1.ConditionTrue
+		}
+	}
+
+	return false
 }
 
 func hasSlurmDrainCondition(pod *corev1.Pod) bool {

--- a/plugins/slinky-drainer/pkg/controller/drainrequest_controller_test.go
+++ b/plugins/slinky-drainer/pkg/controller/drainrequest_controller_test.go
@@ -55,6 +55,7 @@ func TestReconcile_FullDrainCycle(t *testing.T) {
 		nvsentinelStateLabelKey: "draining",
 	})
 	pod := createSlinkyPod(t, tc, node.Name)
+	markPodReady(t, tc, pod.Name, pod.Namespace)
 	// Create a failed pod on the same node — should not block the drain.
 	createFailedPod(t, tc, node.Name)
 	createDrainRequest(t, tc, "drain-full-cycle", drainv1alpha1.DrainRequestSpec{
@@ -228,6 +229,19 @@ func createFailedPod(t *testing.T, tc *testEnvContext, nodeName string) {
 	require.NoError(t, tc.client.Create(tc.ctx, pod))
 
 	pod.Status.Phase = corev1.PodFailed
+	require.NoError(t, tc.client.Status().Update(tc.ctx, pod))
+}
+
+func markPodReady(t *testing.T, tc *testEnvContext, podName, podNamespace string) {
+	t.Helper()
+
+	pod := &corev1.Pod{}
+	require.NoError(t, tc.client.Get(tc.ctx, types.NamespacedName{Name: podName, Namespace: podNamespace}, pod))
+
+	pod.Status.Phase = corev1.PodRunning
+	pod.Status.Conditions = []corev1.PodCondition{
+		{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+	}
 	require.NoError(t, tc.client.Status().Update(tc.ctx, pod))
 }
 

--- a/plugins/slinky-drainer/pkg/controller/drainrequest_controller_test.go
+++ b/plugins/slinky-drainer/pkg/controller/drainrequest_controller_test.go
@@ -55,6 +55,8 @@ func TestReconcile_FullDrainCycle(t *testing.T) {
 		nvsentinelStateLabelKey: "draining",
 	})
 	pod := createSlinkyPod(t, tc, node.Name)
+	// Create a failed pod on the same node — should not block the drain.
+	createFailedPod(t, tc, node.Name)
 	createDrainRequest(t, tc, "drain-full-cycle", drainv1alpha1.DrainRequestSpec{
 		NodeName:         node.Name,
 		ErrorCode:        []string{"79"},
@@ -208,6 +210,25 @@ func createSlinkyPod(t *testing.T, tc *testEnvContext, nodeName string) *corev1.
 	require.NoError(t, tc.client.Create(tc.ctx, pod))
 
 	return pod
+}
+
+func createFailedPod(t *testing.T, tc *testEnvContext, nodeName string) {
+	t.Helper()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "failed-pod-" + nodeName,
+			Namespace: testSlinkyNamespace,
+		},
+		Spec: corev1.PodSpec{
+			NodeName:   nodeName,
+			Containers: []corev1.Container{{Name: "slurmd", Image: "nvcr.io/nvidia/slinky:latest"}},
+		},
+	}
+	require.NoError(t, tc.client.Create(tc.ctx, pod))
+
+	pod.Status.Phase = corev1.PodFailed
+	require.NoError(t, tc.client.Status().Update(tc.ctx, pod))
 }
 
 func markPodDrainReady(t *testing.T, tc *testEnvContext, podName, podNamespace string) {


### PR DESCRIPTION
## Summary

This MR adds a change which makes slinky drainer only wait for pod condition `SlurmNodeStateDrain` on ready pods in slinky namespace. A test also has been added to test this codeflow where we've one pod that is in Failed phase:
```
=== RUN   TestReconcile_FullDrainCycle
2026/03/02 09:11:27 INFO Setting node annotation node=test-node-drain-cycle reason="[J] [NVSentinel] 79 GPU:0 - GPU has fallen off the bus"
2026/03/02 09:11:27 INFO Successfully drained all Slinky pods drainrequest=default/drain-full-cycle count=2
2026/03/02 09:11:28 INFO Node healthy, removing cordon annotation node=test-node-drain-cycle
--- PASS: TestReconcile_FullDrainCycle (8.86s)
PASS
ok  	github.com/nvidia/nvsentinel/plugins/slinky-drainer/pkg/controller	8.904s
```

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Drain readiness now ignores non-ready pods and only evaluates ready pods for drain conditions, preventing failed or not-ready pods from blocking drains.

* **Tests**
  * Added test scenarios and helpers to mark pods ready and simulate failed pods, validating that non-ready/failed pods do not interfere with drain processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->