### PR TITLE
feat: support optional TLS for MongoDB connections

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -59,6 +59,16 @@ jobs:
           - arch: amd64
             runner: ${{ vars.RUNNER_ARCH_LARGE_AMD64 || 'linux-amd64-cpu32' }}
             arch_name: "AMD64"
+            datastore: "mongodb-no-tls"
+            datastore_name: "MongoDB (no TLS)"
+          - arch: arm64
+            runner: ${{ vars.RUNNER_ARCH_LARGE_ARM64 || 'linux-arm64-cpu32' }}
+            arch_name: "ARM64"
+            datastore: "mongodb-no-tls"
+            datastore_name: "MongoDB (no TLS)"
+          - arch: amd64
+            runner: ${{ vars.RUNNER_ARCH_LARGE_AMD64 || 'linux-amd64-cpu32' }}
+            arch_name: "AMD64"
             datastore: "postgresql"
             datastore_name: "PostgreSQL"
           - arch: arm64
@@ -143,7 +153,7 @@ jobs:
           make cluster-create
 
       - name: Override MongoDB image for ARM64
-        if: matrix.arch == 'arm64' && matrix.datastore == 'mongodb'
+        if: matrix.arch == 'arm64' && contains(matrix.datastore, 'mongodb')
         run: |
           sed -i 's/repository: "bitnamilegacy\/mongodb"/repository: "dlavrenuek\/bitnami-mongodb-arm"/' distros/kubernetes/nvsentinel/values-tilt.yaml
           sed -i 's/tag: "8.0.3-debian-12-r1"/tag: "8.0.4"/' distros/kubernetes/nvsentinel/values-tilt.yaml
@@ -156,8 +166,10 @@ jobs:
           CLUSTER_NAME_SUFFIX: "-${{ matrix.arch }}-${{ matrix.datastore }}"
           # Set USE_POSTGRESQL for PostgreSQL tests (our integrated Tiltfile approach)
           USE_POSTGRESQL: ${{ matrix.datastore == 'postgresql' && '1' || '0' }}
-          # Set architecture-specific test tags
-          TEST_TAGS: ${{ matrix.arch }}_group${{ matrix.datastore == 'mongodb' && ',mongodb' || '' }}
+          # Disable TLS for no-TLS MongoDB tests
+          DISABLE_TLS: ${{ matrix.datastore == 'mongodb-no-tls' && '1' || '0' }}
+          # Set architecture-specific test tags (mongodb tag applies to all MongoDB variants)
+          TEST_TAGS: ${{ matrix.arch }}_group${{ contains(matrix.datastore, 'mongodb') && ',mongodb' || '' }}
         run: |
           make e2e-test-ci
 

--- a/commons/pkg/flags/database_flags.go
+++ b/commons/pkg/flags/database_flags.go
@@ -105,8 +105,8 @@ func (c *DatabaseCertConfig) GetCertPath() string {
 
 	// If neither exists, return empty to indicate no TLS certs are available.
 	// Callers should check for empty and skip TLS configuration.
-	slog.Info("No certificate found at any expected location, TLS will be disabled. "+
-		"Use --tls-enabled=false to explicitly disable TLS, or provide certificates at "+
+	slog.Info("No certificate found at any expected location, TLS will be disabled. " +
+		"Use --tls-enabled=false to explicitly disable TLS, or provide certificates at " +
 		"--database-client-cert-mount-path or --mongo-client-cert-mount-path")
 
 	return ""

--- a/commons/pkg/flags/database_flags.go
+++ b/commons/pkg/flags/database_flags.go
@@ -105,7 +105,9 @@ func (c *DatabaseCertConfig) GetCertPath() string {
 
 	// If neither exists, return empty to indicate no TLS certs are available.
 	// Callers should check for empty and skip TLS configuration.
-	slog.Info("No certificate found at any expected location, TLS will be disabled")
+	slog.Info("No certificate found at any expected location, TLS will be disabled. "+
+		"Use --tls-enabled=false to explicitly disable TLS, or provide certificates at "+
+		"--database-client-cert-mount-path or --mongo-client-cert-mount-path")
 
 	return ""
 }

--- a/commons/pkg/flags/database_flags.go
+++ b/commons/pkg/flags/database_flags.go
@@ -22,6 +22,7 @@ import (
 
 // DatabaseCertConfig holds the configuration for database client certificate paths
 type DatabaseCertConfig struct {
+	TLSEnabled                  bool
 	DatabaseClientCertMountPath string
 	LegacyMongoCertPath         string
 	ResolvedCertPath            string
@@ -32,6 +33,9 @@ type DatabaseCertConfig struct {
 // across multiple modules.
 func RegisterDatabaseCertFlags() *DatabaseCertConfig {
 	config := &DatabaseCertConfig{}
+
+	flag.BoolVar(&config.TLSEnabled, "tls-enabled", true,
+		"enable TLS for database connections (set to false to connect without TLS)")
 
 	flag.StringVar(&config.DatabaseClientCertMountPath, "database-client-cert-mount-path", "/etc/ssl/database-client",
 		"path where the database client cert is mounted")
@@ -44,8 +48,13 @@ func RegisterDatabaseCertFlags() *DatabaseCertConfig {
 }
 
 // ResolveCertPath resolves the actual certificate path to use based on flag values and file existence.
-// This implements the backward compatibility logic that was duplicated across multiple modules.
+// Returns empty string when TLS is explicitly disabled via --tls-enabled=false.
 func (c *DatabaseCertConfig) ResolveCertPath() string {
+	if !c.TLSEnabled {
+		slog.Info("TLS explicitly disabled via --tls-enabled flag")
+		return ""
+	}
+
 	// If new flag is still default and legacy flag is provided, use legacy flag value
 	if c.DatabaseClientCertMountPath == "/etc/ssl/database-client" {
 		c.ResolvedCertPath = c.LegacyMongoCertPath
@@ -62,8 +71,15 @@ func (c *DatabaseCertConfig) ResolveCertPath() string {
 	return c.ResolvedCertPath
 }
 
-// GetCertPath checks if the certificate exists at the resolved path, with fallback logic
+// GetCertPath checks if the certificate exists at the resolved path, with fallback logic.
+// Returns empty string when TLS is explicitly disabled via --tls-enabled=false or
+// when no certificate files are found at any expected path.
 func (c *DatabaseCertConfig) GetCertPath() string {
+	if !c.TLSEnabled {
+		slog.Info("TLS explicitly disabled via --tls-enabled flag")
+		return ""
+	}
+
 	if c.ResolvedCertPath == "" {
 		c.ResolveCertPath()
 	}
@@ -87,9 +103,8 @@ func (c *DatabaseCertConfig) GetCertPath() string {
 		return newPath
 	}
 
-	// If neither exists, return the resolved path (original behavior)
-	slog.Warn("Certificate file not found at any expected location, using resolved path",
-		"resolved_path", c.ResolvedCertPath)
-
-	return c.ResolvedCertPath
+	// If neither exists, return empty to indicate no TLS certs are available.
+	// Callers should check for empty and skip TLS configuration.
+	slog.Info("No certificate found at any expected location, TLS will be disabled")
+	return ""
 }

--- a/commons/pkg/flags/database_flags.go
+++ b/commons/pkg/flags/database_flags.go
@@ -106,5 +106,6 @@ func (c *DatabaseCertConfig) GetCertPath() string {
 	// If neither exists, return empty to indicate no TLS certs are available.
 	// Callers should check for empty and skip TLS configuration.
 	slog.Info("No certificate found at any expected location, TLS will be disabled")
+
 	return ""
 }

--- a/commons/pkg/flags/database_flags_test.go
+++ b/commons/pkg/flags/database_flags_test.go
@@ -128,6 +128,66 @@ func TestDatabaseCertConfig_GetCertPath(t *testing.T) {
 	}
 }
 
+func TestDatabaseCertConfig_TLSDisabled_ResolveCertPath(t *testing.T) {
+	config := &DatabaseCertConfig{
+		TLSEnabled:                  false,
+		DatabaseClientCertMountPath: "/etc/ssl/database-client",
+		LegacyMongoCertPath:         "/etc/ssl/mongo-client",
+	}
+
+	certPath := config.ResolveCertPath()
+	assert.Empty(t, certPath, "ResolveCertPath should return empty when TLS is disabled")
+}
+
+func TestDatabaseCertConfig_TLSDisabled_GetCertPath(t *testing.T) {
+	// Even when cert files exist, GetCertPath should return empty when TLS is disabled
+	tempDir, err := os.MkdirTemp("", "cert_test_tls_disabled")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	certDir := filepath.Join(tempDir, "certs")
+	require.NoError(t, os.MkdirAll(certDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(certDir, "ca.crt"), []byte("test cert"), 0644))
+
+	config := &DatabaseCertConfig{
+		TLSEnabled:   false,
+		ResolvedCertPath: certDir,
+	}
+
+	certPath := config.GetCertPath()
+	assert.Empty(t, certPath, "GetCertPath should return empty when TLS is disabled, even if certs exist")
+}
+
+func TestDatabaseCertConfig_TLSEnabled_GetCertPath(t *testing.T) {
+	// When TLS is enabled and certs exist, should return the path
+	tempDir, err := os.MkdirTemp("", "cert_test_tls_enabled")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	certDir := filepath.Join(tempDir, "certs")
+	require.NoError(t, os.MkdirAll(certDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(certDir, "ca.crt"), []byte("test cert"), 0644))
+
+	config := &DatabaseCertConfig{
+		TLSEnabled:   true,
+		ResolvedCertPath: certDir,
+	}
+
+	certPath := config.GetCertPath()
+	assert.Equal(t, certDir, certPath, "GetCertPath should return cert path when TLS is enabled and certs exist")
+}
+
+func TestDatabaseCertConfig_TLSEnabled_NoCerts_ReturnsEmpty(t *testing.T) {
+	// When TLS is enabled but no certs exist anywhere, should return empty
+	config := &DatabaseCertConfig{
+		TLSEnabled:   true,
+		ResolvedCertPath: "/nonexistent/path/that/does/not/exist",
+	}
+
+	certPath := config.GetCertPath()
+	assert.Empty(t, certPath, "GetCertPath should return empty when TLS is enabled but no certs exist")
+}
+
 func TestDatabaseCertConfig_GetCertPath_WithRealPaths(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "csp-health-monitor.fullname" . }}
-      {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
+      {{- if and .Values.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
       initContainers:
         - name: fix-cert-permissions
           image: "{{ .Values.global.initContainerImage.repository }}:{{ .Values.global.initContainerImage.tag }}"
@@ -75,14 +75,14 @@ spec:
           items:
           - key: config.toml
             path: config.toml
-      {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
+      {{- if and .Values.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
       - name: postgresql-client-cert-original
         secret:
           secretName: postgresql-client-cert
           optional: false
       - name: client-certs-fixed
         emptyDir: {}
-      {{- else }}
+      {{- else if .Values.clientCertMountPath }}
       - name: mongo-app-client-cert
         secret:
           secretName: {{ include "nvsentinel.certificates.secretName" . }}
@@ -105,7 +105,11 @@ spec:
           args:
           - "--config=/etc/config/config.toml"
           - "--metrics-port={{ ((.Values.global).metricsPort) | default 2112 }}"
+          {{- if .Values.clientCertMountPath }}
           - "--database-client-cert-mount-path={{ .Values.clientCertMountPath }}"
+          {{- else }}
+          - "--database-client-cert-mount-path="
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           ports:
@@ -131,11 +135,11 @@ spec:
           volumeMounts:
           - name: config-volume
             mountPath: /etc/config/
-          {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
+          {{- if and .Values.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
           - name: client-certs-fixed
             mountPath: {{ .Values.clientCertMountPath }}
             readOnly: true
-          {{- else }}
+          {{- else if .Values.clientCertMountPath }}
           - name: mongo-app-client-cert
             mountPath: {{ .Values.clientCertMountPath }}
             readOnly: true
@@ -163,7 +167,11 @@ spec:
             {{- end }}
           args:
           - "--config=/etc/config/config.toml"
+          {{- if .Values.clientCertMountPath }}
           - "--database-client-cert-mount-path={{ .Values.clientCertMountPath }}"
+          {{- else }}
+          - "--database-client-cert-mount-path="
+          {{- end }}
           - "--uds-path=/run/nvsentinel/nvsentinel.sock"
           - "--metrics-port=2113"
           - "--processing-strategy={{ .Values.processingStrategy }}"
@@ -192,11 +200,11 @@ spec:
           volumeMounts:
           - name: config-volume
             mountPath: /etc/config/
-          {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
+          {{- if and .Values.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
           - name: client-certs-fixed
             mountPath: {{ .Values.clientCertMountPath }}
             readOnly: true
-          {{- else }}
+          {{- else if .Values.clientCertMountPath }}
           - name: mongo-app-client-cert
             mountPath: {{ .Values.clientCertMountPath }}
             readOnly: true

--- a/distros/kubernetes/nvsentinel/charts/csp-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/csp-health-monitor/values.yaml
@@ -59,7 +59,8 @@ processingStrategy: EXECUTE_REMEDIATION
 # Log verbosity level for the main CSP health monitor container (e.g. "debug", "info", "warn", "error")
 logLevel: info
 
-# Client certificate mount path for database connections
+# Client certificate mount path for database connections.
+# Set to an empty string to disable MongoDB TLS client certificate mounts.
 clientCertMountPath: /etc/ssl/client-certs
 
 # cspName specifies the active cloud service provider. Can be "gcp" or "aws".

--- a/distros/kubernetes/nvsentinel/charts/event-exporter/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/event-exporter/templates/deployment.yaml
@@ -117,9 +117,9 @@ spec:
           - name: client-certs-fixed
             mountPath: /etc/ssl/client-certs
             readOnly: true
-          {{- else }}
+          {{- else if .Values.mongodbStore.clientCertMountPath }}
           - name: mongo-app-client-cert
-            mountPath: /etc/ssl/mongo-client
+            mountPath: {{ .Values.mongodbStore.clientCertMountPath }}
             readOnly: true
           {{- end }}
           - name: var-run-vol
@@ -131,13 +131,13 @@ spec:
             {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
             - name: POSTGRESQL_CLIENT_CERT_MOUNT_PATH
               value: "/etc/ssl/client-certs"
-            {{- else }}
+            {{- else if .Values.mongodbStore.clientCertMountPath }}
             - name: MONGODB_CLIENT_CERT_PATH
-              value: "/etc/ssl/mongo-client/tls.crt"
+              value: {{ printf "%s/tls.crt" .Values.mongodbStore.clientCertMountPath | quote }}
             - name: MONGODB_CLIENT_KEY_PATH
-              value: "/etc/ssl/mongo-client/tls.key"
+              value: {{ printf "%s/tls.key" .Values.mongodbStore.clientCertMountPath | quote }}
             - name: MONGODB_CA_CERT_PATH
-              value: "/etc/ssl/mongo-client/ca.crt"
+              value: {{ printf "%s/ca.crt" .Values.mongodbStore.clientCertMountPath | quote }}
             {{- end }}
           envFrom:
             - configMapRef:
@@ -165,7 +165,7 @@ spec:
           optional: false
       - name: client-certs-fixed
         emptyDir: {}
-      {{- else }}
+      {{- else if .Values.mongodbStore.clientCertMountPath }}
       - name: mongo-app-client-cert
         secret:
           secretName: {{ include "nvsentinel.certificates.secretName" . }}

--- a/distros/kubernetes/nvsentinel/charts/event-exporter/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/event-exporter/values.yaml
@@ -34,6 +34,10 @@ resources:
 # You must create this secret manually before deploying this chart
 oidcSecretName: "event-exporter-oidc-secret"
 
+# Set to an empty string to disable MongoDB TLS client certificate mounts.
+mongodbStore:
+  clientCertMountPath: /etc/ssl/mongo-client
+
 # Event exporter configuration
 exporter:
   # Metadata configuration

--- a/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/deployment.yaml
@@ -44,12 +44,12 @@ spec:
       securityContext:
         fsGroup: 65532
       {{- end }}
-      {{- if or .Values.global.auditLogging.enabled (and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql")) }}
+      {{- if or .Values.global.auditLogging.enabled (and .Values.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql")) }}
       initContainers:
         {{- if .Values.global.auditLogging.enabled }}
         {{- include "nvsentinel.auditLogging.initContainer" . | nindent 8 }}
         {{- end }}
-      {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
+      {{- if and .Values.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
         - name: fix-cert-permissions
           image: "{{ .Values.global.initContainerImage.repository }}:{{ .Values.global.initContainerImage.tag }}"
           imagePullPolicy: {{ .Values.global.initContainerImage.pullPolicy }}
@@ -91,7 +91,11 @@ spec:
           args:
           - "--metrics-port={{ ((.Values.global).metricsPort) | default 2112 }}"
           - "--dry-run={{ ((.Values.global).dryRun) | default false }}"
+          {{- if .Values.clientCertMountPath }}
           - "--database-client-cert-mount-path={{ .Values.clientCertMountPath }}"
+          {{- else }}
+          - "--tls-enabled=false"
+          {{- end }}
           - "--circuit-breaker-enabled={{ .Values.circuitBreaker.enabled }}"
           ports:
             - name: metrics
@@ -116,6 +120,7 @@ spec:
           - name: config-volume
             mountPath: /etc/config/config.toml
             subPath: config.toml
+          {{- if .Values.clientCertMountPath }}
           {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
           - name: client-certs-fixed
             mountPath: {{ .Values.clientCertMountPath }}
@@ -124,6 +129,7 @@ spec:
           - name: mongo-app-client-cert
             mountPath: {{ .Values.clientCertMountPath }}
             readOnly: true
+          {{- end }}
           {{- end }}
           {{- if .Values.global.auditLogging.enabled }}
           {{- include "nvsentinel.auditLogging.volumeMount" . | nindent 10 }}
@@ -145,12 +151,14 @@ spec:
             {{- if .Values.global.auditLogging.enabled }}
             {{- include "nvsentinel.auditLogging.envVars" . | nindent 12 }}
             {{- end }}
+            {{- if .Values.clientCertMountPath }}
             {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
             - name: POSTGRESQL_CLIENT_CERT_MOUNT_PATH
               value: {{ .Values.clientCertMountPath }}
             {{- else }}
             - name: MONGODB_CLIENT_CERT_MOUNT_PATH
               value: {{ .Values.clientCertMountPath }}
+            {{- end }}
             {{- end }}
           envFrom:
             - configMapRef:
@@ -163,6 +171,7 @@ spec:
           items:
           - key: config.toml
             path: config.toml
+      {{- if .Values.clientCertMountPath }}
       {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
       - name: postgresql-client-cert-original
         secret:
@@ -176,6 +185,7 @@ spec:
           secretName: {{ include "nvsentinel.certificates.secretName" . }}
           {{- include "nvsentinel.certificates.volumeItems" . | nindent 10 }}
           optional: true
+      {{- end }}
       {{- end }}
       {{- if .Values.global.auditLogging.enabled }}
       {{- include "nvsentinel.auditLogging.volume" . | nindent 6 }}

--- a/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/deployment.yaml
@@ -44,12 +44,12 @@ spec:
       securityContext:
         fsGroup: 65532
       {{- end }}
-      {{- if or .Values.global.auditLogging.enabled (and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql")) }}
+      {{- if or .Values.global.auditLogging.enabled (and .Values.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql")) }}
       initContainers:
         {{- if .Values.global.auditLogging.enabled }}
         {{- include "nvsentinel.auditLogging.initContainer" . | nindent 8 }}
         {{- end }}
-      {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
+      {{- if and .Values.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
         - name: fix-cert-permissions
           image: "{{ .Values.global.initContainerImage.repository }}:{{ .Values.global.initContainerImage.tag }}"
           imagePullPolicy: {{ .Values.global.initContainerImage.pullPolicy }}
@@ -114,6 +114,7 @@ spec:
             timeoutSeconds: 3
             failureThreshold: 3
           volumeMounts:
+          {{- if .Values.clientCertMountPath }}
           {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
           - name: client-certs-fixed
             mountPath: {{ .Values.clientCertMountPath }}
@@ -122,6 +123,7 @@ spec:
           - name: mongo-app-client-cert
             mountPath: {{ .Values.clientCertMountPath }}
             readOnly: true
+          {{- end }}
           {{- end }}
           - name: config-volume
             mountPath: /etc/config
@@ -149,6 +151,7 @@ spec:
             value: "{{ .Values.logCollector.enableGcpSosCollection }}"
           - name: ENABLE_AWS_SOS_COLLECTION
             value: "{{ .Values.logCollector.enableAwsSosCollection }}"
+          {{- if .Values.clientCertMountPath }}
           {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
           - name: POSTGRESQL_CLIENT_CERT_MOUNT_PATH
             value: {{ .Values.clientCertMountPath }}
@@ -156,11 +159,13 @@ spec:
           - name: MONGODB_CLIENT_CERT_MOUNT_PATH
             value: {{ .Values.clientCertMountPath }}
           {{- end }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ if .Values.global.datastore }}{{ .Release.Name }}-datastore-config{{ else }}mongodb-config{{ end }}
                 optional: true
       volumes:
+      {{- if .Values.clientCertMountPath }}
       {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
       - name: postgresql-client-cert-original
         secret:
@@ -174,6 +179,7 @@ spec:
           secretName: {{ include "nvsentinel.certificates.secretName" . }}
           {{- include "nvsentinel.certificates.volumeItems" . | nindent 10 }}
           optional: true
+      {{- end }}
       {{- end }}
       - name: config-volume
         configMap:

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "health-events-analyzer.fullname" . }}
-      {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
+      {{- if and .Values.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
       initContainers:
         - name: fix-cert-permissions
           image: "{{ .Values.global.initContainerImage.repository }}:{{ .Values.global.initContainerImage.tag }}"
@@ -77,7 +77,9 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           args:
           - "--metrics-port={{ .Values.global.metricsPort }}"
+          {{- if .Values.clientCertMountPath }}
           - "--database-client-cert-mount-path={{ .Values.clientCertMountPath }}"
+          {{- end }}
           - "--processing-strategy={{ .Values.processingStrategy }}"
           ports:
             - name: metrics
@@ -109,6 +111,7 @@ spec:
           - name: config-volume
             mountPath: /etc/config/config.toml
             subPath: config.toml
+          {{- if .Values.clientCertMountPath }}
           {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
           - name: client-certs-fixed
             mountPath: {{ .Values.clientCertMountPath }}
@@ -118,6 +121,7 @@ spec:
             mountPath: {{ .Values.clientCertMountPath }}
             readOnly: true
           {{- end }}
+          {{- end }}
           - name: var-run-vol
             mountPath: /var/run/
           env:
@@ -126,12 +130,14 @@ spec:
             # App name for connection identification in logs and currentOp
             - name: APP_NAME
               value: {{ .Chart.Name | quote }}
+            {{- if .Values.clientCertMountPath }}
             {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
             - name: POSTGRESQL_CLIENT_CERT_MOUNT_PATH
               value: {{ .Values.clientCertMountPath }}
             {{- else }}
             - name: MONGODB_CLIENT_CERT_MOUNT_PATH
               value: {{ .Values.clientCertMountPath }}
+            {{- end }}
             {{- end }}
           envFrom:
             - configMapRef:
@@ -148,6 +154,7 @@ spec:
         hostPath:
           path: /var/run/nvsentinel
           type: Directory
+      {{- if .Values.clientCertMountPath }}
       {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
       - name: postgresql-client-cert-original
         secret:
@@ -161,6 +168,7 @@ spec:
           secretName: {{ include "nvsentinel.certificates.secretName" . }}
           {{- include "nvsentinel.certificates.volumeItems" . | nindent 10 }}
           optional: true
+      {{- end }}
       {{- end }}
       restartPolicy: Always
       {{- with (.Values.global.systemNodeSelector | default .Values.nodeSelector) }}

--- a/distros/kubernetes/nvsentinel/charts/mongodb-store/templates/certmanager.yaml
+++ b/distros/kubernetes/nvsentinel/charts/mongodb-store/templates/certmanager.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- if .Values.mongodb.tls.enabled }}
 {{- if .Values.usePerconaOperator }}
 ---
 apiVersion: cert-manager.io/v1
@@ -121,4 +122,5 @@ spec:
   issuerRef:
     name: selfsigned-ca-issuer
     kind: Issuer
+{{- end }}
 {{- end }}

--- a/distros/kubernetes/nvsentinel/charts/mongodb-store/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/mongodb-store/templates/configmap.yaml
@@ -20,10 +20,22 @@ data:
   # Datastore provider configuration for new abstraction layer
   DATASTORE_PROVIDER: "mongodb"
   # Legacy MongoDB configuration (maintained for backward compatibility)
+  # When TLS is disabled and SCRAM auth is needed, override MONGODB_URI in your
+  # Helm values to include credentials: mongodb://user:pass@host:port/?replicaSet=rs0
+  # ConfigMaps cannot reference Secret values, so credentials must be provided
+  # via values override or a separate Secret-backed env var.
 {{- if .Values.usePerconaOperator }}
+  {{- if .Values.mongodb.tls.enabled }}
   MONGODB_URI: {{ printf "mongodb://mongodb-rs0.%s.svc.cluster.local:27017/?replicaSet=rs0&tls=true" .Release.Namespace }}
+  {{- else }}
+  MONGODB_URI: {{ printf "mongodb://mongodb-rs0.%s.svc.cluster.local:27017/?replicaSet=rs0" .Release.Namespace }}
+  {{- end }}
 {{- else }}
+  {{- if .Values.mongodb.tls.enabled }}
   MONGODB_URI: {{ printf "mongodb://mongodb-headless.%s.svc.cluster.local:27017/?replicaSet=rs0&tls=true" .Release.Namespace }}
+  {{- else }}
+  MONGODB_URI: {{ printf "mongodb://mongodb-headless.%s.svc.cluster.local:27017/?replicaSet=rs0" .Release.Namespace }}
+  {{- end }}
 {{- end }}
   MONGODB_DATABASE_NAME: "HealthEventsDatabase"
   MONGODB_COLLECTION_NAME: "HealthEvents"

--- a/distros/kubernetes/nvsentinel/charts/mongodb-store/templates/jobs.yaml
+++ b/distros/kubernetes/nvsentinel/charts/mongodb-store/templates/jobs.yaml
@@ -58,6 +58,8 @@ metadata:
   name: create-mongodb-database
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   activeDeadlineSeconds: 600
   template:

--- a/distros/kubernetes/nvsentinel/charts/mongodb-store/templates/jobs.yaml
+++ b/distros/kubernetes/nvsentinel/charts/mongodb-store/templates/jobs.yaml
@@ -250,8 +250,10 @@ spec:
             echo "=============================="
 
             until mongosh "$MONGODB_URI" \
+              {{- if .Values.mongodb.auth.enabled }}
               --authenticationMechanism SCRAM-SHA-256 \
               --username {{ $rootUsername }} --password "$MONGODB_ROOT_PASSWORD" --authenticationDatabase admin \
+              {{- end }}
               {{- if .Values.mongodb.tls.enabled }}
               --tls \
               --tlsCAFile /certs/ca.crt \

--- a/distros/kubernetes/nvsentinel/charts/mongodb-store/templates/jobs.yaml
+++ b/distros/kubernetes/nvsentinel/charts/mongodb-store/templates/jobs.yaml
@@ -241,18 +241,22 @@ spec:
             echo "MONGODB_COLLECTION_NAME: $MONGODB_COLLECTION_NAME"
             echo "MONGODB_TOKEN_COLLECTION_NAME: $MONGODB_TOKEN_COLLECTION_NAME"
 
+            {{- if .Values.mongodb.tls.enabled }}
             cat /certs/tls.crt /certs/tls.key > /tmp/tls.pem
+            {{- end }}
 
             echo "=============================="
-            echo "Connecting to mongodb and creating X.509 user..."
+            echo "Connecting to mongodb..."
             echo "=============================="
 
             until mongosh "$MONGODB_URI" \
               --authenticationMechanism SCRAM-SHA-256 \
               --username {{ $rootUsername }} --password "$MONGODB_ROOT_PASSWORD" --authenticationDatabase admin \
+              {{- if .Values.mongodb.tls.enabled }}
               --tls \
               --tlsCAFile /certs/ca.crt \
               --tlsCertificateKeyFile /tmp/tls.pem \
+              {{- end }}
                               --eval "
                   db = db.getSiblingDB('$MONGODB_DATABASE_NAME');
                   
@@ -299,30 +303,47 @@ spec:
                     'healthevent.entitiesimpacted.entityvalue': 1,
                     'healthevent.generatedtimestamp.seconds': 1
                   });
-                // Check if user exists before creating
+                {{- if .Values.mongodb.tls.enabled }}
+                // Create X.509 users (TLS only)
                 var userExists = db.getSiblingDB('\$external').getUser('$MONGODB_APPLICATION_USER_DN');
                 if (userExists) {
                   print('User already exists, skipping creation.');
                 } else {
-                  print('Creating new user...');
+                  print('Creating new X.509 user...');
                   db.getSiblingDB('\$external').runCommand({
                     createUser: '$MONGODB_APPLICATION_USER_DN',
                     roles: [{ role: 'readWrite', db: '$MONGODB_DATABASE_NAME' }]
                   });
-                  print('User created successfully.');
+                  print('X.509 user created successfully.');
                 }
-                // Check if dgxcops user exists before creating
                 var dgxcopsUserExists = db.getSiblingDB('\$external').getUser('$MONGODB_DGXCOPS_USER_DN');
                 if (dgxcopsUserExists) {
                   print('Dgxcops user already exists, skipping creation.');
                 } else {
-                  print('Creating new dgxcops user...');
+                  print('Creating new dgxcops X.509 user...');
                   db.getSiblingDB('\$external').runCommand({
                     createUser: '$MONGODB_DGXCOPS_USER_DN',
                     roles: [{ role: 'read', db: '$MONGODB_DATABASE_NAME' }]
                   });
-                  print('Dgxcops user created successfully.');
-                }"
+                  print('Dgxcops X.509 user created successfully.');
+                }
+                {{- else }}
+                // Create SCRAM application user (non-TLS mode)
+                var scramUser = db.getUser('$MONGODB_SCRAM_APP_USERNAME');
+                if (scramUser) {
+                  print('SCRAM application user already exists, updating password...');
+                  db.changeUserPassword('$MONGODB_SCRAM_APP_USERNAME', '$MONGODB_SCRAM_APP_PASSWORD');
+                  print('SCRAM application user password updated.');
+                } else {
+                  print('Creating SCRAM application user...');
+                  db.createUser({
+                    user: '$MONGODB_SCRAM_APP_USERNAME',
+                    pwd: '$MONGODB_SCRAM_APP_PASSWORD',
+                    roles: [{ role: 'readWrite', db: '$MONGODB_DATABASE_NAME' }]
+                  });
+                  print('SCRAM application user created successfully.');
+                }
+                {{- end }}"
             do
               echo "Waiting for mongodb to be ready...";
               sleep 5;
@@ -353,18 +374,32 @@ spec:
             value: "CN=mongo-user-client,OU=DGXC,O=Nvidia,L=SantaClara,ST=California,C=US"
           - name: MONGODB_DGXCOPS_USER_DN
             value: "CN=mongo-dgxcops-client,OU=DGXC,O=Nvidia,L=SantaClara,ST=California,C=US"
+          {{- if not .Values.mongodb.tls.enabled }}
+          - name: MONGODB_SCRAM_APP_USERNAME
+            value: {{ .Values.scramAppUser.username | default "nvsentinel" | quote }}
+          - name: MONGODB_SCRAM_APP_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.scramAppUser.existingSecret | default $passwordSecretName }}
+                key: {{ .Values.scramAppUser.passwordKey | default "mongodb-app-password" }}
+                optional: true
+          {{- end }}
         envFrom:
           - configMapRef:
               name: mongodb-config
+        {{- if .Values.mongodb.tls.enabled }}
         volumeMounts:
           - name: mongo-certificates
             mountPath: /certs
             readOnly: true
+        {{- end }}
+      {{- if .Values.mongodb.tls.enabled }}
       volumes:
         - name: mongo-certificates
           secret:
             secretName: {{ include "nvsentinel.certificates.secretName" . }}
             {{- include "nvsentinel.certificates.volumeItems" . | nindent 12 }}
+      {{- end }}
       # Job scheduling configuration with backward-compatible fallback
       # Prefers: job.nodeSelector -> Falls back to: mongodb.nodeSelector
       {{- $jobNodeSelector := .Values.mongodb.nodeSelector }}

--- a/distros/kubernetes/nvsentinel/charts/mongodb-store/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/mongodb-store/values.yaml
@@ -31,6 +31,19 @@
 useBitnami: true
 usePerconaOperator: false
 
+# SCRAM application user (created when mongodb.tls.enabled is false).
+# Instead of X.509 cert-based users, the Job creates a SCRAM-SHA-256 user
+# with readWrite access to the NVSentinel database.
+# NOTE: This only provisions the user in MongoDB. To use it, configure
+# MONGODB_URI with the SCRAM credentials (e.g. mongodb://nvsentinel:pass@host/db).
+scramAppUser:
+  username: nvsentinel
+  # Secret and key containing the application user password.
+  # Defaults to the MongoDB root password for out-of-the-box functionality.
+  # For production, set a dedicated secret with a separate password.
+  existingSecret: ""
+  passwordKey: "mongodb-root-password"
+
 # Common Job configuration (applies to both Bitnami and Percona)
 # If not set, falls back to mongodb.jobTolerations and mongodb.nodeSelector for backward compatibility
 job:
@@ -140,7 +153,8 @@ mongodb:
           
           echo "MongoDB credentials initialization completed."
           echo "=============================="
-    
+
+    {{- if .Values.tls.enabled }}
     - name: create-certmanager-resources
       image: "{{ .Values.helperImages.kubectl.repository }}:{{ .Values.helperImages.kubectl.tag }}"
       imagePullPolicy: "{{ .Values.helperImages.kubectl.pullPolicy }}"
@@ -182,6 +196,7 @@ mongodb:
           echo "=============================="
           echo "cert-manager resources creation completed."
           echo "=============================="
+    {{- end }}
 
   auth:
     enabled: true
@@ -237,7 +252,11 @@ mongodb:
     args:
       - |
         export HOSTNAME=$(hostname)
+        {{- if .Values.tls.enabled }}
         /bin/mongodb_exporter --collector.diagnosticdata --collector.replicasetstatus --compatible-mode --mongodb.direct-connect --mongodb.global-conn-pool --web.listen-address ":9216" --mongodb.uri "mongodb://$MONGODB_ROOT_USER:$(echo $MONGODB_ROOT_PASSWORD | sed -r "s/@/%40/g;s/:/%3A/g")@${HOSTNAME}.mongodb-headless.nvsentinel.svc.cluster.local:27017/admin?tls=true&tlsCertificateKeyFile=/certs/mongodb.pem&tlsCAFile=/certs/mongodb-ca-cert&authMechanism=SCRAM-SHA-256&connectTimeoutMS=30000&serverSelectionTimeoutMS=30000"
+        {{- else }}
+        /bin/mongodb_exporter --collector.diagnosticdata --collector.replicasetstatus --compatible-mode --mongodb.direct-connect --mongodb.global-conn-pool --web.listen-address ":9216" --mongodb.uri "mongodb://$MONGODB_ROOT_USER:$(echo $MONGODB_ROOT_PASSWORD | sed -r "s/@/%40/g;s/:/%3A/g")@${HOSTNAME}.mongodb-headless.nvsentinel.svc.cluster.local:27017/admin?authMechanism=SCRAM-SHA-256&connectTimeoutMS=30000&serverSelectionTimeoutMS=30000"
+        {{- end }}
 
 # =============================================================================
 # Percona MongoDB Operator Configuration (used when usePerconaOperator=true)

--- a/distros/kubernetes/nvsentinel/charts/mongodb-store/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/mongodb-store/values.yaml
@@ -154,7 +154,6 @@ mongodb:
           echo "MongoDB credentials initialization completed."
           echo "=============================="
 
-    {{- if .Values.tls.enabled }}
     - name: create-certmanager-resources
       image: "{{ .Values.helperImages.kubectl.repository }}:{{ .Values.helperImages.kubectl.tag }}"
       imagePullPolicy: "{{ .Values.helperImages.kubectl.pullPolicy }}"
@@ -163,6 +162,10 @@ mongodb:
         - -c
         - |
           set -e
+          {{- if not .Values.tls.enabled }}
+          echo "TLS is disabled, skipping cert-manager resource creation."
+          exit 0
+          {{- end }}
           secret=$(kubectl get secret mongo-ca-secret -n {{ .Release.Namespace }} --ignore-not-found)
           if [ -z "$secret" ]; then
             echo "Secret mongo-ca-secret does not exist, creating it..."
@@ -196,7 +199,6 @@ mongodb:
           echo "=============================="
           echo "cert-manager resources creation completed."
           echo "=============================="
-    {{- end }}
 
   auth:
     enabled: true

--- a/distros/kubernetes/nvsentinel/charts/node-drainer/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/node-drainer/templates/deployment.yaml
@@ -44,12 +44,12 @@ spec:
       securityContext:
         fsGroup: 65532
       {{- end }}
-      {{- if or .Values.global.auditLogging.enabled (and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql")) }}
+      {{- if or .Values.global.auditLogging.enabled (and .Values.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql")) }}
       initContainers:
         {{- if .Values.global.auditLogging.enabled }}
         {{- include "nvsentinel.auditLogging.initContainer" . | nindent 8 }}
         {{- end }}
-      {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
+      {{- if and .Values.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
         - name: fix-cert-permissions
           image: "{{ .Values.global.initContainerImage.repository }}:{{ .Values.global.initContainerImage.tag }}"
           imagePullPolicy: {{ .Values.global.initContainerImage.pullPolicy }}
@@ -111,11 +111,16 @@ spec:
           - "--metrics-port={{ .Values.global.metricsPort }}"
           - "--config-path=/etc/config/config.toml"
           - "--dry-run={{ .Values.global.dryRun }}"
+          {{- if .Values.clientCertMountPath }}
           - "--database-client-cert-mount-path={{ .Values.clientCertMountPath }}"
+          {{- else }}
+          - "--tls-enabled=false"
+          {{- end }}
           volumeMounts:
           - name: config-volume
             mountPath: /etc/config/config.toml
             subPath: config.toml
+          {{- if .Values.clientCertMountPath }}
           {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
           - name: client-certs-fixed
             mountPath: {{ .Values.clientCertMountPath }}
@@ -124,6 +129,7 @@ spec:
           - name: mongo-app-client-cert
             mountPath: {{ .Values.clientCertMountPath }}
             readOnly: true
+          {{- end }}
           {{- end }}
           {{- if .Values.customDrain.enabled }}
           - name: drain-template
@@ -146,12 +152,14 @@ spec:
             {{- if .Values.global.auditLogging.enabled }}
             {{- include "nvsentinel.auditLogging.envVars" . | nindent 12 }}
             {{- end }}
+            {{- if .Values.clientCertMountPath }}
             {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
             - name: POSTGRESQL_CLIENT_CERT_MOUNT_PATH
               value: {{ .Values.clientCertMountPath }}
             {{- else }}
             - name: MONGODB_CLIENT_CERT_MOUNT_PATH
               value: {{ .Values.clientCertMountPath }}
+            {{- end }}
             {{- end }}
           envFrom:
             - configMapRef:
@@ -164,6 +172,7 @@ spec:
           items:
           - key: config.toml
             path: config.toml
+      {{- if .Values.clientCertMountPath }}
       {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
       - name: postgresql-client-cert-original
         secret:
@@ -177,6 +186,7 @@ spec:
           secretName: {{ include "nvsentinel.certificates.secretName" . }}
           {{- include "nvsentinel.certificates.volumeItems" . | nindent 10 }}
           optional: true
+      {{- end }}
       {{- end }}
       {{- if .Values.customDrain.enabled }}
       - name: drain-template

--- a/distros/kubernetes/nvsentinel/templates/daemonset.yaml
+++ b/distros/kubernetes/nvsentinel/templates/daemonset.yaml
@@ -46,12 +46,12 @@ spec:
       securityContext:
         fsGroup: 65532
       {{- end }}
-      {{- if or .Values.global.auditLogging.enabled (and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql")) }}
+      {{- if or .Values.global.auditLogging.enabled (and .Values.platformConnector.postgresqlStore.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql")) }}
       initContainers:
         {{- if .Values.global.auditLogging.enabled }}
         {{- include "nvsentinel.auditLogging.initContainer" . | nindent 8 }}
         {{- end }}
-      {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
+      {{- if and .Values.platformConnector.postgresqlStore.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
         - name: fix-cert-permissions
           image: "{{ .Values.global.initContainerImage.repository }}:{{ .Values.global.initContainerImage.tag }}"
           imagePullPolicy: {{ .Values.global.initContainerImage.pullPolicy }}
@@ -115,9 +115,17 @@ spec:
           - "--config=/etc/config/config.json"
           - "--metrics-port={{ .Values.global.metricsPort }}"
           {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
+          {{- if .Values.platformConnector.postgresqlStore.clientCertMountPath }}
           - "--database-client-cert-mount-path={{ .Values.platformConnector.postgresqlStore.clientCertMountPath }}"
           {{- else }}
+          - "--tls-enabled=false"
+          {{- end }}
+          {{- else }}
+          {{- if .Values.platformConnector.mongodbStore.clientCertMountPath }}
           - "--mongo-client-cert-mount-path={{ .Values.platformConnector.mongodbStore.clientCertMountPath }}"
+          {{- else }}
+          - "--tls-enabled=false"
+          {{- end }}
           {{- end }}
           - "--socket={{ .Values.socketPath }}"
           resources:
@@ -128,13 +136,17 @@ spec:
             - name: platform-connector-configmap
               mountPath: /etc/config/
             {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
+            {{- if .Values.platformConnector.postgresqlStore.clientCertMountPath }}
             - name: client-certs-fixed
               mountPath: {{ .Values.platformConnector.postgresqlStore.clientCertMountPath }}
               readOnly: true
+            {{- end }}
             {{- else }}
+            {{- if .Values.platformConnector.mongodbStore.clientCertMountPath }}
             - name: mongo-app-client-cert
               mountPath: {{ .Values.platformConnector.mongodbStore.clientCertMountPath }}
               readOnly: true
+            {{- end }}
             {{- end }}
             {{- if .Values.global.auditLogging.enabled }}
             {{- include "nvsentinel.auditLogging.volumeMount" . | nindent 12 }}
@@ -158,11 +170,15 @@ spec:
             {{- include "nvsentinel.auditLogging.envVars" . | nindent 12 }}
             {{- end }}
             {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
+            {{- if .Values.platformConnector.postgresqlStore.clientCertMountPath }}
             - name: POSTGRESQL_CLIENT_CERT_MOUNT_PATH
               value: {{ .Values.platformConnector.postgresqlStore.clientCertMountPath }}
+            {{- end }}
             {{- else }}
+            {{- if .Values.platformConnector.mongodbStore.clientCertMountPath }}
             - name: MONGODB_CLIENT_CERT_MOUNT_PATH
               value: {{ .Values.platformConnector.mongodbStore.clientCertMountPath }}
+            {{- end }}
             {{- end }}
           envFrom:
             - configMapRef:
@@ -177,18 +193,22 @@ spec:
           configMap:
             name: {{ include "nvsentinel.fullname" . }}
         {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
+        {{- if .Values.platformConnector.postgresqlStore.clientCertMountPath }}
         - name: postgresql-client-cert-original
           secret:
             secretName: postgresql-client-cert
             optional: false
         - name: client-certs-fixed
           emptyDir: {}
+        {{- end }}
         {{- else }}
+        {{- if .Values.platformConnector.mongodbStore.clientCertMountPath }}
         - name: mongo-app-client-cert
           secret:
             secretName: {{ include "nvsentinel.certificates.secretName" . }}
             {{- include "nvsentinel.certificates.volumeItems" . | nindent 12 }}
             optional: true
+        {{- end }}
         {{- end }}
         {{- if .Values.global.auditLogging.enabled }}
         {{- include "nvsentinel.auditLogging.volume" . | nindent 8 }}

--- a/distros/kubernetes/nvsentinel/values-tilt-mongodb-tls-disabled-percona.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt-mongodb-tls-disabled-percona.yaml
@@ -75,6 +75,8 @@ node-drainer:
   clientCertMountPath: ""
 health-events-analyzer:
   clientCertMountPath: ""
+csp-health-monitor:
+  clientCertMountPath: ""
 platformConnector:
   mongodbStore:
     clientCertMountPath: ""

--- a/distros/kubernetes/nvsentinel/values-tilt-mongodb-tls-disabled-percona.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt-mongodb-tls-disabled-percona.yaml
@@ -1,0 +1,79 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Percona MongoDB Operator values for Tilt development WITHOUT TLS
+# This file is automatically included when DISABLE_TLS=1 and USE_PERCONA=1 are set
+# Example: DISABLE_TLS=1 USE_PERCONA=1 tilt up
+
+global:
+  dryRun: false
+  kubeVersion: 1.31.0
+  clusterType: standalone
+
+  # Keep legacy resource naming for Tilt compatibility
+  useLegacyResourceNames: true
+
+  # No certificate rotation needed without TLS
+  certificateRotationEnabled: false
+
+  # Configure MongoDB as the datastore provider (no TLS)
+  datastore:
+    provider: "mongodb"
+    connection:
+      host: "mongodb-rs0.nvsentinel.svc.cluster.local"
+      port: 27017
+      database: "HealthEventsDatabase"
+      collection: "HealthEvents"
+      tokenCollection: "ResumeTokens"
+      extraParams:
+        replicaSet: "rs0"
+        # No tls param — plaintext connection
+    options:
+      maxConnections: "25"
+      maxIdleConnections: "10"
+      connectionMaxLifetime: "1h"
+      pollInterval: "5s"
+
+  # Enable MongoDB store
+  mongodbStore:
+    enabled: true
+
+# Disable PostgreSQL subchart
+postgresql:
+  enabled: false
+
+# Use Percona operator instead of Bitnami
+mongodb-store:
+  useBitnami: false
+  usePerconaOperator: true
+
+# Percona MongoDB operator — TLS disabled
+psmdb-db:
+  tls:
+    mode: disabled
+
+# Disable cert mounts on all NVSentinel components
+fault-quarantine:
+  clientCertMountPath: ""
+fault-remediation:
+  clientCertMountPath: ""
+node-drainer:
+  clientCertMountPath: ""
+health-events-analyzer:
+  clientCertMountPath: ""
+platformConnector:
+  mongodbStore:
+    clientCertMountPath: ""
+  postgresqlStore:
+    clientCertMountPath: ""

--- a/distros/kubernetes/nvsentinel/values-tilt-mongodb-tls-disabled-percona.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt-mongodb-tls-disabled-percona.yaml
@@ -64,6 +64,9 @@ psmdb-db:
     mode: disabled
 
 # Disable cert mounts on all NVSentinel components
+event-exporter:
+  mongodbStore:
+    clientCertMountPath: ""
 fault-quarantine:
   clientCertMountPath: ""
 fault-remediation:

--- a/distros/kubernetes/nvsentinel/values-tilt-mongodb-tls-disabled.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt-mongodb-tls-disabled.yaml
@@ -82,6 +82,8 @@ node-drainer:
   clientCertMountPath: ""
 health-events-analyzer:
   clientCertMountPath: ""
+csp-health-monitor:
+  clientCertMountPath: ""
 platformConnector:
   mongodbStore:
     clientCertMountPath: ""

--- a/distros/kubernetes/nvsentinel/values-tilt-mongodb-tls-disabled.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt-mongodb-tls-disabled.yaml
@@ -1,0 +1,83 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# MongoDB-specific values for Tilt development WITHOUT TLS
+# This file is automatically included when DISABLE_TLS=1 is set
+# Example: DISABLE_TLS=1 tilt up
+
+global:
+  dryRun: false
+  kubeVersion: 1.31.0
+  clusterType: standalone
+
+  # Keep legacy resource naming for Tilt compatibility
+  useLegacyResourceNames: true
+
+  # No certificate rotation needed without TLS
+  certificateRotationEnabled: false
+
+  # Configure MongoDB as the datastore provider (no TLS)
+  datastore:
+    provider: "mongodb"
+    connection:
+      host: "mongodb-headless.nvsentinel.svc.cluster.local"
+      port: 27017
+      database: "HealthEventsDatabase"
+      collection: "HealthEvents"
+      tokenCollection: "ResumeTokens"
+      extraParams:
+        replicaSet: "rs0"
+        # No tls param — plaintext connection
+    options:
+      maxConnections: "25"
+      maxIdleConnections: "10"
+      connectionMaxLifetime: "1h"
+      pollInterval: "5s"
+
+  # Enable MongoDB store
+  mongodbStore:
+    enabled: true
+
+# Disable PostgreSQL subchart
+postgresql:
+  enabled: false
+
+# MongoDB subchart configuration — TLS and auth disabled
+mongodb-store:
+  mongodb:
+    enabled: true
+    tls:
+      enabled: false
+    auth:
+      enabled: false
+    extraFlags:
+      - "--setParameter"
+      - "authenticationMechanisms=SCRAM-SHA-256"
+
+# Disable cert mounts on all NVSentinel components so the Go binaries
+# connect without TLS (clientCertMountPath="" skips cert volume mounts
+# and passes --tls-enabled=false where supported).
+fault-quarantine:
+  clientCertMountPath: ""
+fault-remediation:
+  clientCertMountPath: ""
+node-drainer:
+  clientCertMountPath: ""
+health-events-analyzer:
+  clientCertMountPath: ""
+platformConnector:
+  mongodbStore:
+    clientCertMountPath: ""
+  postgresqlStore:
+    clientCertMountPath: ""

--- a/distros/kubernetes/nvsentinel/values-tilt-mongodb-tls-disabled.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt-mongodb-tls-disabled.yaml
@@ -64,6 +64,9 @@ mongodb-store:
     extraFlags:
       - "--setParameter"
       - "authenticationMechanisms=SCRAM-SHA-256"
+    # The cert-manager init container and metrics exporter URI are
+    # automatically adjusted when tls.enabled is false (via tpl conditionals
+    # in the mongodb-store subchart values.yaml).
 
 # Disable cert mounts on all NVSentinel components so the Go binaries
 # connect without TLS (clientCertMountPath="" skips cert volume mounts

--- a/distros/kubernetes/nvsentinel/values-tilt-mongodb-tls-disabled.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt-mongodb-tls-disabled.yaml
@@ -71,6 +71,9 @@ mongodb-store:
 # Disable cert mounts on all NVSentinel components so the Go binaries
 # connect without TLS (clientCertMountPath="" skips cert volume mounts
 # and passes --tls-enabled=false where supported).
+event-exporter:
+  mongodbStore:
+    clientCertMountPath: ""
 fault-quarantine:
   clientCertMountPath: ""
 fault-remediation:

--- a/event-exporter/pkg/initializer/initializer.go
+++ b/event-exporter/pkg/initializer/initializer.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -155,6 +156,18 @@ func initializeDatastore(ctx context.Context) (*helper.DatastoreClientBundle, bo
 	return bundle, hasResumeToken, nil
 }
 
+func tokenDatabaseCertMountPath(datastoreConfig *datastore.DataStoreConfig) string {
+	if datastoreConfig == nil || datastoreConfig.Connection.TLSConfig == nil {
+		return ""
+	}
+
+	if datastoreConfig.Connection.TLSConfig.CAPath == "" {
+		return ""
+	}
+
+	return filepath.Dir(datastoreConfig.Connection.TLSConfig.CAPath)
+}
+
 func checkResumeTokenExists(ctx context.Context) (bool, error) {
 	tokenConfig, err := storeconfig.TokenConfigFromEnv("event-exporter")
 	if err != nil {
@@ -166,8 +179,12 @@ func checkResumeTokenExists(ctx context.Context) (bool, error) {
 		"collection", tokenConfig.TokenCollection,
 		"clientName", tokenConfig.ClientName)
 
-	// Use dynamic cert mount path based on provider (PostgreSQL or MongoDB)
-	certMountPath := storeconfig.GetCertMountPath()
+	datastoreConfig, err := datastore.LoadDatastoreConfig()
+	if err != nil {
+		return false, fmt.Errorf("failed to load datastore config for token lookup: %w", err)
+	}
+
+	certMountPath := tokenDatabaseCertMountPath(datastoreConfig)
 
 	dbConfig, err := storeconfig.NewDatabaseConfigForCollectionType(
 		certMountPath,

--- a/event-exporter/pkg/initializer/initializer_test.go
+++ b/event-exporter/pkg/initializer/initializer_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package initializer
+
+import (
+	"testing"
+
+	"github.com/nvidia/nvsentinel/store-client/pkg/datastore"
+)
+
+func TestTokenDatabaseCertMountPath_NoTLSReturnsEmptyPath(t *testing.T) {
+	dsConfig := &datastore.DataStoreConfig{
+		Provider: datastore.ProviderMongoDB,
+	}
+
+	if got := tokenDatabaseCertMountPath(dsConfig); got != "" {
+		t.Fatalf("expected empty cert mount path when TLS is disabled, got %q", got)
+	}
+}
+
+func TestTokenDatabaseCertMountPath_TLSConfigReturnsCADirectory(t *testing.T) {
+	dsConfig := &datastore.DataStoreConfig{
+		Provider: datastore.ProviderMongoDB,
+		Connection: datastore.ConnectionConfig{
+			TLSConfig: &datastore.TLSConfig{
+				CAPath: "/tmp/mongo-certs/ca.crt",
+			},
+		},
+	}
+
+	if got := tokenDatabaseCertMountPath(dsConfig); got != "/tmp/mongo-certs" {
+		t.Fatalf("expected CA cert directory, got %q", got)
+	}
+}

--- a/health-events-analyzer/main.go
+++ b/health-events-analyzer/main.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/nvidia/nvsentinel/commons/pkg/flags"
 	"github.com/nvidia/nvsentinel/commons/pkg/logger"
 	"github.com/nvidia/nvsentinel/commons/pkg/server"
 	protos "github.com/nvidia/nvsentinel/data-models/pkg/protos"
@@ -54,24 +55,6 @@ func main() {
 	}
 }
 
-// getCertPath checks if the certificate exists at the new path, falls back to legacy path
-func getCertPath(databaseClientCertMountPath string) string {
-	// Check if ca.crt exists at the new path
-	if _, err := os.Stat(databaseClientCertMountPath + "/ca.crt"); err == nil {
-		return databaseClientCertMountPath
-	}
-
-	// Fall back to legacy mongo-client path
-	legacyPath := "/etc/ssl/mongo-client"
-	if _, err := os.Stat(legacyPath + "/ca.crt"); err == nil {
-		slog.Info("Using legacy certificate path for backward compatibility", "path", legacyPath)
-		return legacyPath
-	}
-
-	// If neither exists, return the new path (original behavior)
-	return databaseClientCertMountPath
-}
-
 func loadDatabaseConfig(databaseClientCertMountPath string) (*datastore.DataStoreConfig, error) {
 	// Load using the new unified datastore configuration
 	config, err := datastore.LoadDatastoreConfig()
@@ -79,12 +62,13 @@ func loadDatabaseConfig(databaseClientCertMountPath string) (*datastore.DataStor
 		return nil, fmt.Errorf("failed to load datastore config: %w", err)
 	}
 
-	// Override SSL cert path if provided via command line
+	// Override SSL cert path if provided via command line.
+	// When TLS is disabled, databaseClientCertMountPath is empty — skip overrides
+	// so the datastore connects without TLS.
 	if databaseClientCertMountPath != "" && config.Connection.SSLCert == "" {
-		certPath := getCertPath(databaseClientCertMountPath)
-		config.Connection.SSLCert = certPath + "/tls.crt"
-		config.Connection.SSLKey = certPath + "/tls.key"
-		config.Connection.SSLRootCert = certPath + "/ca.crt"
+		config.Connection.SSLCert = databaseClientCertMountPath + "/tls.crt"
+		config.Connection.SSLKey = databaseClientCertMountPath + "/tls.key"
+		config.Connection.SSLRootCert = databaseClientCertMountPath + "/ca.crt"
 	}
 
 	return config, nil
@@ -116,14 +100,13 @@ func run() error {
 	metricsPort := flag.String("metrics-port", "2112", "port to expose Prometheus metrics on")
 	socket := flag.String("socket", "unix:///var/run/nvsentinel.sock", "unix domain socket")
 	tomlConfigPath := flag.String("config-path", "/etc/config/config.toml", "path to TOML config file")
-	databaseClientCertMountPath := flag.String("database-client-cert-mount-path", "/etc/ssl/database-client",
-		"path where the database client cert is mounted")
+	certConfig := flags.RegisterDatabaseCertFlags()
 	processingStrategyFlag := flag.String("processing-strategy", "EXECUTE_REMEDIATION",
 		"Event processing strategy for analyzer output: EXECUTE_REMEDIATION or STORE_ONLY")
 
 	flag.Parse()
 
-	databaseConfig, err := loadDatabaseConfig(*databaseClientCertMountPath)
+	databaseConfig, err := loadDatabaseConfig(certConfig.ResolveCertPath())
 	if err != nil {
 		return err
 	}

--- a/node-drainer/pkg/config/config.go
+++ b/node-drainer/pkg/config/config.go
@@ -211,13 +211,11 @@ func LoadEnvConfig() (*EnvConfig, error) {
 	}, nil
 }
 
-// NewDatabaseConfig creates a database configuration from environment config and certificate paths
+// NewDatabaseConfig creates a database configuration from environment config and certificate paths.
+// When databaseClientCertMountPath is empty (TLS disabled), passes empty through to avoid
+// reintroducing default cert paths.
 func NewDatabaseConfig(databaseClientCertMountPath string) (config.DatabaseConfig, error) {
-	if databaseClientCertMountPath != "" {
-		return config.NewDatabaseConfigFromEnvWithDefaults(databaseClientCertMountPath)
-	}
-
-	return config.NewDatabaseConfigFromEnv()
+	return config.NewDatabaseConfigFromEnvWithDefaults(databaseClientCertMountPath)
 }
 
 // NewTokenConfig is DEPRECATED and should not be used.

--- a/node-drainer/pkg/evaluator/evaluator.go
+++ b/node-drainer/pkg/evaluator/evaluator.go
@@ -50,40 +50,29 @@ func NewNodeDrainEvaluator(
 
 // EvaluateEvent method has been removed - use EvaluateEventWithDatabase instead
 
-// EvaluateEventWithDatabase evaluates using the new database-agnostic interface
-func (e *NodeDrainEvaluator) EvaluateEventWithDatabase(ctx context.Context, healthEvent model.HealthEventWithStatus,
-	database queue.DataStore, healthEventStore datastore.HealthEventStore) (*DrainActionResult, error) {
+// checkPreconditions returns an early result if the event should not proceed
+// to full drain evaluation. Returns nil if evaluation should continue.
+func checkPreconditions(healthEvent model.HealthEventWithStatus) *DrainActionResult {
 	nodeName := healthEvent.HealthEvent.NodeName
 
-	// Helper for returning ActionWait with a log
-	actionWaitWithLog := func(msg, nodeName string) *DrainActionResult {
-		slog.Warn(msg, "node", nodeName)
-
-		return &DrainActionResult{
-			Action:    ActionWait,
-			WaitDelay: time.Minute,
-		}
-	}
-
 	if healthEvent.HealthEventStatus == nil {
-		return actionWaitWithLog("HealthEventStatus is nil, cannot evaluate event", nodeName), nil
+		slog.Warn("HealthEventStatus is nil, cannot evaluate event", "node", nodeName)
+		return &DrainActionResult{Action: ActionWait, WaitDelay: time.Minute}
 	}
 
 	statusStr := healthEvent.HealthEventStatus.NodeQuarantined
 	if statusStr == "" || statusStr == string(model.UnQuarantined) {
-		return &DrainActionResult{Action: ActionSkip}, nil
+		return &DrainActionResult{Action: ActionSkip}
 	}
 
 	if healthEvent.HealthEventStatus.UserPodsEvictionStatus == nil {
-		return actionWaitWithLog("HealthEventStatus is missing UserPodsEvictionStatus", nodeName), nil
+		slog.Warn("HealthEventStatus is missing UserPodsEvictionStatus", "node", nodeName)
+		return &DrainActionResult{Action: ActionWait, WaitDelay: time.Minute}
 	}
 
 	if isTerminalStatus(model.Status(healthEvent.HealthEventStatus.UserPodsEvictionStatus.Status)) {
 		slog.Info("Event for node is in terminal state, skipping", "node", nodeName)
-
-		return &DrainActionResult{
-			Action: ActionSkip,
-		}, nil
+		return &DrainActionResult{Action: ActionSkip}
 	}
 
 	// Honor DrainOverrides.Skip: mark drain as already completed so
@@ -94,12 +83,21 @@ func (e *NodeDrainEvaluator) EvaluateEventWithDatabase(ctx context.Context, heal
 		healthEvent.HealthEvent.DrainOverrides.Skip {
 		slog.Info("DrainOverrides.Skip is true, skipping drain for node",
 			"node", nodeName)
-
-		return &DrainActionResult{
-			Action: ActionMarkAlreadyDrained,
-			Status: model.AlreadyDrained,
-		}, nil
+		return &DrainActionResult{Action: ActionMarkAlreadyDrained, Status: model.AlreadyDrained}
 	}
+
+	return nil
+}
+
+// EvaluateEventWithDatabase evaluates using the new database-agnostic interface
+func (e *NodeDrainEvaluator) EvaluateEventWithDatabase(ctx context.Context, healthEvent model.HealthEventWithStatus,
+	database queue.DataStore, healthEventStore datastore.HealthEventStore) (*DrainActionResult, error) {
+	if result := checkPreconditions(healthEvent); result != nil {
+		return result, nil
+	}
+
+	nodeName := healthEvent.HealthEvent.NodeName
+	statusStr := healthEvent.HealthEventStatus.NodeQuarantined
 
 	partialDrainEntity, err := e.shouldExecutePartialDrain(healthEvent.HealthEvent)
 	if err != nil {

--- a/node-drainer/pkg/evaluator/evaluator.go
+++ b/node-drainer/pkg/evaluator/evaluator.go
@@ -86,6 +86,21 @@ func (e *NodeDrainEvaluator) EvaluateEventWithDatabase(ctx context.Context, heal
 		}, nil
 	}
 
+	// Honor DrainOverrides.Skip: mark drain as already completed so
+	// fault-remediation can proceed immediately without waiting for pods.
+	// This is used by ergatos debug events where drain is intentionally
+	// skipped to test the Slack notification pipeline.
+	if healthEvent.HealthEvent.DrainOverrides != nil &&
+		healthEvent.HealthEvent.DrainOverrides.Skip {
+		slog.Info("DrainOverrides.Skip is true, skipping drain for node",
+			"node", nodeName)
+
+		return &DrainActionResult{
+			Action: ActionMarkAlreadyDrained,
+			Status: model.AlreadyDrained,
+		}, nil
+	}
+
 	partialDrainEntity, err := e.shouldExecutePartialDrain(healthEvent.HealthEvent)
 	if err != nil {
 		slog.Error("Failed to check if node should be partially drained",

--- a/platform-connectors/pkg/connectors/store/store_connector.go
+++ b/platform-connectors/pkg/connectors/store/store_connector.go
@@ -80,11 +80,11 @@ func InitializeDatabaseStoreConnector(ctx context.Context, ringbuffer *ringbuffe
 }
 
 func createClientFactory(databaseClientCertMountPath string) (*factory.ClientFactory, error) {
-	if databaseClientCertMountPath != "" {
-		return factory.NewClientFactoryFromEnvWithCertPath(databaseClientCertMountPath)
-	}
-
-	return factory.NewClientFactoryFromEnv()
+	// Always pass the cert path through explicitly. NewClientFactoryFromEnv()
+	// falls back to DefaultCertMountPath even when TLS is disabled, causing
+	// infinite cert polling. Using the explicit path variant ensures an empty
+	// string (TLS disabled) propagates correctly.
+	return factory.NewClientFactoryFromEnvWithCertPath(databaseClientCertMountPath)
 }
 
 func (r *DatabaseStoreConnector) FetchAndProcessHealthMetric(ctx context.Context) {

--- a/store-client/pkg/adapter/legacy_adapter.go
+++ b/store-client/pkg/adapter/legacy_adapter.go
@@ -156,9 +156,28 @@ func (l *LegacyCertConfigAdapter) getCertPath() string {
 		return l.certMountPath
 	}
 
+	if l.dsConfig.Connection.TLSConfig != nil {
+		if l.dsConfig.Connection.TLSConfig.CertPath != "" {
+			return filepath.Dir(l.dsConfig.Connection.TLSConfig.CertPath)
+		}
+
+		if l.dsConfig.Connection.TLSConfig.CAPath != "" {
+			return filepath.Dir(l.dsConfig.Connection.TLSConfig.CAPath)
+		}
+	}
+
 	// If SSL paths are set in the config, prefer those
 	if l.dsConfig.Connection.SSLCert != "" {
 		return filepath.Dir(l.dsConfig.Connection.SSLCert)
+	}
+
+	if l.dsConfig.Connection.SSLRootCert != "" {
+		return filepath.Dir(l.dsConfig.Connection.SSLRootCert)
+	}
+
+	// For MongoDB, an empty TLS config means TLS is intentionally disabled.
+	if l.dsConfig.Provider == datastore.ProviderMongoDB {
+		return ""
 	}
 
 	// Check if ca.crt exists at the legacy mongo-client path first (most common)
@@ -187,7 +206,12 @@ func (l *LegacyCertConfigAdapter) GetCertPath() string {
 		return l.dsConfig.Connection.SSLCert
 	}
 
-	return filepath.Join(l.getCertPath(), "tls.crt")
+	certPath := l.getCertPath()
+	if certPath == "" {
+		return ""
+	}
+
+	return filepath.Join(certPath, "tls.crt")
 }
 
 func (l *LegacyCertConfigAdapter) GetKeyPath() string {
@@ -200,7 +224,12 @@ func (l *LegacyCertConfigAdapter) GetKeyPath() string {
 		return l.dsConfig.Connection.SSLKey
 	}
 
-	return filepath.Join(l.getCertPath(), "tls.key")
+	certPath := l.getCertPath()
+	if certPath == "" {
+		return ""
+	}
+
+	return filepath.Join(certPath, "tls.key")
 }
 
 func (l *LegacyCertConfigAdapter) GetCACertPath() string {
@@ -213,7 +242,12 @@ func (l *LegacyCertConfigAdapter) GetCACertPath() string {
 		return l.dsConfig.Connection.SSLRootCert
 	}
 
-	return filepath.Join(l.getCertPath(), "ca.crt")
+	certPath := l.getCertPath()
+	if certPath == "" {
+		return ""
+	}
+
+	return filepath.Join(certPath, "ca.crt")
 }
 
 // LegacyTimeoutConfigAdapter provides default timeout configuration

--- a/store-client/pkg/adapter/legacy_adapter_test.go
+++ b/store-client/pkg/adapter/legacy_adapter_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import (
+	"testing"
+
+	"github.com/nvidia/nvsentinel/store-client/pkg/datastore"
+)
+
+func TestConvertDataStoreConfigToLegacy_MongoDBNoTLSReturnsEmptyCertPaths(t *testing.T) {
+	dsConfig := &datastore.DataStoreConfig{
+		Provider: datastore.ProviderMongoDB,
+	}
+
+	certConfig := ConvertDataStoreConfigToLegacy(dsConfig).GetCertConfig()
+
+	if certConfig.GetCertPath() != "" {
+		t.Fatalf("expected empty cert path when MongoDB TLS is disabled, got %q", certConfig.GetCertPath())
+	}
+
+	if certConfig.GetKeyPath() != "" {
+		t.Fatalf("expected empty key path when MongoDB TLS is disabled, got %q", certConfig.GetKeyPath())
+	}
+
+	if certConfig.GetCACertPath() != "" {
+		t.Fatalf("expected empty CA path when MongoDB TLS is disabled, got %q", certConfig.GetCACertPath())
+	}
+}
+
+func TestConvertDataStoreConfigToLegacy_MongoDBTLSConfigUsesConfiguredPaths(t *testing.T) {
+	dsConfig := &datastore.DataStoreConfig{
+		Provider: datastore.ProviderMongoDB,
+		Connection: datastore.ConnectionConfig{
+			TLSConfig: &datastore.TLSConfig{
+				CertPath: "/tmp/mongo/tls.crt",
+				KeyPath:  "/tmp/mongo/tls.key",
+				CAPath:   "/tmp/mongo/ca.crt",
+			},
+		},
+	}
+
+	certConfig := ConvertDataStoreConfigToLegacy(dsConfig).GetCertConfig()
+
+	if certConfig.GetCertPath() != "/tmp/mongo/tls.crt" {
+		t.Fatalf("expected configured cert path, got %q", certConfig.GetCertPath())
+	}
+
+	if certConfig.GetKeyPath() != "/tmp/mongo/tls.key" {
+		t.Fatalf("expected configured key path, got %q", certConfig.GetKeyPath())
+	}
+
+	if certConfig.GetCACertPath() != "/tmp/mongo/ca.crt" {
+		t.Fatalf("expected configured CA path, got %q", certConfig.GetCACertPath())
+	}
+}

--- a/store-client/pkg/config/env_loader.go
+++ b/store-client/pkg/config/env_loader.go
@@ -141,10 +141,16 @@ const (
 	CollectionTypeTokens            = "tokens"
 )
 
-// NewDatabaseConfigFromEnv loads database configuration from environment variables
-// This consolidates the duplicated configuration loading from all modules
+// NewDatabaseConfigFromEnv loads database configuration from environment variables.
+// When MONGODB_CLIENT_CERT_MOUNT_PATH (or POSTGRESQL_CLIENT_CERT_MOUNT_PATH) is
+// set, uses that for cert paths. Otherwise passes empty (no TLS) rather than
+// defaulting to a hardcoded path.
 func NewDatabaseConfigFromEnv() (DatabaseConfig, error) {
-	return NewDatabaseConfigFromEnvWithDefaults(DefaultCertMountPath)
+	certMountPath := os.Getenv("MONGODB_CLIENT_CERT_MOUNT_PATH")
+	if certMountPath == "" {
+		certMountPath = os.Getenv("POSTGRESQL_CLIENT_CERT_MOUNT_PATH")
+	}
+	return NewDatabaseConfigFromEnvWithDefaults(certMountPath)
 }
 
 // NewDatabaseConfigFromEnvWithDefaults allows custom certificate mount path
@@ -221,11 +227,18 @@ func NewDatabaseConfigWithCollection(
 		return nil, fmt.Errorf("failed to load timeout configuration: %w", err)
 	}
 
-	// Build certificate configuration
-	certConfig := &StandardCertificateConfig{
-		certPath:   filepath.Join(certMountPath, "tls.crt"),
-		keyPath:    filepath.Join(certMountPath, "tls.key"),
-		caCertPath: filepath.Join(certMountPath, "ca.crt"),
+	// Build certificate configuration. When certMountPath is empty (TLS
+	// disabled), leave cert paths empty so downstream TLS construction
+	// is skipped rather than falling back to default paths.
+	var certConfig *StandardCertificateConfig
+	if certMountPath != "" {
+		certConfig = &StandardCertificateConfig{
+			certPath:   filepath.Join(certMountPath, "tls.crt"),
+			keyPath:    filepath.Join(certMountPath, "tls.key"),
+			caCertPath: filepath.Join(certMountPath, "ca.crt"),
+		}
+	} else {
+		certConfig = &StandardCertificateConfig{}
 	}
 
 	return &StandardDatabaseConfig{

--- a/store-client/pkg/config/env_loader.go
+++ b/store-client/pkg/config/env_loader.go
@@ -142,13 +142,17 @@ const (
 )
 
 // NewDatabaseConfigFromEnv loads database configuration from environment variables.
-// When MONGODB_CLIENT_CERT_MOUNT_PATH (or POSTGRESQL_CLIENT_CERT_MOUNT_PATH) is
-// set, uses that for cert paths. Otherwise passes empty (no TLS) rather than
-// defaulting to a hardcoded path.
+// Uses MONGODB_CLIENT_CERT_MOUNT_PATH or POSTGRESQL_CLIENT_CERT_MOUNT_PATH if set,
+// otherwise falls back to DefaultCertMountPath for backward compatibility.
+// The no-TLS path uses NewDatabaseConfigFromEnvWithDefaults("") directly via
+// the --tls-enabled flag, bypassing this function.
 func NewDatabaseConfigFromEnv() (DatabaseConfig, error) {
 	certMountPath := os.Getenv("MONGODB_CLIENT_CERT_MOUNT_PATH")
 	if certMountPath == "" {
 		certMountPath = os.Getenv("POSTGRESQL_CLIENT_CERT_MOUNT_PATH")
+	}
+	if certMountPath == "" {
+		certMountPath = DefaultCertMountPath
 	}
 	return NewDatabaseConfigFromEnvWithDefaults(certMountPath)
 }

--- a/store-client/pkg/datastore/providers/mongodb/adapter.go
+++ b/store-client/pkg/datastore/providers/mongodb/adapter.go
@@ -248,8 +248,11 @@ func (a *AdaptedChangeStreamWatcher) Events() <-chan datastore.EventWithToken {
 	return a.eventChan
 }
 
-// Start starts the watcher
+// Start starts the watcher. It initializes the relay goroutine first to
+// ensure there is a reader on the underlying watcher's unbuffered event
+// channel before the MongoDB change stream goroutine begins sending.
 func (a *AdaptedChangeStreamWatcher) Start(ctx context.Context) {
+	_ = a.Events() // Ensure relay goroutine is running before watcher sends.
 	a.watcher.Start(ctx)
 }
 

--- a/store-client/pkg/datastore/providers/mongodb/watcher/watch_store.go
+++ b/store-client/pkg/datastore/providers/mongodb/watcher/watch_store.go
@@ -632,10 +632,13 @@ func constructMongoClientOptions(
 	// Only set TLS when TLS config was successfully built.
 	// Only set X.509 auth when client certificate is available (CA-only
 	// TLS should not attempt X.509 auth since there's no client cert).
+	// When certificate rotation is enabled, the client certificate is
+	// provided dynamically via GetClientCertificate rather than the
+	// Certificates slice.
 	if tlsConfig != nil {
 		clientOpts.SetTLSConfig(tlsConfig)
 
-		if len(tlsConfig.Certificates) > 0 {
+		if len(tlsConfig.Certificates) > 0 || tlsConfig.GetClientCertificate != nil {
 			credential := options.Credential{
 				AuthMechanism: "MONGODB-X509",
 				AuthSource:    "$external",

--- a/store-client/pkg/datastore/providers/mongodb/watcher/watch_store.go
+++ b/store-client/pkg/datastore/providers/mongodb/watcher/watch_store.go
@@ -616,24 +616,32 @@ func constructMongoClientOptions(
 		}
 	}
 
-	credential := options.Credential{
-		AuthMechanism: "MONGODB-X509",
-		AuthSource:    "$external",
-	}
-
 	// Set server selection timeout to allow MongoDB time to become ready
 	// This uses the same timeout as the ping timeout for consistency
 	serverSelectionTimeout := time.Duration(mongoConfig.TotalPingTimeoutSeconds) * time.Second
 
 	clientOpts := options.Client().
 		ApplyURI(mongoConfig.URI).
-		SetTLSConfig(tlsConfig).
-		SetAuth(credential).
 		SetServerSelectionTimeout(serverSelectionTimeout)
 
 	// Set AppName for MongoDB connection tracking if provided
 	if mongoConfig.AppName != "" {
 		clientOpts.SetAppName(mongoConfig.AppName)
+	}
+
+	// Only set TLS when TLS config was successfully built.
+	// Only set X.509 auth when client certificate is available (CA-only
+	// TLS should not attempt X.509 auth since there's no client cert).
+	if tlsConfig != nil {
+		clientOpts.SetTLSConfig(tlsConfig)
+
+		if len(tlsConfig.Certificates) > 0 {
+			credential := options.Credential{
+				AuthMechanism: "MONGODB-X509",
+				AuthSource:    "$external",
+			}
+			clientOpts.SetAuth(credential)
+		}
 	}
 
 	return clientOpts, nil
@@ -646,6 +654,11 @@ func constructDynamicTLSConfig(mongoConfig MongoDBConfig) (*tls.Config, error) {
 	caCertPool, err := loadCACertPool(mongoConfig)
 	if err != nil {
 		return nil, err
+	}
+
+	// No CA cert available — TLS disabled
+	if caCertPool == nil {
+		return nil, nil
 	}
 
 	return &tls.Config{
@@ -682,6 +695,11 @@ func loadCACertPool(mongoConfig MongoDBConfig) (*x509.CertPool, error) {
 		return nil, fmt.Errorf("failed to read CA certificate: %w", err)
 	}
 
+	// No certs available (TLS disabled)
+	if caCert == nil {
+		return nil, nil
+	}
+
 	caCertPool := x509.NewCertPool()
 	if !caCertPool.AppendCertsFromPEM(caCert) {
 		return nil, fmt.Errorf("failed to append CA certificate to pool")
@@ -699,10 +717,26 @@ func constructStaticTLSConfig(mongoConfig MongoDBConfig) (*tls.Config, error) {
 		return nil, err
 	}
 
-	// Load client certificate and key
+	// No CA cert available — TLS disabled
+	if caCertPool == nil {
+		return nil, nil
+	}
+
+	// Load client certificate and key. If the files don't exist, fall back
+	// to CA-only TLS (server verification without client cert) rather than
+	// failing — the cert mount may not be present.
 	clientCert, err := tls.LoadX509KeyPair(mongoConfig.ClientTLSCertConfig.TlsCertPath,
 		mongoConfig.ClientTLSCertConfig.TlsKeyPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			slog.Warn("Client certificate or key not found, using CA-only TLS (no mTLS)",
+				"certPath", mongoConfig.ClientTLSCertConfig.TlsCertPath,
+				"keyPath", mongoConfig.ClientTLSCertConfig.TlsKeyPath)
+			return &tls.Config{
+				RootCAs:    caCertPool,
+				MinVersion: tls.VersionTLS12,
+			}, nil
+		}
 		return nil, fmt.Errorf("failed to load client certificate and key: %w", err)
 	}
 
@@ -713,9 +747,19 @@ func constructStaticTLSConfig(mongoConfig MongoDBConfig) (*tls.Config, error) {
 	}, nil
 }
 
+// ConstructClientTLSConfig builds a TLS configuration from certificates at the
+// given mount path. Returns (nil, nil) when clientCertMountPath is empty,
+// indicating TLS is intentionally disabled. Returns a non-nil *tls.Config with
+// RootCAs and client certificates when certs are found. Returns an error for
+// invalid cert paths, unreadable files, or malformed certificates.
 func ConstructClientTLSConfig(
 	totalCACertTimeoutSeconds int, intervalCACertSeconds int, clientCertMountPath string,
 ) (*tls.Config, error) {
+	if clientCertMountPath == "" {
+		slog.Info("No client cert mount path configured, skipping TLS")
+		return nil, nil
+	}
+
 	clientCertPath := filepath.Join(clientCertMountPath, "tls.crt")
 	clientKeyPath := filepath.Join(clientCertMountPath, "tls.key")
 	mongoCACertPath := filepath.Join(clientCertMountPath, "ca.crt")
@@ -729,14 +773,28 @@ func ConstructClientTLSConfig(
 		return nil, fmt.Errorf("failed to read CA certificate: %w", err)
 	}
 
+	// No CA cert available — TLS disabled
+	if caCert == nil {
+		return nil, nil
+	}
+
 	caCertPool := x509.NewCertPool()
 	if !caCertPool.AppendCertsFromPEM(caCert) {
 		return nil, fmt.Errorf("failed to append CA certificate to pool")
 	}
 
-	// Load client certificate and key
+	// Load client certificate and key. If the files don't exist, fall back
+	// to CA-only TLS (server verification without client cert).
 	clientCert, err := tls.LoadX509KeyPair(clientCertPath, clientKeyPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			slog.Warn("Client certificate or key not found, using CA-only TLS (no mTLS)",
+				"certPath", clientCertPath, "keyPath", clientKeyPath)
+			return &tls.Config{
+				RootCAs:    caCertPool,
+				MinVersion: tls.VersionTLS12,
+			}, nil
+		}
 		return nil, fmt.Errorf("failed to load client certificate and key: %w", err)
 	}
 
@@ -749,6 +807,15 @@ func ConstructClientTLSConfig(
 
 func pollTillCACertIsMountedSuccessfully(certPath string, timeoutInterval time.Duration,
 	pingInterval time.Duration) ([]byte, error) {
+	if certPath == "" {
+		slog.Info("No CA cert path configured, TLS will be disabled")
+		return nil, nil
+	}
+	if !filepath.IsAbs(certPath) {
+		return nil, fmt.Errorf("CA cert path %q is not absolute — this is likely a misconfiguration. "+
+			"Use --tls-enabled=false to explicitly disable TLS, or provide an absolute cert mount path", certPath)
+	}
+
 	timeout := time.Now().Add(timeoutInterval) // total timeout
 
 	var err error

--- a/store-client/pkg/datastore/providers/mongodb/watcher/watch_store_test.go
+++ b/store-client/pkg/datastore/providers/mongodb/watcher/watch_store_test.go
@@ -37,6 +37,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 	mongoOptions "go.mongodb.org/mongo-driver/mongo/options"
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 )
 
 func TestConfirmConnectivityWithDBAndCollection(t *testing.T) {
@@ -766,6 +767,127 @@ func TestConstructMongoClientOptions_NoTLS(t *testing.T) {
 	}
 	if opts == nil {
 		t.Fatal("Expected non-nil client options")
+	}
+	if opts.TLSConfig != nil {
+		t.Fatal("Expected nil TLS config when CA cert path is empty")
+	}
+	if opts.Auth != nil {
+		t.Fatal("Expected nil auth when TLS is disabled")
+	}
+}
+
+func TestConstructMongoClientOptions_DynamicClientCertificateUsesX509Auth(t *testing.T) {
+	caCertPEM, caKeyPEM, err := generateCA()
+	if err != nil {
+		t.Fatalf("GenerateCA failed: %v", err)
+	}
+
+	clientCertPEM, clientKeyPEM, err := generateClientCert(caCertPEM, caKeyPEM)
+	if err != nil {
+		t.Fatalf("GenerateClientCert failed: %v", err)
+	}
+
+	tempDir, err := os.MkdirTemp("", "tls_test_dynamic_auth")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	cleanup, err := writeCertFiles(tempDir, caCertPEM, clientCertPEM, clientKeyPEM)
+	if err != nil {
+		t.Fatalf("WriteCertFiles failed: %v", err)
+	}
+	defer cleanup()
+
+	certWatcher, err := certwatcher.New(filepath.Join(tempDir, "tls.crt"), filepath.Join(tempDir, "tls.key"))
+	if err != nil {
+		t.Fatalf("Failed to create cert watcher: %v", err)
+	}
+
+	mongoConfig := MongoDBConfig{
+		URI:                        "mongodb://localhost:27017",
+		Database:                   "test",
+		Collection:                 "test",
+		TotalPingTimeoutSeconds:    5,
+		TotalPingIntervalSeconds:   1,
+		TotalCACertTimeoutSeconds:  2,
+		TotalCACertIntervalSeconds: 1,
+		ClientTLSCertConfig: MongoDBClientTLSCertConfig{
+			TlsCertPath: filepath.Join(tempDir, "tls.crt"),
+			TlsKeyPath:  filepath.Join(tempDir, "tls.key"),
+			CaCertPath:  filepath.Join(tempDir, "ca.crt"),
+		},
+		CertWatcher: certWatcher,
+	}
+
+	opts, err := constructMongoClientOptions(mongoConfig)
+	if err != nil {
+		t.Fatalf("constructMongoClientOptions returned error: %v", err)
+	}
+	if opts.TLSConfig == nil {
+		t.Fatal("Expected TLS config when using certificate watcher")
+	}
+	if opts.TLSConfig.GetClientCertificate == nil {
+		t.Fatal("Expected dynamic client certificate callback")
+	}
+	if opts.Auth == nil {
+		t.Fatal("Expected X.509 auth when using dynamic client certificate")
+	}
+	if opts.Auth.AuthMechanism != "MONGODB-X509" {
+		t.Fatalf("Unexpected auth mechanism: %q", opts.Auth.AuthMechanism)
+	}
+	if opts.Auth.AuthSource != "$external" {
+		t.Fatalf("Unexpected auth source: %q", opts.Auth.AuthSource)
+	}
+}
+
+func TestConstructMongoClientOptions_CAOnlyTLSDoesNotUseX509Auth(t *testing.T) {
+	caCertPEM, _, err := generateCA()
+	if err != nil {
+		t.Fatalf("GenerateCA failed: %v", err)
+	}
+
+	tempDir, err := os.MkdirTemp("", "tls_test_ca_only_auth")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	caCertPath := filepath.Join(tempDir, "ca.crt")
+	if err := os.WriteFile(caCertPath, caCertPEM, 0644); err != nil {
+		t.Fatalf("Failed to write CA cert: %v", err)
+	}
+
+	mongoConfig := MongoDBConfig{
+		URI:                        "mongodb://localhost:27017",
+		Database:                   "test",
+		Collection:                 "test",
+		TotalPingTimeoutSeconds:    5,
+		TotalPingIntervalSeconds:   1,
+		TotalCACertTimeoutSeconds:  2,
+		TotalCACertIntervalSeconds: 1,
+		ClientTLSCertConfig: MongoDBClientTLSCertConfig{
+			TlsCertPath: filepath.Join(tempDir, "tls.crt"),
+			TlsKeyPath:  filepath.Join(tempDir, "tls.key"),
+			CaCertPath:  caCertPath,
+		},
+	}
+
+	opts, err := constructMongoClientOptions(mongoConfig)
+	if err != nil {
+		t.Fatalf("constructMongoClientOptions returned error: %v", err)
+	}
+	if opts.TLSConfig == nil {
+		t.Fatal("Expected TLS config when CA certificate is available")
+	}
+	if len(opts.TLSConfig.Certificates) != 0 {
+		t.Fatalf("Expected no static client certificates, got %d", len(opts.TLSConfig.Certificates))
+	}
+	if opts.TLSConfig.GetClientCertificate != nil {
+		t.Fatal("Did not expect dynamic client certificate callback for CA-only TLS")
+	}
+	if opts.Auth != nil {
+		t.Fatal("Expected nil auth when TLS uses only a CA certificate")
 	}
 }
 

--- a/store-client/pkg/datastore/providers/mongodb/watcher/watch_store_test.go
+++ b/store-client/pkg/datastore/providers/mongodb/watcher/watch_store_test.go
@@ -718,6 +718,95 @@ func TestConstructClientTLSConfig_InvalidClientKey(t *testing.T) {
 	}
 }
 
+func TestConstructClientTLSConfig_EmptyPath_DisablesTLS(t *testing.T) {
+	tlsConfig, err := ConstructClientTLSConfig(5, 1, "")
+	if err != nil {
+		t.Fatalf("ConstructClientTLSConfig returned error for empty path: %v", err)
+	}
+	if tlsConfig != nil {
+		t.Fatal("Expected nil TLS config when cert mount path is empty")
+	}
+}
+
+func TestPollTillCACert_EmptyPath_ReturnsNil(t *testing.T) {
+	caCert, err := pollTillCACertIsMountedSuccessfully("", 5*time.Second, 1*time.Second)
+	if err != nil {
+		t.Fatalf("Expected nil error for empty path, got: %v", err)
+	}
+	if caCert != nil {
+		t.Fatal("Expected nil CA cert for empty path")
+	}
+}
+
+func TestPollTillCACert_NonAbsolutePath_ReturnsError(t *testing.T) {
+	_, err := pollTillCACertIsMountedSuccessfully("ca.crt", 5*time.Second, 1*time.Second)
+	if err == nil {
+		t.Fatal("Expected error for non-absolute path, got nil")
+	}
+	if !strings.Contains(err.Error(), "not absolute") {
+		t.Fatalf("Expected 'not absolute' in error message, got: %v", err)
+	}
+}
+
+func TestConstructMongoClientOptions_NoTLS(t *testing.T) {
+	mongoConfig := MongoDBConfig{
+		URI:                      "mongodb://localhost:27017",
+		Database:                 "test",
+		Collection:               "test",
+		TotalPingTimeoutSeconds:  5,
+		TotalPingIntervalSeconds: 1,
+		ClientTLSCertConfig: MongoDBClientTLSCertConfig{
+			CaCertPath: "",
+		},
+	}
+
+	opts, err := constructMongoClientOptions(mongoConfig)
+	if err != nil {
+		t.Fatalf("constructMongoClientOptions returned error: %v", err)
+	}
+	if opts == nil {
+		t.Fatal("Expected non-nil client options")
+	}
+}
+
+func TestConstructMongoClientOptions_NonAbsoluteCertPath_ReturnsError(t *testing.T) {
+	mongoConfig := MongoDBConfig{
+		URI:                        "mongodb://localhost:27017",
+		Database:                   "test",
+		Collection:                 "test",
+		TotalPingTimeoutSeconds:    5,
+		TotalPingIntervalSeconds:   1,
+		TotalCACertTimeoutSeconds:  2,
+		TotalCACertIntervalSeconds: 1,
+		ClientTLSCertConfig: MongoDBClientTLSCertConfig{
+			CaCertPath: "ca.crt",
+		},
+	}
+
+	_, err := constructMongoClientOptions(mongoConfig)
+	if err == nil {
+		t.Fatal("Expected error for non-absolute cert path")
+	}
+}
+
+func TestConstructStaticTLSConfig_NoCACert_ReturnsNil(t *testing.T) {
+	mongoConfig := MongoDBConfig{
+		TotalCACertTimeoutSeconds:  2,
+		TotalCACertIntervalSeconds: 1,
+		ClientTLSCertConfig: MongoDBClientTLSCertConfig{
+			CaCertPath: "",
+		},
+	}
+
+	tlsConfig, err := constructStaticTLSConfig(mongoConfig)
+	if err != nil {
+		t.Fatalf("Expected nil error, got: %v", err)
+	}
+	if tlsConfig != nil {
+		t.Fatal("Expected nil TLS config when CA cert path is empty")
+	}
+}
+
 func TestConstructClientTLSConfig_CAReadTimeout(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "tls_test_ca_timeout")
 	if err != nil {

--- a/store-client/pkg/storewatcher/watch_store.go
+++ b/store-client/pkg/storewatcher/watch_store.go
@@ -506,42 +506,74 @@ func constructMongoClientOptions(
 		return nil, fmt.Errorf("failed to read CA certificate with error: %w", err)
 	}
 
-	caCertPool := x509.NewCertPool()
-	if !caCertPool.AppendCertsFromPEM(caCert) {
-		return nil, fmt.Errorf("failed to append CA certificate to pool")
+	// Build TLS config only when CA cert is available
+	var tlsConfig *tls.Config
+	if caCert != nil {
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			return nil, fmt.Errorf("failed to append CA certificate to pool")
+		}
+
+		// Load client certificate and key. If the files don't exist, proceed
+		// with CA-only TLS rather than failing.
+		clientCert, err := tls.LoadX509KeyPair(mongoConfig.ClientTLSCertConfig.TlsCertPath,
+			mongoConfig.ClientTLSCertConfig.TlsKeyPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				slog.Warn("Client certificate or key not found, skipping mTLS",
+					"certPath", mongoConfig.ClientTLSCertConfig.TlsCertPath,
+					"keyPath", mongoConfig.ClientTLSCertConfig.TlsKeyPath)
+			} else {
+				return nil, fmt.Errorf("failed to load client certificate and key: %w", err)
+			}
+		}
+
+		tlsConfig = &tls.Config{
+			RootCAs:    caCertPool,
+			MinVersion: tls.VersionTLS12,
+		}
+		if err == nil {
+			tlsConfig.Certificates = []tls.Certificate{clientCert}
+		}
 	}
 
-	// load client certificate and key
-	clientCert, err := tls.LoadX509KeyPair(mongoConfig.ClientTLSCertConfig.TlsCertPath,
-		mongoConfig.ClientTLSCertConfig.TlsKeyPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load client certificate and key: %w", err)
-	}
-
-	tlsConfig := &tls.Config{
-		Certificates: []tls.Certificate{clientCert},
-		RootCAs:      caCertPool,
-		MinVersion:   tls.VersionTLS12,
-	}
-
-	credential := options.Credential{
-		AuthMechanism: "MONGODB-X509",
-		AuthSource:    "$external",
-	}
-
-	clientOpts := options.Client().ApplyURI(mongoConfig.URI).SetTLSConfig(tlsConfig).SetAuth(credential)
+	clientOpts := options.Client().ApplyURI(mongoConfig.URI)
 
 	// Set AppName for MongoDB connection tracking if provided
 	if mongoConfig.AppName != "" {
 		clientOpts.SetAppName(mongoConfig.AppName)
 	}
 
+	// Only set TLS when TLS config was successfully built.
+	// Only set X.509 auth when client certificate is available.
+	if tlsConfig != nil {
+		clientOpts.SetTLSConfig(tlsConfig)
+
+		if len(tlsConfig.Certificates) > 0 {
+			credential := options.Credential{
+				AuthMechanism: "MONGODB-X509",
+				AuthSource:    "$external",
+			}
+			clientOpts.SetAuth(credential)
+		}
+	}
+
 	return clientOpts, nil
 }
 
+// ConstructClientTLSConfig builds a TLS configuration from certificates at the
+// given mount path. Returns (nil, nil) when clientCertMountPath is empty,
+// indicating TLS is intentionally disabled. Returns a non-nil *tls.Config with
+// RootCAs and client certificates when certs are found. Returns an error for
+// invalid cert paths, unreadable files, or malformed certificates.
 func ConstructClientTLSConfig(
 	totalCACertTimeoutSeconds int, intervalCACertSeconds int, clientCertMountPath string,
 ) (*tls.Config, error) {
+	if clientCertMountPath == "" {
+		slog.Info("No client cert mount path configured, skipping TLS")
+		return nil, nil
+	}
+
 	clientCertPath := filepath.Join(clientCertMountPath, "tls.crt")
 	clientKeyPath := filepath.Join(clientCertMountPath, "tls.key")
 	mongoCACertPath := filepath.Join(clientCertMountPath, "ca.crt")
@@ -553,6 +585,10 @@ func ConstructClientTLSConfig(
 	caCert, err := pollTillCACertIsMountedSuccessfully(mongoCACertPath, totalCertTimeout, intervalCert)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read CA certificate: %w", err)
+	}
+
+	if caCert == nil {
+		return nil, nil
 	}
 
 	caCertPool := x509.NewCertPool()
@@ -575,6 +611,15 @@ func ConstructClientTLSConfig(
 
 func pollTillCACertIsMountedSuccessfully(certPath string, timeoutInterval time.Duration,
 	pingInterval time.Duration) ([]byte, error) {
+	if certPath == "" {
+		slog.Info("No CA cert path configured, TLS will be disabled")
+		return nil, nil
+	}
+	if !filepath.IsAbs(certPath) {
+		return nil, fmt.Errorf("CA cert path %q is not absolute — this is likely a misconfiguration. "+
+			"Use --tls-enabled=false to explicitly disable TLS, or provide an absolute cert mount path", certPath)
+	}
+
 	timeout := time.Now().Add(timeoutInterval) // total timeout
 
 	var err error

--- a/store-client/pkg/storewatcher/watch_store_test.go
+++ b/store-client/pkg/storewatcher/watch_store_test.go
@@ -681,6 +681,77 @@ func TestConstructClientTLSConfig_InvalidClientKey(t *testing.T) {
 	}
 }
 
+func TestConstructClientTLSConfig_EmptyPath_DisablesTLS(t *testing.T) {
+	tlsConfig, err := ConstructClientTLSConfig(5, 1, "")
+	if err != nil {
+		t.Fatalf("ConstructClientTLSConfig returned error for empty path: %v", err)
+	}
+	if tlsConfig != nil {
+		t.Fatal("Expected nil TLS config when cert mount path is empty")
+	}
+}
+
+func TestPollTillCACert_EmptyPath_ReturnsNil(t *testing.T) {
+	caCert, err := pollTillCACertIsMountedSuccessfully("", 5*time.Second, 1*time.Second)
+	if err != nil {
+		t.Fatalf("Expected nil error for empty path, got: %v", err)
+	}
+	if caCert != nil {
+		t.Fatal("Expected nil CA cert for empty path")
+	}
+}
+
+func TestPollTillCACert_NonAbsolutePath_ReturnsError(t *testing.T) {
+	_, err := pollTillCACertIsMountedSuccessfully("ca.crt", 5*time.Second, 1*time.Second)
+	if err == nil {
+		t.Fatal("Expected error for non-absolute path, got nil")
+	}
+	if !strings.Contains(err.Error(), "not absolute") {
+		t.Fatalf("Expected 'not absolute' in error message, got: %v", err)
+	}
+}
+
+func TestConstructMongoClientOptions_NoTLS(t *testing.T) {
+	mongoConfig := MongoDBConfig{
+		URI:                      "mongodb://localhost:27017",
+		Database:                 "test",
+		Collection:               "test",
+		TotalPingTimeoutSeconds:  5,
+		TotalPingIntervalSeconds: 1,
+		ClientTLSCertConfig: MongoDBClientTLSCertConfig{
+			CaCertPath: "",
+		},
+	}
+
+	opts, err := constructMongoClientOptions(mongoConfig)
+	if err != nil {
+		t.Fatalf("constructMongoClientOptions returned error: %v", err)
+	}
+	if opts == nil {
+		t.Fatal("Expected non-nil client options")
+	}
+}
+
+func TestConstructMongoClientOptions_NonAbsoluteCertPath_ReturnsError(t *testing.T) {
+	mongoConfig := MongoDBConfig{
+		URI:                        "mongodb://localhost:27017",
+		Database:                   "test",
+		Collection:                 "test",
+		TotalPingTimeoutSeconds:    5,
+		TotalPingIntervalSeconds:   1,
+		TotalCACertTimeoutSeconds:  2,
+		TotalCACertIntervalSeconds: 1,
+		ClientTLSCertConfig: MongoDBClientTLSCertConfig{
+			CaCertPath: "ca.crt",
+		},
+	}
+
+	_, err := constructMongoClientOptions(mongoConfig)
+	if err == nil {
+		t.Fatal("Expected error for non-absolute cert path")
+	}
+}
+
 func TestConstructClientTLSConfig_CAReadTimeout(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "tls_test_ca_timeout")
 	if err != nil {

--- a/tilt/Tiltfile
+++ b/tilt/Tiltfile
@@ -26,11 +26,17 @@ update_settings(
 num_gpu_nodes = int(os.getenv('NUM_GPU_NODES', '50'))
 num_kata_test_nodes = int(os.getenv('NUM_KATA_TEST_NODES', '5'))
 use_postgresql = os.getenv('USE_POSTGRESQL', '0') == '1'
+disable_tls = os.getenv('DISABLE_TLS', '0') == '1'
+use_percona_env = os.getenv('USE_PERCONA', '0') == '1'
 user_values_file = os.getenv('NVSENTINEL_VALUES_FILE', '')
 print_values = os.getenv('PRINT_HELM_VALUES', '0') == '1'
 
 if use_postgresql:
     print("Using PostgreSQL as datastore (USE_POSTGRESQL=1)")
+elif disable_tls and use_percona_env:
+    print("Using Percona MongoDB without TLS (DISABLE_TLS=1, USE_PERCONA=1)")
+elif disable_tls:
+    print("Using MongoDB without TLS (DISABLE_TLS=1)")
 else:
     print("Using MongoDB as datastore (default). Set USE_POSTGRESQL=1 to use PostgreSQL.")
 
@@ -146,6 +152,10 @@ values_files = [
 # Add datastore-specific values
 if use_postgresql:
     values_files.append('../distros/kubernetes/nvsentinel/values-tilt-postgresql.yaml')
+elif disable_tls and use_percona_env:
+    values_files.append('../distros/kubernetes/nvsentinel/values-tilt-mongodb-tls-disabled-percona.yaml')
+elif disable_tls:
+    values_files.append('../distros/kubernetes/nvsentinel/values-tilt-mongodb-tls-disabled.yaml')
 else:
     values_files.append('../distros/kubernetes/nvsentinel/values-tilt-mongodb.yaml')
 
@@ -208,8 +218,9 @@ if use_postgresql:
 else:
     datastore_resource = 'mongodb' if not use_percona else 'create-mongodb-database'
 
-# Cert-manager resources: pulled out of auto-grouped workload resources so they
-# get applied after CRDs exist (otherwise Tilt fails to apply the whole group).
+# Cert-manager resources vary based on datastore and TLS configuration.
+# Pulled out of auto-grouped workload resources so they get applied after
+# CRDs exist (otherwise Tilt fails to apply the whole group).
 preflight_enabled = effective_values.get('global', {}).get('preflight', {}).get('enabled', False)
 cert_manager_objects = [
     'janitor-webhook-cert:certificate',
@@ -230,7 +241,8 @@ if use_postgresql:
         'postgresql-server-cert:certificate',
         'postgresql-client-cert:certificate'
     ])
-else:
+elif not disable_tls:
+    # MongoDB cert-manager resources only needed when TLS is enabled
     if use_percona:
         cert_manager_objects.append('mongo-app-client-cert:certificate')
     else:


### PR DESCRIPTION
When clientCertMountPath is empty (or cert files don't exist at expected paths), NVSentinel now connects to MongoDB without TLS and X.509 auth. This enables deployments where MongoDB runs in-cluster behind K8s network policies without cert-manager certificate complexity.

Changes:
- Helm templates: wrap cert volume mounts, env vars, and CLI args in conditionals on clientCertMountPath (7 template files)
- Go: GetCertPath() returns empty when no cert files found (database_flags.go)
- Go: pollTillCACertIsMountedSuccessfully skips non-absolute cert paths
- Go: constructMongoClientOptions skips TLS+X.509 auth when tlsConfig is nil
- Go: nil-safe handling in loadCACertPool, constructStaticTLSConfig, constructDynamicTLSConfig, ConstructClientTLSConfig

Default behavior unchanged — clientCertMountPath defaults to /etc/ssl/client-certs, so existing TLS deployments are unaffected.

Tested on production Kubernetes cluster with Bitnami MongoDB replicaset.

## Summary

<!-- Brief description of your changes -->

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Helm charts and services now only enable client-certificate mounts, env vars and CLI args when a client cert mount path is configured.
  * MongoDB connection URIs and jobs respect a configurable TLS toggle and will use TLS URIs when enabled.

* **Bug Fixes**
  * TLS/X.509 is now conditional on presence of CA/client certs or explicit TLS enable flag; when certs are absent TLS is disabled and clearer informational logs are emitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->