### PR TITLE
Fix slinky-drainer to wait for fully drained state before deleting

### DIFF
--- a/plugins/mock-slurm-operator/pkg/controller/node_controller.go
+++ b/plugins/mock-slurm-operator/pkg/controller/node_controller.go
@@ -32,6 +32,7 @@ import (
 const (
 	annotationKey           = "nodeset.slinky.slurm.net/node-cordon-reason"
 	slurmDrainConditionType = "SlurmNodeStateDrain"
+	slurmIdleConditionType  = "SlurmNodeStateIdle"
 )
 
 type NodeReconciler struct {
@@ -127,13 +128,22 @@ func (r *NodeReconciler) listSlinkyPodsOnNode(ctx context.Context, nodeName stri
 }
 
 func (r *NodeReconciler) updatePodDrainCondition(ctx context.Context, pod *corev1.Pod, reason string) error {
-	pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
-		Type:               slurmDrainConditionType,
-		Status:             corev1.ConditionTrue,
-		LastTransitionTime: metav1.Now(),
-		Reason:             "NodeCordonedBySlinkyDrainer",
-		Message:            reason,
-	})
+	pod.Status.Conditions = append(pod.Status.Conditions,
+		corev1.PodCondition{
+			Type:               slurmDrainConditionType,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: metav1.Now(),
+			Reason:             "NodeCordonedBySlinkyDrainer",
+			Message:            reason,
+		},
+		corev1.PodCondition{
+			Type:               slurmIdleConditionType,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: metav1.Now(),
+			Reason:             "NodeDrained",
+			Message:            "Node is idle after drain",
+		},
+	)
 
 	return r.Status().Update(ctx, pod)
 }

--- a/plugins/slinky-drainer/pkg/controller/drainrequest_controller.go
+++ b/plugins/slinky-drainer/pkg/controller/drainrequest_controller.go
@@ -45,6 +45,15 @@ const (
 	annotationPrefix                 = "[J] [NVSentinel]"
 	nvsentinelStateLabelKey          = "dgxc.nvidia.com/nvsentinel-state"
 	drainRequestFinalizer            = "nvsentinel.nvidia.com/slinky-drainer"
+
+	// Slurm base-state conditions that indicate the node still has running work.
+	// A pod is only considered fully drained when SlurmNodeStateDrain is True
+	// and none of these busy-state conditions are True.
+	// Ref: https://github.com/SlinkyProject/slurm-operator/blob/main/pkg/conditions/conditions.go
+	slurmNodeStateAllocatedConditionType  = "SlurmNodeStateAllocated"
+	slurmNodeStateMixedConditionType      = "SlurmNodeStateMixed"
+	slurmNodeStateCompletingConditionType = "SlurmNodeStateCompleting"
+	slurmNodeStateUndrainConditionType    = "SlurmNodeStateUndrain"
 )
 
 type DrainRequestReconciler struct {
@@ -100,9 +109,9 @@ func (r *DrainRequestReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return r.markDrainComplete(ctx, drainReq, "NoPods", "No Slinky pods found on node")
 	}
 
-	allReady, notReadyPods := r.checkPodsReadyForDrain(pods)
-	if !allReady {
-		slog.Info("Waiting for pods to be ready for drain",
+	allDrained, notReadyPods := r.checkPodsFullyDrained(pods)
+	if !allDrained {
+		slog.Info("Waiting for pods to be fully drained",
 			"drainrequest", req.NamespacedName,
 			"total", len(pods),
 			"notReady", len(notReadyPods),
@@ -289,7 +298,7 @@ func (r *DrainRequestReconciler) getSlinkyPods(ctx context.Context, nodeName str
 	return podList.Items, nil
 }
 
-func (r *DrainRequestReconciler) checkPodsReadyForDrain(pods []corev1.Pod) (bool, []string) {
+func (r *DrainRequestReconciler) checkPodsFullyDrained(pods []corev1.Pod) (bool, []string) {
 	var notReady []string
 
 	for _, pod := range pods {
@@ -297,7 +306,7 @@ func (r *DrainRequestReconciler) checkPodsReadyForDrain(pods []corev1.Pod) (bool
 			continue
 		}
 
-		if !hasSlurmDrainCondition(&pod) {
+		if !isPodDrained(&pod) {
 			notReady = append(notReady, pod.Name)
 		}
 	}
@@ -315,9 +324,28 @@ func isPodReady(pod *corev1.Pod) bool {
 	return false
 }
 
-func hasSlurmDrainCondition(pod *corev1.Pod) bool {
+// isPodDrained returns true when the Slurm node behind this pod has the DRAIN
+// flag set, the UNDRAIN flag is NOT set, and no work is running. This mirrors
+// the Slinky operator's IsNodeDrained logic so we only delete pods after all
+// Slurm jobs have finished.
+func isPodDrained(pod *corev1.Pod) bool {
+	return isNodeDrain(pod) && !isPodBusy(pod)
+}
+
+func isNodeDrain(pod *corev1.Pod) bool {
+	return hasPodCondition(pod, slurmNodeStateDrainConditionType) &&
+		!hasPodCondition(pod, slurmNodeStateUndrainConditionType)
+}
+
+func isPodBusy(pod *corev1.Pod) bool {
+	return hasPodCondition(pod, slurmNodeStateAllocatedConditionType) ||
+		hasPodCondition(pod, slurmNodeStateMixedConditionType) ||
+		hasPodCondition(pod, slurmNodeStateCompletingConditionType)
+}
+
+func hasPodCondition(pod *corev1.Pod, condType corev1.PodConditionType) bool {
 	for _, cond := range pod.Status.Conditions {
-		if cond.Type == slurmNodeStateDrainConditionType && cond.Status == corev1.ConditionTrue {
+		if cond.Type == condType && cond.Status == corev1.ConditionTrue {
 			return true
 		}
 	}

--- a/plugins/slinky-drainer/pkg/controller/drainrequest_controller_test.go
+++ b/plugins/slinky-drainer/pkg/controller/drainrequest_controller_test.go
@@ -67,7 +67,14 @@ func TestReconcile_FullDrainCycle(t *testing.T) {
 
 	assertNodeAnnotation(t, tc, node.Name, "[J] [NVSentinel] 79 GPU:0 - GPU has fallen off the bus")
 
-	markPodDrainReady(t, tc, pod.Name, pod.Namespace)
+	// Simulate DRAINING state: Slurm accepted drain but jobs still running.
+	markPodDraining(t, tc, pod.Name, pod.Namespace)
+
+	// Pod must NOT be deleted while in DRAINING state (busy).
+	assertPodNotDeleted(t, tc, pod.Name, pod.Namespace, 3*time.Second)
+
+	// Simulate transition to DRAINED state: jobs finished, node is idle.
+	markPodDrained(t, tc, pod.Name, pod.Namespace)
 
 	waitForDrainComplete(t, tc, "drain-full-cycle", "default")
 	waitForPodDeletion(t, tc, pod.Name, pod.Namespace)
@@ -95,6 +102,30 @@ func TestReconcile_PreExistingAnnotationPreserved(t *testing.T) {
 
 	waitForDrainComplete(t, tc, "drain-preexisting", "default")
 	assertNodeAnnotation(t, tc, node.Name, "Manual drain by operator")
+}
+
+func TestReconcile_DrainingPodNotDeleted(t *testing.T) {
+	tc := setupTestEnv(t, "drain-still-draining")
+
+	node := createNode(t, tc, "test-node-draining", nil, map[string]string{
+		nvsentinelStateLabelKey: "draining",
+	})
+	pod := createSlinkyPod(t, tc, node.Name)
+	markPodReady(t, tc, pod.Name, pod.Namespace)
+	createDrainRequest(t, tc, "drain-still-draining", drainv1alpha1.DrainRequestSpec{
+		NodeName:  node.Name,
+		ErrorCode: []string{"79"},
+		Reason:    "GPU has fallen off the bus",
+	})
+
+	assertNodeAnnotation(t, tc, node.Name, "[J] [NVSentinel] 79 - GPU has fallen off the bus")
+
+	// Set pod to DRAINING: Drain flag set but node is still busy (Allocated).
+	markPodDraining(t, tc, pod.Name, pod.Namespace)
+
+	// Verify pod is NOT deleted and DrainRequest is NOT completed while draining.
+	assertPodNotDeleted(t, tc, pod.Name, pod.Namespace, 5*time.Second)
+	assertDrainNotComplete(t, tc, "drain-still-draining", "default")
 }
 
 // ---------------------------------------------------------------------------
@@ -235,24 +266,43 @@ func createFailedPod(t *testing.T, tc *testEnvContext, nodeName string) {
 func markPodReady(t *testing.T, tc *testEnvContext, podName, podNamespace string) {
 	t.Helper()
 
-	pod := &corev1.Pod{}
-	require.NoError(t, tc.client.Get(tc.ctx, types.NamespacedName{Name: podName, Namespace: podNamespace}, pod))
+	var pod corev1.Pod
+
+	require.Eventually(t, func() bool {
+		return tc.client.Get(tc.ctx, types.NamespacedName{Name: podName, Namespace: podNamespace}, &pod) == nil
+	}, testTimeout, testPollInterval, "Pod %s/%s should exist", podNamespace, podName)
 
 	pod.Status.Phase = corev1.PodRunning
 	pod.Status.Conditions = []corev1.PodCondition{
 		{Type: corev1.PodReady, Status: corev1.ConditionTrue},
 	}
-	require.NoError(t, tc.client.Status().Update(tc.ctx, pod))
+	require.NoError(t, tc.client.Status().Update(tc.ctx, &pod))
 }
 
-func markPodDrainReady(t *testing.T, tc *testEnvContext, podName, podNamespace string) {
+func markPodDraining(t *testing.T, tc *testEnvContext, podName, podNamespace string) {
 	t.Helper()
 
 	pod := &corev1.Pod{}
 	require.NoError(t, tc.client.Get(tc.ctx, types.NamespacedName{Name: podName, Namespace: podNamespace}, pod))
 
 	pod.Status.Conditions = []corev1.PodCondition{
+		{Type: corev1.PodReady, Status: corev1.ConditionTrue},
 		{Type: slurmNodeStateDrainConditionType, Status: corev1.ConditionTrue},
+		{Type: slurmNodeStateAllocatedConditionType, Status: corev1.ConditionTrue},
+	}
+	require.NoError(t, tc.client.Status().Update(tc.ctx, pod))
+}
+
+func markPodDrained(t *testing.T, tc *testEnvContext, podName, podNamespace string) {
+	t.Helper()
+
+	pod := &corev1.Pod{}
+	require.NoError(t, tc.client.Get(tc.ctx, types.NamespacedName{Name: podName, Namespace: podNamespace}, pod))
+
+	pod.Status.Conditions = []corev1.PodCondition{
+		{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+		{Type: slurmNodeStateDrainConditionType, Status: corev1.ConditionTrue},
+		{Type: "SlurmNodeStateIdle", Status: corev1.ConditionTrue},
 	}
 	require.NoError(t, tc.client.Status().Update(tc.ctx, pod))
 }
@@ -326,6 +376,32 @@ func waitForAnnotationRemoved(t *testing.T, tc *testEnvContext, nodeName string)
 
 		return !exists
 	}, testTimeout, testPollInterval, "Annotation on node %s should be removed", nodeName)
+}
+
+func assertPodNotDeleted(t *testing.T, tc *testEnvContext, podName, podNamespace string, waitDuration time.Duration) {
+	t.Helper()
+
+	assert.Never(t, func() bool {
+		p := &corev1.Pod{}
+		if err := tc.client.Get(tc.ctx, types.NamespacedName{Name: podName, Namespace: podNamespace}, p); err != nil {
+			return apierrors.IsNotFound(err)
+		}
+
+		return p.DeletionTimestamp != nil
+	}, waitDuration, testPollInterval, "Pod %s/%s should NOT be deleted while draining", podNamespace, podName)
+}
+
+func assertDrainNotComplete(t *testing.T, tc *testEnvContext, drName, drNamespace string) {
+	t.Helper()
+
+	dr := &drainv1alpha1.DrainRequest{}
+	require.NoError(t, tc.client.Get(tc.ctx, types.NamespacedName{Name: drName, Namespace: drNamespace}, dr))
+
+	for _, c := range dr.Status.Conditions {
+		if c.Type == drainCompleteConditionType && c.Status == metav1.ConditionTrue {
+			t.Fatalf("DrainRequest %s/%s should NOT have DrainComplete=True while pods are still draining", drNamespace, drName)
+		}
+	}
 }
 
 func assertNodeAnnotation(t *testing.T, tc *testEnvContext, nodeName, expectedValue string) {


### PR DESCRIPTION
## Summary

Fix the slinky-drainer plugin to wait for pods to be fully **drained** (no running Slurm jobs) before deleting them, instead of only checking for the **drain flag** which is set while jobs may still be running.

Previously, `hasSlurmDrainCondition()` only checked for `SlurmNodeStateDrain=True`. The real Slinky operator sets this condition as soon as Slurm *accepts* the drain request (DRAINING state), **before** running jobs finish. The slinky-drainer then immediately deleted the pods, potentially killing active Slurm jobs.

The fix mirrors the Slinky operator's own `IsNodeDrained()` logic from `pkg/conditions/conditions.go`: a pod is only considered drained when `SlurmNodeStateDrain=True` AND none of the busy-state conditions (`SlurmNodeStateAllocated`, `SlurmNodeStateMixed`, `SlurmNodeStateCompleting`) are `True`.

### Changes
- **`slinky-drainer/pkg/controller/drainrequest_controller.go`** — Add busy-state condition constants; replace `hasSlurmDrainCondition` with `isPodDrained`/`isPodBusy`/`hasPodCondition`
- **`slinky-drainer/pkg/controller/drainrequest_controller_test.go`** — Replace `markPodDrainReady` with `markPodDraining`/`markPodDrained`; add DRAINING-not-deleted assertion to `FullDrainCycle`; add new `TestReconcile_DrainingPodNotDeleted` test
- **`mock-slurm-operator/pkg/controller/node_controller.go`** — Set `SlurmNodeStateIdle` alongside `SlurmNodeStateDrain` to simulate a fully drained node

## Type of Change
- [x] 🐛 Bug fix

## Component(s) Affected
- [x] Other: slinky-drainer plugin, mock-slurm-operator

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

All 3 envtest-based integration tests pass:
- `TestReconcile_FullDrainCycle` — verifies DRAINING pods are NOT deleted, then DRAINED pods ARE deleted
- `TestReconcile_PreExistingAnnotationPreserved` — existing behavior preserved
- `TestReconcile_DrainingPodNotDeleted` — focused negative test for DRAINING state

`golangci-lint` reports 0 issues on both slinky-drainer and mock-slurm-operator.

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Drain processing now waits until pods are fully drained before proceeding, preventing premature completion.
  * Node state tracking refined to distinguish idle vs busy (multiple busy sub-states) so busy pods block completion.

* **Behavioral Changes**
  * Pod status now records an explicit idle condition after drain completion.
  * Logs and retry messaging updated to reflect “fully drained” semantics.

* **Tests**
  * Added tests covering multi-stage drain transitions and ensuring pods aren't deleted while busy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->