### PR TITLE
Issue 376

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "csp-health-monitor.fullname" . }}
-      {{- if and .Values.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
+      {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
       initContainers:
         - name: fix-cert-permissions
           image: "{{ .Values.global.initContainerImage.repository }}:{{ .Values.global.initContainerImage.tag }}"
@@ -75,19 +75,15 @@ spec:
           items:
           - key: config.toml
             path: config.toml
-      {{- if and .Values.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
+      {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
       - name: postgresql-client-cert-original
         secret:
           secretName: postgresql-client-cert
           optional: false
       - name: client-certs-fixed
         emptyDir: {}
-      {{- else if .Values.clientCertMountPath }}
-      - name: mongo-app-client-cert
-        secret:
-          secretName: {{ include "nvsentinel.certificates.secretName" . }}
-          {{- include "nvsentinel.certificates.volumeItems" . | nindent 10 }}
-          optional: true
+      {{- else }}
+      {{- include "nvsentinel.mongodb.certVolume" . | nindent 6 }}
       {{- end }}
       - name: platform-connector-uds
         hostPath:
@@ -102,12 +98,14 @@ spec:
             runAsUser: 1001
             runAsGroup: 1001
           {{- end }}
+          {{- $certMountPath := include "nvsentinel.mongodb.certMountPath" . }}
           args:
           - "--config=/etc/config/config.toml"
           - "--metrics-port={{ ((.Values.global).metricsPort) | default 2112 }}"
-          {{- if .Values.clientCertMountPath }}
-          - "--database-client-cert-mount-path={{ .Values.clientCertMountPath }}"
+          {{- if $certMountPath }}
+          - "--database-client-cert-mount-path={{ $certMountPath }}"
           {{- else }}
+          # csp-health-monitor does not register --tls-enabled; empty mount path disables TLS (see store-client env_loader).
           - "--database-client-cert-mount-path="
           {{- end }}
           resources:
@@ -135,14 +133,16 @@ spec:
           volumeMounts:
           - name: config-volume
             mountPath: /etc/config/
-          {{- if and .Values.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
+          {{- if $certMountPath }}
+          {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
           - name: client-certs-fixed
-            mountPath: {{ .Values.clientCertMountPath }}
+            mountPath: {{ $certMountPath }}
             readOnly: true
-          {{- else if .Values.clientCertMountPath }}
+          {{- else if eq (include "nvsentinel.mongodb.hasCertVolume" .) "true" }}
           - name: mongo-app-client-cert
-            mountPath: {{ .Values.clientCertMountPath }}
+            mountPath: {{ $certMountPath }}
             readOnly: true
+          {{- end }}
           {{- end }}
           env:
             - name: LOG_LEVEL
@@ -165,10 +165,11 @@ spec:
             {{- else }}
             runAsUser: 0
             {{- end }}
+          {{- $certMountPath := include "nvsentinel.mongodb.certMountPath" . }}
           args:
           - "--config=/etc/config/config.toml"
-          {{- if .Values.clientCertMountPath }}
-          - "--database-client-cert-mount-path={{ .Values.clientCertMountPath }}"
+          {{- if $certMountPath }}
+          - "--database-client-cert-mount-path={{ $certMountPath }}"
           {{- else }}
           - "--database-client-cert-mount-path="
           {{- end }}
@@ -200,14 +201,16 @@ spec:
           volumeMounts:
           - name: config-volume
             mountPath: /etc/config/
-          {{- if and .Values.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
+          {{- if $certMountPath }}
+          {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
           - name: client-certs-fixed
-            mountPath: {{ .Values.clientCertMountPath }}
+            mountPath: {{ $certMountPath }}
             readOnly: true
-          {{- else if .Values.clientCertMountPath }}
+          {{- else if eq (include "nvsentinel.mongodb.hasCertVolume" .) "true" }}
           - name: mongo-app-client-cert
-            mountPath: {{ .Values.clientCertMountPath }}
+            mountPath: {{ $certMountPath }}
             readOnly: true
+          {{- end }}
           {{- end }}
           - name: platform-connector-uds
             mountPath: /run/nvsentinel

--- a/distros/kubernetes/nvsentinel/charts/event-exporter/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/event-exporter/templates/configmap.yaml
@@ -45,16 +45,16 @@ data:
     [exporter.backfill]
     enabled = {{ .Values.exporter.backfill.enabled }}
     max_age = "{{ .Values.exporter.backfill.maxAge }}"
-    max_events = {{ .Values.exporter.backfill.maxEvents }}
-    batch_size = {{ .Values.exporter.backfill.batchSize }}
-    rate_limit = {{ .Values.exporter.backfill.rateLimit }}
+    max_events = {{ .Values.exporter.backfill.maxEvents | int }}
+    batch_size = {{ .Values.exporter.backfill.batchSize | int }}
+    rate_limit = {{ .Values.exporter.backfill.rateLimit | int }}
 
     [exporter.resume_token]
     database = "{{ .Values.exporter.resumeToken.database }}"
     collection = "{{ .Values.exporter.resumeToken.collection }}"
 
     [exporter.failure_handling]
-    max_retries = {{ .Values.exporter.failureHandling.maxRetries }}
+    max_retries = {{ .Values.exporter.failureHandling.maxRetries | int }}
     initial_backoff = "{{ .Values.exporter.failureHandling.initialBackoff }}"
     max_backoff = "{{ .Values.exporter.failureHandling.maxBackoff }}"
     backoff_multiplier = {{ .Values.exporter.failureHandling.backoffMultiplier }}

--- a/distros/kubernetes/nvsentinel/charts/event-exporter/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/event-exporter/templates/deployment.yaml
@@ -117,9 +117,9 @@ spec:
           - name: client-certs-fixed
             mountPath: /etc/ssl/client-certs
             readOnly: true
-          {{- else if .Values.mongodbStore.clientCertMountPath }}
+          {{- else if and (eq (include "nvsentinel.mongodb.hasCertVolume" .) "true") (include "nvsentinel.mongodb.certMountPathFromMongoStore" . | trim) }}
           - name: mongo-app-client-cert
-            mountPath: {{ .Values.mongodbStore.clientCertMountPath }}
+            mountPath: {{ include "nvsentinel.mongodb.certMountPathFromMongoStore" . | trim }}
             readOnly: true
           {{- end }}
           - name: var-run-vol
@@ -138,6 +138,14 @@ spec:
               value: {{ printf "%s/tls.key" .Values.mongodbStore.clientCertMountPath | quote }}
             - name: MONGODB_CA_CERT_PATH
               value: {{ printf "%s/ca.crt" .Values.mongodbStore.clientCertMountPath | quote }}
+            {{- else if include "nvsentinel.mongodb.certMountPathFromMongoStore" . | trim }}
+            {{- $mongoCertMount := include "nvsentinel.mongodb.certMountPathFromMongoStore" . | trim }}
+            - name: MONGODB_CLIENT_CERT_PATH
+              value: {{ printf "%s/tls.crt" $mongoCertMount | quote }}
+            - name: MONGODB_CLIENT_KEY_PATH
+              value: {{ printf "%s/tls.key" $mongoCertMount | quote }}
+            - name: MONGODB_CA_CERT_PATH
+              value: {{ printf "%s/ca.crt" $mongoCertMount | quote }}
             {{- end }}
           envFrom:
             - configMapRef:
@@ -165,12 +173,8 @@ spec:
           optional: false
       - name: client-certs-fixed
         emptyDir: {}
-      {{- else if .Values.mongodbStore.clientCertMountPath }}
-      - name: mongo-app-client-cert
-        secret:
-          secretName: {{ include "nvsentinel.certificates.secretName" . }}
-          {{- include "nvsentinel.certificates.volumeItems" . | nindent 10 }}
-          optional: true
+      {{- else }}
+      {{- include "nvsentinel.mongodb.certVolume" . | nindent 6 }}
       {{- end }}
       restartPolicy: Always
       {{- with (.Values.global.systemNodeSelector | default .Values.nodeSelector) }}

--- a/distros/kubernetes/nvsentinel/charts/event-exporter/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/event-exporter/values.yaml
@@ -34,7 +34,10 @@ resources:
 # You must create this secret manually before deploying this chart
 oidcSecretName: "event-exporter-oidc-secret"
 
-# Set to an empty string to disable MongoDB TLS client certificate mounts.
+# MongoDB TLS client certificate mount path.
+# Default is /etc/ssl/mongo-client for internal MongoDB (mTLS).
+# Override to "" in your CSP-specific values file when using managed services
+# (Atlas, DocumentDB with SCRAM, Cosmos DB) that do not require client certificates.
 mongodbStore:
   clientCertMountPath: /etc/ssl/mongo-client
 

--- a/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/deployment.yaml
@@ -91,8 +91,9 @@ spec:
           args:
           - "--metrics-port={{ ((.Values.global).metricsPort) | default 2112 }}"
           - "--dry-run={{ ((.Values.global).dryRun) | default false }}"
-          {{- if .Values.clientCertMountPath }}
-          - "--database-client-cert-mount-path={{ .Values.clientCertMountPath }}"
+          {{- $certMountPath := include "nvsentinel.mongodb.certMountPath" . }}
+          {{- if $certMountPath }}
+          - "--database-client-cert-mount-path={{ $certMountPath }}"
           {{- else }}
           - "--tls-enabled=false"
           {{- end }}
@@ -120,14 +121,15 @@ spec:
           - name: config-volume
             mountPath: /etc/config/config.toml
             subPath: config.toml
-          {{- if .Values.clientCertMountPath }}
+          {{- $certMountPath := include "nvsentinel.mongodb.certMountPath" . }}
+          {{- if $certMountPath }}
           {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
           - name: client-certs-fixed
-            mountPath: {{ .Values.clientCertMountPath }}
+            mountPath: {{ $certMountPath }}
             readOnly: true
-          {{- else }}
+          {{- else if eq (include "nvsentinel.mongodb.hasCertVolume" .) "true" }}
           - name: mongo-app-client-cert
-            mountPath: {{ .Values.clientCertMountPath }}
+            mountPath: {{ $certMountPath }}
             readOnly: true
           {{- end }}
           {{- end }}
@@ -151,13 +153,14 @@ spec:
             {{- if .Values.global.auditLogging.enabled }}
             {{- include "nvsentinel.auditLogging.envVars" . | nindent 12 }}
             {{- end }}
-            {{- if .Values.clientCertMountPath }}
+            {{- $certMountPath := include "nvsentinel.mongodb.certMountPath" . }}
+            {{- if $certMountPath }}
             {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
             - name: POSTGRESQL_CLIENT_CERT_MOUNT_PATH
-              value: {{ .Values.clientCertMountPath }}
+              value: {{ $certMountPath }}
             {{- else }}
             - name: MONGODB_CLIENT_CERT_MOUNT_PATH
-              value: {{ .Values.clientCertMountPath }}
+              value: {{ $certMountPath }}
             {{- end }}
             {{- end }}
           envFrom:
@@ -171,21 +174,15 @@ spec:
           items:
           - key: config.toml
             path: config.toml
-      {{- if .Values.clientCertMountPath }}
-      {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
+      {{- if and .Values.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
       - name: postgresql-client-cert-original
         secret:
           secretName: postgresql-client-cert
           optional: false
       - name: client-certs-fixed
         emptyDir: {}
-      {{- else }}
-      - name: mongo-app-client-cert
-        secret:
-          secretName: {{ include "nvsentinel.certificates.secretName" . }}
-          {{- include "nvsentinel.certificates.volumeItems" . | nindent 10 }}
-          optional: true
-      {{- end }}
+      {{- else if eq (include "nvsentinel.mongodb.hasCertVolume" .) "true" }}
+      {{- include "nvsentinel.mongodb.certVolume" . | nindent 6 }}
       {{- end }}
       {{- if .Values.global.auditLogging.enabled }}
       {{- include "nvsentinel.auditLogging.volume" . | nindent 6 }}

--- a/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/deployment.yaml
@@ -114,14 +114,15 @@ spec:
             timeoutSeconds: 3
             failureThreshold: 3
           volumeMounts:
-          {{- if .Values.clientCertMountPath }}
+          {{- $certMountPath := include "nvsentinel.mongodb.certMountPath" . }}
+          {{- if $certMountPath }}
           {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
           - name: client-certs-fixed
-            mountPath: {{ .Values.clientCertMountPath }}
+            mountPath: {{ $certMountPath }}
             readOnly: true
-          {{- else }}
+          {{- else if eq (include "nvsentinel.mongodb.hasCertVolume" .) "true" }}
           - name: mongo-app-client-cert
-            mountPath: {{ .Values.clientCertMountPath }}
+            mountPath: {{ $certMountPath }}
             readOnly: true
           {{- end }}
           {{- end }}
@@ -151,13 +152,14 @@ spec:
             value: "{{ .Values.logCollector.enableGcpSosCollection }}"
           - name: ENABLE_AWS_SOS_COLLECTION
             value: "{{ .Values.logCollector.enableAwsSosCollection }}"
-          {{- if .Values.clientCertMountPath }}
+          {{- $certMountPath := include "nvsentinel.mongodb.certMountPath" . }}
+          {{- if $certMountPath }}
           {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
           - name: POSTGRESQL_CLIENT_CERT_MOUNT_PATH
-            value: {{ .Values.clientCertMountPath }}
+            value: {{ $certMountPath }}
           {{- else }}
           - name: MONGODB_CLIENT_CERT_MOUNT_PATH
-            value: {{ .Values.clientCertMountPath }}
+            value: {{ $certMountPath }}
           {{- end }}
           {{- end }}
           envFrom:
@@ -165,21 +167,15 @@ spec:
                 name: {{ if .Values.global.datastore }}{{ .Release.Name }}-datastore-config{{ else }}mongodb-config{{ end }}
                 optional: true
       volumes:
-      {{- if .Values.clientCertMountPath }}
-      {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
+      {{- if and .Values.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
       - name: postgresql-client-cert-original
         secret:
           secretName: postgresql-client-cert
           optional: false
       - name: client-certs-fixed
         emptyDir: {}
-      {{- else }}
-      - name: mongo-app-client-cert
-        secret:
-          secretName: {{ include "nvsentinel.certificates.secretName" . }}
-          {{- include "nvsentinel.certificates.volumeItems" . | nindent 10 }}
-          optional: true
-      {{- end }}
+      {{- else if eq (include "nvsentinel.mongodb.hasCertVolume" .) "true" }}
+      {{- include "nvsentinel.mongodb.certVolume" . | nindent 6 }}
       {{- end }}
       - name: config-volume
         configMap:

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
@@ -77,8 +77,11 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           args:
           - "--metrics-port={{ .Values.global.metricsPort }}"
-          {{- if .Values.clientCertMountPath }}
-          - "--database-client-cert-mount-path={{ .Values.clientCertMountPath }}"
+          {{- $certMountPath := include "nvsentinel.mongodb.certMountPath" . }}
+          {{- if $certMountPath }}
+          - "--database-client-cert-mount-path={{ $certMountPath }}"
+          {{- else }}
+          - "--tls-enabled=false"
           {{- end }}
           - "--processing-strategy={{ .Values.processingStrategy }}"
           ports:
@@ -111,14 +114,15 @@ spec:
           - name: config-volume
             mountPath: /etc/config/config.toml
             subPath: config.toml
-          {{- if .Values.clientCertMountPath }}
+          {{- $certMountPath := include "nvsentinel.mongodb.certMountPath" . }}
+          {{- if $certMountPath }}
           {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
           - name: client-certs-fixed
-            mountPath: {{ .Values.clientCertMountPath }}
+            mountPath: {{ $certMountPath }}
             readOnly: true
-          {{- else }}
+          {{- else if eq (include "nvsentinel.mongodb.hasCertVolume" .) "true" }}
           - name: mongo-app-client-cert
-            mountPath: {{ .Values.clientCertMountPath }}
+            mountPath: {{ $certMountPath }}
             readOnly: true
           {{- end }}
           {{- end }}
@@ -130,13 +134,14 @@ spec:
             # App name for connection identification in logs and currentOp
             - name: APP_NAME
               value: {{ .Chart.Name | quote }}
-            {{- if .Values.clientCertMountPath }}
+            {{- $certMountPath := include "nvsentinel.mongodb.certMountPath" . }}
+            {{- if $certMountPath }}
             {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
             - name: POSTGRESQL_CLIENT_CERT_MOUNT_PATH
-              value: {{ .Values.clientCertMountPath }}
+              value: {{ $certMountPath }}
             {{- else }}
             - name: MONGODB_CLIENT_CERT_MOUNT_PATH
-              value: {{ .Values.clientCertMountPath }}
+              value: {{ $certMountPath }}
             {{- end }}
             {{- end }}
           envFrom:
@@ -153,22 +158,17 @@ spec:
       - name: var-run-vol
         hostPath:
           path: /var/run/nvsentinel
-          type: Directory
-      {{- if .Values.clientCertMountPath }}
-      {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
+          # DirectoryOrCreate avoids MountVolume failures when the path is not yet a directory (race with other workloads).
+          type: DirectoryOrCreate
+      {{- if and .Values.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
       - name: postgresql-client-cert-original
         secret:
           secretName: postgresql-client-cert
           optional: false
       - name: client-certs-fixed
         emptyDir: {}
-      {{- else }}
-      - name: mongo-app-client-cert
-        secret:
-          secretName: {{ include "nvsentinel.certificates.secretName" . }}
-          {{- include "nvsentinel.certificates.volumeItems" . | nindent 10 }}
-          optional: true
-      {{- end }}
+      {{- else if eq (include "nvsentinel.mongodb.hasCertVolume" .) "true" }}
+      {{- include "nvsentinel.mongodb.certVolume" . | nindent 6 }}
       {{- end }}
       restartPolicy: Always
       {{- with (.Values.global.systemNodeSelector | default .Values.nodeSelector) }}

--- a/distros/kubernetes/nvsentinel/charts/node-drainer/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/node-drainer/templates/deployment.yaml
@@ -111,8 +111,9 @@ spec:
           - "--metrics-port={{ .Values.global.metricsPort }}"
           - "--config-path=/etc/config/config.toml"
           - "--dry-run={{ .Values.global.dryRun }}"
-          {{- if .Values.clientCertMountPath }}
-          - "--database-client-cert-mount-path={{ .Values.clientCertMountPath }}"
+          {{- $certMountPath := include "nvsentinel.mongodb.certMountPath" . }}
+          {{- if $certMountPath }}
+          - "--database-client-cert-mount-path={{ $certMountPath }}"
           {{- else }}
           - "--tls-enabled=false"
           {{- end }}
@@ -120,14 +121,15 @@ spec:
           - name: config-volume
             mountPath: /etc/config/config.toml
             subPath: config.toml
-          {{- if .Values.clientCertMountPath }}
+          {{- $certMountPath := include "nvsentinel.mongodb.certMountPath" . }}
+          {{- if $certMountPath }}
           {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
           - name: client-certs-fixed
-            mountPath: {{ .Values.clientCertMountPath }}
+            mountPath: {{ $certMountPath }}
             readOnly: true
-          {{- else }}
+          {{- else if eq (include "nvsentinel.mongodb.hasCertVolume" .) "true" }}
           - name: mongo-app-client-cert
-            mountPath: {{ .Values.clientCertMountPath }}
+            mountPath: {{ $certMountPath }}
             readOnly: true
           {{- end }}
           {{- end }}
@@ -152,13 +154,14 @@ spec:
             {{- if .Values.global.auditLogging.enabled }}
             {{- include "nvsentinel.auditLogging.envVars" . | nindent 12 }}
             {{- end }}
-            {{- if .Values.clientCertMountPath }}
+            {{- $certMountPath := include "nvsentinel.mongodb.certMountPath" . }}
+            {{- if $certMountPath }}
             {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
             - name: POSTGRESQL_CLIENT_CERT_MOUNT_PATH
-              value: {{ .Values.clientCertMountPath }}
+              value: {{ $certMountPath }}
             {{- else }}
             - name: MONGODB_CLIENT_CERT_MOUNT_PATH
-              value: {{ .Values.clientCertMountPath }}
+              value: {{ $certMountPath }}
             {{- end }}
             {{- end }}
           envFrom:
@@ -172,21 +175,15 @@ spec:
           items:
           - key: config.toml
             path: config.toml
-      {{- if .Values.clientCertMountPath }}
-      {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
+      {{- if and .Values.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
       - name: postgresql-client-cert-original
         secret:
           secretName: postgresql-client-cert
           optional: false
       - name: client-certs-fixed
         emptyDir: {}
-      {{- else }}
-      - name: mongo-app-client-cert
-        secret:
-          secretName: {{ include "nvsentinel.certificates.secretName" . }}
-          {{- include "nvsentinel.certificates.volumeItems" . | nindent 10 }}
-          optional: true
-      {{- end }}
+      {{- else if eq (include "nvsentinel.mongodb.hasCertVolume" .) "true" }}
+      {{- include "nvsentinel.mongodb.certVolume" . | nindent 6 }}
       {{- end }}
       {{- if .Values.customDrain.enabled }}
       - name: drain-template

--- a/distros/kubernetes/nvsentinel/templates/_helpers.tpl
+++ b/distros/kubernetes/nvsentinel/templates/_helpers.tpl
@@ -105,13 +105,153 @@ Audit logging environment variables
 {{- end }}
 
 {{/*
-MongoDB client certificate secret name
+MongoDB client certificate secret name.
+Returns (in priority order):
+  1. global.datastore.auth.clientCertSecretName  (x509 auth with user-provided cert)
+  2. global.datastore.certificates.secretName     (legacy configurable name)
+  3. mongo-app-client-cert-secret                 (default: cert-manager generated)
 */}}
 {{- define "nvsentinel.certificates.secretName" -}}
-{{- if and .Values.global.datastore .Values.global.datastore.certificates .Values.global.datastore.certificates.secretName -}}
+{{- if and .Values.global.datastore .Values.global.datastore.auth .Values.global.datastore.auth.clientCertSecretName -}}
+{{ .Values.global.datastore.auth.clientCertSecretName }}
+{{- else if and .Values.global.datastore .Values.global.datastore.certificates .Values.global.datastore.certificates.secretName -}}
 {{ .Values.global.datastore.certificates.secretName }}
 {{- else -}}
 mongo-app-client-cert-secret
+{{- end -}}
+{{- end -}}
+
+{{/*
+Renders the MongoDB certificate volume definition for a pod spec.
+Handles three cases:
+  1. External MongoDB with x509 auth  → user-provided client cert secret (tls.crt, tls.key, ca.crt)
+  2. External MongoDB with scram + CA → user-provided CA cert secret (ca.crt only)
+  3. Internal MongoDB (default)       → cert-manager generated secret (optional: true)
+Returns empty string if no cert volume is needed (external MongoDB, no certs configured).
+*/}}
+{{- define "nvsentinel.mongodb.certVolume" -}}
+{{- $useExternal := and .Values.global.datastore
+                        (eq .Values.global.datastore.provider "mongodb")
+                        (not .Values.global.mongodbStore.enabled) -}}
+{{- if $useExternal -}}
+  {{- $authMechanism := "scram" -}}
+  {{- if and .Values.global.datastore.auth .Values.global.datastore.auth.mechanism -}}
+  {{- $authMechanism = .Values.global.datastore.auth.mechanism -}}
+  {{- end -}}
+  {{- $clientCertSecret := "" -}}
+  {{- if and .Values.global.datastore.auth .Values.global.datastore.auth.clientCertSecretName -}}
+  {{- $clientCertSecret = .Values.global.datastore.auth.clientCertSecretName -}}
+  {{- end -}}
+  {{- $caSecret := "" -}}
+  {{- if and .Values.global.datastore.tls .Values.global.datastore.tls.caSecretName -}}
+  {{- $caSecret = .Values.global.datastore.tls.caSecretName -}}
+  {{- end -}}
+  {{- if and (eq $authMechanism "x509") (ne $clientCertSecret "") -}}
+- name: mongo-app-client-cert
+  secret:
+    secretName: {{ $clientCertSecret }}
+    {{- include "nvsentinel.certificates.volumeItems" . | nindent 4 }}
+    optional: false
+  {{- else if ne $caSecret "" -}}
+- name: mongo-app-client-cert
+  secret:
+    secretName: {{ $caSecret }}
+    items:
+    - key: ca.crt
+      path: ca.crt
+    optional: false
+  {{- end -}}
+  {{- /* else: no cert volume — external MongoDB with no custom CA or client certs configured */}}
+{{- else -}}
+- name: mongo-app-client-cert
+  secret:
+    secretName: {{ include "nvsentinel.certificates.secretName" . }}
+    {{- include "nvsentinel.certificates.volumeItems" . | nindent 4 }}
+    optional: true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns "true" if a MongoDB cert volume will be rendered by nvsentinel.mongodb.certVolume,
+"false" otherwise. Use this to conditionally render the corresponding volume mount.
+*/}}
+{{- define "nvsentinel.mongodb.hasCertVolume" -}}
+{{- $useExternal := and .Values.global.datastore
+                        (eq .Values.global.datastore.provider "mongodb")
+                        (not .Values.global.mongodbStore.enabled) -}}
+{{- if $useExternal -}}
+  {{- $authMechanism := "scram" -}}
+  {{- if and .Values.global.datastore.auth .Values.global.datastore.auth.mechanism -}}
+  {{- $authMechanism = .Values.global.datastore.auth.mechanism -}}
+  {{- end -}}
+  {{- $clientCertSecret := "" -}}
+  {{- if and .Values.global.datastore.auth .Values.global.datastore.auth.clientCertSecretName -}}
+  {{- $clientCertSecret = .Values.global.datastore.auth.clientCertSecretName -}}
+  {{- end -}}
+  {{- $caSecret := "" -}}
+  {{- if and .Values.global.datastore.tls .Values.global.datastore.tls.caSecretName -}}
+  {{- $caSecret = .Values.global.datastore.tls.caSecretName -}}
+  {{- end -}}
+  {{- if or (and (eq $authMechanism "x509") (ne $clientCertSecret "")) (ne $caSecret "") -}}
+true
+  {{- else -}}
+false
+  {{- end -}}
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns the effective MongoDB cert mount path for a pod.
+- Returns .Values.clientCertMountPath if explicitly set (covers x509 client-cert and CA-only modes).
+- Returns /etc/ssl/mongo-ca only for external MongoDB SCRAM + custom CA (caSecretName set,
+  clientCertMountPath empty). Do not use this fallback for in-cluster MongoDB when
+  clientCertMountPath is empty — e.g. values-tilt-mongodb-tls-disabled.yaml disables TLS
+  by setting clientCertMountPath to ""; hasCertVolume is still true in-cluster, but there
+  is no CA secret and no file at /etc/ssl/mongo-ca/ca.crt.
+- Returns empty string otherwise.
+*/}}
+{{- define "nvsentinel.mongodb.certMountPath" -}}
+{{- if .Values.clientCertMountPath -}}
+{{ .Values.clientCertMountPath }}
+{{- else -}}
+  {{- $useExternal := and .Values.global.datastore
+                          (eq .Values.global.datastore.provider "mongodb")
+                          (not .Values.global.mongodbStore.enabled) -}}
+  {{- if $useExternal -}}
+    {{- $caSecret := "" -}}
+    {{- if and .Values.global.datastore.tls .Values.global.datastore.tls.caSecretName -}}
+    {{- $caSecret = .Values.global.datastore.tls.caSecretName -}}
+    {{- end -}}
+    {{- if ne $caSecret "" -}}
+/etc/ssl/mongo-ca
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Same path resolution as nvsentinel.mongodb.certMountPath but reads
+.Values.mongodbStore.clientCertMountPath (event-exporter subchart layout).
+Use this only from charts that store the path under mongodbStore.
+*/}}
+{{- define "nvsentinel.mongodb.certMountPathFromMongoStore" -}}
+{{- if .Values.mongodbStore.clientCertMountPath -}}
+{{ .Values.mongodbStore.clientCertMountPath }}
+{{- else -}}
+  {{- $useExternal := and .Values.global.datastore
+                          (eq .Values.global.datastore.provider "mongodb")
+                          (not .Values.global.mongodbStore.enabled) -}}
+  {{- if $useExternal -}}
+    {{- $caSecret := "" -}}
+    {{- if and .Values.global.datastore.tls .Values.global.datastore.tls.caSecretName -}}
+    {{- $caSecret = .Values.global.datastore.tls.caSecretName -}}
+    {{- end -}}
+    {{- if ne $caSecret "" -}}
+/etc/ssl/mongo-ca
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/distros/kubernetes/nvsentinel/templates/configmap-datastore.yaml
+++ b/distros/kubernetes/nvsentinel/templates/configmap-datastore.yaml
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 {{- if .Values.global.datastore }}
+{{- /* Default connection port when not set: PostgreSQL 5432, MongoDB 27017 */}}
+{{- $defaultDatastorePort := ternary 27017 5432 (eq .Values.global.datastore.provider "mongodb") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -23,10 +25,18 @@ metadata:
 data:
   datastore.yaml: |
     provider: {{ .Values.global.datastore.provider | quote }}
+    {{- if .Values.global.datastore.uri }}
+    uri: {{ .Values.global.datastore.uri | quote }}
+    {{- end }}
+    {{- if .Values.global.datastore.connection }}
     connection:
+      {{- if .Values.global.datastore.connection.host }}
       host: {{ .Values.global.datastore.connection.host | quote }}
-      port: {{ .Values.global.datastore.connection.port | default 5432 }}
+      {{- end }}
+      port: {{ .Values.global.datastore.connection.port | default $defaultDatastorePort }}
+      {{- if .Values.global.datastore.connection.database }}
       database: {{ .Values.global.datastore.connection.database | quote }}
+      {{- end }}
       {{- if .Values.global.datastore.connection.username }}
       username: {{ .Values.global.datastore.connection.username | quote }}
       {{- end }}
@@ -46,6 +56,14 @@ data:
       extraParams:
         {{- toYaml .Values.global.datastore.connection.extraParams | nindent 8 }}
       {{- end }}
+    {{- end }}
+    {{- if .Values.global.datastore.tls }}
+    tls:
+      enabled: {{ .Values.global.datastore.tls.enabled | default true }}
+      {{- if .Values.global.datastore.tls.caSecretName }}
+      caSecretName: {{ .Values.global.datastore.tls.caSecretName | quote }}
+      {{- end }}
+    {{- end }}
     {{- if .Values.global.datastore.options }}
     options:
       {{- toYaml .Values.global.datastore.options | nindent 6 }}
@@ -53,9 +71,14 @@ data:
 
   # Environment variables for components
   DATASTORE_PROVIDER: {{ .Values.global.datastore.provider | quote }}
+  {{- if .Values.global.datastore.connection }}
+  {{- if .Values.global.datastore.connection.host }}
   DATASTORE_HOST: {{ .Values.global.datastore.connection.host | quote }}
-  DATASTORE_PORT: {{ .Values.global.datastore.connection.port | default 5432 | quote }}
+  {{- end }}
+  DATASTORE_PORT: {{ .Values.global.datastore.connection.port | default $defaultDatastorePort | quote }}
+  {{- if .Values.global.datastore.connection.database }}
   DATASTORE_DATABASE: {{ .Values.global.datastore.connection.database | quote }}
+  {{- end }}
   {{- if .Values.global.datastore.connection.username }}
   DATASTORE_USERNAME: {{ .Values.global.datastore.connection.username | quote }}
   {{- end }}
@@ -71,6 +94,7 @@ data:
   {{- if .Values.global.datastore.connection.sslrootcert }}
   DATASTORE_SSLROOTCERT: {{ .Values.global.datastore.connection.sslrootcert | quote }}
   {{- end }}
+  {{- end }}
 
   # Certificate rotation configuration (MongoDB only)
   # When enabled, client certificates can be rotated without restarting pods
@@ -78,9 +102,31 @@ data:
   MONGODB_ENABLE_CERT_ROTATION: {{ .Values.global.certificateRotationEnabled | default false | quote }}
   {{- end }}
 
-  # Legacy MongoDB environment variables for backward compatibility
-  # These are set for all providers to support legacy code paths that still use the old config system
+  # TLS configuration
+  # Controls whether TLS is used when connecting to the database.
+  # For external DBs without TLS support, set global.datastore.tls.enabled: false
   {{- if eq .Values.global.datastore.provider "mongodb" }}
+  {{- if and .Values.global.datastore.tls (not (kindIs "invalid" .Values.global.datastore.tls.enabled)) }}
+  MONGODB_TLS_ENABLED: {{ .Values.global.datastore.tls.enabled | quote }}
+  {{- else }}
+  MONGODB_TLS_ENABLED: "true"
+  {{- end }}
+  {{- end }}
+
+  # MongoDB connection URI
+  # If global.datastore.uri is set, it is used directly (supports full connection strings
+  # for external/managed services like Atlas, DocumentDB, Cosmos DB).
+  # Otherwise, URI is constructed from individual connection fields (host, port, extraParams).
+  #
+  # NOTE: Unlike the internal mongodb-config ConfigMap (which stores credential-free cluster
+  # addresses), external managed-service URIs may embed username:password directly in the
+  # connection string. ConfigMaps cannot reference Secret values, so credentials must be
+  # supplied via --set-string at deploy time or a secrets manager (e.g., helm-secrets, ESO).
+  # Migrating MONGODB_URI to a secretKeyRef-backed env var is tracked as a follow-up.
+  {{- if eq .Values.global.datastore.provider "mongodb" }}
+  {{- if .Values.global.datastore.uri }}
+  MONGODB_URI: {{ .Values.global.datastore.uri | quote }}
+  {{- else if .Values.global.datastore.connection }}
   {{- $mongodbURI := printf "mongodb://%s:%d/" .Values.global.datastore.connection.host (int (.Values.global.datastore.connection.port | default 27017)) }}
   {{- if .Values.global.datastore.connection.extraParams }}
   {{- $params := list }}
@@ -90,19 +136,45 @@ data:
   {{- $mongodbURI = printf "%s?%s" $mongodbURI (join "&" $params) }}
   {{- end }}
   MONGODB_URI: {{ $mongodbURI | quote }}
+  {{- end }}
   {{- else }}
   # For non-MongoDB datastores, set empty MongoDB URI
   MONGODB_URI: ""
   {{- end }}
+  {{- if .Values.global.datastore.connection }}
+  {{- if .Values.global.datastore.connection.database }}
   MONGODB_DATABASE_NAME: {{ .Values.global.datastore.connection.database | quote }}
+  {{- end }}
   {{- if .Values.global.datastore.connection.collection }}
   MONGODB_COLLECTION_NAME: {{ .Values.global.datastore.connection.collection | quote }}
   {{- else }}
-  MONGODB_COLLECTION_NAME: "health_events"
+  MONGODB_COLLECTION_NAME: "HealthEvents"
   {{- end }}
   {{- if .Values.global.datastore.connection.tokenCollection }}
   MONGODB_TOKEN_COLLECTION_NAME: {{ .Values.global.datastore.connection.tokenCollection | quote }}
   {{- else }}
   MONGODB_TOKEN_COLLECTION_NAME: "ResumeTokens"
   {{- end }}
+  {{- if .Values.global.datastore.connection.maintenanceEventCollection }}
+  MONGODB_MAINTENANCE_EVENT_COLLECTION_NAME: {{ .Values.global.datastore.connection.maintenanceEventCollection | quote }}
+  {{- else }}
+  MONGODB_MAINTENANCE_EVENT_COLLECTION_NAME: "MaintenanceEvents"
+  {{- end }}
+  {{- else if .Values.global.datastore.database }}
+  MONGODB_DATABASE_NAME: {{ .Values.global.datastore.database | quote }}
+  MONGODB_COLLECTION_NAME: "HealthEvents"
+  MONGODB_TOKEN_COLLECTION_NAME: "ResumeTokens"
+  MONGODB_MAINTENANCE_EVENT_COLLECTION_NAME: "MaintenanceEvents"
+  {{- end }}
+
+  # Operational defaults — same values as internal mongodb-config.
+  # These control timeouts, retry intervals, and TTL for collections.
+  MONGODB_COLLECTION_EXPIRY_SECONDS: "2592000"
+  MONGODB_PING_TIMEOUT_TOTAL_SECONDS: "30"
+  MONGODB_PING_INTERVAL_SECONDS: "5"
+  CA_CERT_MOUNT_TIMEOUT_TOTAL_SECONDS: "360"
+  CA_CERT_READ_INTERVAL_SECONDS: "5"
+  MONGODB_CHANGE_STREAM_RETRY_DEADLINE_SECONDS: "300"
+  MONGODB_CHANGE_STREAM_RETRY_INTERVAL_SECONDS: "5"
+  UNPROCESSED_EVENTS_METRIC_UPDATE_INTERVAL_SECONDS: "25"
 {{- end }}

--- a/distros/kubernetes/nvsentinel/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/templates/configmap.yaml
@@ -27,7 +27,7 @@ data:
       "MaxNodeConditionMessageLength": {{ .Values.platformConnector.k8sConnector.maxNodeConditionMessageLength }},
       "CompactedHealthEventMsgLen": {{ .Values.platformConnector.k8sConnector.compactedHealthEventMsgLen }},
       "StoreConnectorMaxRetries": {{ .Values.platformConnector.mongodbStore.maxRetries }},
-      "enableMongoDBStorePlatformConnector": "{{ .Values.global.mongodbStore.enabled }}",
+      "enableMongoDBStorePlatformConnector": "{{ or .Values.global.mongodbStore.enabled (and .Values.global.datastore (eq (default "" .Values.global.datastore.provider) "mongodb")) }}",
       "enablePostgresDBStorePlatformConnector": {{ if and .Values.global.datastore .Values.global.datastore.provider }}{{ eq .Values.global.datastore.provider "postgresql" | quote }}{{ else }}"false"{{ end }}
       {{- with .Values.platformConnector.pipeline }}
       ,"pipeline": {{ . | toJson }}

--- a/distros/kubernetes/nvsentinel/templates/daemonset.yaml
+++ b/distros/kubernetes/nvsentinel/templates/daemonset.yaml
@@ -46,12 +46,12 @@ spec:
       securityContext:
         fsGroup: 65532
       {{- end }}
-      {{- if or .Values.global.auditLogging.enabled (and .Values.platformConnector.postgresqlStore.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql")) }}
+      {{- if or .Values.global.auditLogging.enabled (and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql")) }}
       initContainers:
         {{- if .Values.global.auditLogging.enabled }}
         {{- include "nvsentinel.auditLogging.initContainer" . | nindent 8 }}
         {{- end }}
-      {{- if and .Values.platformConnector.postgresqlStore.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
+      {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
         - name: fix-cert-permissions
           image: "{{ .Values.global.initContainerImage.repository }}:{{ .Values.global.initContainerImage.tag }}"
           imagePullPolicy: {{ .Values.global.initContainerImage.pullPolicy }}
@@ -80,6 +80,7 @@ spec:
       {{- end }}
       containers:
         - name: platform-connector
+          {{- $mongoPC := .Values.platformConnector.mongodbStore.clientCertMountPath | default (include "nvsentinel.mongodb.certMountPath" . | trim) }}
           image: "{{ .Values.platformConnector.image.repository }}:{{ .Values.platformConnector.image.tag | default .Values.global.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.platformConnector.image.pullPolicy }}
           securityContext:
@@ -115,17 +116,12 @@ spec:
           - "--config=/etc/config/config.json"
           - "--metrics-port={{ .Values.global.metricsPort }}"
           {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
-          {{- if .Values.platformConnector.postgresqlStore.clientCertMountPath }}
           - "--database-client-cert-mount-path={{ .Values.platformConnector.postgresqlStore.clientCertMountPath }}"
+          {{- else if $mongoPC }}
+          - "--mongo-client-cert-mount-path={{ $mongoPC }}"
           {{- else }}
+          {{- /* platform-connectors uses RegisterDatabaseCertFlags; explicit TLS off when no cert mount (e.g. Tilt Mongo TLS disabled). */}}
           - "--tls-enabled=false"
-          {{- end }}
-          {{- else }}
-          {{- if .Values.platformConnector.mongodbStore.clientCertMountPath }}
-          - "--mongo-client-cert-mount-path={{ .Values.platformConnector.mongodbStore.clientCertMountPath }}"
-          {{- else }}
-          - "--tls-enabled=false"
-          {{- end }}
           {{- end }}
           - "--socket={{ .Values.socketPath }}"
           resources:
@@ -135,18 +131,14 @@ spec:
               mountPath: /var/run
             - name: platform-connector-configmap
               mountPath: /etc/config/
-            {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
-            {{- if .Values.platformConnector.postgresqlStore.clientCertMountPath }}
+            {{- if and .Values.platformConnector.postgresqlStore.clientCertMountPath .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
             - name: client-certs-fixed
               mountPath: {{ .Values.platformConnector.postgresqlStore.clientCertMountPath }}
               readOnly: true
-            {{- end }}
-            {{- else }}
-            {{- if .Values.platformConnector.mongodbStore.clientCertMountPath }}
+            {{- else if and (eq (include "nvsentinel.mongodb.hasCertVolume" .) "true") $mongoPC }}
             - name: mongo-app-client-cert
-              mountPath: {{ .Values.platformConnector.mongodbStore.clientCertMountPath }}
+              mountPath: {{ $mongoPC }}
               readOnly: true
-            {{- end }}
             {{- end }}
             {{- if .Values.global.auditLogging.enabled }}
             {{- include "nvsentinel.auditLogging.volumeMount" . | nindent 12 }}
@@ -170,15 +162,11 @@ spec:
             {{- include "nvsentinel.auditLogging.envVars" . | nindent 12 }}
             {{- end }}
             {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
-            {{- if .Values.platformConnector.postgresqlStore.clientCertMountPath }}
             - name: POSTGRESQL_CLIENT_CERT_MOUNT_PATH
               value: {{ .Values.platformConnector.postgresqlStore.clientCertMountPath }}
-            {{- end }}
             {{- else }}
-            {{- if .Values.platformConnector.mongodbStore.clientCertMountPath }}
             - name: MONGODB_CLIENT_CERT_MOUNT_PATH
-              value: {{ .Values.platformConnector.mongodbStore.clientCertMountPath }}
-            {{- end }}
+              value: {{ $mongoPC }}
             {{- end }}
           envFrom:
             - configMapRef:
@@ -193,22 +181,14 @@ spec:
           configMap:
             name: {{ include "nvsentinel.fullname" . }}
         {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}
-        {{- if .Values.platformConnector.postgresqlStore.clientCertMountPath }}
         - name: postgresql-client-cert-original
           secret:
             secretName: postgresql-client-cert
             optional: false
         - name: client-certs-fixed
           emptyDir: {}
-        {{- end }}
         {{- else }}
-        {{- if .Values.platformConnector.mongodbStore.clientCertMountPath }}
-        - name: mongo-app-client-cert
-          secret:
-            secretName: {{ include "nvsentinel.certificates.secretName" . }}
-            {{- include "nvsentinel.certificates.volumeItems" . | nindent 12 }}
-            optional: true
-        {{- end }}
+        {{- include "nvsentinel.mongodb.certVolume" . | nindent 8 }}
         {{- end }}
         {{- if .Values.global.auditLogging.enabled }}
         {{- include "nvsentinel.auditLogging.volume" . | nindent 8 }}

--- a/distros/kubernetes/nvsentinel/templates/job-external-mongodb-setup.yaml
+++ b/distros/kubernetes/nvsentinel/templates/job-external-mongodb-setup.yaml
@@ -1,0 +1,283 @@
+{{/*
+Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+{{/*
+This job runs only when using an external MongoDB (mongodbStore.enabled=false +
+global.datastore set with provider=mongodb). It creates the required database,
+collections, and indexes in the external MongoDB.
+
+When using internal MongoDB (mongodbStore.enabled=true), the equivalent job runs
+inside the mongodb-store subchart instead.
+*/}}
+{{- $useExternalMongodb := and .Values.global.datastore
+                               (eq .Values.global.datastore.provider "mongodb")
+                               (not .Values.global.mongodbStore.enabled) }}
+{{- if $useExternalMongodb }}
+
+{{- $setupJob := ((.Values.global.datastore).setupJob) | default dict }}
+{{- $image := ($setupJob.image) | default dict }}
+{{- $imageRepo := $image.repository | default "ghcr.io/rtsp/docker-mongosh" }}
+{{- $imageTag := $image.tag | default "2.5.2" }}
+{{- $imagePullPolicy := $image.pullPolicy | default "IfNotPresent" }}
+
+{{- $tlsEnabled := true }}
+{{- if and .Values.global.datastore.tls (kindIs "bool" .Values.global.datastore.tls.enabled) }}
+{{- $tlsEnabled = .Values.global.datastore.tls.enabled }}
+{{- end }}
+
+{{- $authMechanism := "scram" }}
+{{- if and .Values.global.datastore.auth .Values.global.datastore.auth.mechanism }}
+{{- $authMechanism = .Values.global.datastore.auth.mechanism }}
+{{- end }}
+
+{{- $caSecretName := "" }}
+{{- if and .Values.global.datastore.tls .Values.global.datastore.tls.caSecretName }}
+{{- $caSecretName = .Values.global.datastore.tls.caSecretName }}
+{{- end }}
+
+{{- $clientCertSecretName := "" }}
+{{- if and .Values.global.datastore.auth .Values.global.datastore.auth.clientCertSecretName }}
+{{- $clientCertSecretName = .Values.global.datastore.auth.clientCertSecretName }}
+{{- end }}
+
+{{- $adminSecret := "" }}
+{{- if $setupJob.adminSecret }}
+{{- $adminSecret = $setupJob.adminSecret }}
+{{- else if and .Values.global.datastore.auth .Values.global.datastore.auth.existingSecret }}
+{{- $adminSecret = .Values.global.datastore.auth.existingSecret }}
+{{- end }}
+
+{{- $needCertVolume := or (ne $caSecretName "") (ne $clientCertSecretName "") }}
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-external-mongodb-setup
+  labels:
+    {{- include "nvsentinel.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  activeDeadlineSeconds: 600
+  template:
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: mongo-setup
+        image: "{{ $imageRepo }}:{{ $imageTag }}"
+        imagePullPolicy: {{ $imagePullPolicy }}
+        command:
+          - sh
+          - -c
+          - |
+            set -e
+
+            echo "=============================="
+            echo "Starting external MongoDB setup job..."
+            echo "=============================="
+            echo "MONGODB_URI:          [REDACTED]"
+            echo "MONGODB_DATABASE_NAME: $MONGODB_DATABASE_NAME"
+            echo "MONGODB_TLS_ENABLED:  $MONGODB_TLS_ENABLED"
+            echo "MONGODB_AUTH_MECHANISM: $MONGODB_AUTH_MECHANISM"
+
+            # Build mongosh connection arguments dynamically
+            MONGOSH_ARGS="$MONGODB_URI"
+
+            # TLS flags
+            if [ "$MONGODB_TLS_ENABLED" = "true" ]; then
+              MONGOSH_ARGS="$MONGOSH_ARGS --tls"
+              # CA cert may come from a dedicated CA secret or from the client cert secret
+              if [ -f /ca-certs/ca.crt ]; then
+                MONGOSH_ARGS="$MONGOSH_ARGS --tlsCAFile /ca-certs/ca.crt"
+                echo "Using CA cert: /ca-certs/ca.crt"
+              elif [ -f /client-certs/ca.crt ]; then
+                MONGOSH_ARGS="$MONGOSH_ARGS --tlsCAFile /client-certs/ca.crt"
+                echo "Using CA cert: /client-certs/ca.crt"
+              else
+                echo "No CA cert found, using system CAs"
+              fi
+            fi
+
+            # X.509 client cert (only for x509 auth mechanism)
+            if [ "$MONGODB_AUTH_MECHANISM" = "x509" ]; then
+              if [ -f /client-certs/tls.crt ] && [ -f /client-certs/tls.key ]; then
+                cat /client-certs/tls.crt /client-certs/tls.key > /tmp/client.pem
+                MONGOSH_ARGS="$MONGOSH_ARGS --tlsCertificateKeyFile /tmp/client.pem"
+                MONGOSH_ARGS="$MONGOSH_ARGS --authenticationMechanism MONGODB-X509"
+                echo "Using X.509 client certificate"
+              else
+                echo "ERROR: auth.mechanism=x509 but no client cert found at /client-certs/tls.crt"
+                exit 1
+              fi
+            fi
+
+            # SCRAM credentials (only if provided via adminSecret and not embedded in URI)
+            if [ -n "$MONGODB_ADMIN_USERNAME" ] && [ -n "$MONGODB_ADMIN_PASSWORD" ]; then
+              MONGOSH_ARGS="$MONGOSH_ARGS --username $MONGODB_ADMIN_USERNAME \
+                --password $MONGODB_ADMIN_PASSWORD \
+                --authenticationDatabase admin \
+                --authenticationMechanism SCRAM-SHA-256"
+              echo "Using SCRAM-SHA-256 with provided credentials"
+            fi
+
+            echo "=============================="
+            echo "Connecting to MongoDB and creating collections..."
+            echo "=============================="
+
+            until mongosh $MONGOSH_ARGS \
+              --eval "
+                db = db.getSiblingDB('$MONGODB_DATABASE_NAME');
+
+                // Create collections if they don't exist
+                ['$MONGODB_COLLECTION_NAME',
+                 '$MONGODB_TOKEN_COLLECTION_NAME',
+                 '$MONGODB_MAINTENANCE_EVENT_COLLECTION_NAME'].forEach(function(col) {
+                  if (!db.getCollectionNames().includes(col)) {
+                    db.createCollection(col);
+                    print('Created collection: ' + col);
+                  } else {
+                    print('Collection already exists: ' + col);
+                  }
+                });
+
+                // Create TTL and query indexes
+                db.$MONGODB_COLLECTION_NAME.createIndex(
+                  { 'createdAt': 1 },
+                  { expireAfterSeconds: $MONGODB_COLLECTION_EXPIRY_SECONDS }
+                );
+                db.$MONGODB_MAINTENANCE_EVENT_COLLECTION_NAME.createIndex(
+                  { 'actualEndTime': 1 },
+                  { expireAfterSeconds: $MONGODB_COLLECTION_EXPIRY_SECONDS }
+                );
+                db.$MONGODB_MAINTENANCE_EVENT_COLLECTION_NAME.createIndex(
+                  { 'scheduledStartTime': 1 }
+                );
+                db.$MONGODB_MAINTENANCE_EVENT_COLLECTION_NAME.createIndex(
+                  { 'cspStatus': 1 }
+                );
+                db.$MONGODB_COLLECTION_NAME.createIndex({
+                  'healthevent.nodename': 1,
+                  'healthevent.entitiesimpacted.entitytype': 1,
+                  'healthevent.entitiesimpacted.entityvalue': 1,
+                  'healthevent.generatedtimestamp.seconds': 1
+                });
+
+                {{- if eq $authMechanism "x509" }}
+                // X.509 user creation (only for x509 auth mechanism)
+                var appUserDN = '$MONGODB_APPLICATION_USER_DN';
+                var opsUserDN = '$MONGODB_DGXCOPS_USER_DN';
+
+                var userExists = db.getSiblingDB('\$external').getUser(appUserDN);
+                if (userExists) {
+                  print('App user already exists, skipping.');
+                } else {
+                  db.getSiblingDB('\$external').runCommand({
+                    createUser: appUserDN,
+                    roles: [{ role: 'readWrite', db: '$MONGODB_DATABASE_NAME' }]
+                  });
+                  print('App user created: ' + appUserDN);
+                }
+
+                var opsUserExists = db.getSiblingDB('\$external').getUser(opsUserDN);
+                if (opsUserExists) {
+                  print('Ops user already exists, skipping.');
+                } else {
+                  db.getSiblingDB('\$external').runCommand({
+                    createUser: opsUserDN,
+                    roles: [{ role: 'read', db: '$MONGODB_DATABASE_NAME' }]
+                  });
+                  print('Ops user created: ' + opsUserDN);
+                }
+                {{- end }}
+
+                print('MongoDB setup complete.');
+              "
+            do
+              echo "Waiting for MongoDB to be ready...";
+              sleep 5;
+            done
+
+            echo "=============================="
+            echo "External MongoDB setup completed."
+            echo "=============================="
+        env:
+          - name: MONGODB_TLS_ENABLED
+            value: {{ $tlsEnabled | quote }}
+          - name: MONGODB_AUTH_MECHANISM
+            value: {{ $authMechanism | quote }}
+          {{- if eq $authMechanism "x509" }}
+          - name: MONGODB_APPLICATION_USER_DN
+            value: {{ (.Values.global.datastore.auth).x509ApplicationUserDN | default "CN=mongo-user-client,OU=DGXC,O=Nvidia,L=SantaClara,ST=California,C=US" | quote }}
+          - name: MONGODB_DGXCOPS_USER_DN
+            value: {{ (.Values.global.datastore.auth).x509DgxcopsUserDN | default "CN=mongo-dgxcops-client,OU=DGXC,O=Nvidia,L=SantaClara,ST=California,C=US" | quote }}
+          {{- end }}
+          {{- if ne $adminSecret "" }}
+          - name: MONGODB_ADMIN_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ $adminSecret }}
+                key: username
+          - name: MONGODB_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ $adminSecret }}
+                key: password
+          {{- end }}
+        envFrom:
+          - configMapRef:
+              name: {{ .Release.Name }}-datastore-config
+        {{- if $needCertVolume }}
+        volumeMounts:
+          {{- if ne $clientCertSecretName "" }}
+          - name: mongo-client-certs
+            mountPath: /client-certs
+            readOnly: true
+          {{- end }}
+          {{- if ne $caSecretName "" }}
+          - name: mongo-ca-certs
+            mountPath: /ca-certs
+            readOnly: true
+          {{- end }}
+        {{- end }}
+      {{- if $needCertVolume }}
+      volumes:
+        {{- if ne $clientCertSecretName "" }}
+        # x509 auth: client cert secret (contains tls.crt, tls.key, and optionally ca.crt)
+        - name: mongo-client-certs
+          secret:
+            secretName: {{ $clientCertSecretName }}
+        {{- end }}
+        {{- if ne $caSecretName "" }}
+        # TLS only: CA cert secret (contains ca.crt)
+        - name: mongo-ca-certs
+          secret:
+            secretName: {{ $caSecretName }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.global.systemNodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.systemNodeTolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: OnFailure
+{{- end }}

--- a/distros/kubernetes/nvsentinel/values-atlas-gcp.yaml
+++ b/distros/kubernetes/nvsentinel/values-atlas-gcp.yaml
@@ -1,0 +1,70 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NVSentinel — MongoDB Atlas (GCP) values override
+# See docs/external-datastore.md for setup instructions.
+#
+# Usage:
+#   helm upgrade --install nvsentinel . \
+#     -f values.yaml \
+#     -f values-atlas-gcp.yaml \
+#     --set-string global.datastore.uri="mongodb+srv://<user>:<pass>@<cluster>.mongodb.net/HealthEventsDatabase?retryWrites=false" \
+#     --namespace nvsentinel
+
+global:
+  mongodbStore:
+    enabled: false
+
+  datastore:
+    provider: "mongodb"
+
+    # Full Atlas connection string (mongodb+srv) — must be passed at deploy time
+    # via --set-string (see Usage above). Do not store credentials in this file.
+    # Format: mongodb+srv://<user>:<pass>@<cluster>.mongodb.net/HealthEventsDatabase?retryWrites=false
+    uri: ""
+
+    connection:
+      database: "HealthEventsDatabase"
+
+    tls:
+      enabled: true
+      caSecretName: ""  # Atlas uses public DigiCert CA — system CAs are sufficient.
+
+    auth:
+      mechanism: "scram"
+
+# Atlas uses SCRAM-SHA-256 with no custom CA cert — no client certificate files
+# are needed. clientCertMountPath: "" prevents the cert-polling loop at startup.
+health-events-analyzer:
+  clientCertMountPath: ""
+
+fault-remediation:
+  clientCertMountPath: ""
+
+fault-quarantine:
+  clientCertMountPath: ""
+
+node-drainer:
+  clientCertMountPath: ""
+
+event-exporter:
+  mongodbStore:
+    clientCertMountPath: ""
+
+csp-health-monitor:
+  clientCertMountPath: ""
+
+platformConnector:
+  mongodbStore:
+    clientCertMountPath: ""

--- a/distros/kubernetes/nvsentinel/values-aws-docdb.yaml
+++ b/distros/kubernetes/nvsentinel/values-aws-docdb.yaml
@@ -1,0 +1,72 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NVSentinel — AWS DocumentDB values override
+# See docs/external-datastore.md for setup instructions.
+#
+# Usage:
+#   helm upgrade --install nvsentinel . \
+#     -f values.yaml \
+#     -f values-aws-docdb.yaml \
+#     --set-string global.datastore.uri="mongodb://<user>:<pass>@<cluster>.<region>.docdb.amazonaws.com:27017/?tls=true&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false" \
+#     --namespace nvsentinel
+
+global:
+  mongodbStore:
+    enabled: false
+
+  datastore:
+    provider: "mongodb"
+
+    # Full DocumentDB connection string — must be passed at deploy time via
+    # --set-string (see Usage above). Do not store credentials in this file.
+    # Format: mongodb://<user>:<pass>@<cluster>.<region>.docdb.amazonaws.com:27017/?tls=true&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false
+    uri: ""
+
+    connection:
+      database: "HealthEventsDatabase"
+
+    tls:
+      enabled: true
+      # CA cert secret created from the AWS global CA bundle (see docs/external-datastore.md).
+      caSecretName: "docdb-ca"
+
+    auth:
+      mechanism: "scram"
+
+# DocumentDB uses SCRAM auth with a custom CA cert. clientCertMountPath: "" signals
+# SCRAM mode (no client cert bundle) while still allowing the CA cert to be mounted
+# via the caSecretName above.
+health-events-analyzer:
+  clientCertMountPath: ""
+
+fault-remediation:
+  clientCertMountPath: ""
+
+fault-quarantine:
+  clientCertMountPath: ""
+
+node-drainer:
+  clientCertMountPath: ""
+
+event-exporter:
+  mongodbStore:
+    clientCertMountPath: ""
+
+csp-health-monitor:
+  clientCertMountPath: ""
+
+platformConnector:
+  mongodbStore:
+    clientCertMountPath: ""

--- a/distros/kubernetes/nvsentinel/values-cosmosdb-test.yaml
+++ b/distros/kubernetes/nvsentinel/values-cosmosdb-test.yaml
@@ -1,0 +1,72 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NVSentinel — Azure Cosmos DB for MongoDB values override
+# See docs/external-datastore.md for setup instructions.
+#
+# Usage:
+#   helm upgrade --install nvsentinel . \
+#     -f values.yaml \
+#     -f values-cosmosdb-test.yaml \
+#     --set-string global.datastore.uri="mongodb+srv://<user>:<pass>@<account>.mongocluster.cosmos.azure.com/?tls=true&authMechanism=SCRAM-SHA-256&retrywrites=false&maxIdleTimeMS=120000" \
+#     --namespace nvsentinel
+
+global:
+  mongodbStore:
+    enabled: false
+
+  datastore:
+    provider: "mongodb"
+
+    # Full Cosmos DB connection string — must be passed at deploy time via
+    # --set-string (see Usage above). Do not store credentials in this file.
+    # Format: mongodb+srv://<user>:<pass>@<account>.mongocluster.cosmos.azure.com/?tls=true&authMechanism=SCRAM-SHA-256&retrywrites=false&maxIdleTimeMS=120000
+    # Cosmos DB uses a public DigiCert CA — no custom CA cert required.
+    uri: ""
+
+    connection:
+      database: "HealthEventsDatabase"
+
+    tls:
+      enabled: true
+      caSecretName: ""  # Cosmos DB uses public DigiCert CA — system CAs are sufficient.
+
+    auth:
+      mechanism: "scram"
+
+# Cosmos DB uses SCRAM-SHA-256 with no custom CA cert — no client certificate files
+# are needed. clientCertMountPath: "" prevents the cert-polling loop at startup.
+health-events-analyzer:
+  clientCertMountPath: ""
+
+fault-remediation:
+  clientCertMountPath: ""
+
+fault-quarantine:
+  clientCertMountPath: ""
+
+node-drainer:
+  clientCertMountPath: ""
+
+event-exporter:
+  mongodbStore:
+    clientCertMountPath: ""
+
+csp-health-monitor:
+  clientCertMountPath: ""
+
+
+platformConnector:
+  mongodbStore:
+    clientCertMountPath: ""

--- a/distros/kubernetes/nvsentinel/values.yaml
+++ b/distros/kubernetes/nvsentinel/values.yaml
@@ -23,19 +23,79 @@ global:
   metricsPort: 2112
 
   # Datastore configuration
-  # By default, datastore is not configured (use mongodb-config ConfigMap directly)
-  # To use the centralized datastore configuration, uncomment and configure below
+  # By default, datastore is not configured (internal mongodb-config ConfigMap is used).
+  # Uncomment and configure this section to use an external/managed database service,
+  # or to switch providers (e.g. from MongoDB to PostgreSQL).
+  #
+  # When using an external DB, also set:
+  #   global.mongodbStore.enabled: false   (skip deploying internal MongoDB)
+  #
   # datastore:
-  #   provider: "mongodb"  # or "postgresql"
+  #   # Database provider. Supported values: "mongodb", "postgresql"
+  #   provider: "mongodb"
+  #
+  #   # --- Connection ---
+  #   # Option 1 — full connection URI (use for external/managed MongoDB services).
+  #   # Required for Atlas, DocumentDB, and Cosmos DB which need a full connection string.
+  #   # If set, takes priority over the individual connection fields below.
+  #   # Examples:
+  #   #   MongoDB Atlas:    mongodb+srv://user:pass@cluster.mongodb.net/
+  #   #   AWS DocumentDB:   mongodb://user:pass@cluster.xxx.us-east-1.docdb.amazonaws.com:27017/
+  #   #   Azure Cosmos DB:  mongodb://account:key==@account.mongo.cosmos.azure.com:10255/?ssl=true
+  #   uri: ""
+  #
+  #   # Option 2 — individual connection fields (use for PostgreSQL).
+  #   # PostgreSQL requires separate fields for SSL mode, cert paths, etc.
+  #   # Not needed for external MongoDB — use the uri field above instead.
   #   connection:
-  #     host: "mongodb"
-  #     port: 27017
-  #     database: "nvsentinel"
-  #   certificates:
-  #     secretName: "mongo-app-client-cert-secret"  # Secret containing client certificates
-  #     certKey: "tls.crt"      # Key for client certificate (default: tls.crt)
-  #     keyKey: "tls.key"       # Key for client private key (default: tls.key)
-  #     caKey: "ca.crt"         # Key for CA certificate (default: ca.crt)
+  #     host: ""
+  #     port: 5432           # 5432 for PostgreSQL, 27017 for MongoDB
+  #     database: "HealthEventsDatabase"
+  #     # PostgreSQL-only fields:
+  #     # username: ""
+  #     # sslmode: "require"   # disable | require | verify-ca | verify-full
+  #
+  #   # --- TLS ---
+  #   tls:
+  #     # Set to false only if the external DB does not support TLS (not recommended).
+  #     enabled: true
+  #     # Name of a Kubernetes Secret containing the CA certificate (key: ca.crt).
+  #     # Required when connecting to an external DB with a private/custom CA.
+  #     # Leave empty to use system CAs (e.g. public cloud services with public CA certs).
+  #     caSecretName: ""
+  #
+  #   # --- Authentication ---
+  #   auth:
+  #     # Authentication mechanism:
+  #     #   scram  - username/password (SCRAM-SHA-256). Credentials embedded in uri, or via existingSecret.
+  #     #   x509   - client certificate authentication (used by internal MongoDB).
+  #     mechanism: "scram"
+  #     # For scram: name of a Kubernetes Secret containing DB credentials.
+  #     # Secret must have keys: username, password.
+  #     # Not needed if credentials are already embedded in the uri field above.
+  #     existingSecret: ""
+  #     # For x509: name of a Kubernetes Secret containing the client certificate.
+  #     # Secret must have keys: tls.crt, tls.key, ca.crt.
+  #     clientCertSecretName: ""
+  #     # For x509: Subject DN of the application user certificate.
+  #     # Defaults to the NVIDIA internal DN if not set.
+  #     x509ApplicationUserDN: ""
+  #     # For x509: Subject DN of the dgxcops user certificate.
+  #     # Defaults to the NVIDIA internal DN if not set.
+  #     x509DgxcopsUserDN: ""
+  #
+  #   # --- Database setup job ---
+  #   # The setup job creates required collections and indexes in the external MongoDB.
+  #   # It runs once on install/upgrade when using an external DB.
+  #   setupJob:
+  #     image:
+  #       repository: ghcr.io/rtsp/docker-mongosh
+  #       tag: "2.5.2"
+  #       pullPolicy: IfNotPresent
+  #     # Optional: name of an existing Kubernetes Secret with admin credentials
+  #     # for the setup job to authenticate. Secret must have keys: username, password.
+  #     # Not needed if admin credentials are embedded in the uri field above.
+  #     adminSecret: ""
 
   # Certificate rotation (MongoDB only)
   # When enabled, client certificates can be rotated without restarting pods.

--- a/docs/external-datastore.md
+++ b/docs/external-datastore.md
@@ -1,0 +1,574 @@
+# External Datastore Support for NVSentinel
+
+> This document tracks the design decisions, implementation plan, and per-CSP configuration
+> for connecting NVSentinel to externally managed database services.
+
+---
+
+## Overview
+
+By default, NVSentinel deploys its own MongoDB database inside the same Kubernetes cluster it
+monitors. This works well for general deployments, but creates an overhead problem for lean GPU
+clusters that are focused purely on compute workloads.
+
+This feature adds support for connecting NVSentinel to an **externally managed database** —
+such as a hosted MongoDB or PostgreSQL service from a cloud provider — instead of running one
+inside the monitored cluster.
+
+### Supported External Services (Target)
+
+| Cloud Provider | MongoDB-compatible | PostgreSQL-compatible |
+|---|---|---|
+| AWS | Amazon DocumentDB | Amazon RDS / Aurora PostgreSQL |
+| Azure | Azure Cosmos DB for MongoDB | Azure Database for PostgreSQL |
+| Google Cloud | MongoDB Atlas on GCP | Cloud SQL for PostgreSQL |
+| OCI | MongoDB on OCI | Oracle Autonomous Database |
+
+---
+
+## Problem Statement
+
+- Clusters focused on GPU workloads should not have to host a database
+- Running a 3-replica MongoDB replicaset inside a GPU cluster wastes resources
+- Customers want to use managed, hosted database services from their cloud provider
+- Managed services offer built-in HA, backups, and scaling without operator burden
+
+---
+
+## Design Decision: Configuration Approach
+
+### Options Considered
+
+#### Option A — Extend existing `global.datastore` section
+
+The `global.datastore` section already exists in `values.yaml` as a foundation for
+switching between database providers (MongoDB, PostgreSQL). This same section is extended
+to also support external/hosted databases by adding `uri`, `tls`, and `auth` sub-sections.
+
+**Pros:**
+- `configmap-datastore.yaml` already exists and creates `nvsentinel-datastore-config` when
+  `global.datastore` is set — the Helm scaffolding is in place
+- All 7 DB-consuming service templates (`daemonset`, `fault-quarantine`, `fault-remediation`,
+  `health-events-analyzer`, `node-drainer`, `event-exporter`, `csp-health-monitor`) already
+  contain the switch logic:
+  `{{ if .Values.global.datastore }}nvsentinel-datastore-config{{ else }}mongodb-config{{ end }}`
+- Services that don't use the DB (`janitor`, `labeler`, `syslog-health-monitor`) correctly
+  don't reference either ConfigMap — no changes needed there
+- No new config section needed — less user-facing complexity
+
+**Cons:**
+- Was originally designed for switching providers (mongodb vs postgresql), not for external DB
+  support — the concept is being stretched beyond its original intent
+- Currently lacks `uri`, `tls`, `auth` fields — needs significant extension
+- `configmap-datastore.yaml` constructs `MONGODB_URI` as `mongodb://host:port/` only — it
+  cannot accept raw URIs like `mongodb+srv://user:pass@atlas.mongodb.net/`. Raw URI support
+  must be added.
+- The init job (`mongodb-store/templates/jobs.yaml`) hardcodes `mongodb-config` — it does
+  NOT participate in the `global.datastore` switching path and must be separately updated
+- Risk of confusion between "which provider" and "where is it running" (internal vs external)
+
+#### Option B — New `externalMongodb` / `externalPostgresql` sections
+
+**Pros:**
+- Very explicit and clear — user immediately knows this section is for external databases only
+- No risk of breaking existing teams already using `global.datastore` for PostgreSQL — that
+  section is untouched
+- Each DB type has its own dedicated, focused config — easier to reason about per provider
+- Cleaner separation of concerns: `global.mongodbStore.enabled` controls internal deployment,
+  `externalMongodb` controls external connection — no overlap
+
+**Cons:**
+- Requires a new separate section per database type (`externalMongodb`, `externalPostgresql`) —
+  grows as more providers are added in the future
+- All 7 service templates that already switch on `global.datastore` would need to also handle
+  the new section — more template logic to maintain across the codebase
+- TLS and auth configuration would be duplicated per DB type section (e.g., both
+  `externalMongodb.tls` and `externalPostgresql.tls`)
+- The existing `configmap-datastore.yaml` and switching logic already present in 7 service
+  templates would be bypassed entirely — prior work not reused
+
+### Common Requirements
+
+Whichever option is chosen, the user will need to supply these to connect to an external DB:
+
+| Field | Purpose | Example |
+|---|---|---|
+| Full connection URI | Connect to external DB with credentials embedded | `mongodb+srv://user:pass@cluster.mongodb.net/` |
+| TLS enabled/disabled | Whether to use TLS | `true` / `false` |
+| CA cert secret name | Kubernetes Secret with CA cert — required only when the service uses a private CA (e.g. AWS DocumentDB). Leave empty for services that use a public CA (MongoDB Atlas, Azure DocumentDB). | `docdb-ca` |
+
+### Expected Behavior
+
+| Scenario | `mongodbStore.enabled` | External URI provided | Result |
+|---|---|---|---|
+| Internal MongoDB | `true` | No | Deploy Bitnami/Percona MongoDB in-cluster (unchanged) |
+| External MongoDB | `false` | Yes | Connect to external MongoDB — nothing deployed in-cluster |
+| External PostgreSQL | `false` | Yes | Connect to external PostgreSQL — nothing deployed in-cluster |
+| Neither | `false` | No | No DB configured — services will have no connection |
+
+---
+
+## Implementation Plan
+
+> **Note:** The detailed Helm chart implementation plan (Phase 1) depends on the design
+> decision above (Option A vs Option B) and will be filled in once that is finalized.
+> Phases 2 and 3 are common to both options.
+
+### Phase 1 — Helm Chart Changes
+
+> To be detailed after design decision is made. At a high level, regardless of which option
+> is chosen, the following areas will need changes:
+>
+> - `values.yaml` — new config fields for external DB connection (URI, TLS, auth)
+> - `configmap-datastore.yaml` (Option A) or a new ConfigMap template (Option B) — to pass
+>   the external URI and credentials to services as environment variables
+> - `mongodb-store/templates/jobs.yaml` — make TLS flags and X.509 user creation conditional
+>   so the init job can connect to an external DB
+> - Deployment templates (all DB-consuming subcharts) — conditional cert mounting based on
+>   whether TLS and/or client certs are configured
+
+### Phase 2 — Per-CSP Testing and Documentation
+
+- [x] AWS DocumentDB
+- [x] Azure Cosmos DB for MongoDB (Azure DocumentDB vCore)
+- [x] Google Cloud (MongoDB Atlas on GCP)
+- [ ] OCI
+
+### Phase 3 — Example Values Files
+
+- [x] `values-aws-docdb.yaml`
+- [x] `values-azure-cosmosdb.yaml`
+- [x] `values-atlas-gcp.yaml`
+- [ ] `values-oci-mongodb.yaml`
+
+---
+
+## What Does NOT Change
+
+- **Go application code** — already reads `MONGODB_URI` as a plain string. A raw external URI
+  will work once the ConfigMap is populated correctly.
+- **Default behavior** — all existing deployments with `mongodbStore.enabled: true` are
+  completely unaffected. This is purely additive.
+- **PostgreSQL internal support** — existing `postgresql.enabled: true` path is unchanged.
+
+---
+
+## Per-CSP Configuration Guide
+
+> This section will be filled in as each CSP is tested.
+
+### Connection URI Format Reference
+
+```
+MongoDB Atlas:
+  mongodb+srv://<user>:<pass>@<cluster>.mongodb.net/HealthEventsDatabase?retryWrites=false
+
+AWS DocumentDB:
+  mongodb://<user>:<pass>@<cluster>.cluster-<suffix>.<region>.docdb.amazonaws.com:27017/?tls=true&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false
+
+Azure DocumentDB vCore:
+  mongodb+srv://<user>:<pass>@<cluster>.mongocluster.cosmos.azure.com/?tls=true&authMechanism=SCRAM-SHA-256&retrywrites=false&maxIdleTimeMS=120000
+```
+
+### Database and Collection Setup (Automatic)
+
+You do **not** need to manually create the `HealthEventsDatabase` database or any collections
+in any of the CSPs below. On every `helm install` or `helm upgrade`, NVSentinel automatically
+runs the `nvsentinel-external-mongodb-setup` Job which:
+
+- Creates the `HealthEventsDatabase` database (MongoDB creates it lazily on first write)
+- Creates the `HealthEvents`, `ResumeTokens`, and `MaintenanceEvents` collections if they don't exist
+- Creates TTL indexes (auto-expire old events) and query indexes on all collections
+
+All you need is a cluster endpoint and a database user with read/write access.
+
+---
+
+### AWS DocumentDB
+
+**Service:** Amazon DocumentDB (MongoDB 5.0 compatible)
+
+---
+
+#### Step 1 — Obtain a DocumentDB Cluster
+
+**Choose one of the two options below** depending on whether you are creating a new cluster
+or connecting to one that already exists.
+
+---
+
+##### Option A — Create a New Cluster
+
+In the AWS Console, navigate to **Amazon DocumentDB → Clusters → Create** with these settings:
+
+- **Engine version:** 5.0.0 (minimum; supports change streams)
+- **Cluster type:** Instance-based cluster
+- **Authentication:** Username/password (SCRAM)
+- **VPC:** Same VPC as your EKS cluster (or VPC-peered)
+- **Subnet group:** Create a subnet group covering your private subnets
+- **Security group:** Create a new security group — allow TCP port `27017` inbound from your EKS node CIDR ranges (see [Networking](#networking-and-security-groups) below)
+
+After creation, note the **Cluster endpoint** (read/write):
+```
+<cluster-id>.cluster-<suffix>.<region>.docdb.amazonaws.com
+```
+
+---
+
+##### Option B — Use an Existing Cluster
+
+Verify the following before proceeding:
+
+1. **Engine version** — must be `5.0.0` or higher (change streams require this).
+2. **Change streams** — must be explicitly enabled (see Step 2 below).
+3. **Network access** — EKS node CIDR ranges must be allowed on TCP port `27017` in the cluster's security group.
+4. **VPC** — cluster must be in the same VPC as your EKS cluster, or reachable via VPC peering / Transit Gateway.
+5. **Credentials** — have a username and password ready for NVSentinel.
+
+---
+
+#### Step 2 — Enable Change Streams
+
+DocumentDB does **not** enable change streams by default. You must explicitly enable them.
+
+**2a. Create or update a cluster parameter group:**
+
+In **Amazon DocumentDB → Parameter groups**, create a custom parameter group (or modify an existing one) and set:
+
+```
+change_stream_log_retention_duration = 10800   # seconds (3 hours minimum recommended)
+```
+
+Apply the parameter group to your cluster and reboot.
+
+**2b. Enable change streams on the database via `mongosh`:**
+
+From a pod with network access to DocumentDB (e.g. a debug pod in your EKS cluster):
+
+```bash
+mongosh "mongodb://<user>:<password>@<cluster-endpoint>:27017/admin?tls=true&replicaSet=rs0&tlsAllowInvalidCertificates=true" \
+  --eval 'db.adminCommand({ modifyChangeStreams: 1, database: "HealthEventsDatabase", collection: "", enable: true })'
+```
+
+Without this, `health-events-analyzer` and `fault-quarantine` will fail to start their change stream watchers.
+
+---
+
+#### Step 3 — Configure DNS Resolution from EKS
+
+DocumentDB cluster endpoints use private DNS names (e.g. `nvsentinel-test-1.cluster-c9g8sagiqhcr.us-east-1.docdb.amazonaws.com`) that resolve within AWS VPC. EKS pods must be able to resolve these names.
+
+**Create an AWS Route 53 Private Hosted Zone:**
+
+1. Go to **Route 53 → Hosted zones → Create hosted zone**.
+2. Set the **Domain name** to match the DocumentDB endpoint suffix (e.g. `cluster-c9g8sagiqhcr.us-east-1.docdb.amazonaws.com`).
+3. Set **Type** to **Private hosted zone** and associate it with your EKS VPC.
+4. Create an **A record** pointing the cluster endpoint hostname to the DocumentDB cluster's private IP address.
+
+> The private IP of the DocumentDB cluster can be found via `nslookup` from any EC2 instance in the VPC, or via the AWS Console under the cluster's instance details.
+
+**Verify from an EKS pod:**
+
+```bash
+kubectl run -it --rm dns-test --image=busybox --restart=Never -- \
+  nslookup <cluster-endpoint>
+```
+
+Expected output: a valid IP address. `NXDOMAIN` means the Route 53 hosted zone or A record is incorrect.
+
+---
+
+#### Step 4 — Create CA Certificate Secret
+
+DocumentDB uses a private Amazon RDS CA that is not trusted by default Go TLS. You must mount it into NVSentinel pods.
+
+**Download the AWS RDS CA bundle:**
+
+```bash
+curl -o rds-ca.crt https://truststore.pki.rds.amazonaws.com/us-east-1/us-east-1-bundle.pem
+```
+
+**Create a Kubernetes secret:**
+
+```bash
+kubectl create secret generic docdb-ca \
+  --from-file=ca.crt=rds-ca.crt \
+  --namespace nvsentinel
+```
+
+The key **must** be named `ca.crt` — this is what the Helm chart volume mounts reference.
+
+---
+
+#### Step 5 — Helm Values Configuration
+
+Create a values override file (e.g. `values-aws-docdb.yaml`) with your connection details:
+
+```yaml
+global:
+  mongodbStore:
+    enabled: false   # disable the in-cluster MongoDB
+
+  datastore:
+    provider: "mongodb"
+    uri: "mongodb://<user>:<password>@<cluster-endpoint>:27017/HealthEventsDatabase?tls=true&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
+    connection:
+      host: "<cluster-endpoint>"
+      port: 27017
+      database: "HealthEventsDatabase"
+    tls:
+      enabled: true
+      caSecretName: "docdb-ca"   # name of the secret created in Step 4
+```
+
+> Percent-encode any special characters in the password: `#` → `%23`, `@` → `%40`, `%` → `%25`
+
+---
+
+#### Networking and Security Groups
+
+This was the most common source of connectivity failures during testing. EKS pods can have IPs from **multiple CIDR ranges** depending on the CNI configuration — not just the primary VPC CIDR.
+
+In the DocumentDB cluster's security group, add an inbound rule for **each** CIDR range your pods use:
+
+```
+Type:     Custom TCP
+Port:     27017
+Source:   10.0.0.0/16    # primary VPC CIDR
+```
+
+```
+Type:     Custom TCP
+Port:     27017
+Source:   100.65.0.0/16  # secondary pod CIDR (if using custom networking)
+```
+
+> If some pods connect successfully but others get `dial tcp: i/o timeout`, check the pod IPs — pods with IPs outside the allowed CIDR range will be blocked by the security group.
+
+To find the pod CIDRs in use:
+
+```bash
+kubectl get pods -n nvsentinel -o wide
+# Look at the IP column — if some IPs are 100.65.x.x, that CIDR must be added
+```
+
+---
+
+### Azure Cosmos DB for MongoDB
+
+**Service:** Azure DocumentDB with MongoDB Compatibility (vCore)
+
+**MongoDB Version:** 8.0
+
+---
+
+#### Important: Choosing the Right Azure Service
+
+Azure has **two different** Cosmos DB MongoDB offerings. They are NOT interchangeable:
+
+| Service | API | Change Streams | Use for NVSentinel? |
+|---|---|---|---|
+| Azure Cosmos DB for MongoDB (RU/Serverless) | MongoDB 4.2 | **Not supported** | **No** — `NVSentinel` requires Change Streams |
+| Azure DocumentDB (with MongoDB compatibility) — vCore | MongoDB 8.0 | **Supported** | **Yes** |
+
+Always create the **"Azure DocumentDB (with MongoDB compatibility)"** resource, NOT "Azure Cosmos DB for MongoDB".
+
+---
+
+#### Step 1 — Obtain a DocumentDB Cluster
+
+**Choose one of the two options below** depending on whether you are creating a new cluster
+or connecting to one that already exists.
+
+---
+
+##### Option A — Create a New Cluster
+
+In Azure Portal, create a new **"Azure DocumentDB (with MongoDB compatibility)"** resource
+(vCore tier, MongoDB 8.0, SCRAM auth). Match the region to your AKS cluster.
+
+> Refer to the [Azure DocumentDB quickstart](https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/vcore/quickstart-portal)
+> for full creation steps.
+
+---
+
+##### Option B — Use an Existing Cluster
+
+Verify the following before proceeding:
+
+1. **Service type** — confirm the resource is **Azure DocumentDB vCore** (not RU/Serverless). Change Streams are only supported on vCore.
+2. **MongoDB version** — must be **5.0 or higher** (8.0 recommended).
+3. **Network access** — AKS outbound IPs must be allowed in **Settings → Networking** to reach port `27017`.
+4. **Credentials** — have an admin username and password ready for NVSentinel.
+
+---
+
+##### Connection String (both options)
+
+Go to **Settings → Connection Strings** and copy the Primary Connection String:
+
+```
+mongodb+srv://<username>:<password>@<cluster-name>.mongocluster.cosmos.azure.com/?tls=true&authMechanism=SCRAM-SHA-256&retrywrites=false&maxIdleTimeMS=120000
+```
+
+Percent-encode any special characters in the password: `#` → `%23`, `@` → `%40`, `%` → `%25`
+
+> If special characters are not encoded, `platform-connectors` will fail with
+> `MongoParseError: Password contains unescaped characters` on startup.
+
+---
+
+#### Step 2 — Helm Values Configuration
+
+Create a values override file (e.g. `values-external-mongodb.yaml`) with your connection details:
+
+```yaml
+global:
+  mongodbStore:
+    enabled: false   # disable the in-cluster MongoDB
+
+  datastore:
+    provider: "mongodb"
+    uri: "<your-mongodb-connection-string>"  # paste your connection string here
+    connection:
+      host: "<cluster>.mongocluster.cosmos.azure.com"
+      port: 27017
+      database: "HealthEventsDatabase"
+    tls:
+      enabled: true
+      caSecretName: ""  # Azure uses DigiCert public CA — system CAs are sufficient
+```
+
+---
+
+### Google Cloud — MongoDB Atlas
+
+**Service:** MongoDB Atlas (M0 free tier or M10+) hosted on GCP
+
+---
+
+#### Why MongoDB Atlas on GCP?
+
+GCP does not offer a native first-party MongoDB-compatible managed service the way AWS offers DocumentDB or Azure offers Cosmos DB. The only production-grade options on GCP are:
+
+| Option | Change Streams | VPC Peering | Notes |
+|---|---|---|---|
+| MongoDB Atlas (M10+) | Yes | Yes | Recommended for production |
+| MongoDB Atlas (M0 free) | Yes | No | IP allowlisting only; suitable for testing |
+| Self-hosted MongoDB on GCE | Yes | Yes | Not managed; operator burden |
+| Cloud SQL | No | Yes | PostgreSQL only; no MongoDB API |
+
+MongoDB Atlas is the recommended solution. Atlas uses the standard MongoDB driver protocol so all aggregation features work natively — no compatibility workarounds needed.
+
+---
+
+#### Step 1 — Obtain a MongoDB Atlas Cluster
+
+**Choose one of the two options below** depending on whether you are creating a new cluster
+or connecting to one that already exists.
+
+---
+
+##### Option A — Create a New Cluster
+
+1. Go to [cloud.mongodb.com](https://cloud.mongodb.com) → **Create a deployment**
+2. Choose **M0 (Free)** for testing or **M10+** for production
+3. Select **GCP** as the provider and choose the region closest to your GKE cluster (e.g. `us-central1`)
+4. Name the cluster and click **Create**
+5. When prompted to create a database user, set a username and password (SCRAM-SHA-256 auth)
+6. Note the connection string from **Connect → Drivers**:
+   ```
+   mongodb+srv://<username>:<password>@<cluster-name>.mongodb.net/
+   ```
+
+---
+
+##### Option B — Use an Existing Cluster
+
+Verify the following before proceeding:
+
+1. **Change streams** — Atlas supports change streams on all tiers (M0 and above). No extra configuration needed.
+2. **Network access** — GKE node/pod IPs must be in the Atlas IP Access List (see Step 2).
+3. **Credentials** — have a database user with SCRAM-SHA-256 auth credentials ready.
+
+---
+
+#### Step 2 — Configure Network Access
+
+MongoDB Atlas M0 does not support VPC peering. IP allowlisting is the only option.
+
+In the Atlas UI, go to **Security → Network Access → Add IP Address**:
+
+- For **testing**: click **Allow Access from Anywhere** to add `0.0.0.0/0`
+- For **production** (M10+): add your GKE node pool CIDR ranges only. Find them with:
+
+```bash
+kubectl get nodes -o wide
+# Note the EXTERNAL-IP or INTERNAL-IP column for each node
+```
+
+> M10+ clusters support VPC peering with GCP. Refer to the [Atlas VPC Peering documentation](https://www.mongodb.com/docs/atlas/security-vpc-peering/) for production setup.
+
+---
+
+#### Step 3 — Helm Values Configuration
+
+No CA certificate secret is needed — Atlas uses DigiCert public CA which is trusted by the Go TLS runtime by default.
+
+Create a values override file `values-atlas-gcp.yaml`:
+
+```yaml
+global:
+  mongodbStore:
+    enabled: false   # disable the in-cluster MongoDB
+
+  datastore:
+    provider: "mongodb"
+    # Paste your Atlas connection string here — percent-encode special chars in password:
+    # '#' → '%23', '@' → '%40', '%' → '%25'
+    uri: "mongodb+srv://<user>:<password>@<cluster>.mongodb.net/HealthEventsDatabase?retryWrites=false"
+    connection:
+      host: "<cluster>.mongodb.net"
+      port: 27017
+      database: "HealthEventsDatabase"
+    tls:
+      enabled: true
+      caSecretName: ""   # Atlas uses public DigiCert CA — no custom CA cert required
+```
+
+---
+
+### OCI
+
+**Status:** Skipped — no viable managed MongoDB service available on OCI.
+
+---
+
+#### Research Summary
+
+All available OCI-native options were evaluated:
+
+| Option | Change Streams | Notes |
+|---|---|---|
+| Oracle Autonomous Database (MongoDB API) | No | Oracle's own docs explicitly list Change Streams as unsupported. NVSentinel requires Change Streams. |
+| MongoDB Atlas on OCI | N/A | MongoDB Atlas officially supports only AWS, GCP, and Azure. OCI is not a supported Atlas provider. |
+| OCI Marketplace MongoDB (Apps4Rent, ScaleGrid) | Yes | Only paid third-party options; available in limited regions (UK South London only). |
+| Self-managed MongoDB on OCI Compute VM | Yes | Full MongoDB compatibility including Change Streams. Oracle's own reference architecture for MongoDB on OCI recommends this approach. |
+
+The only viable option is a **self-managed MongoDB deployment on OCI Compute VMs**. However,
+when attempting to create a Compute instance in the OCI Console (both US West San Jose and
+UK South London regions, multiple compartments), no VM images appeared under any OS tab
+(Oracle Linux, Ubuntu, Red Hat) and no shapes were available for selection.
+
+OCI testing is skipped for now.
+
+---
+
+## References
+
+- [Issue #376 — External Datastore Support](https://github.com/nvidia/nvsentinel/issues/376)
+- [PR #965 — Optional TLS for MongoDB](https://github.com/nvidia/nvsentinel/pull/965)
+- [PostgreSQL Provider Documentation](./postgresql-provider.md)
+- [MongoDB Atlas Documentation](https://www.mongodb.com/docs/atlas/)
+- [AWS DocumentDB Developer Guide](https://docs.aws.amazon.com/documentdb/latest/developerguide/)
+- [Azure Cosmos DB for MongoDB](https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/)

--- a/store-client/pkg/datastore/config.go
+++ b/store-client/pkg/datastore/config.go
@@ -141,7 +141,33 @@ func setMongoDBTLSDefaults(config *DataStoreConfig) {
 		return
 	}
 
+	// CA-only: server certificate verification for SCRAM auth (e.g. DocumentDB, managed MongoDB).
+	// Only valid when neither client cert var is set. If one is set but not the other,
+	// that is a misconfiguration — log an error instead of silently downgrading to CA-only.
+	if caPath != "" {
+		if certPath != "" || keyPath != "" {
+			slog.Error("Incomplete x509 client cert configuration: MONGODB_CA_CERT_PATH is set "+
+				"alongside only one of MONGODB_CLIENT_CERT_PATH / MONGODB_CLIENT_KEY_PATH; "+
+				"both must be provided together. TLS will not be configured.",
+				"certPath", certPath, "keyPath", keyPath, "caPath", caPath)
+
+			return
+		}
+
+		config.Connection.TLSConfig = &TLSConfig{
+			CAPath: caPath,
+		}
+
+		return
+	}
+
 	// Final fallback: hardcoded legacy path if certs exist there
+	applyLegacyTLSCertPath(config)
+}
+
+// applyLegacyTLSCertPath falls back to a hardcoded legacy certificate path for
+// backward compatibility when no other TLS configuration is present.
+func applyLegacyTLSCertPath(config *DataStoreConfig) {
 	legacyPath := "/etc/ssl/mongo-client"
 
 	if fileExists(legacyPath + "/ca.crt") {


### PR DESCRIPTION
## Summary

## Problem we are solving

NVSentinel could only use its in-cluster MongoDB. Lean GPU clusters should not host a database.
This PR adds first-class support for managed MongoDB-compatible services (AWS DocumentDB, MongoDB Atlas, Azure Cosmos DB).

---

## What Changed

**Core chart**

- distros/kubernetes/nvsentinel/templates/_helpers.tpl — Mongo helpers: cert volume, mount path resolution, gates for when to mount certs.
- distros/kubernetes/nvsentinel/templates/configmap-datastore.yaml — Datastore ConfigMap: connection / MONGODB_URI / TLS / operational env aligned with external Mongo.
- distros/kubernetes/nvsentinel/templates/configmap.yaml — Platform connector enablement when using external Mongo (not only in-cluster).
- distros/kubernetes/nvsentinel/templates/daemonset.yaml — Platform connector: Mongo TLS / cert args and mounts aligned with helpers.
- distros/kubernetes/nvsentinel/values.yaml — Default / global datastore and related chart values for external DB use.

**Hook + samples**
- distros/kubernetes/nvsentinel/templates/job-external-mongodb-setup.yaml (new) — Helm hook Job to prepare external Mongo (collections / indexes as designed).
- distros/kubernetes/nvsentinel/values-atlas-gcp.yaml (new)
- distros/kubernetes/nvsentinel/values-aws-docdb.yaml (new)
- distros/kubernetes/nvsentinel/values-cosmosdb-test.yaml (new) — Minimal per-provider overrides; credentials at deploy time as documented.

**Subcharts (deployments)**
- charts/csp-health-monitor/templates/deployment.yaml
- charts/event-exporter/templates/configmap.yaml, deployment.yaml, values.yaml
- charts/fault-quarantine/templates/deployment.yaml
- charts/fault-remediation/templates/deployment.yaml
- charts/health-events-analyzer/templates/deployment.yaml
- charts/node-drainer/templates/deployment.yaml

**Docs**
docs/external-datastore.md (new) — How to deploy against external managed MongoDB-compatible services.

**Go**
store-client/pkg/datastore/config.go — Datastore configuration support aligned with external / unified datastore model.

---

## Test Results

| Component | AWS DocumentDB (EKS) | MongoDB Atlas (GKE) | Azure Cosmos DB (AKS) |
|---|---|---|---|
| DB connectivity (all 7) | PASS | PASS | PASS |
| `platform-connectors` | PASS | PASS | PASS |
| `gpu-health-monitor` | PASS | PASS | PASS |
| `fault-quarantine` | PASS | PASS | PASS |
| `node-drainer` | PASS | PASS | PASS |
| `fault-remediation` | PASS | PASS | FAIL — Cosmos DB limitation (see below) |
| `health-events-analyzer` | WARN — 8 rules fail (DocDB limits) | PASS | WARN — 4 rules fail (Cosmos DB limits) |
| `event-exporter` | PASS | PASS | PASS |
| `csp-health-monitor` | PASS | PASS | PASS |

**Core e2e flow (GPU error → DB → quarantine → drain): VERIFIED on all 3 providers**

---

## Known Limitations (follow-up issues)

| Issue | DocDB | Cosmos DB | Atlas |
|---|---|---|---|
| HEA: `$setWindowFields`, `$$NOW`, `$lookup` multi-condition | FAIL — 8 rules | PASS | PASS |
| HEA: `$$this` in `$filter`/`$map` | WARN — partial | FAIL — 4 rules | PASS |
| `fault-remediation`: change stream pipeline crash | PASS | FAIL — `(DollarSizeRequiresArray) $size requires an array argument, received type: null` — see below | PASS |
| `fault-quarantine`: expired resume token on restart | PASS | FAIL — `(InvalidOptions) Expired resume token or cursor, reinitialize the change stream cursor` — see below | PASS |

**HEA — Azure Cosmos DB (`$$this` in aggregation):**
```
(Location17276) Attempting to use an undefined variable: this.entitytype
```
4 rules use `$$this` inside `$filter`/`$map` to inspect entity arrays. Cosmos DB does not support
`$$this` in these contexts. Fix: rewrite affected rules using `$unwind` + `$match`.

**HEA — AWS DocumentDB (unsupported aggregation stages):**
8 rules use `$setWindowFields`, `$$NOW`, or multi-condition `$lookup` — none of which DocumentDB supports.
Non-fatal; `fault-quarantine` change stream is independent and unaffected.
Fix: rewrite the 8 rules using DocumentDB-compatible equivalents.

**`fault-remediation` — Azure Cosmos DB (`$size` on null):**
```
(DollarSizeRequiresArray) $size requires an array argument, but received a value of type: null
```
Cosmos DB evaluates all `$match` `$expr` conditions eagerly instead of short-circuiting, so `$size`
is applied to fields that are absent (null) on some documents. Fix: wrap with `$ifNull`:
`{$size: {$ifNull: [{$objectToArray: "$updateDescription.updatedFields"}, []]}}`.

**`fault-quarantine` — Azure Cosmos DB (expired resume token on restart):**
```
(InvalidOptions) Expired resume token or cursor, reinitialize the change stream cursor
```
`fault-quarantine` stores its change stream position in the `ResumeTokens` collection so it can resume
exactly where it left off after a restart. Cosmos DB has a shorter change stream retention window than
native MongoDB (~1 hour vs hours/days). If the pod is down longer than that window, the stored token
has expired and Cosmos DB rejects it. `fault-quarantine` retries for 5 minutes then crashes instead of
falling back to a fresh stream.
Workaround: before restarting, clear the stale token: `db.ResumeTokens.deleteMany({})`.
Fix: catch `InvalidOptions` / expired-token errors and automatically reinitialize the change stream
from the current position rather than crashing.

None of these block the core quarantine/drain flow. All are tracked as follow-up.



## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for external MongoDB and PostgreSQL databases across major cloud providers (AWS DocumentDB, Azure Cosmos DB, Google Cloud MongoDB Atlas).
  * Introduced automatic setup jobs for external MongoDB initialization.
  * Added pre-configured deployment templates for cloud provider integrations.

* **Documentation**
  * Added comprehensive guide for external datastore configuration and cloud provider setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->