### PR TITLE
fix(labeler): add flag for host-installed GPU drivers

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/labeler/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/labeler/templates/deployment.yaml
@@ -61,6 +61,9 @@ spec:
             - "--kata-label"
             - "{{ .Values.kataLabelOverride }}"
             {{- end }}
+            {{- if .Values.assumeDriverInstalled }}
+            - "--assume-driver-installed"
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           ports:

--- a/distros/kubernetes/nvsentinel/charts/labeler/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/labeler/values.yaml
@@ -36,6 +36,12 @@ podAnnotations: {}
 # Note: The input label value must be truthy (case-insensitive): "true", "enabled", "1", or "yes"
 kataLabelOverride: ""
 
+# Pre-installed driver configuration
+# When enabled, the labeler unconditionally sets nvsentinel.dgxc.nvidia.com/driver.installed=true
+# on all GPU nodes, skipping driver pod detection. Use this for clusters where NVIDIA drivers
+# are installed directly on the host rather than via GPU Operator driver containers.
+assumeDriverInstalled: false
+
 resources:
   requests:
     cpu: 100m

--- a/labeler/main.go
+++ b/labeler/main.go
@@ -128,8 +128,9 @@ func parseFlags() (
 		fmt.Sprintf("Custom node label to check for Kata Containers support. If empty, uses default '%s'",
 			labeler.KataRuntimeDefaultLabel))
 	assumeDriverInstalled = flag.Bool("assume-driver-installed", false,
-		"Assume GPU drivers are pre-installed on all nodes. Sets driver.installed=true unconditionally, "+
-			"skipping driver pod detection. Use for clusters with host-installed drivers.")
+		"Assume GPU drivers are pre-installed on GPU nodes (nvidia.com/gpu.present=true). "+
+			"Sets driver.installed=true unconditionally for those nodes, skipping driver pod detection. "+
+			"Use for clusters with host-installed drivers.")
 
 	flag.Parse()
 

--- a/labeler/main.go
+++ b/labeler/main.go
@@ -64,7 +64,8 @@ func main() {
 }
 
 func run() error {
-	kubeconfig, metricsPort, dcgmAppLabel, driverAppLabel, gkeInstallerAppLabel, kataLabel := parseFlags()
+	kubeconfig, metricsPort, dcgmAppLabel, driverAppLabel,
+		gkeInstallerAppLabel, kataLabel, assumeDriverInstalled := parseFlags()
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
@@ -81,11 +82,12 @@ func run() error {
 	)
 
 	params := initializer.InitializationParams{
-		KubeconfigPath:       *kubeconfig,
-		DCGMAppLabel:         *dcgmAppLabel,
-		DriverAppLabel:       *driverAppLabel,
-		GKEInstallerAppLabel: *gkeInstallerAppLabel,
-		KataLabel:            *kataLabel,
+		KubeconfigPath:        *kubeconfig,
+		DCGMAppLabel:          *dcgmAppLabel,
+		DriverAppLabel:        *driverAppLabel,
+		GKEInstallerAppLabel:  *gkeInstallerAppLabel,
+		KataLabel:             *kataLabel,
+		AssumeDriverInstalled: *assumeDriverInstalled,
 	}
 
 	components, err := initializer.InitializeAll(params)
@@ -112,7 +114,10 @@ func run() error {
 	return g.Wait()
 }
 
-func parseFlags() (kubeconfig, metricsPort, dcgmAppLabel, driverAppLabel, gkeInstallerAppLabel, kataLabel *string) {
+func parseFlags() (
+	kubeconfig, metricsPort, dcgmAppLabel, driverAppLabel,
+	gkeInstallerAppLabel, kataLabel *string, assumeDriverInstalled *bool,
+) {
 	kubeconfig = flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	metricsPort = flag.String("metrics-port", "2112", "Port to expose Prometheus metrics on")
 	dcgmAppLabel = flag.String("dcgm-app-label", "nvidia-dcgm", "App label value for DCGM pods")
@@ -122,6 +127,9 @@ func parseFlags() (kubeconfig, metricsPort, dcgmAppLabel, driverAppLabel, gkeIns
 	kataLabel = flag.String("kata-label", "",
 		fmt.Sprintf("Custom node label to check for Kata Containers support. If empty, uses default '%s'",
 			labeler.KataRuntimeDefaultLabel))
+	assumeDriverInstalled = flag.Bool("assume-driver-installed", false,
+		"Assume GPU drivers are pre-installed on all nodes. Sets driver.installed=true unconditionally, "+
+			"skipping driver pod detection. Use for clusters with host-installed drivers.")
 
 	flag.Parse()
 

--- a/labeler/pkg/initializer/init.go
+++ b/labeler/pkg/initializer/init.go
@@ -28,11 +28,12 @@ import (
 )
 
 type InitializationParams struct {
-	KubeconfigPath       string
-	DCGMAppLabel         string
-	DriverAppLabel       string
-	GKEInstallerAppLabel string
-	KataLabel            string
+	KubeconfigPath        string
+	DCGMAppLabel          string
+	DriverAppLabel        string
+	GKEInstallerAppLabel  string
+	KataLabel             string
+	AssumeDriverInstalled bool
 }
 
 type Components struct {
@@ -56,6 +57,7 @@ func InitializeAll(params InitializationParams) (*Components, error) {
 		params.DriverAppLabel,
 		params.GKEInstallerAppLabel,
 		params.KataLabel,
+		params.AssumeDriverInstalled,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating labeler instance: %w", err)

--- a/labeler/pkg/labeler/labeler.go
+++ b/labeler/pkg/labeler/labeler.go
@@ -56,13 +56,14 @@ var (
 
 // Labeler manages node labeling based on pod information
 type Labeler struct {
-	clientset            kubernetes.Interface
-	podInformer          cache.SharedIndexInformer
-	nodeInformer         cache.SharedIndexInformer
-	gkeInstallerInformer cache.SharedIndexInformer
-	informersSynced      []cache.InformerSynced
-	ctx                  context.Context
-	kataLabels           []string
+	clientset             kubernetes.Interface
+	podInformer           cache.SharedIndexInformer
+	nodeInformer          cache.SharedIndexInformer
+	gkeInstallerInformer  cache.SharedIndexInformer
+	informersSynced       []cache.InformerSynced
+	ctx                   context.Context
+	kataLabels            []string
+	assumeDriverInstalled bool
 }
 
 func (l *Labeler) allInformersSynced() bool {
@@ -77,7 +78,7 @@ func (l *Labeler) allInformersSynced() bool {
 
 // NewLabeler creates a new Labeler instance
 func NewLabeler(clientset kubernetes.Interface, resyncPeriod time.Duration,
-	dcgmApp, driverApp, gkeInstallerApp, kataLabelOverride string) (*Labeler, error) {
+	dcgmApp, driverApp, gkeInstallerApp, kataLabelOverride string, assumeDriverInstalled bool) (*Labeler, error) {
 	podInformer, err := createPodInformer(clientset, resyncPeriod, dcgmApp, driverApp)
 	if err != nil {
 		return nil, fmt.Errorf("create pod informer: %w", err)
@@ -100,8 +101,9 @@ func NewLabeler(clientset kubernetes.Interface, resyncPeriod time.Duration,
 			nodeInformer.HasSynced,
 			gkeInstallerInformer.HasSynced,
 		},
-		ctx:        context.Background(),
-		kataLabels: buildKataLabels(kataLabelOverride),
+		ctx:                   context.Background(),
+		kataLabels:            buildKataLabels(kataLabelOverride),
+		assumeDriverInstalled: assumeDriverInstalled,
 	}
 
 	if err := l.registerPodEventHandlers(); err != nil {
@@ -110,6 +112,10 @@ func NewLabeler(clientset kubernetes.Interface, resyncPeriod time.Duration,
 
 	if err := l.registerNodeEventHandlers(); err != nil {
 		return nil, fmt.Errorf("register node event handlers: %w", err)
+	}
+
+	if assumeDriverInstalled {
+		slog.Info("Labeler configured to assume drivers are pre-installed on all GPU nodes")
 	}
 
 	slog.Info("Labeler created, watching DCGM and driver pods, and nodes for kata detection")
@@ -389,6 +395,10 @@ func hasReadyDriverPod(objs []any, excludePod *v1.Pod) bool {
 
 // getDriverLabelForNode returns the expected driver label value for a specific node
 func (l *Labeler) getDriverLabelForNode(nodeName string) (string, error) {
+	if l.assumeDriverInstalled {
+		return LabelValueTrue, nil
+	}
+
 	objs, err := l.podInformer.GetIndexer().ByIndex(NodeDriverIndex, nodeName)
 	if err != nil {
 		return "", fmt.Errorf("failed to get driver pods by node index for node %s: %w", nodeName, err)
@@ -477,6 +487,10 @@ func (l *Labeler) getDCGMVersionForNodeExcluding(nodeName string, excludePod *v1
 // getDriverLabelForNodeExcluding returns the expected driver label value for a specific node,
 // excluding a specific pod from consideration (used for delete events)
 func (l *Labeler) getDriverLabelForNodeExcluding(nodeName string, excludePod *v1.Pod) (string, error) {
+	if l.assumeDriverInstalled {
+		return LabelValueTrue, nil
+	}
+
 	objs, err := l.podInformer.GetIndexer().ByIndex(NodeDriverIndex, nodeName)
 	if err != nil {
 		return "", fmt.Errorf("failed to get driver pods by node index for node %s: %w", nodeName, err)
@@ -619,18 +633,28 @@ func (l *Labeler) reconcileNodeLabelsInPlace(node *v1.Node, driverLabel, dcgmVer
 		return needsUpdate
 	}
 
-	if driverLabel == "" && node.Labels[DriverInstalledLabel] != "" {
+	if node.Labels[DriverInstalledLabel] != driverLabel {
 		needsUpdate = true
 
-		delete(node.Labels, DriverInstalledLabel)
-		slog.Info("Removing stale driver installed label from node", "node", node.Name)
+		if driverLabel == "" {
+			delete(node.Labels, DriverInstalledLabel)
+			slog.Info("Removing stale driver installed label from node", "node", node.Name)
+		} else {
+			node.Labels[DriverInstalledLabel] = driverLabel
+			slog.Info("Setting driver installed label on node", "node", node.Name)
+		}
 	}
 
-	if dcgmVersion == "" && node.Labels[DCGMVersionLabel] != "" {
+	if node.Labels[DCGMVersionLabel] != dcgmVersion {
 		needsUpdate = true
 
-		delete(node.Labels, DCGMVersionLabel)
-		slog.Info("Removing stale DCGM version label from node", "node", node.Name)
+		if dcgmVersion == "" {
+			delete(node.Labels, DCGMVersionLabel)
+			slog.Info("Removing stale DCGM version label from node", "node", node.Name)
+		} else {
+			node.Labels[DCGMVersionLabel] = dcgmVersion
+			slog.Info("Setting DCGM version label on node", "node", node.Name, "version", dcgmVersion)
+		}
 	}
 
 	return needsUpdate

--- a/labeler/pkg/labeler/labeler.go
+++ b/labeler/pkg/labeler/labeler.go
@@ -393,9 +393,25 @@ func hasReadyDriverPod(objs []any, excludePod *v1.Pod) bool {
 	return false
 }
 
+const gpuPresentLabel = "nvidia.com/gpu.present"
+
+func (l *Labeler) isGPUNode(nodeName string) bool {
+	obj, exists, err := l.nodeInformer.GetStore().GetByKey(nodeName)
+	if err != nil || !exists {
+		return false
+	}
+
+	node, ok := obj.(*v1.Node)
+	if !ok {
+		return false
+	}
+
+	return node.Labels[gpuPresentLabel] == LabelValueTrue
+}
+
 // getDriverLabelForNode returns the expected driver label value for a specific node
 func (l *Labeler) getDriverLabelForNode(nodeName string) (string, error) {
-	if l.assumeDriverInstalled {
+	if l.assumeDriverInstalled && l.isGPUNode(nodeName) {
 		return LabelValueTrue, nil
 	}
 
@@ -487,7 +503,7 @@ func (l *Labeler) getDCGMVersionForNodeExcluding(nodeName string, excludePod *v1
 // getDriverLabelForNodeExcluding returns the expected driver label value for a specific node,
 // excluding a specific pod from consideration (used for delete events)
 func (l *Labeler) getDriverLabelForNodeExcluding(nodeName string, excludePod *v1.Pod) (string, error) {
-	if l.assumeDriverInstalled {
+	if l.assumeDriverInstalled && l.isGPUNode(nodeName) {
 		return LabelValueTrue, nil
 	}
 

--- a/labeler/pkg/labeler/labeler_test.go
+++ b/labeler/pkg/labeler/labeler_test.go
@@ -624,7 +624,7 @@ func TestLabeler_handlePodEvent(t *testing.T) {
 				require.NoError(t, err, "failed to update pod status")
 			}
 
-			labeler, err := NewLabeler(cli, time.Minute, "nvidia-dcgm", "nvidia-driver-daemonset", "nvidia-driver-installer", "")
+			labeler, err := NewLabeler(cli, time.Minute, "nvidia-dcgm", "nvidia-driver-daemonset", "nvidia-driver-installer", "", false)
 			require.NoError(t, err)
 			go func() {
 				require.NoError(t, labeler.Run(ctx), "failed to run labeler")
@@ -751,6 +751,7 @@ func TestKataLabelOverride(t *testing.T) {
 				"nvidia-driver-daemonset",
 				"nvidia-driver-installer",
 				tt.override,
+				false,
 			)
 
 			if err != nil {
@@ -770,13 +771,13 @@ func TestNewLabeler_InvalidLabelSelectors_ReturnsError(t *testing.T) {
 	clientset := fake.NewSimpleClientset()
 
 	t.Run("invalid pod label selector", func(t *testing.T) {
-		_, err := NewLabeler(clientset, time.Minute, "invalid(value", "driver", "gke", "")
+		_, err := NewLabeler(clientset, time.Minute, "invalid(value", "driver", "gke", "", false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "create pod informer")
 	})
 
 	t.Run("invalid GKE installer label selector", func(t *testing.T) {
-		_, err := NewLabeler(clientset, time.Minute, "dcgm", "driver", "invalid(value", "")
+		_, err := NewLabeler(clientset, time.Minute, "dcgm", "driver", "invalid(value", "", false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "create GKE installer informer")
 	})
@@ -801,6 +802,7 @@ func TestKataLabelOverrideIsolation(t *testing.T) {
 		"nvidia-driver-daemonset",
 		"nvidia-driver-installer",
 		"first.io/kata",
+		false,
 	)
 	if err != nil {
 		t.Fatalf("NewLabeler(first) error = %v", err)
@@ -814,6 +816,7 @@ func TestKataLabelOverrideIsolation(t *testing.T) {
 		"nvidia-driver-daemonset",
 		"nvidia-driver-installer",
 		"second.io/kata",
+		false,
 	)
 	if err != nil {
 		t.Fatalf("NewLabeler(second) error = %v", err)
@@ -827,6 +830,7 @@ func TestKataLabelOverrideIsolation(t *testing.T) {
 		"nvidia-driver-daemonset",
 		"nvidia-driver-installer",
 		"",
+		false,
 	)
 	if err != nil {
 		t.Fatalf("NewLabeler(empty) error = %v", err)
@@ -952,7 +956,7 @@ func TestKataLabelDetection(t *testing.T) {
 			require.NoError(t, err, "failed to create node")
 
 			// Create labeler with kata override if specified
-			labeler, err := NewLabeler(cli, time.Minute, "nvidia-dcgm", "nvidia-driver-daemonset", "nvidia-driver-installer", tt.kataOverride)
+			labeler, err := NewLabeler(cli, time.Minute, "nvidia-dcgm", "nvidia-driver-daemonset", "nvidia-driver-installer", tt.kataOverride, false)
 			require.NoError(t, err, "failed to create labeler")
 
 			// Start labeler
@@ -1118,7 +1122,7 @@ func TestStaleLabelsRemoval(t *testing.T) {
 				require.NoError(t, err, "failed to update pod status")
 			}
 
-			labeler, err := NewLabeler(cli, time.Minute, "nvidia-dcgm", "nvidia-driver-daemonset", "nvidia-driver-installer", "")
+			labeler, err := NewLabeler(cli, time.Minute, "nvidia-dcgm", "nvidia-driver-daemonset", "nvidia-driver-installer", "", false)
 			require.NoError(t, err, "failed to create labeler")
 
 			labelerCtx, labelerCancel := context.WithCancel(ctx)
@@ -1191,6 +1195,107 @@ func TestStaleLabelsRemoval(t *testing.T) {
 
 				return true
 			}, 15*time.Second, 500*time.Millisecond, "labels not set correctly on node %s", tt.existingNode.Name)
+		})
+	}
+}
+
+func TestAssumeDriverInstalled(t *testing.T) {
+	tests := []struct {
+		name                  string
+		assumeDriverInstalled bool
+		existingNode          *corev1.Node
+		expectedDriverLabel   string
+		shouldHaveDriverLabel bool
+	}{
+		{
+			name:                  "assume-driver-installed sets label without driver pods",
+			assumeDriverInstalled: true,
+			existingNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "gpu-node",
+					Labels: map[string]string{},
+				},
+			},
+			expectedDriverLabel:   "true",
+			shouldHaveDriverLabel: true,
+		},
+		{
+			name:                  "assume-driver-installed preserves label on reconciliation",
+			assumeDriverInstalled: true,
+			existingNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gpu-node",
+					Labels: map[string]string{
+						DriverInstalledLabel: "true",
+					},
+				},
+			},
+			expectedDriverLabel:   "true",
+			shouldHaveDriverLabel: true,
+		},
+		{
+			name:                  "without flag stale label is removed when no driver pods",
+			assumeDriverInstalled: false,
+			existingNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gpu-node",
+					Labels: map[string]string{
+						DriverInstalledLabel: "true",
+					},
+				},
+			},
+			shouldHaveDriverLabel: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			testEnv := envtest.Environment{}
+			cfg, err := testEnv.Start()
+			require.NoError(t, err, "failed to setup envtest")
+			defer func() { _ = testEnv.Stop() }()
+
+			cli, err := kubernetes.NewForConfig(cfg)
+			require.NoError(t, err, "failed to create kubernetes client")
+
+			_, err = cli.CoreV1().Nodes().Create(ctx, tt.existingNode, metav1.CreateOptions{})
+			require.NoError(t, err, "failed to create node")
+
+			labeler, err := NewLabeler(cli, time.Minute, "nvidia-dcgm", "nvidia-driver-daemonset", "nvidia-driver-installer", "", tt.assumeDriverInstalled)
+			require.NoError(t, err, "failed to create labeler")
+
+			labelerCtx, labelerCancel := context.WithCancel(ctx)
+			defer labelerCancel()
+
+			go func() {
+				_ = labeler.Run(labelerCtx)
+			}()
+
+			require.Eventually(t, func() bool {
+				return labeler.allInformersSynced()
+			}, 10*time.Second, 100*time.Millisecond, "labeler informers did not sync")
+
+			err = labeler.handleNodeEvent(tt.existingNode)
+			require.NoError(t, err, "failed to handle node event")
+
+			require.Eventually(t, func() bool {
+				node, err := cli.CoreV1().Nodes().Get(ctx, tt.existingNode.Name, metav1.GetOptions{})
+				if err != nil {
+					t.Logf("Failed to get node: %v", err)
+					return false
+				}
+
+				driverLabel, driverExists := node.Labels[DriverInstalledLabel]
+				t.Logf("Node labels: driver=%q (exists=%v)", driverLabel, driverExists)
+
+				if tt.shouldHaveDriverLabel {
+					return driverExists && driverLabel == tt.expectedDriverLabel
+				}
+				return !driverExists
+			}, 15*time.Second, 500*time.Millisecond, "driver label not set correctly on node %s", tt.existingNode.Name)
 		})
 	}
 }

--- a/labeler/pkg/labeler/labeler_test.go
+++ b/labeler/pkg/labeler/labeler_test.go
@@ -1208,25 +1208,39 @@ func TestAssumeDriverInstalled(t *testing.T) {
 		shouldHaveDriverLabel bool
 	}{
 		{
-			name:                  "assume-driver-installed sets label without driver pods",
+			name:                  "assume-driver-installed sets label on GPU node without driver pods",
 			assumeDriverInstalled: true,
 			existingNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "gpu-node",
-					Labels: map[string]string{},
+					Name: "gpu-node",
+					Labels: map[string]string{
+						"nvidia.com/gpu.present": "true",
+					},
 				},
 			},
 			expectedDriverLabel:   "true",
 			shouldHaveDriverLabel: true,
 		},
 		{
-			name:                  "assume-driver-installed preserves label on reconciliation",
+			name:                  "assume-driver-installed skips non-GPU node",
+			assumeDriverInstalled: true,
+			existingNode: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "control-plane-node",
+					Labels: map[string]string{},
+				},
+			},
+			shouldHaveDriverLabel: false,
+		},
+		{
+			name:                  "assume-driver-installed preserves label on GPU node reconciliation",
 			assumeDriverInstalled: true,
 			existingNode: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "gpu-node",
 					Labels: map[string]string{
-						DriverInstalledLabel: "true",
+						"nvidia.com/gpu.present": "true",
+						DriverInstalledLabel:     "true",
 					},
 				},
 			},


### PR DESCRIPTION
## Summary

On clusters with host-installed NVIDIA drivers, no `nvidia-driver-daemonset` pods exist. As a result, the labeler never sets `nvsentinel.dgxc.nvidia.com/driver.installed=true`, so DaemonSets like `syslog-health-monitor` and `metadata-collector` never schedule. Design doc 018 acknowledges this gap and suggests manual labeling, but the labeler actively removes manually-applied labels on reconciliation.

## Solution

Add `--assume-driver-installed` flag. When enabled, the labeler sets `driver.installed=true` on all nodes with `nvidia.com/gpu.present=true`, skipping pod-based detection. Non-GPU nodes are unaffected.

## Type of Change
- [ ] 🐛 Bug fix
- [ X ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ X ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ X ] Tests pass locally
- [ X ] Manual testing completed
- [ X ] No breaking changes (or documented)

## Checklist
- [ X ] Self-review completed
- [ ] Documentation updated (if needed)
- [ X ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional configuration flag to assume GPU drivers are pre-installed on nodes, allowing the labeler to directly mark GPU nodes as having drivers without waiting for driver pod detection.
* **Tests**
  * Added unit coverage to validate behavior when the assume-driver-installed option is enabled or disabled across GPU and non‑GPU node scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->