### PR TITLE
fix: custom drain mode should handle parallel drains

### DIFF
--- a/demos/local-slinky-drain-demo/scripts/00-setup.sh
+++ b/demos/local-slinky-drain-demo/scripts/00-setup.sh
@@ -152,7 +152,7 @@ install_custom_drain_crd() {
 install_nvsentinel() {
     section "Phase 5: Installing NVSentinel"
     
-    local nvsentinel_version="${NVSENTINEL_VERSION:-v0.6.0}"
+    local nvsentinel_version="${NVSENTINEL_VERSION:-v0.10.0}"
     
     log "Installing Prometheus Operator CRDs (for PodMonitor)..."
     kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.68.0/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml

--- a/node-drainer/pkg/evaluator/evaluator.go
+++ b/node-drainer/pkg/evaluator/evaluator.go
@@ -28,10 +28,8 @@ import (
 	"github.com/nvidia/nvsentinel/node-drainer/pkg/config"
 	"github.com/nvidia/nvsentinel/node-drainer/pkg/customdrain"
 	"github.com/nvidia/nvsentinel/node-drainer/pkg/queue"
-	"github.com/nvidia/nvsentinel/store-client/pkg/client"
 	"github.com/nvidia/nvsentinel/store-client/pkg/datastore"
 	"github.com/nvidia/nvsentinel/store-client/pkg/query"
-	"github.com/nvidia/nvsentinel/store-client/pkg/utils"
 )
 
 const (
@@ -106,7 +104,7 @@ func (e *NodeDrainEvaluator) EvaluateEventWithDatabase(ctx context.Context, heal
 	}
 
 	if e.config.CustomDrain.Enabled && e.customDrainClient != nil {
-		return e.evaluateCustomDrain(ctx, healthEvent, database, partialDrainEntity)
+		return e.evaluateCustomDrain(ctx, healthEvent, partialDrainEntity)
 	}
 
 	return e.evaluateUserNamespaceActions(ctx, healthEvent, partialDrainEntity)
@@ -322,20 +320,9 @@ func isTerminalStatus(status model.Status) bool {
 }
 
 func (e *NodeDrainEvaluator) evaluateCustomDrain(ctx context.Context, healthEvent model.HealthEventWithStatus,
-	database queue.DataStore, partialDrainEntity *protos.Entity) (*DrainActionResult, error) {
+	partialDrainEntity *protos.Entity) (*DrainActionResult, error) {
 	nodeName := healthEvent.HealthEvent.NodeName
-
-	eventID, err := getEventID(ctx, database, nodeName)
-	if err != nil {
-		slog.Error("Failed to get event ID for custom drain",
-			"node", nodeName,
-			"error", err)
-
-		return &DrainActionResult{
-			Action:    ActionWait,
-			WaitDelay: customDrainPollInterval,
-		}, nil
-	}
+	eventID := healthEvent.HealthEvent.Id
 
 	crName := customdrain.GenerateCRName(nodeName, eventID)
 
@@ -403,33 +390,6 @@ func (e *NodeDrainEvaluator) evaluateCustomDrain(ctx context.Context, healthEven
 		Action: ActionMarkAlreadyDrained,
 		Status: model.AlreadyDrained,
 	}, nil
-}
-
-func getEventID(ctx context.Context, database queue.DataStore, nodeName string) (string, error) {
-	opts := &client.FindOneOptions{
-		Sort: map[string]any{"_id": -1},
-	}
-
-	filter := map[string]any{
-		"healthevent.nodename": nodeName,
-	}
-
-	result, err := database.FindDocument(ctx, filter, opts)
-	if err != nil {
-		return "", fmt.Errorf("failed to query database for node %s: %w", nodeName, err)
-	}
-
-	var document map[string]any
-	if err := result.Decode(&document); err != nil {
-		return "", fmt.Errorf("failed to decode health event for node %s: %w", nodeName, err)
-	}
-
-	eventID, err := utils.ExtractDocumentID(document)
-	if err != nil {
-		return "", fmt.Errorf("failed to extract document ID for node %s: %w", nodeName, err)
-	}
-
-	return eventID, nil
 }
 
 /*

--- a/node-drainer/pkg/evaluator/evaluator.go
+++ b/node-drainer/pkg/evaluator/evaluator.go
@@ -324,6 +324,10 @@ func (e *NodeDrainEvaluator) evaluateCustomDrain(ctx context.Context, healthEven
 	nodeName := healthEvent.HealthEvent.NodeName
 	eventID := healthEvent.HealthEvent.Id
 
+	if eventID == "" {
+		return nil, fmt.Errorf("health event for node %s is missing Id, cannot generate DrainRequest CR name", nodeName)
+	}
+
 	crName := customdrain.GenerateCRName(nodeName, eventID)
 
 	exists, err := e.customDrainClient.Exists(ctx, crName)

--- a/node-drainer/pkg/reconciler/reconciler.go
+++ b/node-drainer/pkg/reconciler/reconciler.go
@@ -287,6 +287,12 @@ func (r *Reconciler) ProcessEventGeneric(ctx context.Context,
 
 	eventID := utils.ExtractEventID(event)
 
+	if healthEventWithStatus.HealthEvent != nil && healthEventWithStatus.HealthEvent.Id == "" {
+		if docID, err := utils.ExtractDocumentID(event); err == nil {
+			healthEventWithStatus.HealthEvent.Id = docID
+		}
+	}
+
 	slog.Debug("Processing event", "node", nodeName, "eventID", eventID)
 
 	metrics.TotalEventsReceived.Inc()

--- a/node-drainer/pkg/reconciler/reconciler_integration_test.go
+++ b/node-drainer/pkg/reconciler/reconciler_integration_test.go
@@ -1367,6 +1367,7 @@ func createPod(ctx context.Context, t *testing.T, client kubernetes.Interface, n
 
 type healthEventOptions struct {
 	nodeName          string
+	eventID           string
 	nodeQuarantined   model.Status
 	drainForce        bool
 	recommendedAction protos.RecommendedAction
@@ -1374,8 +1375,14 @@ type healthEventOptions struct {
 }
 
 func createHealthEvent(opts healthEventOptions) map[string]interface{} {
+	eventID := opts.nodeName + "-event"
+	if opts.eventID != "" {
+		eventID = opts.eventID
+	}
+
 	healthEvent := &protos.HealthEvent{
 		NodeName:          opts.nodeName,
+		Id:                eventID,
 		CheckName:         "test-check",
 		RecommendedAction: opts.recommendedAction,
 		EntitiesImpacted:  opts.entitiesImpacted,
@@ -1385,12 +1392,6 @@ func createHealthEvent(opts healthEventOptions) map[string]interface{} {
 		healthEvent.DrainOverrides = &protos.BehaviourOverrides{Force: true}
 	}
 
-	eventID := opts.nodeName + "-event"
-	// Return just the fullDocument content, as the event watcher extracts this
-	// from the change stream before passing to the reconciler
-	// NOTE: Always use a pointer for proto structs (e.g., *protos.HealthEventStatus)!
-	// Proto-generated structs may embed sync.Mutex or other non-copyable fields.
-	// Using a value type can cause unsafe copies and subtle bugs (see Go linter: copylocksdefault).
 	return map[string]interface{}{
 		"_id":         eventID,
 		"healthevent": healthEvent,
@@ -1861,6 +1862,100 @@ func TestReconciler_CustomDrainHappyPath(t *testing.T) {
 		_, err := setup.dynamicClient.Resource(gvr).Namespace("default").Get(setup.ctx, crName, metav1.GetOptions{})
 		return errors.IsNotFound(err)
 	}, 10*time.Second, 500*time.Millisecond, "CR should be deleted after drain completes")
+}
+
+func TestReconciler_CustomDrainMultipleEventsOnSameNode(t *testing.T) {
+	customDrainCfg := config.CustomDrainConfig{
+		Enabled:               true,
+		TemplateMountPath:     "../customdrain/testdata",
+		TemplateFileName:      "drain-template.yaml",
+		Namespace:             "default",
+		ApiGroup:              "drain.example.com",
+		Version:               "v1alpha1",
+		Kind:                  "DrainRequest",
+		StatusConditionType:   "Complete",
+		StatusConditionStatus: "True",
+		Timeout:               config.Duration{Duration: 30 * time.Minute},
+	}
+
+	setup := setupCustomDrainTest(t, customDrainCfg)
+
+	nodeName := "multi-event-node"
+	createNode(setup.ctx, t, setup.client, nodeName)
+	createNamespace(setup.ctx, t, setup.client, "default")
+
+	gvr := schema.GroupVersionResource{
+		Group:    "drain.example.com",
+		Version:  "v1alpha1",
+		Resource: "drainrequests",
+	}
+
+	eventA := createHealthEvent(healthEventOptions{
+		nodeName:        nodeName,
+		eventID:         "event-aaa",
+		nodeQuarantined: model.Quarantined,
+	})
+	eventB := createHealthEvent(healthEventOptions{
+		nodeName:        nodeName,
+		eventID:         "event-bbb",
+		nodeQuarantined: model.Quarantined,
+	})
+
+	setup.mockDB.storeEvent(nodeName, eventB)
+
+	// Process Event A — should create its own DrainRequest CR
+	err := setup.reconciler.ProcessEventGeneric(setup.ctx, eventA, setup.mockDB, setup.healthEventStore, nodeName)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "waiting for custom drain CR to complete")
+
+	crNameA := customdrain.GenerateCRName(nodeName, "event-aaa")
+	crNameB := customdrain.GenerateCRName(nodeName, "event-bbb")
+
+	_, err = setup.dynamicClient.Resource(gvr).Namespace("default").Get(setup.ctx, crNameA, metav1.GetOptions{})
+	require.NoError(t, err, "DrainRequest for Event A should exist")
+
+	// Process Event B — should create a separate DrainRequest CR
+	err = setup.reconciler.ProcessEventGeneric(setup.ctx, eventB, setup.mockDB, setup.healthEventStore, nodeName)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "waiting for custom drain CR to complete")
+
+	_, err = setup.dynamicClient.Resource(gvr).Namespace("default").Get(setup.ctx, crNameB, metav1.GetOptions{})
+	require.NoError(t, err, "DrainRequest for Event B should exist")
+
+	// Retry Event A while CR is incomplete — should poll Event A's CR, not Event B's
+	err = setup.reconciler.ProcessEventGeneric(setup.ctx, eventA, setup.mockDB, setup.healthEventStore, nodeName)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "waiting for retry delay",
+		"Event A should be waiting on its own CR, not trying to create a new one")
+
+	// Complete Event A's DrainRequest
+	crA, err := setup.dynamicClient.Resource(gvr).Namespace("default").Get(setup.ctx, crNameA, metav1.GetOptions{})
+	require.NoError(t, err)
+	err = unstructured.SetNestedField(crA.Object, []any{
+		map[string]any{
+			"type":               "Complete",
+			"status":             "True",
+			"lastTransitionTime": time.Now().Format(time.RFC3339),
+			"reason":             "DrainSucceeded",
+			"message":            "All pods drained",
+		},
+	}, "status", "conditions")
+	require.NoError(t, err)
+	_, err = setup.dynamicClient.Resource(gvr).Namespace("default").UpdateStatus(setup.ctx, crA, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// Process Event A again — should detect completion and mark AlreadyDrained
+	err = setup.reconciler.ProcessEventGeneric(setup.ctx, eventA, setup.mockDB, setup.healthEventStore, nodeName)
+	require.NoError(t, err, "Event A should complete successfully after its CR is done")
+
+	require.Eventually(t, func() bool {
+		_, err := setup.dynamicClient.Resource(gvr).Namespace("default").Get(setup.ctx, crNameA, metav1.GetOptions{})
+		return errors.IsNotFound(err)
+	}, 10*time.Second, 500*time.Millisecond, "Event A's CR should be cleaned up")
+
+	// Event B's CR should still exist independently
+	_, err = setup.dynamicClient.Resource(gvr).Namespace("default").Get(setup.ctx, crNameB, metav1.GetOptions{})
+	require.NoError(t, err, "Event B's CR should still exist — it hasn't been completed yet")
 }
 
 func TestReconciler_CustomDrainCRDNotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR fixes the node-drainer getting stuck when multiple fatal health events fire for the same node. The evaluator was querying MongoDB for the latest event's ID to derive the DrainRequest CR name instead of using the event it was given, while the executor always used the event's own ID. With multiple events in the database these diverged, causing an "already exists" error on every retry that short-circuits execution before the completed DrainRequest's status is ever checked — leaving the node stuck in draining forever. The fix removes the database query and uses the event ID already present in the health event. A reconciler integration test is added that fires two events for the same node and verifies both complete independently — it fails without the fix and passes with it.

## Testing
On following the same step as described in the linked issue, verified that the issue is no longer reproducible

### With circuit breaker stopping at event 1:

Picked up a node and sent couple of health event back to back:
```bash
$ curl -s -X POST http://localhost:8080/health-event -H 'Content-Type: application/json' -d '{
      "version":1,
      "agent":"gpu-health-monitor",
      "componentClass":"GPU",
      "checkName":"GpuXidError",
      "isFatal":true,
      "isHealthy":false,
      "message":"GPU XID 79 - GPU has fallen off the bus",
      "recommendedAction":15,
      "errorCode":["79"],
      "entitiesImpacted":[{"entityType":"GPU","entityValue":"0"}],
      "nodeName":"nvsentinel-demo-worker"
}'

$ curl -s -X POST http://localhost:8080/health-event -H 'Content-Type: application/json' -d '{
    "version":1,
    "agent":"gpu-health-monitor",
    "componentClass":"GPU",
    "checkName":"GpuXidError",
    "isFatal":true,
    "isHealthy":false,
    "message":"GPU XID 79 - GPU has fallen off the bus",
    "recommendedAction":15,
    "errorCode":["79"],
    "entitiesImpacted":[{"entityType":"GPU","entityValue":"0"}],
    "nodeName":"nvsentinel-demo-worker"
}'
```

Node drainer is able to proceed forward without a mess:
```
{"time":"2026-03-06T09:04:47.256674127Z","level":"INFO","msg":"Creating custom drain CR","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","crName":"drain-nvsentinel-demo-worker-69aa98af156a17834ad68ee3"}
{"time":"2026-03-06T09:04:47.256688968Z","level":"INFO","msg":"Evaluated action for node","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","action":"CreateCR"}
{"time":"2026-03-06T09:04:47.258843553Z","level":"INFO","msg":"Labeling node","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","from":"quarantined","to":"draining"}
{"time":"2026-03-06T09:04:47.266329725Z","level":"INFO","msg":"Label updated successfully for node","module":"node-drainer","version":"dev","label":"dgxc.nvidia.com/nvsentinel-state","node":"nvsentinel-demo-worker"}
{"time":"2026-03-06T09:04:47.274620018Z","level":"INFO","msg":"Created custom drain CR","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","crName":"drain-nvsentinel-demo-worker-69aa98af156a17834ad68ee3"}
{"time":"2026-03-06T09:04:47.274780749Z","level":"WARN","msg":"Error processing event for node (will retry)","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","attempt":1,"error":"waiting for custom drain CR to complete: drain-nvsentinel-demo-worker-69aa98af156a17834ad68ee3"}
{"time":"2026-03-06T09:04:57.279869769Z","level":"INFO","msg":"Drain CR completed","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","crName":"drain-nvsentinel-demo-worker-69aa98af156a17834ad68ee3"}
{"time":"2026-03-06T09:04:57.279889132Z","level":"INFO","msg":"Evaluated action for node","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","action":"MarkAlreadyDrained"}
{"time":"2026-03-06T09:04:57.282514747Z","level":"INFO","msg":"Health event status has been updated","module":"node-drainer","version":"dev","documentID":"69aa98af156a17834ad68ee3","evictionStatus":"AlreadyDrained"}
{"time":"2026-03-06T09:04:57.288191089Z","level":"INFO","msg":"Deleted custom drain CR","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","crName":"drain-nvsentinel-demo-worker-69aa98af156a17834ad68ee3"}
```

Events in DB:
```
db.HealthEvents.find({'healthevent.nodename':'nvsentinel-demo-worker'})
[
  {
    _id: ObjectId('69aa98af156a17834ad68ee3'),
    createdAt: ISODate('2026-03-06T09:04:47.193Z'),
    healthevent: {
      version: Long('1'),
      agent: 'gpu-health-monitor',
      componentclass: 'GPU',
      checkname: 'GpuXidError',
      isfatal: true,
      ishealthy: false,
      message: 'GPU XID 79 - GPU has fallen off the bus',
      recommendedaction: 15,
      errorcode: [ '79' ],
      entitiesimpacted: [ { entitytype: 'GPU', entityvalue: '0' } ],
      metadata: null,
      generatedtimestamp: { seconds: Long('1772787887'), nanos: 175807581 },
      nodename: 'nvsentinel-demo-worker',
      quarantineoverrides: null,
      drainoverrides: null,
      processingstrategy: 1,
      id: ''
    },
    healtheventstatus: {
      nodequarantined: 'Quarantined',
      userpodsevictionstatus: { status: 'AlreadyDrained', message: '' },
      faultremediated: null,
      quarantinefinishtimestamp: { seconds: Long('1772787887'), nanos: 231581029 },
      drainfinishtimestamp: { seconds: Long('1772787897'), nanos: 280129617 }
    }
  },
  {
    _id: ObjectId('69aa98af156a17834ad68ee4'),
    createdAt: ISODate('2026-03-06T09:04:47.210Z'),
    healthevent: {
      version: Long('1'),
      agent: 'gpu-health-monitor',
      componentclass: 'GPU',
      checkname: 'GpuXidError',
      isfatal: true,
      ishealthy: false,
      message: 'GPU XID 79 - GPU has fallen off the bus',
      recommendedaction: 15,
      errorcode: [ '79' ],
      entitiesimpacted: [ { entitytype: 'GPU', entityvalue: '0' } ],
      metadata: null,
      generatedtimestamp: { seconds: Long('1772787887'), nanos: 206260294 },
      nodename: 'nvsentinel-demo-worker',
      quarantineoverrides: null,
      drainoverrides: null,
      processingstrategy: 1,
      id: ''
    },
    healtheventstatus: {
      nodequarantined: null,
      userpodsevictionstatus: { status: '' },
      faultremediated: null
    }
  }
]
```

With circuit breaker disabled and the same steps:
```
{"time":"2026-03-06T09:12:01.091183466Z","level":"INFO","msg":"Set initial eviction status to InProgress","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker"}
{"time":"2026-03-06T09:12:01.091210192Z","level":"INFO","msg":"Attempting to store resume token","module":"node-drainer","version":"dev","client":"node-drainer"}
{"time":"2026-03-06T09:12:01.09632204Z","level":"INFO","msg":"Creating custom drain CR","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","crName":"drain-nvsentinel-demo-worker-69aa9a61156a17834ad68ee9"}
{"time":"2026-03-06T09:12:01.09633318Z","level":"INFO","msg":"Evaluated action for node","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","action":"CreateCR"}
{"time":"2026-03-06T09:12:01.097294232Z","level":"INFO","msg":"Set initial eviction status to InProgress","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker"}
{"time":"2026-03-06T09:12:01.097317036Z","level":"INFO","msg":"Attempting to store resume token","module":"node-drainer","version":"dev","client":"node-drainer"}
{"time":"2026-03-06T09:12:01.098097831Z","level":"INFO","msg":"Labeling node","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","from":"quarantined","to":"draining"}
{"time":"2026-03-06T09:12:01.104755734Z","level":"INFO","msg":"Label updated successfully for node","module":"node-drainer","version":"dev","label":"dgxc.nvidia.com/nvsentinel-state","node":"nvsentinel-demo-worker"}
{"time":"2026-03-06T09:12:01.104790485Z","level":"INFO","msg":"Ignoring completed pod %s in namespace %s on node %s (status: %s) during eviction check","module":"node-drainer","version":"dev","sticky-workload-1":"slinky","nvsentinel-demo-worker":"Succeeded"}
{"time":"2026-03-06T09:12:01.109562512Z","level":"INFO","msg":"Created custom drain CR","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","crName":"drain-nvsentinel-demo-worker-69aa9a61156a17834ad68ee9"}
{"time":"2026-03-06T09:12:01.109587341Z","level":"WARN","msg":"Error processing event for node (will retry)","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","attempt":1,"error":"waiting for custom drain CR to complete: drain-nvsentinel-demo-worker-69aa9a61156a17834ad68ee9"}
{"time":"2026-03-06T09:12:01.109701741Z","level":"INFO","msg":"HealthEvents which are part of quarantineHealthEvent annotation","module":"node-drainer","version":"dev","eventCount":1}
{"time":"2026-03-06T09:12:01.112739808Z","level":"INFO","msg":"Creating custom drain CR","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","crName":"drain-nvsentinel-demo-worker-69aa9a61156a17834ad68eea"}
{"time":"2026-03-06T09:12:01.112760386Z","level":"INFO","msg":"Evaluated action for node","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","action":"CreateCR"}
{"time":"2026-03-06T09:12:01.114408058Z","level":"INFO","msg":"Labeling node","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","from":"draining","to":"draining"}
{"time":"2026-03-06T09:12:01.114422156Z","level":"INFO","msg":"No update needed for node","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","label":"dgxc.nvidia.com/nvsentinel-state","value":"draining"}
{"time":"2026-03-06T09:12:01.11443769Z","level":"INFO","msg":"Ignoring completed pod %s in namespace %s on node %s (status: %s) during eviction check","module":"node-drainer","version":"dev","sticky-workload-1":"slinky","nvsentinel-demo-worker":"Succeeded"}
{"time":"2026-03-06T09:12:01.11968218Z","level":"INFO","msg":"Created custom drain CR","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","crName":"drain-nvsentinel-demo-worker-69aa9a61156a17834ad68eea"}
{"time":"2026-03-06T09:12:01.119699361Z","level":"WARN","msg":"Error processing event for node (will retry)","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","attempt":1,"error":"waiting for custom drain CR to complete: drain-nvsentinel-demo-worker-69aa9a61156a17834ad68eea"}
{"time":"2026-03-06T09:12:11.115837299Z","level":"INFO","msg":"Drain CR completed","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","crName":"drain-nvsentinel-demo-worker-69aa9a61156a17834ad68ee9"}
{"time":"2026-03-06T09:12:11.115850055Z","level":"INFO","msg":"Evaluated action for node","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","action":"MarkAlreadyDrained"}
{"time":"2026-03-06T09:12:11.118995431Z","level":"INFO","msg":"Health event status has been updated","module":"node-drainer","version":"dev","documentID":"69aa9a61156a17834ad68ee9","evictionStatus":"AlreadyDrained"}
{"time":"2026-03-06T09:12:11.122499065Z","level":"INFO","msg":"Deleted custom drain CR","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","crName":"drain-nvsentinel-demo-worker-69aa9a61156a17834ad68ee9"}
{"time":"2026-03-06T09:12:11.122593501Z","level":"INFO","msg":"HealthEvents which are part of quarantineHealthEvent annotation","module":"node-drainer","version":"dev","eventCount":1}
{"time":"2026-03-06T09:12:11.126508606Z","level":"INFO","msg":"Drain CR completed","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","crName":"drain-nvsentinel-demo-worker-69aa9a61156a17834ad68eea"}
{"time":"2026-03-06T09:12:11.126514145Z","level":"INFO","msg":"Evaluated action for node","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","action":"MarkAlreadyDrained"}
{"time":"2026-03-06T09:12:11.128170601Z","level":"INFO","msg":"Health event status has been updated","module":"node-drainer","version":"dev","documentID":"69aa9a61156a17834ad68eea","evictionStatus":"AlreadyDrained"}
{"time":"2026-03-06T09:12:11.13416336Z","level":"INFO","msg":"Deleted custom drain CR","module":"node-drainer","version":"dev","node":"nvsentinel-demo-worker","crName":"drain-nvsentinel-demo-worker-69aa9a61156a17834ad68eea"}
```

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Track and process multiple concurrent health events on the same node with separate drain requests.

* **Improvements**
  * Custom drain evaluation now uses event IDs directly, removing reliance on datastore lookups.
  * Health event IDs are more reliably populated from incoming documents when missing.

* **Tests**
  * Added integration test validating independent handling, completion, and cleanup for multiple events.

* **Chore**
  * Updated demo setup to use a newer NVSentinel version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->