### PR TITLE
fix(chart): default global.tolerations to tolerate all taints

### DIFF
--- a/distros/kubernetes/nvsentinel/values.yaml
+++ b/distros/kubernetes/nvsentinel/values.yaml
@@ -67,7 +67,8 @@ global:
     compress: true  # Compress rotated log files
 
   nodeSelector: {}
-  tolerations: []
+  tolerations:
+    - operator: Exists
   affinity: {}
   systemNodeSelector: {}
   systemNodeTolerations: []


### PR DESCRIPTION
## Summary
- Default `global.tolerations` to `[{operator: Exists}]` in the public Helm chart, matching the internal platform template behavior.

## Problem
NVSentinel GPU-node daemonsets (platform-connectors, gpu-health-monitor, syslog-health-monitor, metadata-collector) fail to schedule on GPU nodes that have `NoSchedule`/`NoExecute` taints (commonly set by ASG or cluster provisioning). All subchart templates use `(.Values.global.tolerations | default .Values.tolerations)`, so this single default propagates to all daemonsets.

## Test plan
- [ ] Deploy NVSentinel on a cluster with tainted GPU nodes and verify all daemonsets schedule correctly
- [ ] Verify `helm show values` reflects the new default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default Kubernetes toleration settings to enable broader taint tolerance by default, improving deployment flexibility across cluster configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->