### PR TITLE
fix(watcher): exit goroutine on change stream error

### DIFF
--- a/store-client/pkg/datastore/providers/mongodb/watcher/watch_store.go
+++ b/store-client/pkg/datastore/providers/mongodb/watcher/watch_store.go
@@ -355,6 +355,7 @@ func (w *ChangeStreamWatcher) Start(ctx context.Context) {
 					}
 				} else if csErr != nil {
 					slog.Error("Failed to watch change stream", "client", w.clientName, "error", csErr)
+					return
 				}
 			}
 		}

--- a/store-client/pkg/datastore/providers/mongodb/watcher/watch_store_test.go
+++ b/store-client/pkg/datastore/providers/mongodb/watcher/watch_store_test.go
@@ -194,6 +194,47 @@ func TestChangeStreamWatcher_Start(t *testing.T) {
 		err = watcher.Close(ctx)
 		require.NoError(t, err)
 	})
+
+	mt.Run("Start exits goroutine on change stream error", func(mt *mtest.T) {
+		mt.AddMockResponses(
+			// Initial change stream cursor
+			mtest.CreateCursorResponse(1, "testdb.testcollection", mtest.FirstBatch),
+			// getMore returns an error
+			mtest.CreateCommandErrorResponse(mtest.CommandError{Code: 123, Message: "stream error"}),
+		)
+
+		coll := mt.Client.Database("testdb").Collection("testcollection")
+		changeStream, err := coll.Watch(context.Background(), mongo.Pipeline{})
+		require.NoError(mt, err)
+
+		watcher := &ChangeStreamWatcher{
+			client:       mt.Client,
+			changeStream: changeStream,
+			eventChannel: make(chan Event, 1),
+			clientName:   "testclient-error",
+			done:         make(chan struct{}),
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		watcher.Start(ctx)
+
+		// The goroutine should exit and close the event channel
+		select {
+		case <-watcher.done:
+			// Goroutine exited as expected
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout waiting for goroutine to exit on change stream error")
+		}
+
+		// Event channel should be closed
+		_, open := <-watcher.eventChannel
+		require.False(t, open, "event channel should be closed after stream error")
+
+		// Close the change stream to release the mtest session
+		_ = watcher.changeStream.Close(context.Background())
+	})
 }
 
 func TestChangeStreamWatcher_MarkProcessed(t *testing.T) {


### PR DESCRIPTION
Related #958 

## Summary

When a change stream error occurs, the Start goroutine logs the error but keeps looping which caused event processing to silently stop. This PR adds a return so the goroutine exits cleanly, closing the event channel and signaling `w.done`. 

I considered `os.Exit(1)` to let Kubernetes restart the pod, but the codebase doesn't have any instance of `os.Exit` or `log.Fatal` calls anywhere. Instead, it relies on error propagation and graceful shutdown throughout. `log`/`slog` omits a fatal level, and `os.Exit` from a goroutine bypasses defers, skips cleanup, and makes the code untestable. A clean return follows existing patterns.

## Type of Change
- [ X ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ X ] Core Services
- [ ] Documentation/CI
- [ X ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ X ] Tests pass locally
- [ X ] Manual testing completed
- [ X ] No breaking changes (or documented)

## Checklist
- [ X ] Self-review completed
- [ X ] Documentation updated (if needed)
- [ X ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed MongoDB change stream watcher to properly exit on errors instead of continuing in a degraded state, improving data synchronization reliability and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->