### PR TITLE
feat: add helm chart and tiltfile for slurm-drain-monitor

### DIFF
--- a/distros/kubernetes/nvsentinel/Chart.yaml
+++ b/distros/kubernetes/nvsentinel/Chart.yaml
@@ -73,3 +73,6 @@ dependencies:
   - name: k8sdatastore-crds
     version: "0.1.0"
     condition: global.k8sdatastoreCrds.enabled
+  - name: slurm-drain-monitor
+    version: "0.1.0"
+    condition: global.slurmDrainMonitor.enabled

--- a/distros/kubernetes/nvsentinel/charts/slurm-drain-monitor/Chart.yaml
+++ b/distros/kubernetes/nvsentinel/charts/slurm-drain-monitor/Chart.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: slurm-drain-monitor
+description: Monitors Slurm NodeSet pods for external drain conditions and publishes health events
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/distros/kubernetes/nvsentinel/charts/slurm-drain-monitor/templates/_helpers.tpl
+++ b/distros/kubernetes/nvsentinel/charts/slurm-drain-monitor/templates/_helpers.tpl
@@ -1,0 +1,40 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "slurm-drain-monitor.name" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "slurm-drain-monitor.fullname" -}}
+{{- "slurm-drain-monitor" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "slurm-drain-monitor.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "slurm-drain-monitor.labels" -}}
+helm.sh/chart: {{ include "slurm-drain-monitor.chart" . }}
+{{ include "slurm-drain-monitor.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "slurm-drain-monitor.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "slurm-drain-monitor.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/distros/kubernetes/nvsentinel/charts/slurm-drain-monitor/templates/clusterrole.yaml
+++ b/distros/kubernetes/nvsentinel/charts/slurm-drain-monitor/templates/clusterrole.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "slurm-drain-monitor.fullname" . }}
+  labels:
+    {{- include "slurm-drain-monitor.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch

--- a/distros/kubernetes/nvsentinel/charts/slurm-drain-monitor/templates/clusterrolebinding.yaml
+++ b/distros/kubernetes/nvsentinel/charts/slurm-drain-monitor/templates/clusterrolebinding.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "slurm-drain-monitor.fullname" . }}
+  labels:
+    {{- include "slurm-drain-monitor.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "slurm-drain-monitor.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "slurm-drain-monitor.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io

--- a/distros/kubernetes/nvsentinel/charts/slurm-drain-monitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/slurm-drain-monitor/templates/configmap.yaml
@@ -1,0 +1,40 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "slurm-drain-monitor.fullname" . }}
+  labels:
+    {{- include "slurm-drain-monitor.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+data:
+  slurm-drain-monitor.toml: |
+    namespace = {{ .Values.namespace | quote }}
+    labelSelector = {{ .Values.labelSelector | quote }}
+    reasonDelimiter = {{ .Values.reasonDelimiter | quote }}
+    {{- range .Values.patterns }}
+
+    [[patterns]]
+    name = {{ .name | quote }}
+    regex = {{ .regex | quote }}
+    checkName = {{ .checkName | quote }}
+    componentClass = {{ .componentClass | quote }}
+    isFatal = {{ .isFatal }}
+    {{- if .message }}
+    message = {{ .message | quote }}
+    {{- end }}
+    recommendedAction = {{ .recommendedAction | quote }}
+    {{- end }}

--- a/distros/kubernetes/nvsentinel/charts/slurm-drain-monitor/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/slurm-drain-monitor/templates/deployment.yaml
@@ -1,0 +1,107 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "slurm-drain-monitor.fullname" . }}
+  labels:
+    {{- include "slurm-drain-monitor.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "slurm-drain-monitor.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "slurm-drain-monitor.labels" . | nindent 8 }}
+    spec:
+      {{- if .Values.global }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
+      serviceAccountName: {{ include "slurm-drain-monitor.fullname" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default ((.Values.global).image).tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--config-path=/config/slurm-drain-monitor.toml"
+            - "--platform-connector-socket=unix://{{ ((.Values.global).socketPath) | default "/var/run/nvsentinel.sock" }}"
+            - "--metrics-bind-address=:{{ ((.Values.global).metricsPort) | default 2112 }}"
+            - "--health-probe-bind-address=:8081"
+            - "--max-concurrent-reconciles={{ .Values.maxConcurrentReconciles }}"
+            - "--resync-period={{ .Values.resyncPeriod }}"
+            - "--processing-strategy={{ .Values.processingStrategy }}"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          ports:
+            - name: metrics
+              containerPort: {{ ((.Values.global).metricsPort) | default 2112 }}
+            - name: health
+              containerPort: 8081
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          env:
+            - name: LOG_LEVEL
+              value: "{{ .Values.logLevel }}"
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+            - name: socket
+              mountPath: /var/run
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "slurm-drain-monitor.fullname" . }}
+        {{- range .Values.volumes }}
+        - {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with ((.Values.global).systemNodeSelector | default .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with ((.Values.global).affinity | default .Values.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with ((.Values.global).systemNodeTolerations | default .Values.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/distros/kubernetes/nvsentinel/charts/slurm-drain-monitor/templates/serviceaccount.yaml
+++ b/distros/kubernetes/nvsentinel/charts/slurm-drain-monitor/templates/serviceaccount.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "slurm-drain-monitor.fullname" . }}
+  labels:
+    {{- include "slurm-drain-monitor.labels" . | nindent 4 }}

--- a/distros/kubernetes/nvsentinel/charts/slurm-drain-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/slurm-drain-monitor/values.yaml
@@ -1,0 +1,68 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default values for slurm-drain-monitor.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+logLevel: info
+
+image:
+  repository: ghcr.io/nvidia/nvsentinel/slurm-drain-monitor
+  pullPolicy: IfNotPresent
+  tag: ""
+
+podAnnotations: {}
+
+maxConcurrentReconciles: 1
+resyncPeriod: 5m
+
+# Top-level config fields for the TOML configuration
+namespace: slurm
+labelSelector: "app.kubernetes.io/name=slurmd,app.kubernetes.io/component=worker"
+reasonDelimiter: "; "
+
+# Patterns to match against Slurm drain reasons.
+# Each pattern is rendered as a [[patterns]] TOML table.
+patterns:
+  - name: slurm-healthcheck
+    regex: '^\[HC\]'
+    checkName: SlurmHealthCheck
+    componentClass: NODE
+    isFatal: false
+    message: ""
+    recommendedAction: CONTACT_SUPPORT
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+volumes:
+  - name: socket
+    hostPath:
+      path: /var/run/nvsentinel
+      type: DirectoryOrCreate
+
+# Processing strategy for health events
+# valid values: EXECUTE_REMEDIATION, STORE_ONLY
+# default: EXECUTE_REMEDIATION
+# EXECUTE_REMEDIATION: normal behavior; downstream modules may update cluster state.
+# STORE_ONLY: observability-only behavior; event should be persisted/exported but should not modify cluster resources (i.e., no node conditions, no quarantine, no drain, no remediation).
+processingStrategy: EXECUTE_REMEDIATION

--- a/distros/kubernetes/nvsentinel/values-tilt.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt.yaml
@@ -90,6 +90,9 @@ global:
   kubernetesObjectMonitor:
     enabled: true
 
+  slurmDrainMonitor:
+    enabled: true
+
   eventExporter:
     enabled: true
 

--- a/distros/kubernetes/nvsentinel/values.yaml
+++ b/distros/kubernetes/nvsentinel/values.yaml
@@ -110,6 +110,8 @@ global:
     enabled: false
   k8sdatastoreCrds:
     enabled: false
+  slurmDrainMonitor:
+    enabled: false
     
 # Network policy configuration
 # The metrics-access network policy restricts ingress to metrics ports only.

--- a/health-monitors/slurm-drain-monitor/Tiltfile
+++ b/health-monitors/slurm-drain-monitor/Tiltfile
@@ -1,0 +1,21 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build and deploy
+custom_build(
+    'ghcr.io/nvidia/nvsentinel/slurm-drain-monitor',
+    '../../scripts/ko-tilt-build.sh . $EXPECTED_REF',
+    deps=['./', '../../commons', '../../data-models'],
+    skips_local_docker=True
+)

--- a/tilt/Tiltfile
+++ b/tilt/Tiltfile
@@ -132,6 +132,7 @@ include('../health-monitors/gpu-health-monitor/Tiltfile')
 include('../health-monitors/csp-health-monitor/Tiltfile')
 include('../health-monitors/kubernetes-object-monitor/Tiltfile')
 include('../health-monitors/syslog-health-monitor/Tiltfile')
+include('../health-monitors/slurm-drain-monitor/Tiltfile')
 include('../labeler/Tiltfile')
 include('../log-collector/Tiltfile')
 include('../preflight/Tiltfile')
@@ -321,6 +322,11 @@ k8s_resource(
 
 k8s_resource(
     'kubernetes-object-monitor',
+    resource_deps=['platform-connectors']
+)
+
+k8s_resource(
+    'slurm-drain-monitor',
     resource_deps=['platform-connectors']
 )
 


### PR DESCRIPTION
## Summary

add helm chart and tiltfile for slurm-drain-monitor

## Type of Change
- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [X] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [X] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added Slurm drain monitor to detect external drain conditions on Kubernetes nodes and publish health events
- Provides flexible, pattern-based health checking with configurable remediation strategies
- Can be enabled or disabled through configuration options

## Chores
- Updated Kubernetes charts and dependencies to integrate the new monitoring capability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->