### PR TITLE
fix: fix UAT tests to comply with dcgm 4.4.2

### DIFF
--- a/tests/uat/tests.sh
+++ b/tests/uat/tests.sh
@@ -123,6 +123,36 @@ wait_for_node_condition() {
     error "Timeout waiting for node condition '$condition_type' on node $node"
 }
 
+wait_for_any_node_condition() {
+    local node=$1
+    shift
+    local conditions=("$@")
+    local timeout=${UAT_CONDITION_TIMEOUT:-60}
+    local elapsed=0
+
+    log "Waiting for any node condition [${conditions[*]}] on node $node..."
+
+    local jq_filter
+    jq_filter=$(printf ' or .type == "%s"' "${conditions[@]}")
+    jq_filter=".status.conditions[] | select((${jq_filter# or }) and .status == \"True\") | .type"
+
+    while [[ $elapsed -lt $timeout ]]; do
+        local matched
+        matched=$(kubectl get node "$node" -o json | jq -r "$jq_filter" | head -1)
+
+        if [[ -n "$matched" ]]; then
+            log "Node condition '$matched' found ✓"
+            return 0
+        fi
+
+        sleep 5
+        elapsed=$((elapsed + 5))
+    done
+
+    error "Timeout waiting for any node condition [${conditions[*]}] on node $node"
+}
+
+
 wait_for_node_quarantine() {
     local node=$1
     local timeout=${UAT_QUARANTINE_TIMEOUT:-120}
@@ -313,10 +343,12 @@ test_gpu_monitoring_dcgm() {
     fi
     log "Node event verified: GpuPowerWatch is non-fatal, appears in events ✓"
 
-    # XID 95 results in DCGM_FR_UNCONTAINED_ERROR from GpuAllWatch which requires a RESTART_VM action.
+    # XID 95 results in DCGM_FR_UNCONTAINED_ERROR which requires a RESTART_VM action.
+    # DCGM 4.2.x maps this to DCGM_HEALTH_WATCH_MEM (GpuMemWatch).
+    # DCGM 4.4.x+ reclassified it as a "devastating" XID under DCGM_HEALTH_WATCH_ALL (GpuAllWatch).
     kubectl exec -n gpu-operator "$dcgm_pod" -- dcgmi test --inject --gpuid 0 -f 230 -v 95
 
-    wait_for_node_condition "$gpu_node" "GpuAllWatch"
+    wait_for_any_node_condition "$gpu_node" "GpuAllWatch" "GpuMemWatch"
 
     wait_for_node_quarantine "$gpu_node"
 

--- a/tests/uat/tests.sh
+++ b/tests/uat/tests.sh
@@ -313,10 +313,10 @@ test_gpu_monitoring_dcgm() {
     fi
     log "Node event verified: GpuPowerWatch is non-fatal, appears in events ✓"
 
-    # XID 95 results in A DCGM_FR_UNCONTAINED_ERROR from GpuMemWatch which requires a RESTART_VM action
+    # XID 95 results in DCGM_FR_UNCONTAINED_ERROR from GpuAllWatch which requires a RESTART_VM action.
     kubectl exec -n gpu-operator "$dcgm_pod" -- dcgmi test --inject --gpuid 0 -f 230 -v 95
 
-    wait_for_node_condition "$gpu_node" "GpuMemWatch"
+    wait_for_node_condition "$gpu_node" "GpuAllWatch"
 
     wait_for_node_quarantine "$gpu_node"
 


### PR DESCRIPTION
## Summary

Fix: fix UAT tests  in order to comply with dcgm version 4.4.2.

Earlier when XID95 was injected with dcgm version 4.2.0 or earlier, GpuMemWatch event come. now with dcgm version 4.4.2, since xid95 is destructive xid, it came as part of GpuAllWatch. As part of the fix, updating the UAT test to monitor for XID95 via GpuAllWatch rather than GpuMemWatch.
`
  GpuAllWatch                                True      Mon, 09 Mar 2026 11:41:19 +0530   Mon, 09 Mar 2026 11:41:19 +0530   GpuAllWatchIsNotHealthy               ErrorCode:DCGM_FR_UNCONTAINED_ERROR GPU:0 PCI:0000:16:00.0 GPU_UUID:GPU-65e4956a-8db1-af7f-47f8-b355e3b7bf07 GPU had an uncontained error (XID 95) Drain the GPU and reset it or reboot the node. Recommended Action=RESTART_VM;`

Testing the UAT script on the CT cluster to verify the test

```
Test 1: GPU monitoring via DCGM — XID 95 (DCGM_FR_UNCONTAINED_ERROR)
  - Injected power watch error (field 240) → verified GpuPowerWatch non-fatal event appeared
  - Injected XID 95 (field 230) → GpuAllWatch condition detected in ~12s
  - Node quarantined, rebooted (~9min), uncordoned — PASSED

  Test 2: XID monitoring via syslog — XID 79 (GPU fallen off bus)
  - Injected XID 79 via logger on driver pod
  - SysLogsXIDError condition detected in ~16s
  - Node quarantined, rebooted (~9min), uncordoned — PASSED

  Test 3: XID monitoring via syslog — XID 119 (COMPONENT_RESET)
  - SKIPPED — partialDrainEnabled not set to true in node-drainer config on this cluster

```
## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [x] Other: UAT

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved GPU health monitoring tests to detect multiple GPU health conditions (broader matching), replaced single-condition waits with a generalized check, and adjusted timeouts/logging to make test behavior more reliable and less flaky.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->