### PR TITLE
fix: store resume token under correct clientName in fault-remediation (Issue #954)

### DIFF
--- a/fault-remediation/pkg/initializer/init.go
+++ b/fault-remediation/pkg/initializer/init.go
@@ -165,6 +165,9 @@ func initDatastoreAndWatcher(
 	watcherConfig := watcher.WatcherConfig{
 		Pipeline:       pipeline,
 		CollectionName: "HealthEvents",
+		Options: map[string]interface{}{
+			"ClientName": "fault-remediation",
+		},
 	}
 
 	watcherInstance, err := watcher.CreateChangeStreamWatcher(ctx, ds, watcherConfig)

--- a/fault-remediation/pkg/initializer/init.go
+++ b/fault-remediation/pkg/initializer/init.go
@@ -165,9 +165,7 @@ func initDatastoreAndWatcher(
 	watcherConfig := watcher.WatcherConfig{
 		Pipeline:       pipeline,
 		CollectionName: "HealthEvents",
-		Options: map[string]interface{}{
-			"ClientName": "fault-remediation",
-		},
+		ClientName:     "fault-remediation",
 	}
 
 	watcherInstance, err := watcher.CreateChangeStreamWatcher(ctx, ds, watcherConfig)

--- a/store-client/pkg/datastore/providers/mongodb/watcher_factory.go
+++ b/store-client/pkg/datastore/providers/mongodb/watcher_factory.go
@@ -50,10 +50,10 @@ func (f *MongoWatcherFactory) CreateChangeStreamWatcher(
 	}
 
 	// Create the change stream watcher using the existing factory
-	watcher, err := mongoStore.CreateChangeStreamWatcher(ctx, "watcher-factory", mongoPipeline)
+	watcher, err := mongoStore.CreateChangeStreamWatcher(ctx, config.ClientName(), mongoPipeline)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create MongoDB change stream watcher: %w", err)
-	}
+	} 
 
 	return watcher, nil
 }

--- a/store-client/pkg/datastore/providers/mongodb/watcher_factory.go
+++ b/store-client/pkg/datastore/providers/mongodb/watcher_factory.go
@@ -53,7 +53,7 @@ func (f *MongoWatcherFactory) CreateChangeStreamWatcher(
 	watcher, err := mongoStore.CreateChangeStreamWatcher(ctx, config.ClientName(), mongoPipeline)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create MongoDB change stream watcher: %w", err)
-	} 
+	}
 
 	return watcher, nil
 }

--- a/store-client/pkg/datastore/providers/mongodb/watcher_factory.go
+++ b/store-client/pkg/datastore/providers/mongodb/watcher_factory.go
@@ -50,7 +50,7 @@ func (f *MongoWatcherFactory) CreateChangeStreamWatcher(
 	}
 
 	// Create the change stream watcher using the existing factory
-	watcher, err := mongoStore.CreateChangeStreamWatcher(ctx, config.ClientName(), mongoPipeline)
+	watcher, err := mongoStore.CreateChangeStreamWatcher(ctx, config.ClientName, mongoPipeline)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create MongoDB change stream watcher: %w", err)
 	}

--- a/store-client/pkg/datastore/providers/postgresql/watcher_factory.go
+++ b/store-client/pkg/datastore/providers/postgresql/watcher_factory.go
@@ -42,7 +42,7 @@ func (f *PostgreSQLWatcherFactory) CreateChangeStreamWatcher(
 		return nil, fmt.Errorf("expected PostgreSQL datastore, got %T", ds)
 	}
 
-	clientName := f.extractClientName(config)
+	clientName := config.ClientName()
 	tableName := config.CollectionName
 
 	if tableName == "" {
@@ -67,17 +67,6 @@ func (f *PostgreSQLWatcherFactory) CreateChangeStreamWatcher(
 	f.applyPipelineFilter(changeStreamWatcher, config.Pipeline, tableName)
 
 	return NewPostgreSQLChangeStreamWatcherWithUnwrap(changeStreamWatcher), nil
-}
-
-// extractClientName extracts client name from config options.
-func (f *PostgreSQLWatcherFactory) extractClientName(config watcher.WatcherConfig) string {
-	if config.Options != nil {
-		if name, ok := config.Options["ClientName"].(string); ok && name != "" {
-			return name
-		}
-	}
-
-	return "watcher-factory"
 }
 
 // applyPipelineFilter applies pipeline filter to the watcher if provided.

--- a/store-client/pkg/datastore/providers/postgresql/watcher_factory.go
+++ b/store-client/pkg/datastore/providers/postgresql/watcher_factory.go
@@ -42,7 +42,7 @@ func (f *PostgreSQLWatcherFactory) CreateChangeStreamWatcher(
 		return nil, fmt.Errorf("expected PostgreSQL datastore, got %T", ds)
 	}
 
-	clientName := config.ClientName()
+	clientName := config.ClientName
 	tableName := config.CollectionName
 
 	if tableName == "" {

--- a/store-client/pkg/watcher/factory.go
+++ b/store-client/pkg/watcher/factory.go
@@ -17,6 +17,7 @@ package watcher
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sync"
 
 	"github.com/nvidia/nvsentinel/store-client/pkg/datastore"
@@ -43,6 +44,8 @@ func (c WatcherConfig) ClientName() string {
 			return name
 		}
 	}
+
+	slog.Warn("ClientName not set in WatcherConfig options, falling back to default", "fallback", "watcher-factory")
 
 	return "watcher-factory"
 }

--- a/store-client/pkg/watcher/factory.go
+++ b/store-client/pkg/watcher/factory.go
@@ -37,6 +37,16 @@ type WatcherConfig struct {
 	Options map[string]interface{} `json:"options,omitempty"`
 }
 
+func (c WatcherConfig) ClientName() string {
+	if c.Options != nil {
+		if name, ok := c.Options["ClientName"].(string); ok && name != "" {
+			return name
+		}
+	}
+
+	return "watcher-factory"
+}
+
 // WatcherFactory creates change stream watchers for specific datastore providers
 type WatcherFactory interface {
 	CreateChangeStreamWatcher(

--- a/store-client/pkg/watcher/factory.go
+++ b/store-client/pkg/watcher/factory.go
@@ -17,7 +17,6 @@ package watcher
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"sync"
 
 	"github.com/nvidia/nvsentinel/store-client/pkg/datastore"
@@ -34,20 +33,11 @@ type WatcherConfig struct {
 	// Resume token for continuing from a specific point
 	ResumeToken []byte `json:"resumeToken,omitempty"`
 
+	// Client name for logging and identification
+	ClientName string `json:"clientName"`
+
 	// Provider-specific options
 	Options map[string]interface{} `json:"options,omitempty"`
-}
-
-func (c WatcherConfig) ClientName() string {
-	if c.Options != nil {
-		if name, ok := c.Options["ClientName"].(string); ok && name != "" {
-			return name
-		}
-	}
-
-	slog.Warn("ClientName not set in WatcherConfig options, falling back to default", "fallback", "watcher-factory")
-
-	return "watcher-factory"
 }
 
 // WatcherFactory creates change stream watchers for specific datastore providers
@@ -80,6 +70,10 @@ func CreateChangeStreamWatcher(
 	ds datastore.DataStore,
 	config WatcherConfig,
 ) (datastore.ChangeStreamWatcher, error) {
+	if config.ClientName == "" {
+		return nil, fmt.Errorf("ClientName is required in WatcherConfig")
+	}
+
 	// Determine the provider from the datastore config
 	provider, err := getProviderFromDataStore(ds)
 	if err != nil {


### PR DESCRIPTION
## Summary
Solves Issue #954 
`MongoWatcherFactory` had `clientName` hardcoded as `"watcher-factory"` so resume token was always stored under wrong name. Although postgres factory in the same code was already doing it right, had its own `extractClientName` helper reading from config.

Other components are fine since they pass `clientName` directly to the legacy adapter, only `fault-remediation` goes through the new `WatcherFactory` path so it was the only one affected.

Quick fix would be copy what postgres was doing into mongo as well. But same logic in two places felt off so moved it to `ClientName()` on `WatcherConfig` instead, deleted the postgres helper, both factories just call `config.ClientName()` now. Open to change if  i missed to understand this as good decision

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Change stream watchers now use configurable client names instead of hard-coded defaults for consistent identification across providers.
  * Watcher creation now requires a client name and will fail if it is not provided.

* **Chores**
  * Removed an unused helper and streamlined client-name handling across watcher implementations.
  * Initial configuration sets a default client name for the remediation service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->