### PR TITLE
fix: use /run/systemd/journal/dev-log

### DIFF
--- a/janitor/pkg/config/default.go
+++ b/janitor/pkg/config/default.go
@@ -30,7 +30,7 @@ const (
 	HostDevVolumeName     = "host-dev"
 	HostDevPath           = "/dev"
 	HostDevLogVolumeName  = "dev-log"
-	HostDevLogPath        = "/dev/log"
+	HostDevLogPath        = "/run/systemd/journal/dev-log"
 )
 
 func applyConfigDefaults(config *Config) {


### PR DESCRIPTION
## Summary

Only AWS is running into issues with mounting /dev and /dev/log HostPath volumes into GPU reset pod. It is failing with the following error:
```
message: 'failed to create containerd task: failed to create shim task: OCI
          runtime create failed: runc create failed: unable to start container process:
          error during container init: error mounting "/run/systemd/journal/dev-log"
          to rootfs at "/dev/log": create mountpoint for /dev/log mount: make mountpoint
          "/dev/log": file exists: unknown'
```
The first one mounts the /dev directory and the second mounts a socket at /dev/log. We have to explicitly mount the nested HostPath because it is a symlink pointing to /run/systemd/journal/dev-log. So if we don't have the second mount, it will refer to the symlink within the container which doesn't exist whereas the explicit HostPath will resolve the symlink on the host and actually mount the socket at /dev/log in the container. This has been working on Forge, OCI, and GCP without issues where the same symlink exists at /dev/log. It looks like a bug in runc with HostPath volumes referring to symlinks which is fixed in a newer version: https://github.com/awslabs/amazon-eks-ami/issues/2510.

Rather than mount /dev and mount /dev/log which follows the symlink and mounts /run/systemd/journal/dev-log, can continue to mount /dev and directly mount /run/systemd/journal/dev-log. Note that mounting /dev will continue to create the symlink from /dev/log to /run/systemd/journal/dev-log. This ensures that the logger command here can continue to use the default socket at /dev/log rather than need to override the socket in our CLI command here: https://github.com/NVIDIA/NVSentinel/blob/main/gpu-reset/gpu_reset.sh#L181
```
logger -p daemon.err "GPU reset executed: ${UUID}"
```

## Testing

Confirmed that all clouds rely on a symlink from /dev/log to /run/systemd/journal/dev-log and there are no cases where the socket is mounted directly at /dev/log. These tests show:
- all clouds rely on a symlink from /dev/log -> /run/systemd/journal/dev-log
- mounting /dev + /run/systemd/journal/dev-log allows a container to write to /dev/log via logger command which is propagated to syslog

Test pod included the following volume mounts which is the same configuration as the GPU reset pod:
```
        volumeMounts:
        - name: dev
          mountPath: /dev
          mountPropagation: HostToContainer
        - name: dev-log
          mountPath: /run/systemd/journal/dev-log
          mountPropagation: HostToContainer
...
      volumes:
      - name: dev
        hostPath:
          path: /dev
      - name: dev-log
        hostPath:
          path: /run/systemd/journal/dev-log
```

1. AWS:

1a. Not mounting /dev/log
```
# ls -l /dev/log
lrwxrwxrwx 1 root root 28 Mar  3 21:08 /dev/log -> /run/systemd/journal/dev-log
# ls /run/systemd/journal/dev-log
ls: cannot access '/run/systemd/journal/dev-log': No such file or directory

# logger -p daemon.err "test message"
# tail -n 10000 /var/log/syslog | grep "test message"
#
```

1b. Mounting /run/systemd/journal/dev-log
```
# ls -l /dev/log
lrwxrwxrwx 1 root root 28 Mar  3 21:08 /dev/log -> /run/systemd/journal/dev-log
# ls -l /run/systemd/journal/dev-log
srw-rw-rw- 1 root root 0 Mar  3 21:08 /run/systemd/journal/dev-log

# logger -p daemon.err "test message2"
# tail -n 10000 /var/log/syslog | grep "test message"
2026-03-06T19:20:00.805815+00:00 ip-100-64-190-136 root: test message2
```

2. Forge:

2a. Not mounting /dev/log
```
# ls -l /dev/log
lrwxrwxrwx 1 root root 28 Mar  4 23:27 /dev/log -> /run/systemd/journal/dev-log
# ls -l /run/systemd/journal/dev-log
ls: cannot access '/run/systemd/journal/dev-log': No such file or directory

# logger -p daemon.err "test message"
# tail -n 10000 /var/log/syslog | grep "test message"
#
```
2b. Mounting /run/systemd/journal/dev-log
```
# ls -l /dev/log
lrwxrwxrwx 1 root root 28 Mar  4 23:27 /dev/log -> /run/systemd/journal/dev-log
# ls -l /run/systemd/journal/dev-log
srw-rw-rw- 1 root root 0 Mar  4 23:27 /run/systemd/journal/dev-log

# logger -p daemon.err "test message2"
# tail -n 10000 /var/log/syslog | grep "test message"
Mar  6 19:39:54 nvcf-dgxc-k8s-forge-az20-ct1-worker-2012 root: test message2
```

3. GCP:

3a. Not mounting /dev/log
```
# ls -l /dev/log
lrwxrwxrwx 1 root root 28 Mar  4 02:02 /dev/log -> /run/systemd/journal/dev-log
# ls -l /run/systemd/journal/dev-log
ls: cannot access '/run/systemd/journal/dev-log': No such file or directory
```
GCP doesn’t have a way to read syslog file from HostPath volume mount

3b. Mounting /run/systemd/journal/dev-log
```
# ls -l /dev/log
lrwxrwxrwx 1 root root 28 Mar  4 02:02 /dev/log -> /run/systemd/journal/dev-log
# ls -l /run/systemd/journal/dev-log
srw-rw-rw- 1 root root 0 Mar  4 02:02 /run/systemd/journal/dev-log
```

GCP doesn’t have a way to read syslog file from HostPath volume mount

4. OCI:

4a. Not mounting /dev/log
```
# ls -l /dev/log
lrwxrwxrwx 1 root root 28 Feb 26 20:15 /dev/log -> /run/systemd/journal/dev-log
# ls -l /run/systemd/journal/dev-log
ls: cannot access '/run/systemd/journal/dev-log': No such file or directory

# logger -p daemon.err "test message"
# tail -n 10000 /var/log/syslog | grep "test message"
#
```
4b. Mounting /run/systemd/journal/dev-log
```
# ls -l /dev/log
lrwxrwxrwx 1 root root 28 Feb 26 20:15 /dev/log -> /run/systemd/journal/dev-log
# ls -l /run/systemd/journal/dev-log
srw-rw-rw- 1 root root 0 Feb 26 20:15 /run/systemd/journal/dev-log

# logger -p daemon.err "test message2"
# tail -n 10000 /var/log/syslog | grep "test message"
2026-03-06T20:31:06.595061+00:00 gpu-500713 root: test message2
```

5. Azure:

5a. Not mounting /dev/log
```
# ls -l /dev/log
lrwxrwxrwx 1 root root 28 Jan 16 01:50 /dev/log -> /run/systemd/journal/dev-log
# ls -l /run/systemd/journal/dev-log
ls: cannot access '/run/systemd/journal/dev-log': No such file or directory

# logger -p daemon.err "test message"
# tail -n 10000 /var/log/syslog | grep "test message"
#
```

5b. Mounting /run/systemd/journal/dev-log
```
# ls -l /dev/log
lrwxrwxrwx 1 root root 28 Jan 16 01:50 /dev/log -> /run/systemd/journal/dev-log
# ls -l /run/systemd/journal/dev-log
srw-rw-rw- 1 root root 0 Jan 16 01:50 /run/systemd/journal/dev-log

# logger -p daemon.err "test message2"
# tail -n 10000 /var/log/syslog | grep "test message"
Mar  6 20:43:42 aks-gpunodes-28453945-vmss000000 root: test message2
```

## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [X] Janitor
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system log mounting path configuration to use the systemd journal socket for enhanced compatibility with modern logging infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->