### PR TITLE
fix: trim down health-event msg field while respective the maxLength of node Condition msg Section

### DIFF
--- a/distros/kubernetes/nvsentinel/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/templates/configmap.yaml
@@ -25,6 +25,7 @@ data:
       "K8sConnectorQps": {{ printf "%.2f" .Values.platformConnector.k8sConnector.qps }},
       "K8sConnectorBurst": {{ .Values.platformConnector.k8sConnector.burst }},
       "MaxNodeConditionMessageLength": {{ .Values.platformConnector.k8sConnector.maxNodeConditionMessageLength }},
+      "CompactedHealthEventMsgLen": {{ .Values.platformConnector.k8sConnector.compactedHealthEventMsgLen }},
       "StoreConnectorMaxRetries": {{ .Values.platformConnector.mongodbStore.maxRetries }},
       "enableMongoDBStorePlatformConnector": "{{ .Values.global.mongodbStore.enabled }}",
       "enablePostgresDBStorePlatformConnector": {{ if and .Values.global.datastore .Values.global.datastore.provider }}{{ eq .Values.global.datastore.provider "postgresql" | quote }}{{ else }}"false"{{ end }}

--- a/distros/kubernetes/nvsentinel/values-full.yaml
+++ b/distros/kubernetes/nvsentinel/values-full.yaml
@@ -270,6 +270,10 @@ platformConnector:
     # If the node condition message is longer than this value, it will be truncated
     # This is to prevent the node condition message from being too long and causing the Kubernetes node status to be too large
     maxNodeConditionMessageLength: 1024
+    # Maximum length of the compacted message prefix (before Recommended Action) per health event.
+    # Controls how much of the ErrorCode and entity identifiers (GPU, PCI, etc.) are preserved
+    # when messages are compacted to fit within maxNodeConditionMessageLength.
+    compactedHealthEventMsgLen: 72
     # Enable Kubernetes status updates
     enabled: true
     # Rate limiting for Kubernetes API calls

--- a/distros/kubernetes/nvsentinel/values-tilt.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt.yaml
@@ -3823,6 +3823,7 @@ platformConnector:
   k8sConnector:
     enabled: true
     maxNodeConditionMessageLength: 1024
+    compactedHealthEventMsgLen: 72
     qps: 5.0
     burst: 10
   

--- a/distros/kubernetes/nvsentinel/values.yaml
+++ b/distros/kubernetes/nvsentinel/values.yaml
@@ -151,6 +151,8 @@ platformConnector:
   k8sConnector:
     enabled: true
     maxNodeConditionMessageLength: 1024
+    # Max length of the compacted message prefix (before Recommended Action) per health event
+    compactedHealthEventMsgLen: 72
     qps: 5.0
     burst: 10
 

--- a/platform-connectors/main.go
+++ b/platform-connectors/main.go
@@ -117,13 +117,24 @@ func initializeK8sConnector(
 			config["MaxNodeConditionMessageLength"])
 	}
 
+	compactedEventMsgLen, ok := config["CompactedHealthEventMsgLen"].(int64)
+	if !ok {
+		return nil, fmt.Errorf("failed to convert CompactedHealthEventMsgLen to int64: %v",
+			config["CompactedHealthEventMsgLen"])
+	}
+
 	burst, ok := config["K8sConnectorBurst"].(int64)
 	if !ok {
 		return nil, fmt.Errorf("failed to convert K8sConnectorBurst to int: %v", config["K8sConnectorBurst"])
 	}
 
+	k8sConnectorCfg := kubernetes.K8sConnectorConfig{
+		MaxNodeConditionMessageLength: maxNodeConditionMessageLength,
+		CompactedHealthEventMsgLen:    compactedEventMsgLen,
+	}
+
 	k8sConnector, _, err := kubernetes.InitializeK8sConnector(ctx, k8sRingBuffer, qps, int(burst),
-		stopCh, maxNodeConditionMessageLength)
+		stopCh, k8sConnectorCfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize K8sConnector: %w", err)
 	}

--- a/platform-connectors/pkg/connectors/kubernetes/k8s_connector.go
+++ b/platform-connectors/pkg/connectors/kubernetes/k8s_connector.go
@@ -34,35 +34,46 @@ hence it is complex to test this. Hence, ignoring this initilization part for no
 Hence, ignoring this file as part of unit testing for now.
 */
 
-type K8sConnector struct {
-	// clientset is the Kubernetes client
-	clientset kubernetes.Interface
-	// ringBuffer are client for pushing data to the resource count sink
-	ringBuffer                    *ringbuffer.RingBuffer
-	stopCh                        <-chan struct{}
-	ctx                           context.Context
-	maxNodeConditionMessageLength int64
+// K8sConnectorConfig holds tunable parameters for the K8sConnector.
+type K8sConnectorConfig struct {
+	MaxNodeConditionMessageLength int64
+	CompactedHealthEventMsgLen    int64
 }
 
+type K8sConnector struct {
+	clientset  kubernetes.Interface
+	ringBuffer *ringbuffer.RingBuffer
+	stopCh     <-chan struct{}
+	ctx        context.Context
+	config     K8sConnectorConfig
+}
+
+// NewK8sConnector creates a K8sConnector with the given Kubernetes client, ring buffer, and configuration.
 func NewK8sConnector(
 	client kubernetes.Interface,
 	ringBuffer *ringbuffer.RingBuffer,
-	stopCh <-chan struct{}, ctx context.Context, maxNodeConditionMessageLength int64) *K8sConnector {
+	stopCh <-chan struct{}, ctx context.Context,
+	cfg K8sConnectorConfig) *K8sConnector {
 	return &K8sConnector{
-		clientset:                     client,
-		ringBuffer:                    ringBuffer,
-		stopCh:                        stopCh,
-		ctx:                           ctx,
-		maxNodeConditionMessageLength: maxNodeConditionMessageLength,
+		clientset:  client,
+		ringBuffer: ringBuffer,
+		stopCh:     stopCh,
+		ctx:        ctx,
+		config:     cfg,
 	}
 }
 
 func InitializeK8sConnector(ctx context.Context, ringbuffer *ringbuffer.RingBuffer,
-	qps float32, burst int, stopCh <-chan struct{}, maxNodeConditionMessageLength int64,
+	qps float32, burst int, stopCh <-chan struct{}, cfg K8sConnectorConfig,
 ) (*K8sConnector, kubernetes.Interface, error) {
-	if maxNodeConditionMessageLength <= 0 {
+	if cfg.MaxNodeConditionMessageLength <= 0 {
 		return nil, nil, fmt.Errorf("maxNodeConditionMessageLength must be greater than 0, got %d",
-			maxNodeConditionMessageLength)
+			cfg.MaxNodeConditionMessageLength)
+	}
+
+	if cfg.CompactedHealthEventMsgLen <= 0 {
+		return nil, nil, fmt.Errorf("CompactedHealthEventMsgLen must be greater than 0, got %d",
+			cfg.CompactedHealthEventMsgLen)
 	}
 
 	// Create the in-cluster config
@@ -83,7 +94,7 @@ func InitializeK8sConnector(ctx context.Context, ringbuffer *ringbuffer.RingBuff
 		return nil, nil, fmt.Errorf("error creating kubernetes clientset: %w", err)
 	}
 
-	kubernetesConnector := NewK8sConnector(clientSet, ringbuffer, stopCh, ctx, maxNodeConditionMessageLength)
+	kubernetesConnector := NewK8sConnector(clientSet, ringbuffer, stopCh, ctx, cfg)
 
 	return kubernetesConnector, clientSet, nil
 }

--- a/platform-connectors/pkg/connectors/kubernetes/k8s_connector_envtest_test.go
+++ b/platform-connectors/pkg/connectors/kubernetes/k8s_connector_envtest_test.go
@@ -30,7 +30,10 @@ import (
 	"github.com/nvidia/nvsentinel/data-models/pkg/protos"
 )
 
-const defaultMaxNodeConditionMessageLength = int64(1024)
+var defaultConnectorConfig = K8sConnectorConfig{
+	MaxNodeConditionMessageLength: 1024,
+	CompactedHealthEventMsgLen:    72,
+}
 
 // go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 // source <(setup-envtest use -p env)
@@ -64,7 +67,7 @@ func TestK8sConnector_WithEnvtest_NodeConditionUpdate(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultConnectorConfig)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,
@@ -146,7 +149,7 @@ func TestK8sConnector_WithEnvtest_NodeConditionClear(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultConnectorConfig)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,
@@ -203,7 +206,7 @@ func TestK8sConnector_WithEnvtest_NodeEventCreation(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultConnectorConfig)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,
@@ -272,7 +275,7 @@ func TestK8sConnector_WithEnvtest_AddMessages(t *testing.T) {
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	connector := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
+	connector := NewK8sConnector(cli, nil, stopCh, ctx, defaultConnectorConfig)
 
 	healthEvents := []*protos.HealthEvent{
 		{
@@ -332,7 +335,7 @@ func TestK8sConnector_WithEnvtest_RemoveMessages(t *testing.T) {
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	connector := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
+	connector := NewK8sConnector(cli, nil, stopCh, ctx, defaultConnectorConfig)
 
 	healthEvents := []*protos.HealthEvent{
 		{
@@ -378,7 +381,7 @@ func TestK8sConnector_WithEnvtest_MultipleEventsForSameNode(t *testing.T) {
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	connector := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
+	connector := NewK8sConnector(cli, nil, stopCh, ctx, defaultConnectorConfig)
 
 	healthEventsProto := &protos.HealthEvents{
 		Events: []*protos.HealthEvent{
@@ -463,7 +466,7 @@ func TestK8sConnector_WithEnvtest_TransitionTimeUpdates(t *testing.T) {
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	connector := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
+	connector := NewK8sConnector(cli, nil, stopCh, ctx, defaultConnectorConfig)
 
 	healthEvents := []*protos.HealthEvent{
 		{
@@ -511,7 +514,7 @@ func TestK8sConnector_WithEnvtest_EventCountIncrement(t *testing.T) {
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	connector := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
+	connector := NewK8sConnector(cli, nil, stopCh, ctx, defaultConnectorConfig)
 
 	healthEvent := &protos.HealthEvent{
 		CheckName:          "GpuThermalWatch",
@@ -563,7 +566,7 @@ func TestK8sConnector_WithEnvtest_NodeNotFound(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultConnectorConfig)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,
@@ -607,7 +610,7 @@ func TestK8sConnector_WithEnvtest_EmptyHealthEvents(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultConnectorConfig)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,
@@ -636,7 +639,7 @@ func TestK8sConnector_WithEnvtest_MultipleEntities(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultConnectorConfig)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,
@@ -700,7 +703,7 @@ func TestK8sConnector_WithEnvtest_SpecialCharactersInMessage(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultConnectorConfig)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,
@@ -756,7 +759,7 @@ func TestK8sConnector_WithEnvtest_MultipleCheckTypes(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultMaxNodeConditionMessageLength)
+	k8sConn := NewK8sConnector(cli, nil, stopCh, ctx, defaultConnectorConfig)
 
 	healthEvents := &protos.HealthEvents{
 		Version: 1,

--- a/platform-connectors/pkg/connectors/kubernetes/k8s_connector_envtest_test.go
+++ b/platform-connectors/pkg/connectors/kubernetes/k8s_connector_envtest_test.go
@@ -16,6 +16,8 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -739,6 +741,151 @@ func TestK8sConnector_WithEnvtest_SpecialCharactersInMessage(t *testing.T) {
 		}
 	}
 	assert.True(t, conditionFound, "node condition with special characters was not created")
+}
+
+// TestK8sConnector_WithEnvtest_CompactionAndDeduplication verifies the full real-world flow:
+// health events are appended one by one to the same node condition. Once the accumulated
+// message exceeds 1024 bytes, compaction fires and the result must contain no two entries
+// with identical compacted text. A duplicate event (same entity + same Recommended Action,
+// different diagnostic text) must collapse to a single entry, not accumulate.
+func TestK8sConnector_WithEnvtest_CompactionAndDeduplication(t *testing.T) {
+	ctx := context.Background()
+	testEnv, cli := setupEnvtest(t)
+	defer testEnv.Stop()
+
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
+	_, err := cli.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create node")
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	connector := NewK8sConnector(cli, nil, stopCh, ctx, defaultConnectorConfig)
+
+	// Send 5 health events for 5 distinct GPUs. Each message is ~197 bytes;
+	// 5 messages total ~990 bytes < 1024 — no compaction should fire yet.
+	// The timestamp is embedded in the diagnostic text and falls within the
+	// 72-byte compacted prefix, so it distinguishes entries after compaction.
+	for i := 0; i < 5; i++ {
+		events := []*protos.HealthEvent{
+			{
+				CheckName: "GpuXidError",
+				IsHealthy: false,
+				Message: fmt.Sprintf(
+					"kernel: [16450076.00000%d] NVRM: Xid (PCI:0000:0%d:00.0): 119, pid=10000%d, name=proc, Timeout after 6s waiting for GPU GSP response",
+					i+1, i, i+1),
+				EntitiesImpacted: []*protos.Entity{
+					{EntityType: "GPU", EntityValue: fmt.Sprintf("%d", i)},
+					{EntityType: "PCI", EntityValue: fmt.Sprintf("0000:0%d:00.0", i)},
+				},
+				ErrorCode:          []string{"119"},
+				IsFatal:            true,
+				GeneratedTimestamp: timestamppb.New(time.Now()),
+				RecommendedAction:  protos.RecommendedAction_COMPONENT_RESET,
+				NodeName:           "test-node",
+			},
+		}
+		_, err = connector.updateNodeConditions(ctx, events)
+		require.NoError(t, err, "failed to process event for GPU:%d", i)
+	}
+
+	// Verify: 5 entries, no compaction yet.
+	node, err = cli.CoreV1().Nodes().Get(ctx, "test-node", metav1.GetOptions{})
+	require.NoError(t, err)
+	var condMsg string
+	for _, c := range node.Status.Conditions {
+		if c.Type == "GpuXidError" {
+			condMsg = c.Message
+			break
+		}
+	}
+	require.NotEmpty(t, condMsg, "GpuXidError condition not found after 5 events")
+	assert.Less(t, len(condMsg), 1024, "5 messages should not yet exceed 1024 bytes")
+	assert.NotContains(t, condMsg, truncationSuffix, "compaction must not have fired yet")
+
+	// Send a duplicate event for GPU:0 (same GPU/PCI entities + same Recommended Action,
+	// different timestamp in diagnostic text). This pushes the total to ~1188 bytes > 1024,
+	// triggering Tier 1 compaction. deduplicateMessagesByIdentity drops the old GPU:0 entry
+	// and keeps this fresher one; all 5 surviving entries are then compacted to ~555 bytes.
+	dupEvent := []*protos.HealthEvent{
+		{
+			CheckName: "GpuXidError",
+			IsHealthy: false,
+			Message:   "kernel: [16450077.000001] NVRM: Xid (PCI:0000:00:00.0): 119, pid=9999999, name=proc, Timeout after 6s waiting for GPU GSP response",
+			EntitiesImpacted: []*protos.Entity{
+				{EntityType: "GPU", EntityValue: "0"},
+				{EntityType: "PCI", EntityValue: "0000:00:00.0"},
+			},
+			ErrorCode:          []string{"119"},
+			IsFatal:            true,
+			GeneratedTimestamp: timestamppb.New(time.Now()),
+			RecommendedAction:  protos.RecommendedAction_COMPONENT_RESET,
+			NodeName:           "test-node",
+		},
+	}
+	_, err = connector.updateNodeConditions(ctx, dupEvent)
+	require.NoError(t, err, "failed to process duplicate event for GPU:0")
+
+	node, err = cli.CoreV1().Nodes().Get(ctx, "test-node", metav1.GetOptions{})
+	require.NoError(t, err)
+	condMsg = ""
+	for _, c := range node.Status.Conditions {
+		if c.Type == "GpuXidError" {
+			condMsg = c.Message
+			break
+		}
+	}
+	require.NotEmpty(t, condMsg, "GpuXidError condition not found after duplicate event")
+
+	// 1. Condition message must be within the 1024-byte Kubernetes limit.
+	assert.LessOrEqual(t, len(condMsg), 1024,
+		"condition message must not exceed 1024 bytes after compaction")
+
+	// 2. Entries must be in compacted form (free-text truncated at 72 bytes).
+	assert.Contains(t, condMsg, truncationSuffix,
+		"entries must be in compacted form after limit was exceeded")
+
+	// 3. No two compacted entries in the condition message may have identical text.
+	//    If dedup and compaction are working correctly, each entry originates from a
+	//    different entity and carries a distinct 72-byte prefix.
+	parts := strings.Split(condMsg, ";")
+	var entries []string
+	for _, p := range parts {
+		if p != "" && p != truncationSuffix {
+			entries = append(entries, p)
+		}
+	}
+	seen := make(map[string]int)
+	for _, e := range entries {
+		seen[e]++
+	}
+	for entry, count := range seen {
+		assert.Equal(t, 1, count,
+			"compacted entry appears %d times (expected 1): %q", count, entry)
+	}
+
+	// 4. GPU:0 must appear exactly once — the old entry replaced by the fresh one.
+	gpu0Count := 0
+	for _, e := range entries {
+		if strings.Contains(e, "GPU:0") && strings.Contains(e, "PCI:0000:00:00.0") {
+			gpu0Count++
+		}
+	}
+	assert.Equal(t, 1, gpu0Count,
+		"GPU:0 must appear exactly once after dedup+compaction")
+
+	// 5. Old GPU:0 entry must be gone; the fresh one must survive.
+	//    The timestamp "16450076.000001" falls within the 72-byte compacted prefix,
+	//    so its absence confirms the old entry was dropped.
+	assert.NotContains(t, condMsg, "16450076.000001",
+		"old GPU:0 entry (timestamp 16450076.000001) must be dropped")
+	assert.Contains(t, condMsg, "16450077.000001",
+		"fresh GPU:0 entry (timestamp 16450077.000001) must survive in compacted prefix")
+
+	// 6. All other GPU entries (1–4) must still be present after compaction.
+	for i := 1; i < 5; i++ {
+		assert.Contains(t, condMsg, fmt.Sprintf("GPU:%d", i),
+			"GPU:%d entry must survive compaction", i)
+	}
 }
 
 // TestK8sConnector_WithEnvtest_MultipleCheckTypes tests multiple different check types on same node

--- a/platform-connectors/pkg/connectors/kubernetes/k8s_platform_connector_test.go
+++ b/platform-connectors/pkg/connectors/kubernetes/k8s_platform_connector_test.go
@@ -1808,3 +1808,62 @@ func TestTruncateConditionMessage_EntityIdentifierPreservation(t *testing.T) {
 	assert.Contains(t, result, "Recommended Action=RESTART_VM",
 		"Recommended action must be preserved")
 }
+
+func TestMessagesMatchByIdentity(t *testing.T) {
+	tests := []struct {
+		name  string
+		a     string
+		b     string
+		match bool
+	}{
+		{
+			name:  "Full vs compacted - GPU and PCI match",
+			a:     "ErrorCode:DCGM_FR_NVLINK_DOWN GPU:3 PCI:0000:c4:00.0 GPU_UUID:GPU-8614c5d9-371d-1d8a-9bab-78d0434427ec GPU 3's NvLink link 0 down Recommended Action=RESTART_VM",
+			b:     "ErrorCode:DCGM_FR_NVLINK_DOWN GPU:3 PCI:0000:c4:00.0 GPU_UUID:GPU-8614c... Recommended Action=RESTART_VM",
+			match: true,
+		},
+		{
+			name:  "Same GPU different NvLink - same fault identity",
+			a:     "ErrorCode:DCGM_FR_NVLINK_DOWN GPU:3 PCI:0000:c4:00.0 GPU_UUID:GPU-8614c5d9-371d-1d8a-9bab-78d0434427ec GPU 3's NvLink link 0 down Recommended Action=RESTART_VM",
+			b:     "ErrorCode:DCGM_FR_NVLINK_DOWN GPU:3 PCI:0000:c4:00.0 GPU_UUID:GPU-8614c5d9-371d-1d8a-9bab-78d0434427ec GPU 3's NvLink link 5 down Recommended Action=RESTART_VM",
+			match: true,
+		},
+		{
+			name:  "Different GPU - no match",
+			a:     "ErrorCode:DCGM_FR_NVLINK_DOWN GPU:3 PCI:0000:c4:00.0 Recommended Action=RESTART_VM",
+			b:     "ErrorCode:DCGM_FR_NVLINK_DOWN GPU:4 PCI:0000:c5:00.0 Recommended Action=RESTART_VM",
+			match: false,
+		},
+		{
+			name:  "Different ErrorCode - no match",
+			a:     "ErrorCode:DCGM_FR_NVLINK_DOWN GPU:3 PCI:0000:c4:00.0 Recommended Action=RESTART_VM",
+			b:     "ErrorCode:DCGM_FR_CORRUPT_INFOROM GPU:3 PCI:0000:c4:00.0 Recommended Action=RESTART_VM",
+			match: false,
+		},
+		{
+			name:  "Different Recommended Action - no match",
+			a:     "ErrorCode:DCGM_FR_NVLINK_DOWN GPU:3 PCI:0000:c4:00.0 Recommended Action=RESTART_VM",
+			b:     "ErrorCode:DCGM_FR_NVLINK_DOWN GPU:3 PCI:0000:c4:00.0 Recommended Action=CONTACT_SUPPORT",
+			match: false,
+		},
+		{
+			name:  "No Recommended Action in either - still matches on ErrorCode and entity",
+			a:     "ErrorCode:119 PCI:0002:00:00 GPU_UUID:GPU-22222222 kernel: some text",
+			b:     "ErrorCode:119 PCI:0002:00:00 GPU_UUID:GPU-22222... kernel: other text",
+			match: true,
+		},
+		{
+			name:  "No entities in common - no match",
+			a:     "ErrorCode:119 PCI:0002:00:00 Recommended Action=COMPONENT_RESET",
+			b:     "ErrorCode:119 PCI:0003:00:00 Recommended Action=COMPONENT_RESET",
+			match: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := messagesMatchByIdentity(tc.a, tc.b)
+			assert.Equal(t, tc.match, result)
+		})
+	}
+}

--- a/platform-connectors/pkg/connectors/kubernetes/k8s_platform_connector_test.go
+++ b/platform-connectors/pkg/connectors/kubernetes/k8s_platform_connector_test.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"net/url"
 	"os"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -51,8 +52,11 @@ func TestMain(m *testing.M) {
 	ctx = context.Background()
 	stopCh := make(chan struct{})
 	ringBuffer := ringbuffer.NewRingBuffer("k8sRingBuffer", ctx)
-	maxNodeConditionMessageLength := int64(1024)
-	k8sConnector = NewK8sConnector(clientSet, ringBuffer, stopCh, ctx, maxNodeConditionMessageLength)
+	cfg := K8sConnectorConfig{
+		MaxNodeConditionMessageLength: 1024,
+		CompactedHealthEventMsgLen:    72,
+	}
+	k8sConnector = NewK8sConnector(clientSet, ringBuffer, stopCh, ctx, cfg)
 	exitVal := m.Run()
 	os.Exit(exitVal)
 }
@@ -1346,8 +1350,10 @@ func TestUpdateNodeConditions_ErrorHandling(t *testing.T) {
 			defer close(stopCh)
 
 			ringBuffer := ringbuffer.NewRingBuffer(fmt.Sprintf("testRingBuffer-%d", i), localCtx)
-			maxNodeConditionMessageLength := int64(1024)
-			connector := NewK8sConnector(localClientSet, ringBuffer, stopCh, localCtx, maxNodeConditionMessageLength)
+			connector := NewK8sConnector(localClientSet, ringBuffer, stopCh, localCtx, K8sConnectorConfig{
+				MaxNodeConditionMessageLength: 1024,
+				CompactedHealthEventMsgLen:    72,
+			})
 
 			if tt.setupNode {
 				node := &corev1.Node{
@@ -1540,8 +1546,10 @@ func TestProcessHealthEvents_StoreOnlyStrategy(t *testing.T) {
 			defer close(stopCh)
 
 			ringBuffer := ringbuffer.NewRingBuffer(fmt.Sprintf("storeOnlyTestBuffer-%d", i), localCtx)
-			maxNodeConditionMessageLength := int64(1024)
-			connector := NewK8sConnector(localClientSet, ringBuffer, stopCh, localCtx, maxNodeConditionMessageLength)
+			connector := NewK8sConnector(localClientSet, ringBuffer, stopCh, localCtx, K8sConnectorConfig{
+				MaxNodeConditionMessageLength: 1024,
+				CompactedHealthEventMsgLen:    72,
+			})
 
 			nodeName := "store-only-test-node"
 			fakeNode := &corev1.Node{
@@ -1619,12 +1627,60 @@ func TestProcessHealthEvents_StoreOnlyStrategy(t *testing.T) {
 	}
 }
 
+func TestCompactMessageField(t *testing.T) {
+	tests := []struct {
+		name     string
+		msg      string
+		maxLen   int
+		expected string
+	}{
+		{
+			name:     "Short message - no compaction needed",
+			msg:      "ErrorCode:DCGM_FR_NVLINK_DOWN GPU:3 Link down Recommended Action=RESTART_VM",
+			maxLen:   128,
+			expected: "ErrorCode:DCGM_FR_NVLINK_DOWN GPU:3 Link down Recommended Action=RESTART_VM",
+		},
+		{
+			name:     "Long message - truncated to maxLen",
+			msg:      "ErrorCode:DCGM_FR_NVLINK_DOWN GPU:3 GPU 3's NvLink link 0 is currently down Check DCGM and system logs for errors. Reset GPU. Restart DCGM. Rerun diagnostics. Recommended Action=RESTART_VM",
+			maxLen:   80,
+			expected: "ErrorCode:DCGM_FR_NVLINK_DOWN GPU:3 GPU 3's NvLink link 0 is currently down Chec... Recommended Action=RESTART_VM",
+		},
+		{
+			name:     "No Recommended Action marker - returned as-is",
+			msg:      "some unstructured message without the marker",
+			maxLen:   10,
+			expected: "some unstructured message without the marker",
+		},
+		{
+			name:     "Message with multiple entities - truncated to maxLen",
+			msg:      "ErrorCode:DCGM_FR_NVLINK_DOWN GPU:3 PCI:0000:c4:00.0 GPU_UUID:GPU-8614c5d9-371d-1d8a-9bab-78d0434427ec GPU 3's NvLink link 0 is currently down Check DCGM and system logs for errors. Recommended Action=RESTART_VM",
+			maxLen:   128,
+			expected: "ErrorCode:DCGM_FR_NVLINK_DOWN GPU:3 PCI:0000:c4:00.0 GPU_UUID:GPU-8614c5d9-371d-1d8a-9bab-78d0434427ec GPU 3's NvLink link 0 is ... Recommended Action=RESTART_VM",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := compactMessageField(tc.msg, tc.maxLen)
+			assert.Equal(t, tc.expected, result)
+
+			if strings.Contains(tc.msg, recommendedActionMarker) {
+				assert.Contains(t, result, recommendedActionMarker,
+					"Recommended Action must always be preserved")
+			}
+		})
+	}
+}
+
 func TestTruncateConditionMessage(t *testing.T) {
-	// Generate test messages that would exceed 1KB when combined
 	generateLongMessages := func(count int) []string {
 		var msgs []string
 		for i := 0; i < count; i++ {
-			msgs = append(msgs, "ErrorCode:45 PCI:0000:29:00 GPU:GPU-8614c5d9-371d-1d8a-9bab-78d0434427ec ROBUST_CHANNEL Resolution: WORKFLOW_XID_45 Recommended Action=CONTACT_SUPPORT")
+			msgs = append(msgs, fmt.Sprintf(
+				"ErrorCode:DCGM_FR_NVLINK_DOWN GPU:%d PCI:0000:c4:00.0 GPU_UUID:GPU-8614c5d9-371d-1d8a-9bab-78d0434427ec "+
+					"GPU %d's NvLink link 0 is currently down Check DCGM and system logs for errors. Reset GPU. Restart DCGM. Rerun diagnostics. "+
+					"Recommended Action=RESTART_VM", i, i))
 		}
 		return msgs
 	}
@@ -1637,7 +1693,7 @@ func TestTruncateConditionMessage(t *testing.T) {
 		description                   string
 	}{
 		{
-			name:                          "Empty NodeConditionMessage  with 1KB limit",
+			name:                          "Empty NodeConditionMessage with 1KB limit",
 			maxNodeConditionMessageLength: 1024,
 			messages:                      []string{},
 			shouldTruncate:                false,
@@ -1671,13 +1727,29 @@ func TestTruncateConditionMessage(t *testing.T) {
 			shouldTruncate:                true,
 			description:                   "With 256 byte limit, even 3 NodeConditionMessages should be truncated",
 		},
+		{
+			name:                          "Single message exceeding limit - should truncate not produce ;...",
+			maxNodeConditionMessageLength: 1024,
+			messages:                      []string{strings.Repeat("ErrorCode:DCGM_FR_NVLINK_DOWN GPU:3 NvLink link down. ", 50)},
+			shouldTruncate:                true,
+			description:                   "Single message larger than max should be truncated, not skipped",
+		},
+		{
+			name:                          "Single message exactly at limit boundary",
+			maxNodeConditionMessageLength: 100,
+			messages:                      []string{"ErrorCode:DCGM_FR_TEMP_VIOLATION GPU:0 Thermal threshold exceeded. Recommended Action=RESTART_VM"},
+			shouldTruncate:                false,
+			description:                   "Message that exactly fits (msg + ';' = maxLen - suffixLen) should not be truncated",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			// Create connector with configurable maxNodeConditionMessageLength
 			connector := &K8sConnector{
-				maxNodeConditionMessageLength: tc.maxNodeConditionMessageLength,
+				config: K8sConnectorConfig{
+					MaxNodeConditionMessageLength: tc.maxNodeConditionMessageLength,
+					CompactedHealthEventMsgLen:    72,
+				},
 			}
 
 			result := connector.truncateNodeConditionMessage(tc.messages)
@@ -1691,6 +1763,8 @@ func TestTruncateConditionMessage(t *testing.T) {
 					"NodeConditionMessage length should not exceed configured max")
 				assert.Contains(t, result, truncationSuffix,
 					"truncated NodeConditionMessage should contain truncation suffix '...'")
+				assert.NotEqual(t, ";...", result,
+					"truncated message must contain partial content, not just ';...'")
 			} else {
 				// When no truncation is expected
 				assert.NotContains(t, result, truncationSuffix,
@@ -1706,4 +1780,31 @@ func TestTruncateConditionMessage(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTruncateConditionMessage_EntityIdentifierPreservation(t *testing.T) {
+	connector := &K8sConnector{config: K8sConnectorConfig{MaxNodeConditionMessageLength: 1024, CompactedHealthEventMsgLen: 72}}
+
+	var msgs []string
+	for i := 0; i < 8; i++ {
+		msgs = append(msgs, fmt.Sprintf(
+			"ErrorCode:DCGM_FR_NVLINK_DOWN GPU:%d PCI:0000:c4:00.0 GPU_UUID:GPU-8614c5d9-371d-1d8a-9bab-78d0434427ec "+
+				"GPU %d's NvLink link 0 is currently down Check DCGM and system logs for errors. Reset GPU. Restart DCGM. Rerun diagnostics. "+
+				"Recommended Action=RESTART_VM", i, i))
+	}
+
+	result := connector.truncateNodeConditionMessage(msgs)
+
+	t.Logf("Result length: %d / 1024", len(result))
+	assert.LessOrEqual(t, len(result), 1024)
+	for i := 0; i < 8; i++ {
+		assert.Contains(t, result, fmt.Sprintf("GPU:%d ", i),
+			"GPU %d identifier must survive compaction for clearing", i)
+	}
+	assert.Contains(t, result, "PCI:0000:c4:00.0",
+		"PCI identifier must survive compaction for clearing")
+	assert.Contains(t, result, "ErrorCode:DCGM_FR_NVLINK_DOWN",
+		"Error code must be preserved")
+	assert.Contains(t, result, "Recommended Action=RESTART_VM",
+		"Recommended action must be preserved")
 }

--- a/platform-connectors/pkg/connectors/kubernetes/k8s_platform_connector_test.go
+++ b/platform-connectors/pkg/connectors/kubernetes/k8s_platform_connector_test.go
@@ -1678,9 +1678,9 @@ func TestTruncateConditionMessage(t *testing.T) {
 		var msgs []string
 		for i := 0; i < count; i++ {
 			msgs = append(msgs, fmt.Sprintf(
-				"ErrorCode:DCGM_FR_NVLINK_DOWN GPU:%d PCI:0000:c4:00.0 GPU_UUID:GPU-8614c5d9-371d-1d8a-9bab-78d0434427ec "+
+				"ErrorCode:DCGM_FR_NVLINK_DOWN GPU:%d PCI:0000:c%d:00.0 GPU_UUID:GPU-8614c5d9-371d-1d8a-9bab-78d04344270%d "+
 					"GPU %d's NvLink link 0 is currently down Check DCGM and system logs for errors. Reset GPU. Restart DCGM. Rerun diagnostics. "+
-					"Recommended Action=RESTART_VM", i, i))
+					"Recommended Action=RESTART_VM", i, i+1, i, i))
 		}
 		return msgs
 	}
@@ -1785,12 +1785,17 @@ func TestTruncateConditionMessage(t *testing.T) {
 func TestTruncateConditionMessage_EntityIdentifierPreservation(t *testing.T) {
 	connector := &K8sConnector{config: K8sConnectorConfig{MaxNodeConditionMessageLength: 1024, CompactedHealthEventMsgLen: 72}}
 
+	pciAddresses := []string{
+		"0000:c1:00.0", "0000:c2:00.0", "0000:c3:00.0", "0000:c4:00.0",
+		"0000:c5:00.0", "0000:c6:00.0", "0000:c7:00.0", "0000:c8:00.0",
+	}
+
 	var msgs []string
 	for i := 0; i < 8; i++ {
 		msgs = append(msgs, fmt.Sprintf(
-			"ErrorCode:DCGM_FR_NVLINK_DOWN GPU:%d PCI:0000:c4:00.0 GPU_UUID:GPU-8614c5d9-371d-1d8a-9bab-78d0434427ec "+
+			"ErrorCode:DCGM_FR_NVLINK_DOWN GPU:%d PCI:%s GPU_UUID:GPU-8614c5d9-371d-1d8a-9bab-78d0434427e%d "+
 				"GPU %d's NvLink link 0 is currently down Check DCGM and system logs for errors. Reset GPU. Restart DCGM. Rerun diagnostics. "+
-				"Recommended Action=RESTART_VM", i, i))
+				"Recommended Action=RESTART_VM", i, pciAddresses[i], i, i))
 	}
 
 	result := connector.truncateNodeConditionMessage(msgs)
@@ -1800,9 +1805,9 @@ func TestTruncateConditionMessage_EntityIdentifierPreservation(t *testing.T) {
 	for i := 0; i < 8; i++ {
 		assert.Contains(t, result, fmt.Sprintf("GPU:%d ", i),
 			"GPU %d identifier must survive compaction for clearing", i)
+		assert.Contains(t, result, fmt.Sprintf("PCI:%s", pciAddresses[i]),
+			"PCI identifier for GPU %d must survive compaction for clearing", i)
 	}
-	assert.Contains(t, result, "PCI:0000:c4:00.0",
-		"PCI identifier must survive compaction for clearing")
 	assert.Contains(t, result, "ErrorCode:DCGM_FR_NVLINK_DOWN",
 		"Error code must be preserved")
 	assert.Contains(t, result, "Recommended Action=RESTART_VM",
@@ -1866,4 +1871,105 @@ func TestMessagesMatchByIdentity(t *testing.T) {
 			assert.Equal(t, tc.match, result)
 		})
 	}
+}
+
+func TestDeduplicationBehavior(t *testing.T) {
+	msgOld := "ErrorCode:119 PCI:0002:00:00 GPU_UUID:GPU-22222222-2222-2222-2222-222222222222 " +
+		"kernel: [16450076.435595] NVRM: Xid (PCI:0002:00:00): 119, pid=1582259 Recommended Action=COMPONENT_RESET"
+	msgNew := "ErrorCode:119 PCI:0002:00:00 GPU_UUID:GPU-22222222-2222-2222-2222-222222222222 " +
+		"kernel: [16450077.123456] NVRM: Xid (PCI:0002:00:00): 119, pid=9999999 Recommended Action=COMPONENT_RESET"
+	msgUnrelated := "ErrorCode:79 PCI:0001:00:00 GPU_UUID:GPU-11111111-1111-1111-1111-111111111111 " +
+		"kernel: [16450078.000000] NVRM: Xid (PCI:0001:00:00): 79 Recommended Action=CONTACT_SUPPORT"
+
+	t.Run("Exact duplicate always blocked by addMessageIfNotExist", func(t *testing.T) {
+		connector := NewK8sConnector(nil, nil, nil, context.Background(), K8sConnectorConfig{
+			MaxNodeConditionMessageLength: 4096,
+			CompactedHealthEventMsgLen:    72,
+		})
+
+		event := &protos.HealthEvent{
+			ErrorCode:         []string{"119"},
+			EntitiesImpacted:  []*protos.Entity{{EntityType: "PCI", EntityValue: "0002:00:00"}},
+			Message:           "kernel: same message",
+			RecommendedAction: protos.RecommendedAction_COMPONENT_RESET,
+		}
+
+		msgs := connector.addMessageIfNotExist(nil, event)
+		require.Len(t, msgs, 1, "First add should create 1 entry")
+
+		msgs = connector.addMessageIfNotExist(msgs, event)
+		assert.Len(t, msgs, 1, "Exact same event should not create a second entry")
+	})
+
+	t.Run("Below limit - different timestamps preserved as separate entries", func(t *testing.T) {
+		connector := &K8sConnector{config: K8sConnectorConfig{
+			MaxNodeConditionMessageLength: 4096,
+			CompactedHealthEventMsgLen:    72,
+		}}
+
+		messages := []string{msgOld, msgUnrelated, msgNew}
+		result := connector.truncateNodeConditionMessage(messages)
+
+		assert.Contains(t, result, "pid=1582259", "Old message should be preserved below limit")
+		assert.Contains(t, result, "pid=9999999", "New message should be preserved below limit")
+		assert.Contains(t, result, "ErrorCode:79", "Unrelated message should be preserved")
+	})
+
+	t.Run("Above limit - identity duplicates consolidated keeping freshest", func(t *testing.T) {
+		connector := &K8sConnector{config: K8sConnectorConfig{
+			MaxNodeConditionMessageLength: 300,
+			CompactedHealthEventMsgLen:    72,
+		}}
+
+		messages := []string{msgOld, msgUnrelated, msgNew}
+		result := connector.truncateNodeConditionMessage(messages)
+		parts := strings.Split(result, ";")
+		count := 0
+
+		for _, part := range parts {
+			if strings.Contains(part, "ErrorCode:119") && strings.Contains(part, "PCI:0002:00:00") {
+				count++
+			}
+		}
+
+		assert.Equal(t, 1, count, "Should have exactly 1 entry for ErrorCode:119 PCI:0002:00:00 after dedup")
+		assert.Contains(t, result, "ErrorCode:79", "Unrelated message should survive dedup")
+		assert.NotContains(t, result, "pid=1582259", "Older duplicate should be dropped")
+	})
+
+	t.Run("Above limit - same-entity duplicate produces single compacted entry", func(t *testing.T) {
+		// Two messages with identical entity (PCI:0002:00:00) and Recommended Action
+		// but different diagnostic text. When above limit, dedup must consolidate them
+		// to exactly one entry in the compacted output — not two.
+		connector := &K8sConnector{config: K8sConnectorConfig{
+			MaxNodeConditionMessageLength: 300,
+			CompactedHealthEventMsgLen:    72,
+		}}
+
+		messages := []string{msgOld, msgNew}
+		result := connector.truncateNodeConditionMessage(messages)
+
+		var entries []string
+		for _, p := range strings.Split(result, ";") {
+			if p != "" && p != truncationSuffix {
+				entries = append(entries, p)
+			}
+		}
+
+		// Both messages share the same identity (PCI:0002:00:00 + COMPONENT_RESET),
+		// so exactly one compacted entry should remain after dedup.
+		require.Len(t, entries, 1, "Same-entity duplicates must produce exactly one entry after dedup+compaction")
+
+		// The surviving entry must be in compacted form (diagnostic text truncated).
+		assert.Contains(t, entries[0], truncationSuffix,
+			"Surviving entry must be in compacted form")
+		assert.Contains(t, entries[0], "PCI:0002:00:00",
+			"Entity identifier must be preserved in the compacted entry")
+		assert.Contains(t, entries[0], "Recommended Action=COMPONENT_RESET",
+			"Recommended Action must be preserved in the compacted entry")
+
+		// The freshest message (pid=9999999) must be the one kept.
+		assert.NotContains(t, result, "pid=1582259", "Older duplicate must be dropped")
+	})
+
 }

--- a/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
+++ b/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
@@ -232,14 +232,68 @@ func parseMessages(message string) []string {
 
 func (r *K8sConnector) addMessageIfNotExist(messages []string, healthEvent *protos.HealthEvent) []string {
 	newMessage := r.constructHealthEventMessage(healthEvent)
+	trimmed := newMessage[:len(newMessage)-1]
 
-	for _, msg := range messages {
-		if fmt.Sprintf("%s;", msg) == newMessage {
+	for i, msg := range messages {
+		if messagesMatchByIdentity(msg, trimmed) {
+			messages[i] = trimmed
+
 			return messages
 		}
 	}
 
-	return append(messages, newMessage[:len(newMessage)-1])
+	return append(messages, trimmed)
+}
+
+// extractMessageIdentity parses ErrorCodes, entity tokens (GPU, PCI, GPU_UUID),
+// and Recommended Action from a node condition message. Works on both full and
+// compacted messages.
+func extractMessageIdentity(msg string) (errorCodes []string, entities []string, recommendedAction string) {
+	raIdx := strings.LastIndex(msg, recommendedActionMarker)
+	if raIdx >= 0 {
+		recommendedAction = strings.TrimRight(msg[raIdx:], " ")
+	}
+
+	prefix := msg
+	if raIdx >= 0 {
+		prefix = msg[:raIdx]
+	}
+
+	for _, token := range strings.Fields(prefix) {
+		switch {
+		case strings.HasPrefix(token, "ErrorCode:"):
+			errorCodes = append(errorCodes, token)
+		case strings.HasPrefix(token, "GPU:") ||
+			strings.HasPrefix(token, "PCI:") ||
+			strings.HasPrefix(token, "GPU_UUID:"):
+			entities = append(entities, token)
+		}
+	}
+
+	return errorCodes, entities, recommendedAction
+}
+
+// messagesMatchByIdentity returns true if two messages represent the same fault:
+// same ErrorCodes, same Recommended Action, and at least one shared entity
+// (GPU, PCI, or GPU_UUID). Entity any-match handles the case where GPU_UUID is
+// truncated by compaction but GPU or PCI identifiers still match.
+func messagesMatchByIdentity(a, b string) bool {
+	aErr, aEnt, aRA := extractMessageIdentity(a)
+	bErr, bEnt, bRA := extractMessageIdentity(b)
+
+	if aRA != bRA || !slices.Equal(aErr, bErr) {
+		return false
+	}
+
+	for _, ae := range aEnt {
+		for _, be := range bEnt {
+			if ae == be {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func (r *K8sConnector) removeImpactedEntitiesMessages(messages []string,

--- a/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
+++ b/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
@@ -232,17 +232,14 @@ func parseMessages(message string) []string {
 
 func (r *K8sConnector) addMessageIfNotExist(messages []string, healthEvent *protos.HealthEvent) []string {
 	newMessage := r.constructHealthEventMessage(healthEvent)
-	trimmed := newMessage[:len(newMessage)-1]
 
-	for i, msg := range messages {
-		if messagesMatchByIdentity(msg, trimmed) {
-			messages[i] = trimmed
-
+	for _, msg := range messages {
+		if fmt.Sprintf("%s;", msg) == newMessage {
 			return messages
 		}
 	}
 
-	return append(messages, trimmed)
+	return append(messages, newMessage[:len(newMessage)-1])
 }
 
 // extractMessageIdentity parses ErrorCodes, entity tokens (GPU, PCI, GPU_UUID),
@@ -264,8 +261,7 @@ func extractMessageIdentity(msg string) (errorCodes []string, entities []string,
 		case strings.HasPrefix(token, "ErrorCode:"):
 			errorCodes = append(errorCodes, token)
 		case strings.HasPrefix(token, "GPU:") ||
-			strings.HasPrefix(token, "PCI:") ||
-			strings.HasPrefix(token, "GPU_UUID:"):
+			strings.HasPrefix(token, "PCI:"):
 			entities = append(entities, token)
 		}
 	}
@@ -294,6 +290,31 @@ func messagesMatchByIdentity(a, b string) bool {
 	}
 
 	return false
+}
+
+// deduplicateMessagesByIdentity removes identity-duplicate messages, keeping the
+// last (freshest) occurrence. This is only called when total message length
+// exceeds the node condition limit, to reclaim space before compaction.
+func deduplicateMessagesByIdentity(messages []string) []string {
+	var result []string
+
+	for i, msg := range messages {
+		duplicate := false
+
+		for j := i + 1; j < len(messages); j++ {
+			if messagesMatchByIdentity(msg, messages[j]) {
+				duplicate = true
+
+				break
+			}
+		}
+
+		if !duplicate {
+			result = append(result, msg)
+		}
+	}
+
+	return result
 }
 
 func (r *K8sConnector) removeImpactedEntitiesMessages(messages []string,
@@ -732,8 +753,11 @@ func compactMessageField(msg string, maxLen int) string {
 func (r *K8sConnector) truncateNodeConditionMessage(messages []string) string {
 	maxLen := int(r.config.MaxNodeConditionMessageLength)
 
-	// Tier 1: if full messages exceed the limit, compact the free-text fields.
+	// When messages exceed the limit, first remove identity-duplicates (same
+	// ErrorCode + entity + Recommended Action) to reclaim space, then compact.
 	if totalMessageLength(messages) > maxLen {
+		messages = deduplicateMessagesByIdentity(messages)
+
 		compacted := make([]string, len(messages))
 		for i, msg := range messages {
 			compacted[i] = compactMessageField(msg, int(r.config.CompactedHealthEventMsgLen))

--- a/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
+++ b/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
@@ -38,9 +38,10 @@ import (
 )
 
 const (
-	DefaultNamespace   = "default"
-	NoHealthFailureMsg = "No Health Failures"
-	truncationSuffix   = "..."
+	DefaultNamespace        = "default"
+	NoHealthFailureMsg      = "No Health Failures"
+	truncationSuffix        = "..."
+	recommendedActionMarker = "Recommended Action="
 )
 
 // updateNodeConditions updates node conditions for a single node.
@@ -629,30 +630,90 @@ func isKubernetesStringError(errStr string) bool {
 	return false
 }
 
-// truncateNodeConditionMessage builds the node condition message while respecting the max node condition
-// message length. It preserves complete error entries and adds a truncation indicator if needed.
-func (r *K8sConnector) truncateNodeConditionMessage(messages []string) string {
-	maxLen := int(r.maxNodeConditionMessageLength) - len(truncationSuffix)
+// totalMessageLength returns the byte length of messages joined with ";" separators plus a trailing ";".
+func totalMessageLength(messages []string) int {
+	total := 0
 
+	for i, msg := range messages {
+		if i > 0 {
+			total++
+		}
+
+		total += len(msg)
+	}
+
+	total++ // trailing ";"
+
+	return total
+}
+
+// compactMessageField truncates the message content before the Recommended Action
+// suffix to maxLen bytes, preserving the Recommended Action suffix needed for
+// recovery matching.
+//
+// Input format:  "ErrorCode:X GPU:3 PCI:addr <diagnostic text> Recommended Action=Y"
+// Output format: "ErrorCode:X GPU:3 PCI:addr <truncated>... Recommended Action=Y"
+func compactMessageField(msg string, maxLen int) string {
+	raIdx := strings.LastIndex(msg, recommendedActionMarker)
+	if raIdx < 0 {
+		return msg
+	}
+
+	beforeRA := strings.TrimRight(msg[:raIdx], " ")
+	raPart := msg[raIdx:]
+
+	if len(beforeRA) <= maxLen {
+		return msg
+	}
+
+	return beforeRA[:maxLen] + truncationSuffix + " " + raPart
+}
+
+// truncateNodeConditionMessage builds the node condition message while respecting the max node condition
+// message length. It applies two tiers of truncation:
+//  1. If full messages exceed the limit, compact each message's free-text diagnostic field
+//     to compactMessageFieldLen bytes, preserving entity identifiers needed for recovery.
+//  2. If compacted messages still exceed the limit, truncate the last entry at the byte level
+//     to fill the remaining space.
+func (r *K8sConnector) truncateNodeConditionMessage(messages []string) string {
+	maxLen := int(r.config.MaxNodeConditionMessageLength)
+
+	// Tier 1: if full messages exceed the limit, compact the free-text fields.
+	if totalMessageLength(messages) > maxLen {
+		compacted := make([]string, len(messages))
+		for i, msg := range messages {
+			compacted[i] = compactMessageField(msg, int(r.config.CompactedHealthEventMsgLen))
+		}
+
+		messages = compacted
+	}
+
+	// Tier 2: build the result, truncating at byte level if compacted messages still don't fit.
 	var result strings.Builder
 
 	truncated := false
 
 	for i, msg := range messages {
-		var newEntry string
-		if i == 0 {
-			newEntry = msg
-		} else {
-			newEntry = ";" + msg
+		separator := ""
+		if i > 0 {
+			separator = ";"
 		}
 
-		// Check if adding this entry would exceed the limit (+1 for trailing semicolon)
-		if result.Len()+len(newEntry)+1 > maxLen {
+		// +1 accounts for the trailing semicolon that is always appended after the loop
+		if result.Len()+len(separator)+len(msg)+1 > maxLen {
+			available := maxLen - result.Len() - len(separator) - 1 - len(truncationSuffix)
+			if available > 0 {
+				result.WriteString(separator)
+				result.WriteString(msg[:available])
+			}
+
 			truncated = true
+
 			break
 		}
 
-		result.WriteString(newEntry)
+		result.WriteString(separator)
+		result.WriteString(msg)
 	}
 
 	result.WriteString(";")

--- a/tests/syslog_health_monitor_test.go
+++ b/tests/syslog_health_monitor_test.go
@@ -193,7 +193,7 @@ func TestSyslogHealthMonitorXIDDetection(t *testing.T) {
 		t.Logf("Injecting %d additional XID messages (includes 1 duplicate) to exceed 1KB limit", len(additionalXidMessages))
 		helpers.InjectSyslogMessages(t, helpers.StubJournalHTTPPort, additionalXidMessages)
 
-		t.Log("Verifying truncation and dedup: message <= 1KB, has '...' suffix, no duplicate entries")
+		t.Log("Verifying compaction and dedup: message <= 1KB, no '...' suffix, no duplicate entries")
 		require.Eventually(t, func() bool {
 			condition, err := helpers.CheckNodeConditionExists(ctx, client, nodeName,
 				"SysLogsXIDError", "SysLogsXIDErrorIsNotHealthy")
@@ -204,18 +204,18 @@ func TestSyslogHealthMonitorXIDDetection(t *testing.T) {
 
 			messageLen := len(condition.Message)
 
+			if !strings.Contains(condition.Message, "ErrorCode:79") {
+				t.Logf("Waiting for all messages to be processed (%d bytes so far)", messageLen)
+				return false
+			}
+
 			if messageLen > maxConditionMessageLength {
 				t.Logf("FAIL: Message length %d exceeds max %d", messageLen, maxConditionMessageLength)
 				return false
 			}
 
-			if !strings.HasSuffix(condition.Message, truncationSuffix) {
-				t.Logf("FAIL: Message should end with truncation suffix '%s'", truncationSuffix)
-				return false
-			}
-
-			if !strings.Contains(condition.Message, "ErrorCode:119") {
-				t.Logf("FAIL: Message should contain ErrorCode:119 from first inject")
+			if strings.HasSuffix(condition.Message, truncationSuffix) {
+				t.Logf("Waiting for dedup to settle (%d bytes, still has '%s')", messageLen, truncationSuffix)
 				return false
 			}
 
@@ -234,11 +234,34 @@ func TestSyslogHealthMonitorXIDDetection(t *testing.T) {
 				return false
 			}
 
-			t.Logf("PASS: %d bytes, truncated with '%s', dedup verified (1 entry for XID 119/PCI:0002:00:00)",
-				messageLen, truncationSuffix)
+			t.Logf("PASS: %d bytes, compacted without hard truncation, dedup verified", messageLen)
 			return true
 		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval,
-			"Node condition message should be truncated to 1KB with no duplicates")
+			"10 compacted entries should fit within 1KB without hard truncation")
+
+		return ctx
+	})
+
+	feature.Assess("Inject one more XID to trigger hard truncation", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err, "failed to create kubernetes client")
+
+		nodeName := ctx.Value(keySyslogNodeName).(string)
+
+		helpers.InjectSyslogMessages(t, helpers.StubJournalHTTPPort, []string{
+			"kernel: [16450076.435595] NVRM: Xid (PCI:0001:00:00): 94, pid=789101, name=process, Contained ECC error.",
+		})
+
+		require.Eventually(t, func() bool {
+			condition, err := helpers.CheckNodeConditionExists(ctx, client, nodeName,
+				"SysLogsXIDError", "SysLogsXIDErrorIsNotHealthy")
+			if err != nil || condition == nil {
+				return false
+			}
+
+			return len(condition.Message) <= 1024 && strings.HasSuffix(condition.Message, "...")
+		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval,
+			"11th entry should trigger hard truncation with '...' suffix")
 
 		return ctx
 	})

--- a/tests/syslog_health_monitor_test.go
+++ b/tests/syslog_health_monitor_test.go
@@ -171,15 +171,29 @@ func TestSyslogHealthMonitorXIDDetection(t *testing.T) {
 			truncationSuffix          = "..."
 		)
 
+		// We need 10+ unique node condition entries to exceed 1024 bytes after per-message
+		// compaction (each compacted message is ~110 bytes). The burst test already created 3
+		// entries (XIDs 119, 94, 145), so we inject 7 more across all 4 GPU PCI addresses.
+		// The last message is a duplicate of XID 119 on PCI:0002:00:00 (already present from
+		// the burst test) to verify identity-based dedup replaces rather than duplicates.
 		additionalXidMessages := []string{
-			"kernel: [16450076.435595] NVRM: Xid (PCI:0002:00:00): 119, pid=15822500, name=nvc:[driver], Timeout after 6s of waiting for RPC response from GPU1 GSP! Expected function 76 (GSP_RM_CONTROL) (0x20802a02 0x8).",
+			// XID 119 on remaining GPUs (0002:00:00 already exists from burst test)
+			"kernel: [16450076.435595] NVRM: Xid (PCI:0001:00:00): 119, pid=15822501, name=nvc:[driver], Timeout after 6s of waiting for RPC response from GPU1 GSP! Expected function 76 (GSP_RM_CONTROL) (0x20802a02 0x8).",
+			"kernel: [16450076.435595] NVRM: Xid (PCI:0000:17:00): 119, pid=15822502, name=nvc:[driver], Timeout after 6s of waiting for RPC response from GPU0 GSP! Expected function 76 (GSP_RM_CONTROL) (0x20802a02 0x8).",
+			"kernel: [16450076.435595] NVRM: Xid (PCI:0000:19:00): 119, pid=15822503, name=nvc:[driver], Timeout after 6s of waiting for RPC response from GPU3 GSP! Expected function 76 (GSP_RM_CONTROL) (0x20802a02 0x8).",
+			// XID 79 on all GPUs
 			"kernel: [16450076.435595] NVRM: Xid (PCI:0001:00:00): 79, pid=123457, name=test-again, GPU has fallen off the bus.",
+			"kernel: [16450076.435595] NVRM: Xid (PCI:0002:00:00): 79, pid=123458, name=test-again, GPU has fallen off the bus.",
+			"kernel: [16450076.435595] NVRM: Xid (PCI:0000:17:00): 79, pid=123459, name=test-again, GPU has fallen off the bus.",
+			"kernel: [16450076.435595] NVRM: Xid (PCI:0000:19:00): 79, pid=123460, name=test-again, GPU has fallen off the bus.",
+			// Duplicate: XID 119 on PCI:0002:00:00 already exists from burst test
+			"kernel: [16450076.435595] NVRM: Xid (PCI:0002:00:00): 119, pid=9999999, name=nvc:[driver], Timeout after 6s of waiting for RPC response from GPU1 GSP! Expected function 76 (GSP_RM_CONTROL) (0x20802a02 0x8).",
 		}
 
-		t.Logf("Injecting %d additional XID messages to exceed 1KB limit", len(additionalXidMessages))
+		t.Logf("Injecting %d additional XID messages (includes 1 duplicate) to exceed 1KB limit", len(additionalXidMessages))
 		helpers.InjectSyslogMessages(t, helpers.StubJournalHTTPPort, additionalXidMessages)
 
-		t.Log("Verifying node condition message is truncated to 1KB limit with exactly one truncation suffix")
+		t.Log("Verifying truncation and dedup: message <= 1KB, has '...' suffix, no duplicate entries")
 		require.Eventually(t, func() bool {
 			condition, err := helpers.CheckNodeConditionExists(ctx, client, nodeName,
 				"SysLogsXIDError", "SysLogsXIDErrorIsNotHealthy")
@@ -205,12 +219,27 @@ func TestSyslogHealthMonitorXIDDetection(t *testing.T) {
 				return false
 			}
 
-			t.Logf("Message truncated correctly: %d bytes (at 1KB limit) with suffix '%s'", messageLen, truncationSuffix)
+			// Verify dedup: ErrorCode:119 + PCI:0002:00:00 should appear exactly once
+			parts := strings.Split(condition.Message, ";")
+			count := 0
+
+			for _, part := range parts {
+				if strings.Contains(part, "ErrorCode:119") && strings.Contains(part, "PCI:0002:00:00") {
+					count++
+				}
+			}
+
+			if count != 1 {
+				t.Logf("FAIL: Expected exactly 1 entry for ErrorCode:119 PCI:0002:00:00, found %d", count)
+				return false
+			}
+
+			t.Logf("PASS: %d bytes, truncated with '%s', dedup verified (1 entry for XID 119/PCI:0002:00:00)",
+				messageLen, truncationSuffix)
 			return true
 		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval,
-			"Node condition message should be truncated to 1KB with exactly one truncation suffix")
+			"Node condition message should be truncated to 1KB with no duplicates")
 
-		t.Log("Truncation test PASSED: Message correctly truncated to 1KB limit")
 		return ctx
 	})
 


### PR DESCRIPTION
## Summary
Issue: https://github.com/NVIDIA/NVSentinel/issues/1009

Node condition messages are compacted to fit within the Kubernetes 1024-byte limit by truncating the per-event message prefix (diagnostic text, GPU_UUID) while preserving the fields critical for error clearing — ErrorCode, GPU ID, PCI address, and Recommended Action. 

<!-- Brief description of your changes -->

1. Two-tier truncation logic (process_node_events.go): Added compactMessageField which truncates only the free-text diagnostic portion before Recommended Action=, preserving ErrorCode, entity identifiers (GPU, PCI, GPU_UUID), and the Recommended Action suffix. The existing truncateNodeConditionMessage now applies compaction first (Tier 1) and falls back to byte-level truncation (Tier 2) only if compacted messages still exceed the limit. Suffix space (...) is reserved only when truncation actually occurs.

2. New K8sConnectorConfig struct (k8s_connector.go): Refactored K8sConnector to use a config struct encapsulating MaxNodeConditionMessageLength and the new CompactedHealthEventMsgLen, replacing individual parameters in NewK8sConnector and InitializeK8sConnector.

UT: 
Tested it on real cluster with GpuInforomWatch injected on 8 gpus. It is able to correctly publish those 8 gpu's by trimming down the msg field.

`  GpuInforomWatch                                   True    Fri, 13 Mar 2026 11:35:51 +0530   Fri, 13 Mar 2026 11:33:51 +0530   GpuInforomWatchIsNotHealthy                                  ErrorCode:DCGM_FR_CORRUPT_INFOROM GPU:0 PCI:0000:04:00.0 GPU_UUID:GPU-13... Recommended Action=COMPONENT_RESET;ErrorCode:DCGM_FR_CORRUPT_INFOROM GPU:1 PCI:0000:05:00.0 GPU_UUID:GPU-16... Recommended Action=COMPONENT_RESET;ErrorCode:DCGM_FR_CORRUPT_INFOROM GPU:2 PCI:0000:0b:00.0 GPU_UUID:GPU-03... Recommended Action=COMPONENT_RESET;ErrorCode:DCGM_FR_CORRUPT_INFOROM GPU:3 PCI:0000:0c:00.0 GPU_UUID:GPU-99... Recommended Action=COMPONENT_RESET;ErrorCode:DCGM_FR_CORRUPT_INFOROM GPU:4 PCI:0000:84:00.0 GPU_UUID:GPU-09... Recommended Action=COMPONENT_RESET;ErrorCode:DCGM_FR_CORRUPT_INFOROM GPU:5 PCI:0000:85:00.0 GPU_UUID:GPU-e2... Recommended Action=COMPONENT_RESET;ErrorCode:DCGM_FR_CORRUPT_INFOROM GPU:6 PCI:0000:8b:00.0 GPU_UUID:GPU-c4... Recommended Action=COMPONENT_RESET;ErrorCode:DCGM_FR_CORRUPT_INFOROM GPU:7 PCI:0000:8c:00.0 GPU_UUID:GPU-a5... Recommended Action=COMPONENT_RESET;`



## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable health-event message compaction: long Kubernetes health messages are compacted while preserving entity identifiers, error codes, and the "Recommended Action" marker.

* **Configuration**
  * Added a new parameter to control the compacted health-event message prefix length across Kubernetes deployments.

* **Bug Fixes**
  * Improved truncation/deduplication to maintain separators, append truncation suffixes consistently, and reduce duplicate entries.

* **Tests**
  * Expanded tests to validate compaction, deduplication, and truncation behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->