### PR TITLE
fix: slinky drainer should also check for slurm node availablibility

### DIFF
--- a/plugins/slinky-drainer/pkg/controller/drainrequest_controller.go
+++ b/plugins/slinky-drainer/pkg/controller/drainrequest_controller.go
@@ -46,9 +46,9 @@ const (
 	slurmNodeStateAllocatedConditionType  = "SlurmNodeStateAllocated"
 	slurmNodeStateMixedConditionType      = "SlurmNodeStateMixed"
 	slurmNodeStateCompletingConditionType = "SlurmNodeStateCompleting"
-	annotationPrefix                 = "[J] [NVSentinel]"
-	nvsentinelStateLabelKey          = "dgxc.nvidia.com/nvsentinel-state"
-	drainRequestFinalizer            = "nvsentinel.nvidia.com/slinky-drainer"
+	annotationPrefix                      = "[J] [NVSentinel]"
+	nvsentinelStateLabelKey               = "dgxc.nvidia.com/nvsentinel-state"
+	drainRequestFinalizer                 = "nvsentinel.nvidia.com/slinky-drainer"
 )
 
 type DrainRequestReconciler struct {

--- a/plugins/slinky-drainer/pkg/controller/drainrequest_controller.go
+++ b/plugins/slinky-drainer/pkg/controller/drainrequest_controller.go
@@ -39,9 +39,13 @@ import (
 )
 
 const (
-	drainCompleteConditionType       = "DrainComplete"
-	slurmNodeStateDrainConditionType = "SlurmNodeStateDrain"
-	annotationKey                    = "nodeset.slinky.slurm.net/node-cordon-reason"
+	drainCompleteConditionType = "DrainComplete"
+	annotationKey              = "nodeset.slinky.slurm.net/node-cordon-reason"
+
+	slurmNodeStateDrainConditionType      = "SlurmNodeStateDrain"
+	slurmNodeStateAllocatedConditionType  = "SlurmNodeStateAllocated"
+	slurmNodeStateMixedConditionType      = "SlurmNodeStateMixed"
+	slurmNodeStateCompletingConditionType = "SlurmNodeStateCompleting"
 	annotationPrefix                 = "[J] [NVSentinel]"
 	nvsentinelStateLabelKey          = "dgxc.nvidia.com/nvsentinel-state"
 	drainRequestFinalizer            = "nvsentinel.nvidia.com/slinky-drainer"
@@ -297,7 +301,7 @@ func (r *DrainRequestReconciler) checkPodsReadyForDrain(pods []corev1.Pod) (bool
 			continue
 		}
 
-		if !hasSlurmDrainCondition(&pod) {
+		if !hasSlurmDrainCondition(&pod) || isNodeBusy(&pod.Status) {
 			notReady = append(notReady, pod.Name)
 		}
 	}
@@ -306,19 +310,23 @@ func (r *DrainRequestReconciler) checkPodsReadyForDrain(pods []corev1.Pod) (bool
 }
 
 func isPodReady(pod *corev1.Pod) bool {
-	for _, cond := range pod.Status.Conditions {
-		if cond.Type == corev1.PodReady {
-			return cond.Status == corev1.ConditionTrue
-		}
-	}
-
-	return false
+	return isConditionTrue(&pod.Status, string(corev1.PodReady))
 }
 
 func hasSlurmDrainCondition(pod *corev1.Pod) bool {
-	for _, cond := range pod.Status.Conditions {
-		if cond.Type == slurmNodeStateDrainConditionType && cond.Status == corev1.ConditionTrue {
-			return true
+	return isConditionTrue(&pod.Status, slurmNodeStateDrainConditionType)
+}
+
+func isNodeBusy(status *corev1.PodStatus) bool {
+	return isConditionTrue(status, slurmNodeStateAllocatedConditionType) ||
+		isConditionTrue(status, slurmNodeStateMixedConditionType) ||
+		isConditionTrue(status, slurmNodeStateCompletingConditionType)
+}
+
+func isConditionTrue(status *corev1.PodStatus, conditionType string) bool {
+	for _, cond := range status.Conditions {
+		if string(cond.Type) == conditionType {
+			return cond.Status == corev1.ConditionTrue
 		}
 	}
 

--- a/plugins/slinky-drainer/pkg/controller/drainrequest_controller_test.go
+++ b/plugins/slinky-drainer/pkg/controller/drainrequest_controller_test.go
@@ -97,6 +97,94 @@ func TestReconcile_PreExistingAnnotationPreserved(t *testing.T) {
 	assertNodeAnnotation(t, tc, node.Name, "Manual drain by operator")
 }
 
+func TestCheckPodsReadyForDrain(t *testing.T) {
+	makePod := func(name string, conditions ...corev1.PodCondition) corev1.Pod {
+		return corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Status:     corev1.PodStatus{Conditions: conditions},
+		}
+	}
+
+	cond := func(typ string, status corev1.ConditionStatus) corev1.PodCondition {
+		return corev1.PodCondition{Type: corev1.PodConditionType(typ), Status: status}
+	}
+
+	ready := cond(string(corev1.PodReady), corev1.ConditionTrue)
+	drained := cond(slurmNodeStateDrainConditionType, corev1.ConditionTrue)
+	allocated := cond(slurmNodeStateAllocatedConditionType, corev1.ConditionTrue)
+	mixed := cond(slurmNodeStateMixedConditionType, corev1.ConditionTrue)
+	completing := cond(slurmNodeStateCompletingConditionType, corev1.ConditionTrue)
+
+	tests := []struct {
+		name          string
+		pods          []corev1.Pod
+		expectReady   bool
+		expectPending []string
+	}{
+		{
+			name:        "ready + drained + not busy",
+			pods:        []corev1.Pod{makePod("p1", ready, drained)},
+			expectReady: true,
+		},
+		{
+			name:          "ready + drained + allocated (busy)",
+			pods:          []corev1.Pod{makePod("p1", ready, drained, allocated)},
+			expectReady:   false,
+			expectPending: []string{"p1"},
+		},
+		{
+			name:          "ready + drained + mixed (busy)",
+			pods:          []corev1.Pod{makePod("p1", ready, drained, mixed)},
+			expectReady:   false,
+			expectPending: []string{"p1"},
+		},
+		{
+			name:          "ready + drained + completing (busy)",
+			pods:          []corev1.Pod{makePod("p1", ready, drained, completing)},
+			expectReady:   false,
+			expectPending: []string{"p1"},
+		},
+		{
+			name:          "ready but no drain condition",
+			pods:          []corev1.Pod{makePod("p1", ready)},
+			expectReady:   false,
+			expectPending: []string{"p1"},
+		},
+		{
+			name:        "not ready pod skipped",
+			pods:        []corev1.Pod{makePod("p1")},
+			expectReady: true,
+		},
+		{
+			name: "mix of ready drained and failed",
+			pods: []corev1.Pod{
+				makePod("good", ready, drained),
+				makePod("failed"),
+			},
+			expectReady: true,
+		},
+		{
+			name: "one busy blocks drain",
+			pods: []corev1.Pod{
+				makePod("done", ready, drained),
+				makePod("busy", ready, drained, allocated),
+			},
+			expectReady:   false,
+			expectPending: []string{"busy"},
+		},
+	}
+
+	r := &DrainRequestReconciler{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			allReady, notReady := r.checkPodsReadyForDrain(tt.pods)
+			assert.Equal(t, tt.expectReady, allReady)
+			assert.Equal(t, tt.expectPending, notReady)
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Test setup
 // ---------------------------------------------------------------------------


### PR DESCRIPTION

## Summary

Prior to this change, we were checking the following things before deleting pods from slinky namespace:
1. All pod that are ready have pod condition of type `SlurmNodeStateDrain`  set to true

After this change, we have added an extra check to ensure that the SlurmNode is not busy.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added support for additional Slurm node states (Allocated, Mixed, Completing) during pod draining operations
  * Strengthened pod readiness checks with refactored condition evaluation logic

* **Tests**
  * Added test coverage for pod readiness verification in drain scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->