### PR TITLE
feat: add scale test for GPU reset

### DIFF
--- a/janitor/pkg/controller/gpureset_controller.go
+++ b/janitor/pkg/controller/gpureset_controller.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"maps"
 	"reflect"
-	"sort"
 	"strings"
 	"time"
 
@@ -108,15 +107,23 @@ func (r *GPUResetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, fmt.Errorf("failed to get GPUReset %s: %w", req.NamespacedName, err)
 	}
 
-	if !gpuReset.DeletionTimestamp.IsZero() {
-		return r.reconcileDelete(ctx, &gpuReset)
-	}
-
+	reconcileDelete := !gpuReset.DeletionTimestamp.IsZero()
 	completedReconciling := gpuReset.Status.CompletionTime != nil
-	if !completedReconciling {
+
+	if !completedReconciling || reconcileDelete {
 		locked := r.NodeLock.LockNode(ctx, &gpuReset, gpuReset.Spec.NodeName)
 		if !locked {
 			return ctrl.Result{RequeueAfter: time.Second * 2}, nil
+		}
+
+		// We need to lock the current node because reconcileDelete executes FinalizerRestoringServices which can conflict
+		// with TearingDownServices from active GPUResets which currently have the node lock.
+		// Note that the current CR will be removed after reconcileDelete removes the finalizer, and we'll exit above
+		// with a no-op when the GPUReset is not found. We do not need to explicitly call CheckUnlock because
+		// garbage collection will ensure that the lease lock is deleted. This also prevents us from needing to handle
+		// failures related to CheckUnlock failing when the current GPUReset is removed from API.
+		if reconcileDelete {
+			return r.reconcileDelete(ctx, &gpuReset)
 		}
 
 		result, err := r.reconcileHelper(ctx, &gpuReset)
@@ -296,75 +303,14 @@ func (r *GPUResetReconciler) reconcileDelete(ctx context.Context, gr *v1alpha1.G
 //
 // It also enforces the 'pending' and 'active' gauge metrics based on the current cluster state.
 func (r *GPUResetReconciler) isReady(ctx context.Context, gr *v1alpha1.GPUReset) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
-
 	nodeName := gr.Spec.NodeName
 
-	var gpuResetsForNode v1alpha1.GPUResetList
-	if err := r.List(ctx, &gpuResetsForNode, client.MatchingFields{"spec.nodeName": nodeName}); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to list GPUResets for node %s: %w", nodeName, err)
-	}
-
-	var gpuResetCandidates []*v1alpha1.GPUReset
-
-	for i := range gpuResetsForNode.Items {
-		gpuReset := &gpuResetsForNode.Items[i]
-		if gpuReset.Status.CompletionTime == nil {
-			gpuResetCandidates = append(gpuResetCandidates, gpuReset)
-		}
-	}
-
-	if len(gpuResetCandidates) == 0 {
-		// update metrics: enforce the absolute state (Active=0, Pending=0)
-		metrics.GPUResetActiveRequests.WithLabelValues(nodeName).Set(0)
-		metrics.GPUResetPendingRequests.WithLabelValues(nodeName).Set(0)
-
-		log.V(1).Info("No pending GPU resets found for node, will recheck", "node", nodeName,
-			"recheck_after", 5*time.Second)
-
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-	}
-
-	sort.Slice(gpuResetCandidates, func(i, j int) bool {
-		return gpuResetCandidates[i].CreationTimestamp.Before(&gpuResetCandidates[j].CreationTimestamp)
-	})
-
-	var reason v1alpha1.GPUResetReason
-
-	var message string
-
-	var status metav1.ConditionStatus
-
-	isCandidateToRun := gpuResetCandidates[0].UID == gr.UID
-	ready := false
-
-	if isCandidateToRun {
-		status = metav1.ConditionTrue
-		reason = v1alpha1.ReasonReadyForReset
-		message = "Node ready for GPU reset"
-		ready = true
-	} else {
-		status = metav1.ConditionFalse
-		reason = v1alpha1.ReasonResourceContention
-		message = fmt.Sprintf("Waiting for %s to complete before starting", gpuResetCandidates[0].Name)
-	}
-
-	if err := r.updateCondition(ctx, gr, v1alpha1.Ready, status, reason, message); err != nil {
+	if err := r.updateCondition(ctx, gr, v1alpha1.Ready, metav1.ConditionTrue, v1alpha1.ReasonReadyForReset,
+		"Node ready for GPU reset"); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to update GPUReset %s: %w", gr.Name, err)
 	}
-
-	activeRequestsCount := 1.0
-	pendingRequestsCount := float64(len(gpuResetCandidates) - 1)
-	// update metrics: enforce the absolute state (Active=1, Pending=Total-1)
-	metrics.GPUResetActiveRequests.WithLabelValues(nodeName).Set(activeRequestsCount)
-	metrics.GPUResetPendingRequests.WithLabelValues(nodeName).Set(pendingRequestsCount)
-
-	if !ready {
-		log.V(1).Info("Pending completion of active GPU reset on node", "node", nodeName, "active_reset",
-			gpuResetCandidates[0].Name)
-
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-	}
+	// update metrics: enforce the absolute state (Active=1)
+	metrics.GPUResetActiveRequests.WithLabelValues(nodeName).Set(1.0)
 
 	return ctrl.Result{}, nil
 }
@@ -1068,8 +1014,6 @@ func (r *GPUResetReconciler) reconcileTerminalFailure(
 		if readyCond != nil && readyCond.Status == metav1.ConditionTrue {
 			// update metrics: enforce the absolute state (Active=0)
 			metrics.GPUResetActiveRequests.WithLabelValues(nodeName).Set(0)
-		} else {
-			metrics.GPUResetPendingRequests.WithLabelValues(nodeName).Dec()
 		}
 
 		metrics.GPUResetRequestsCompletedTotal.WithLabelValues(nodeName, "failure").Inc()

--- a/janitor/pkg/controller/gpureset_controller_test.go
+++ b/janitor/pkg/controller/gpureset_controller_test.go
@@ -173,7 +173,6 @@ var _ = Describe("GPUReset Controller", func() {
 		metrics.GPUResetRequestsCompletedTotal.Reset()
 		metrics.GPUResetDurationSeconds.Reset()
 		metrics.GPUResetActiveRequests.Reset()
-		metrics.GPUResetPendingRequests.Reset()
 		metrics.GPUResetFailureReasonsTotal.Reset()
 
 		cancel()
@@ -649,90 +648,6 @@ var _ = Describe("GPUReset Controller", func() {
 					}
 				}
 			}
-		})
-
-		It("should keep second reset not-ready until the first one is complete", func() {
-			By("Creating the first GPUReset")
-			reset1 := &v1alpha1.GPUReset{
-				ObjectMeta: metav1.ObjectMeta{Name: "first-reset"},
-				Spec: v1alpha1.GPUResetSpec{
-					NodeName: nodeName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, reset1)).To(Succeed())
-
-			// Ensure a different creation timestamp
-			time.Sleep(2 * time.Second)
-
-			By("Creating the second GPUReset for the same node")
-			reset2 := &v1alpha1.GPUReset{
-				ObjectMeta: metav1.ObjectMeta{Name: "second-reset"},
-				Spec: v1alpha1.GPUResetSpec{
-					NodeName: nodeName,
-				},
-			}
-			Expect(k8sClient.Create(ctx, reset2)).To(Succeed())
-
-			By("Waiting for the first reset to be initialized, scheduled, and the job created")
-			var updatedReset1 v1alpha1.GPUReset
-			var createdJob batchv1.Job
-			reset1Key := types.NamespacedName{Name: reset1.Name}
-			Eventually(func(g Gomega) {
-				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: reset1Key})
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(k8sClient.Get(ctx, reset1Key, &updatedReset1)).To(Succeed())
-				g.Expect(meta.IsStatusConditionTrue(updatedReset1.Status.Conditions, string(v1alpha1.Ready))).To(BeTrue())
-				g.Expect(updatedReset1.Status.JobRef).NotTo(BeNil())
-				g.Expect(updatedReset1.Status.Phase).To(Equal(v1alpha1.ResetInProgress))
-
-				// wait for job to exist
-				job1Key := types.NamespacedName{Name: updatedReset1.Status.JobRef.Name, Namespace: updatedReset1.Status.JobRef.Namespace}
-				g.Expect(k8sClient.Get(ctx, job1Key, &createdJob)).To(Succeed())
-			}, "10s", "100ms").Should(Succeed())
-
-			By("Verifying the second reset is not ready due to resource contention")
-			var updatedReset2 v1alpha1.GPUReset
-			reset2Key := types.NamespacedName{Name: reset2.Name}
-			Eventually(func(g Gomega) {
-				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: reset2Key})
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(k8sClient.Get(ctx, reset2Key, &updatedReset2)).To(Succeed())
-
-				cond := meta.FindStatusCondition(updatedReset2.Status.Conditions, string(v1alpha1.Ready))
-				g.Expect(cond).NotTo(BeNil())
-				g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
-				g.Expect(cond.Reason).To(Equal(string(v1alpha1.ReasonResourceContention)))
-				g.Expect(cond.Message).To(ContainSubstring("Waiting for first-reset to complete"))
-				g.Expect(updatedReset2.Status.Phase).To(Equal(v1alpha1.ResetPending))
-			}, "10s", "100ms").Should(Succeed())
-
-			By("Simulating job success and full completion of the first reset")
-			Expect(updatedReset1.Status.JobRef).NotTo(BeNil(), "Expected reset1 to have a JobRef before simulating completion")
-			job1Key := types.NamespacedName{Name: updatedReset1.Status.JobRef.Name, Namespace: updatedReset1.Status.JobRef.Namespace}
-			Expect(k8sClient.Get(ctx, job1Key, &createdJob)).To(Succeed())
-			createdJob.Status.Succeeded = 1
-			Expect(k8sClient.Status().Update(ctx, &createdJob)).To(Succeed())
-
-			reconciler.checkPodsReadyFn = func(ctx context.Context, nodeName string) (bool, error) {
-				return true, nil
-			}
-
-			Eventually(func(g Gomega) {
-				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: reset1Key})
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(k8sClient.Get(ctx, reset1Key, &updatedReset1)).To(Succeed())
-				g.Expect(meta.IsStatusConditionTrue(updatedReset1.Status.Conditions, string(v1alpha1.Complete))).To(BeTrue())
-				g.Expect(updatedReset1.Status.Phase).To(Equal(v1alpha1.ResetSucceeded))
-			}, "10s", "100ms").Should(Succeed(), "Timed out waiting for reset1 to reach Complete state")
-
-			By("Waiting for the second reset to become scheduled after the first completed")
-			Eventually(func(g Gomega) {
-				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: reset2Key})
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(k8sClient.Get(ctx, reset2Key, &updatedReset2)).To(Succeed())
-				g.Expect(meta.IsStatusConditionTrue(updatedReset2.Status.Conditions, string(v1alpha1.Ready))).To(BeTrue())
-				g.Expect(updatedReset2.Status.Phase).To(Equal(v1alpha1.ResetPending))
-			}, "10s", "100ms").Should(Succeed())
 		})
 	})
 
@@ -1356,7 +1271,6 @@ var _ = Describe("GPUReset Controller", func() {
 			}, "10s", "250ms").Should(Succeed())
 
 			Expect(testutil.ToFloat64(metrics.GPUResetRequestsTotal.WithLabelValues(nodeName))).To(Equal(1.0))
-			Expect(testutil.ToFloat64(metrics.GPUResetPendingRequests.WithLabelValues(nodeName))).To(Equal(0.0))
 			Expect(testutil.ToFloat64(metrics.GPUResetActiveRequests.WithLabelValues(nodeName))).To(Equal(0.0))
 
 			By("Waiting for promotion to Active")
@@ -1370,7 +1284,6 @@ var _ = Describe("GPUReset Controller", func() {
 				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 			}, "10s", "250ms").Should(Succeed())
 
-			Expect(testutil.ToFloat64(metrics.GPUResetPendingRequests.WithLabelValues(nodeName))).To(Equal(0.0))
 			Expect(testutil.ToFloat64(metrics.GPUResetActiveRequests.WithLabelValues(nodeName))).To(Equal(1.0))
 
 			By("Waiting for the job to be created")
@@ -1414,7 +1327,6 @@ var _ = Describe("GPUReset Controller", func() {
 			}, "10s", "250ms").Should(Succeed())
 
 			Expect(testutil.ToFloat64(metrics.GPUResetActiveRequests.WithLabelValues(nodeName))).To(Equal(0.0))
-			Expect(testutil.ToFloat64(metrics.GPUResetPendingRequests.WithLabelValues(nodeName))).To(Equal(0.0))
 			Expect(testutil.ToFloat64(metrics.GPUResetRequestsCompletedTotal.WithLabelValues(nodeName, "success"))).To(Equal(1.0))
 			Expect(testutil.ToFloat64(metrics.GPUResetRequestsCompletedTotal.WithLabelValues(nodeName, "failure"))).To(Equal(0.0))
 
@@ -1450,7 +1362,6 @@ var _ = Describe("GPUReset Controller", func() {
 			}, "10s", "250ms").Should(Succeed())
 
 			Expect(testutil.ToFloat64(metrics.GPUResetRequestsTotal.WithLabelValues(nodeName))).To(Equal(1.0))
-			Expect(testutil.ToFloat64(metrics.GPUResetPendingRequests.WithLabelValues(nodeName))).To(Equal(0.0))
 			Expect(testutil.ToFloat64(metrics.GPUResetActiveRequests.WithLabelValues(nodeName))).To(Equal(0.0))
 
 			By("Waiting for promotion to Active")
@@ -1464,7 +1375,6 @@ var _ = Describe("GPUReset Controller", func() {
 				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 			}, "10s", "250ms").Should(Succeed())
 
-			Expect(testutil.ToFloat64(metrics.GPUResetPendingRequests.WithLabelValues(nodeName))).To(Equal(0.0))
 			Expect(testutil.ToFloat64(metrics.GPUResetActiveRequests.WithLabelValues(nodeName))).To(Equal(1.0))
 
 			By("Waiting for the job to be created")
@@ -1498,7 +1408,6 @@ var _ = Describe("GPUReset Controller", func() {
 			}, "10s", "100ms").Should(Succeed())
 
 			Expect(testutil.ToFloat64(metrics.GPUResetActiveRequests.WithLabelValues(nodeName))).To(Equal(0.0))
-			Expect(testutil.ToFloat64(metrics.GPUResetPendingRequests.WithLabelValues(nodeName))).To(Equal(0.0))
 			Expect(testutil.ToFloat64(metrics.GPUResetRequestsCompletedTotal.WithLabelValues(nodeName, "failure"))).To(Equal(1.0))
 			Expect(testutil.ToFloat64(metrics.GPUResetRequestsCompletedTotal.WithLabelValues(nodeName, "success"))).To(Equal(0.0))
 			Expect(testutil.ToFloat64(metrics.GPUResetFailureReasonsTotal.WithLabelValues(nodeName, string(v1alpha1.ReasonResetJobFailed)))).To(Equal(1.0))

--- a/janitor/pkg/metrics/metrics.go
+++ b/janitor/pkg/metrics/metrics.go
@@ -74,11 +74,6 @@ var (
 		Buckets: prometheus.LinearBuckets(30, 30, 10),
 	}, []string{"node", "status"})
 
-	GPUResetPendingRequests = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "gpu_reset_pending_requests",
-		Help: "The number of GPU reset requests currently pending (e.g., waiting due to resource contention).",
-	}, []string{"node"})
-
 	GPUResetActiveRequests = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "gpu_reset_active_requests",
 		Help: "The number of GPU reset requests currently in progress.",
@@ -102,7 +97,6 @@ func NewActionMetrics() *ActionMetrics {
 		GPUResetRequestsTotal,
 		GPUResetRequestsCompletedTotal,
 		GPUResetDurationSeconds,
-		GPUResetPendingRequests,
 		GPUResetActiveRequests,
 		GPUResetFailureReasonsTotal,
 	)

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -7,6 +7,7 @@ toolchain go1.25.3
 require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/go-logr/logr v1.4.3
+	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/nvidia/nvsentinel/commons v0.0.0
 	github.com/nvidia/nvsentinel/data-models v0.0.0
@@ -50,7 +51,6 @@ require (
 	github.com/go-openapi/swag/typeutils v0.25.4 // indirect
 	github.com/go-openapi/swag/yamlutils v0.25.4 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/tests/gpu_reset_test.go
+++ b/tests/gpu_reset_test.go
@@ -19,17 +19,24 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 	"tests/helpers"
 
 	"github.com/nvidia/nvsentinel/commons/pkg/statemanager"
+)
+
+const (
+	gpuResetFinalizer = "janitor.dgxc.nvidia.com/finalizer"
 )
 
 func TestGPUReset(t *testing.T) {
@@ -180,7 +187,7 @@ func TestGPUReset(t *testing.T) {
 		assert.NoError(t, err, "failed to get nvidia-dcgm-pod")
 		t.Logf("Restored DCGM pod is : %s", newDCGMPod.Name)
 
-		err = helpers.DeleteCR(ctx, client, gpuReset)
+		err = helpers.DeleteCR(ctx, t, client, gpuReset, true)
 		assert.NoError(t, err, "failed to delete GPUReset CR")
 
 		return ctx
@@ -246,6 +253,160 @@ func TestGPUReset(t *testing.T) {
 		err = helpers.DeleteNamespace(ctx, t, client, namespaceName)
 		assert.NoError(t, err, "failed to delete workloads namespace")
 
+		helpers.RestoreQuarantineConfig(ctx, t, c)
+		helpers.RestoreNodeDrainerConfig(ctx, t, c)
+
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}
+
+func TestGPUResetScale(t *testing.T) {
+	// Only used for manual testing
+	t.Skip()
+	feature := features.New("TestGPUResetScale").
+		WithLabel("suite", "gpu-reset-scale")
+
+	// Test settings
+	var numNodes = 10                   // the given Kind cluster must have at least this number of real worker nodes
+	var gpusPerNode = 8                 // the number of GPUs per node can be chosen without any Kind infra changes
+	var eventsPerGPU = 2                // number of duplicated unhealthy health events generated per GPU
+	var skipControllerFinalizer = false // determines whether we require gpu-reset-controller to remove its finalizer
+
+	var nodeNames []string
+	var events []*helpers.HealthEventTemplate
+	var startTime time.Time
+	var endTime time.Time
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		t.Logf("Test Overview:")
+		t.Logf("Node count: %d", numNodes)
+		t.Logf("GPUs per node: %d", gpusPerNode)
+		t.Logf("Unhealthy events per GPU: %d", eventsPerGPU)
+		t.Logf("Skip controller finalizer: %t", skipControllerFinalizer)
+		t.Logf("Total GPUs: %d", numNodes*gpusPerNode)
+		t.Logf("Total unhealthy events: %d", numNodes*gpusPerNode*eventsPerGPU)
+
+		client, err := c.NewClient()
+		assert.NoError(t, err, "failed to create kubernetes client")
+
+		ctx = helpers.ApplyQuarantineConfig(ctx, t, c, "data/basic-matching-configmap.yaml")
+		ctx = helpers.ApplyNodeDrainerConfig(ctx, t, c, "data/nd-all-modes.yaml")
+
+		// Use all real (non-KWOK) nodes for scale test to validate actual container execution
+		nodeNames, err = helpers.GetRealNodeNames(ctx, client, numNodes)
+		assert.NoError(t, err, "failed to get real node")
+		assert.True(t, len(nodeNames) == numNodes, "expected at exact number of nodes", numNodes)
+		t.Logf("Found %d real nodes for GPU reset test", len(nodeNames))
+
+		return ctx
+	})
+
+	feature.Assess("Can send fatal health events for all GPUs", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		startTime = time.Now()
+		for _, nodeName := range nodeNames {
+			for i := range gpusPerNode {
+				gpuUUID := uuid.New().String()
+				event := helpers.NewHealthEvent(nodeName).
+					WithErrorCode("119").
+					WithRecommendedAction(2).
+					WithEntitiesImpacted([]helpers.EntityImpacted{
+						{EntityType: "GPU", EntityValue: fmt.Sprintf("%d", i)},
+						{EntityType: "GPU_UUID", EntityValue: fmt.Sprintf("GPU-%s", gpuUUID)},
+					})
+				for j := range eventsPerGPU {
+					t.Logf("Sending unhealthy event for node %s and GPU %s (count %d)", nodeName, gpuUUID, j)
+					helpers.SendHealthEvent(ctx, t, event)
+					if j == 0 { // only keep track of 1 event per GPU
+						events = append(events, event)
+					}
+				}
+			}
+		}
+		return ctx
+	})
+
+	feature.Assess("GPUReset CRs are created and complete for all nodes", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		assert.NoError(t, err, "failed to create kubernetes client")
+
+		for _, nodeName := range nodeNames {
+			for i := range gpusPerNode {
+				gpuReset := helpers.WaitForCR(ctx, t, client, nodeName, helpers.GPUResetGVK)
+				t.Logf("Found GPUReset for node %s (count %d)", nodeName, i)
+
+				status, found, err := unstructured.NestedMap(gpuReset.Object, "status")
+				if err != nil || !found {
+					assert.Fail(t, "failed to find status field in CR", gpuReset.GetName(), err)
+				}
+				conditions, found, err := unstructured.NestedSlice(status, "conditions")
+				if err != nil || !found {
+					assert.Fail(t, "failed to find status conditions field in CR", gpuReset.GetName(), err)
+				}
+				var foundCompleteCondition bool
+				for _, c := range conditions {
+					condMap := c.(map[string]interface{})
+
+					if condMap["type"].(string) == "Complete" {
+						foundCompleteCondition = true
+						assert.Equal(t, "GPUResetSucceeded", condMap["reason"].(string))
+						assert.Equal(t, "True", condMap["status"].(string))
+					}
+				}
+				assert.True(t, foundCompleteCondition, "Did not find Complete condition on CR", gpuReset.GetName())
+
+				if skipControllerFinalizer {
+					controllerutil.RemoveFinalizer(gpuReset, gpuResetFinalizer)
+					err := client.Resources().Update(ctx, gpuReset)
+					assert.NoError(t, err, "failed to remove finalizer on CR", gpuReset.GetName())
+				}
+				err = helpers.DeleteCR(ctx, t, client, gpuReset, true)
+				assert.NoError(t, err, "failed to delete GPUReset CR")
+			}
+		}
+
+		endTime = time.Now()
+		duration := endTime.Sub(startTime)
+		t.Logf("Scale test duration seconds: %f", duration.Seconds())
+
+		gpuResetList, err := helpers.ListAllCRs(ctx, client, helpers.GPUResetGVK)
+		assert.NoError(t, err)
+		assert.Equal(t, len(gpuResetList.Items), 0, "Expected all GPUReset CRs to be deleted")
+		return ctx
+	})
+
+	feature.Assess("Can send healthy events for all GPUs", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		// An alternative would be to send 1 healthy event per node without entities impacted to clear all unhealthy events.
+		// We'll send 1 healthy event per GPU to simulate the actual GPU reset workflow.
+		for _, event := range events {
+			event.WithHealthy(true).
+				WithFatal(false).
+				WithMessage("No health failures")
+			gpuUUID := event.EntitiesImpacted[1].EntityValue
+
+			t.Logf("Sending healthy event for node %s and GPU %s", event.NodeName, gpuUUID)
+			helpers.SendHealthEvent(ctx, t, event)
+		}
+		return ctx
+	})
+
+	feature.Assess("Nodes are uncordoned", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		assert.NoError(t, err, "failed to create kubernetes client")
+
+		for _, nodeName := range nodeNames {
+			t.Logf("Waiting for node %s to be uncordoned", nodeName)
+			helpers.WaitForNodesCordonState(ctx, t, client, []string{nodeName}, false)
+
+			// Wait for node condition to be updated to healthy
+			t.Logf("Waiting for node %s condition to become healthy", nodeName)
+			helpers.WaitForNodeConditionWithCheckName(ctx, t, client, nodeName, "GpuXidError",
+				"No Health Failures", "GpuXidErrorIsHealthy", v1.ConditionFalse)
+		}
+		return ctx
+	})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		helpers.RestoreQuarantineConfig(ctx, t, c)
 		helpers.RestoreNodeDrainerConfig(ctx, t, c)
 

--- a/tests/helpers/health_events_analyzer.go
+++ b/tests/helpers/health_events_analyzer.go
@@ -230,7 +230,7 @@ func waitForRemediationToComplete(ctx context.Context, t *testing.T, client klie
 		return true
 	}, EventuallyWaitTimeout, WaitInterval, "node should be fully cleaned up before next remediation cycle")
 
-	err := DeleteCR(ctx, client, rebootNodeCR)
+	err := DeleteCR(ctx, t, client, rebootNodeCR, false)
 	require.NoError(t, err, "failed to delete RebootNode CR")
 }
 

--- a/tests/helpers/kube.go
+++ b/tests/helpers/kube.go
@@ -726,7 +726,7 @@ func DeleteAllCRs(ctx context.Context, t *testing.T, c klient.Client, groupVersi
 	}
 
 	for _, item := range crList.Items {
-		err = DeleteCR(ctx, c, &item)
+		err = DeleteCR(ctx, t, c, &item, false)
 		if err != nil {
 			return fmt.Errorf("failed to delete CR: %w", err)
 		}
@@ -735,7 +735,8 @@ func DeleteAllCRs(ctx context.Context, t *testing.T, c klient.Client, groupVersi
 	return nil
 }
 
-func DeleteCR(ctx context.Context, c klient.Client, cr *unstructured.Unstructured) error {
+func DeleteCR(ctx context.Context, t *testing.T, c klient.Client, cr *unstructured.Unstructured,
+	waitForRemoval bool) error {
 	err := c.Resources().Delete(ctx, cr)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -743,6 +744,13 @@ func DeleteCR(ctx context.Context, c klient.Client, cr *unstructured.Unstructure
 		}
 
 		return fmt.Errorf("failed to delete CR %s: %w", cr.GetName(), err)
+	}
+
+	if waitForRemoval {
+		require.Eventually(t, func() bool {
+			err := c.Resources().Get(ctx, cr.GetName(), cr.GetNamespace(), cr)
+			return err != nil && apierrors.IsNotFound(err)
+		}, EventuallyWaitTimeout, WaitInterval, "CR %s should be removed from API", cr.GetName())
 	}
 
 	return nil

--- a/tests/janitor_test.go
+++ b/tests/janitor_test.go
@@ -309,11 +309,11 @@ func TestJanitorNodeLocking(t *testing.T) {
 		assert.True(t, periodOverlapsOnNode1And2, "RebootNode periods on different nodes should overlap")
 
 		// Clean up both CRs
-		err = helpers.DeleteCR(ctx, client, rebootNodeCR)
+		err = helpers.DeleteCR(ctx, t, client, rebootNodeCR, false)
 		require.NoError(t, err, "RebootNode should be deleted successfully")
-		err = helpers.DeleteCR(ctx, client, rebootNodeCR2)
+		err = helpers.DeleteCR(ctx, t, client, rebootNodeCR2, false)
 		require.NoError(t, err, "RebootNode should be deleted successfully")
-		err = helpers.DeleteCR(ctx, client, gpuResetCR)
+		err = helpers.DeleteCR(ctx, t, client, gpuResetCR, false)
 		require.NoError(t, err, "GPUReset should be deleted successfully")
 
 		return ctx

--- a/tests/smoke_test.go
+++ b/tests/smoke_test.go
@@ -148,7 +148,7 @@ func TestFatalHealthEvent(t *testing.T) {
 
 		rebootNode := helpers.WaitForCR(ctx, t, client, nodeName, helpers.RebootNodeGVK)
 
-		err = helpers.DeleteCR(ctx, client, rebootNode)
+		err = helpers.DeleteCR(ctx, t, client, rebootNode, false)
 		assert.NoError(t, err, "failed to delete RebootNode CR")
 
 		return ctx


### PR DESCRIPTION
## Summary

This PR adds a GPUReset scale test. This test is disabled by default and will not run as part of e2e tests. The test allows the following settings to be modified:
- numNodes: the number of Kind nodes to use in the given test (cluster must have at least this number of real Kind nodes)
- gpusPerNode: the number of virtual GPUs per node that will be considered as unhealthy during the test
- eventsPerGPU: number of duplicated unhealthy health events generated per GPU
- skipControllerFinalizer: determines whether we require gpu-reset-controller to remove its finalizer. This setting can be used to also make the controller exercise its finalizer removal logic during the scale test. Setting this to true will result in the test having equivalent behavior to not deleting the CRs created as part of the scale test (because we're not making the gpu-reset-controller acquire the node lock and remove the finalizer prior to CR removal)

2 concurrency issues were discovered from the scale test which are also fixed as part of this PR:
- The controller-level locking implemented within the gpu-reset-controller has been removed in favor of the node-level locking functionality across all Janitor controllers. A deadlock was possible if a GPUReset CR successfully acquired the node lock before a competing GPUReset CR for the same node with an earlier creation timestamp. In this case, the current job would fail waiting on the ResourceContention status condition.
- If there is an active GPUReset being processed while a completed GPUReset was deleted, it was possible for the TearingDownServices stage of the active job to compete with the FinalizerRestoringServices stage of the job being deleted. This race condition has been fixed by requiring that GPUReset CRDs which are being deleted need to acquire the node lock prior to attempting to restore GPU Operator services.

## Test Results
The following tests measure the latency from creating unhealthy events for the given GPUs to when all GPUResets have been processed by the gpu-reset-controller. Note that the following tests are run on Kind with the following properties:
- fault-remediation creates GPUReset CR targeting a real Kind worker node
- gpu-reset-controller processes the GPUReset CR and tears down GPU Operator components + creates GPUReset job
- job-controller creates real GPUReset pod
- GPUReset pod runs a dummy alpine image and instantly succeeds (does not run nvidia-smi command to reset a real GPU)
- gpu-reset-controller restores GPU Operator components

As a result, this will scale tests gpu-reset-controller operations, however, the overall latency for GPUReset reconciling will be much lower due to the dummy GPUReset pod not needing to actually reset a GPU.

1. 5 nodes, 8 GPUs per node, 40 total GPUResets CRs, CRs are deleted after processing: 7.05s/GPU remediation
```
=== RUN   TestGPUResetScale/TestGPUResetScale
    gpu_reset_test.go:282: Test Overview:
    gpu_reset_test.go:283: Node count: 5
    gpu_reset_test.go:284: GPUs per node: 8
    gpu_reset_test.go:285: Unhealthy events per GPU: 2
    gpu_reset_test.go:286: Skip controller finalizer: false
    gpu_reset_test.go:287: Total GPUs: 40
    gpu_reset_test.go:288: Total unhealthy events: 80
...
    gpu_reset_test.go:370: Scale test duration seconds: 282.420294
```
2. 5 nodes, 8 GPUs per node, 40 total GPUResets CRs, CRs are NOT deleted after processing: 2.95s/GPU remediation
```
=== RUN   TestGPUResetScale/TestGPUResetScale
    gpu_reset_test.go:282: Test Overview:
    gpu_reset_test.go:283: Node count: 5
    gpu_reset_test.go:284: GPUs per node: 8
    gpu_reset_test.go:285: Unhealthy events per GPU: 2
    gpu_reset_test.go:286: Skip controller finalizer: true
    gpu_reset_test.go:287: Total GPUs: 40
    gpu_reset_test.go:288: Total unhealthy events: 80
...
    gpu_reset_test.go:370: Scale test duration seconds: 118.915934
```
3. 10 nodes, 8 GPUs per node, 80 total GPUResets CRs, CRs are deleted after processing: 6.39s/GPU remediation
```
=== RUN   TestGPUResetScale
=== RUN   TestGPUResetScale/TestGPUResetScale
    gpu_reset_test.go:282: Test Overview:
    gpu_reset_test.go:283: Node count: 10
    gpu_reset_test.go:284: GPUs per node: 8
    gpu_reset_test.go:285: Unhealthy events per GPU: 2
    gpu_reset_test.go:286: Skip controller finalizer: false
    gpu_reset_test.go:287: Total GPUs: 80
    gpu_reset_test.go:288: Total unhealthy events: 160
...
    gpu_reset_test.go:370: Scale test duration seconds: 511.626313
```
4. 10 nodes, 8 GPUs per node, 80 total GPUResets CRs, CRs are NOT deleted after processing: 2.45s/GPU remediation
```
=== RUN   TestGPUResetScale/TestGPUResetScale
    gpu_reset_test.go:282: Test Overview:
    gpu_reset_test.go:283: Node count: 10
    gpu_reset_test.go:284: GPUs per node: 8
    gpu_reset_test.go:285: Unhealthy events per GPU: 2
    gpu_reset_test.go:286: Skip controller finalizer: true
    gpu_reset_test.go:287: Total GPUs: 80
    gpu_reset_test.go:288: Total unhealthy events: 160
...
    gpu_reset_test.go:370: Scale test duration seconds: 196.884359
```



## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [X] Janitor
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Simplified GPU reset readiness and deletion handling; clearer node-level synchronization and Active state reporting.

* **Removed Features**
  * GPUResetPendingRequests metric removed from monitoring output.

* **Tests**
  * Added a GPU reset scale test for manual validation; updated test cleanup to wait-for-removal behavior and adjusted test helpers to accept testing context and a removal flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->