### PR TITLE
fix: linting error in node drainer

### DIFF
--- a/commons/pkg/flags/database_flags_test.go
+++ b/commons/pkg/flags/database_flags_test.go
@@ -57,6 +57,7 @@ func TestDatabaseCertConfig_ResolveCertPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := &DatabaseCertConfig{
+				TLSEnabled:                  true,
 				DatabaseClientCertMountPath: tt.databaseClientCertMountPath,
 				LegacyMongoCertPath:         tt.legacyMongoCertPath,
 			}
@@ -102,30 +103,42 @@ func TestDatabaseCertConfig_GetCertPath(t *testing.T) {
 			description:  "When resolved path has ca.crt, it should be used",
 		},
 		{
-			name:         "resolved path missing fallback to legacy",
+			name:         "resolved path missing no fallback returns empty",
 			resolvedPath: filepath.Join(tempDir, "nonexistent"),
-			expectedPath: "/etc/ssl/mongo-client", // Falls back to hardcoded legacy path
-			description:  "When resolved path missing, should fallback to legacy path",
+			expectedPath: "",
+			description:  "When resolved path and all fallback paths are missing, should return empty",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := &DatabaseCertConfig{
+				TLSEnabled:       true,
 				ResolvedCertPath: tt.resolvedPath,
 			}
 
 			certPath := config.GetCertPath()
-
-			if tt.expectedPath == "/etc/ssl/mongo-client" {
-				// For fallback cases, just check it's using the fallback logic
-				assert.True(t, certPath == "/etc/ssl/mongo-client" || certPath == "/etc/ssl/database-client" || certPath == tt.resolvedPath,
-					"Should use fallback logic when resolved path doesn't exist")
-			} else {
-				assert.Equal(t, tt.expectedPath, certPath, tt.description)
-			}
+			assert.Equal(t, tt.expectedPath, certPath, tt.description)
 		})
 	}
+
+	// Test fallback to legacy path when resolved path is missing.
+	// GetCertPath has hardcoded fallback paths, so this can only run
+	// in environments where /etc/ssl/mongo-client/ca.crt exists.
+	t.Run("resolved path missing fallback to legacy", func(t *testing.T) {
+		if _, err := os.Stat("/etc/ssl/mongo-client/ca.crt"); err != nil {
+			t.Skip("Skipping fallback test: /etc/ssl/mongo-client/ca.crt not present on this host")
+		}
+
+		config := &DatabaseCertConfig{
+			TLSEnabled:       true,
+			ResolvedCertPath: filepath.Join(tempDir, "nonexistent"),
+		}
+
+		certPath := config.GetCertPath()
+		assert.Equal(t, "/etc/ssl/mongo-client", certPath,
+			"When resolved path is missing, should fallback to legacy path")
+	})
 }
 
 func TestDatabaseCertConfig_TLSDisabled_ResolveCertPath(t *testing.T) {
@@ -150,7 +163,7 @@ func TestDatabaseCertConfig_TLSDisabled_GetCertPath(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(certDir, "ca.crt"), []byte("test cert"), 0644))
 
 	config := &DatabaseCertConfig{
-		TLSEnabled:   false,
+		TLSEnabled:       false,
 		ResolvedCertPath: certDir,
 	}
 
@@ -169,7 +182,7 @@ func TestDatabaseCertConfig_TLSEnabled_GetCertPath(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(certDir, "ca.crt"), []byte("test cert"), 0644))
 
 	config := &DatabaseCertConfig{
-		TLSEnabled:   true,
+		TLSEnabled:       true,
 		ResolvedCertPath: certDir,
 	}
 
@@ -180,7 +193,7 @@ func TestDatabaseCertConfig_TLSEnabled_GetCertPath(t *testing.T) {
 func TestDatabaseCertConfig_TLSEnabled_NoCerts_ReturnsEmpty(t *testing.T) {
 	// When TLS is enabled but no certs exist anywhere, should return empty
 	config := &DatabaseCertConfig{
-		TLSEnabled:   true,
+		TLSEnabled:       true,
 		ResolvedCertPath: "/nonexistent/path/that/does/not/exist",
 	}
 
@@ -189,19 +202,34 @@ func TestDatabaseCertConfig_TLSEnabled_NoCerts_ReturnsEmpty(t *testing.T) {
 }
 
 func TestDatabaseCertConfig_GetCertPath_WithRealPaths(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "cert_test_real_paths")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	legacyPath := filepath.Join(tempDir, "mongo-client")
+	newPath := filepath.Join(tempDir, "database-client")
+
+	require.NoError(t, os.MkdirAll(legacyPath, 0755))
+	require.NoError(t, os.MkdirAll(newPath, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(legacyPath, "ca.crt"), []byte("legacy cert"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(newPath, "ca.crt"), []byte("new cert"), 0644))
+
 	tests := []struct {
 		name         string
 		resolvedPath string
+		expectedPath string
 		description  string
 	}{
 		{
 			name:         "legacy path preference",
-			resolvedPath: "/etc/ssl/mongo-client",
+			resolvedPath: legacyPath,
+			expectedPath: legacyPath,
 			description:  "Should handle legacy path correctly",
 		},
 		{
 			name:         "new path preference",
-			resolvedPath: "/etc/ssl/database-client",
+			resolvedPath: newPath,
+			expectedPath: newPath,
 			description:  "Should handle new path correctly",
 		},
 	}
@@ -209,16 +237,16 @@ func TestDatabaseCertConfig_GetCertPath_WithRealPaths(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := &DatabaseCertConfig{
+				TLSEnabled:       true,
 				ResolvedCertPath: tt.resolvedPath,
 			}
 
 			certPath := config.GetCertPath()
 
-			// Since we can't guarantee these paths exist in test environment,
-			// just verify the function returns a reasonable path
 			assert.NotEmpty(t, certPath, "GetCertPath should return a non-empty path")
-			assert.Contains(t, []string{"/etc/ssl/mongo-client", "/etc/ssl/database-client", tt.resolvedPath},
+			assert.Contains(t, []string{legacyPath, newPath, tt.resolvedPath},
 				certPath, "Should return one of the expected paths")
+			assert.Equal(t, tt.expectedPath, certPath, tt.description)
 		})
 	}
 }

--- a/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
@@ -1046,11 +1046,17 @@ func TestEventSequenceWithSupersedingGroup(t *testing.T) {
 	assert.True(t, shouldCreate, "COMPONENT_RESET should be allowed (same group as previous "+
 		"COMPONENT_RESET that completed)")
 
-	// Verify annotation removed for CR-2 but not CR-3
-	state, _, err = r.annotationManager.GetRemediationState(ctx, nodeName)
-	require.NoError(t, err)
-	assert.Equal(t, "", state.EquivalenceGroups["reset-GPU-455d8f70-2051-db6c-0430-ffc457bff834"].MaintenanceCR)
-	assert.Equal(t, crName3, state.EquivalenceGroups["reset-GPU-927d8f70-2051-db6c-0430-ffc457bff834"].MaintenanceCR)
+	// Verify annotation removed for CR-2 but not CR-3.
+	// Use Eventually because RemoveGroupsFromState writes to the API server but
+	// GetRemediationState reads from the informer cache, which syncs asynchronously.
+	assert.Eventually(t, func() bool {
+		state, _, err = r.annotationManager.GetRemediationState(ctx, nodeName)
+		if err != nil {
+			return false
+		}
+		return state.EquivalenceGroups["reset-GPU-455d8f70-2051-db6c-0430-ffc457bff834"].MaintenanceCR == "" &&
+			state.EquivalenceGroups["reset-GPU-927d8f70-2051-db6c-0430-ffc457bff834"].MaintenanceCR == crName3
+	}, 5*time.Second, 100*time.Millisecond, "Expected CR-2 group to be removed and CR-3 group to remain")
 
 	// Event 9: COMPONENT_RESET missing GPU_UUID should result in a nvsentinel-state label having value remediation-failed.
 	_, _ = stateManager.UpdateNVSentinelStateNodeLabel(ctx, nodeName, statemanager.DrainSucceededLabelValue, false)

--- a/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
@@ -541,10 +541,17 @@ func TestCRBasedDeduplication_Integration(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, shouldCreateCR, "Should allow retry after CR failed")
 
-		// Verify annotation was cleaned up
-		state, _, err := r.annotationManager.GetRemediationState(ctx, nodeName)
-		require.NoError(t, err)
-		assert.NotContains(t, state.EquivalenceGroups, "restart", "Failed CR should be removed from annotation")
+		// Verify annotation was cleaned up.
+		// Use Eventually because RemoveGroupsFromState writes to the API server but
+		// GetRemediationState reads from the informer cache, which syncs asynchronously.
+		assert.Eventually(t, func() bool {
+			state, _, err := r.annotationManager.GetRemediationState(ctx, nodeName)
+			if err != nil {
+				return false
+			}
+			_, exists := state.EquivalenceGroups["restart"]
+			return !exists
+		}, 5*time.Second, 100*time.Millisecond, "Failed CR should be removed from annotation")
 
 		// Event 2: Create retry CR
 		event2 := &events.HealthEventDoc{
@@ -566,7 +573,7 @@ func TestCRBasedDeduplication_Integration(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Verify new annotation
-		state, _, err = r.annotationManager.GetRemediationState(ctx, nodeName)
+		state, _, err := r.annotationManager.GetRemediationState(ctx, nodeName)
 		require.NoError(t, err)
 		assert.Contains(t, state.EquivalenceGroups, "restart")
 		assert.Equal(t, secondCRName, state.EquivalenceGroups["restart"].MaintenanceCR)

--- a/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
@@ -1054,8 +1054,9 @@ func TestEventSequenceWithSupersedingGroup(t *testing.T) {
 		if err != nil {
 			return false
 		}
-		return state.EquivalenceGroups["reset-GPU-455d8f70-2051-db6c-0430-ffc457bff834"].MaintenanceCR == "" &&
-			state.EquivalenceGroups["reset-GPU-927d8f70-2051-db6c-0430-ffc457bff834"].MaintenanceCR == crName3
+		_, cr2GroupExists := state.EquivalenceGroups["reset-GPU-455d8f70-2051-db6c-0430-ffc457bff834"]
+		cr3Group, cr3GroupExists := state.EquivalenceGroups["reset-GPU-927d8f70-2051-db6c-0430-ffc457bff834"]
+		return !cr2GroupExists && cr3GroupExists && cr3Group.MaintenanceCR == crName3
 	}, 5*time.Second, 100*time.Millisecond, "Expected CR-2 group to be removed and CR-3 group to remain")
 
 	// Event 9: COMPONENT_RESET missing GPU_UUID should result in a nvsentinel-state label having value remediation-failed.

--- a/node-drainer/pkg/evaluator/evaluator.go
+++ b/node-drainer/pkg/evaluator/evaluator.go
@@ -83,6 +83,7 @@ func checkPreconditions(healthEvent model.HealthEventWithStatus) *DrainActionRes
 		healthEvent.HealthEvent.DrainOverrides.Skip {
 		slog.Info("DrainOverrides.Skip is true, skipping drain for node",
 			"node", nodeName)
+
 		return &DrainActionResult{Action: ActionMarkAlreadyDrained, Status: model.AlreadyDrained}
 	}
 

--- a/store-client/pkg/config/env_loader.go
+++ b/store-client/pkg/config/env_loader.go
@@ -151,9 +151,11 @@ func NewDatabaseConfigFromEnv() (DatabaseConfig, error) {
 	if certMountPath == "" {
 		certMountPath = os.Getenv("POSTGRESQL_CLIENT_CERT_MOUNT_PATH")
 	}
+
 	if certMountPath == "" {
 		certMountPath = DefaultCertMountPath
 	}
+
 	return NewDatabaseConfigFromEnvWithDefaults(certMountPath)
 }
 

--- a/store-client/pkg/datastore/config.go
+++ b/store-client/pkg/datastore/config.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strconv"
 
 	"gopkg.in/yaml.v3"
@@ -26,6 +27,7 @@ import (
 // LoadDatastoreConfig loads datastore configuration from environment variables and YAML
 func LoadDatastoreConfig() (*DataStoreConfig, error) {
 	provider := os.Getenv("DATASTORE_PROVIDER")
+	//nolint:gosec // G706 - structured slog value, safely escaped by handler
 	slog.Info("Loading datastore config", "provider", provider)
 
 	if provider != "" {
@@ -211,7 +213,7 @@ func loadDefaultConfig() *DataStoreConfig {
 
 // loadDatastoreConfigFromYAMLFile loads configuration from a YAML file
 func loadDatastoreConfigFromYAMLFile(yamlPath string) (*DataStoreConfig, error) {
-	data, err := os.ReadFile(yamlPath)
+	data, err := os.ReadFile(filepath.Clean(yamlPath))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read datastore config file %s: %w", yamlPath, err)
 	}

--- a/store-client/pkg/datastore/providers/mongodb/register.go
+++ b/store-client/pkg/datastore/providers/mongodb/register.go
@@ -64,6 +64,7 @@ func NewMongoDBDataStore(ctx context.Context, config datastore.DataStoreConfig) 
 		slog.Info("Extracted cert directory from TLSConfig", "certDir", certDir)
 	} else if envPath := os.Getenv("MONGODB_CLIENT_CERT_MOUNT_PATH"); envPath != "" {
 		certMountPath = &envPath
+		//nolint:gosec // G706 - structured slog value, safely escaped by handler
 		slog.Info("Using MONGODB_CLIENT_CERT_MOUNT_PATH from environment", "envPath", envPath)
 	} else {
 		slog.Warn("No certificate path found in TLSConfig or environment")

--- a/store-client/pkg/datastore/providers/mongodb/watcher/watch_store.go
+++ b/store-client/pkg/datastore/providers/mongodb/watcher/watch_store.go
@@ -307,7 +307,7 @@ func openChangeStreamWithRetry(
 
 func (w *ChangeStreamWatcher) Start(ctx context.Context) {
 	// Create a child context that we can cancel on Close()
-	watchCtx, cancel := context.WithCancel(ctx)
+	watchCtx, cancel := context.WithCancel(ctx) //nolint:gosec // G118 - cancel is stored in w.cancel and called in Close()
 	w.cancel = cancel
 
 	go func() {
@@ -735,11 +735,13 @@ func constructStaticTLSConfig(mongoConfig MongoDBConfig) (*tls.Config, error) {
 			slog.Warn("Client certificate or key not found, using CA-only TLS (no mTLS)",
 				"certPath", mongoConfig.ClientTLSCertConfig.TlsCertPath,
 				"keyPath", mongoConfig.ClientTLSCertConfig.TlsKeyPath)
+
 			return &tls.Config{
 				RootCAs:    caCertPool,
 				MinVersion: tls.VersionTLS12,
 			}, nil
 		}
+
 		return nil, fmt.Errorf("failed to load client certificate and key: %w", err)
 	}
 
@@ -793,11 +795,13 @@ func ConstructClientTLSConfig(
 		if os.IsNotExist(err) {
 			slog.Warn("Client certificate or key not found, using CA-only TLS (no mTLS)",
 				"certPath", clientCertPath, "keyPath", clientKeyPath)
+
 			return &tls.Config{
 				RootCAs:    caCertPool,
 				MinVersion: tls.VersionTLS12,
 			}, nil
 		}
+
 		return nil, fmt.Errorf("failed to load client certificate and key: %w", err)
 	}
 
@@ -814,6 +818,7 @@ func pollTillCACertIsMountedSuccessfully(certPath string, timeoutInterval time.D
 		slog.Info("No CA cert path configured, TLS will be disabled")
 		return nil, nil
 	}
+
 	if !filepath.IsAbs(certPath) {
 		return nil, fmt.Errorf("CA cert path %q is not absolute — this is likely a misconfiguration. "+
 			"Use --tls-enabled=false to explicitly disable TLS, or provide an absolute cert mount path", certPath)

--- a/store-client/pkg/datastore/providers/postgresql/changestream.go
+++ b/store-client/pkg/datastore/providers/postgresql/changestream.go
@@ -590,6 +590,7 @@ func (w *PostgreSQLChangeStreamWatcher) fetchNewChanges(ctx context.Context) err
 		  )`
 
 	// Append server-side filter if available
+	//nolint:gosec // G202 - sqlFilterClause uses parameterized $N placeholders, not raw user input
 	query := baseQuery + sqlFilterClause + `
 		ORDER BY changed_at ASC, id ASC
 		LIMIT 100

--- a/store-client/pkg/helper/datastore_helper.go
+++ b/store-client/pkg/helper/datastore_helper.go
@@ -167,6 +167,7 @@ func createStandardizedFactory(config DatastoreClientConfig) (*factory.ClientFac
 	}
 
 	if envCertPath != "" {
+		//nolint:gosec // G706 - structured slog values, safely escaped by handler
 		slog.Debug("Using environment config with cert path from env var",
 			"module", config.ModuleName,
 			"certPath", envCertPath,

--- a/store-client/pkg/query/builder.go
+++ b/store-client/pkg/query/builder.go
@@ -497,10 +497,10 @@ func mongoFieldToJSONB(fieldPath string) string {
 	for i, part := range parts {
 		if i < len(parts)-1 {
 			// Intermediate path: use -> to keep as JSONB
-			jsonbPath.WriteString(fmt.Sprintf("->'%s'", part))
+			fmt.Fprintf(&jsonbPath, "->'%s'", part)
 		} else {
 			// Final path: use ->> to extract as text
-			jsonbPath.WriteString(fmt.Sprintf("->>'%s'", part))
+			fmt.Fprintf(&jsonbPath, "->>'%s'", part)
 		}
 	}
 
@@ -536,7 +536,7 @@ func buildDualCaseJSONBPath(parts []string) string {
 
 	// Build the base path up to the last element
 	for i := 0; i < len(parts)-1; i++ {
-		basePath.WriteString(fmt.Sprintf("->'%s'", parts[i]))
+		fmt.Fprintf(&basePath, "->'%s'", parts[i])
 	}
 
 	lastField := parts[len(parts)-1]

--- a/store-client/pkg/storewatcher/watch_store.go
+++ b/store-client/pkg/storewatcher/watch_store.go
@@ -485,56 +485,9 @@ func GetCollectionClient(
 func constructMongoClientOptions(
 	mongoConfig MongoDBConfig,
 ) (*options.ClientOptions, error) {
-	timeout := mongoConfig.TotalCACertTimeoutSeconds
-	if timeout == 0 {
-		timeout = 600 // 10 minutes by default
-	}
-
-	totalCertTimeout := time.Duration(timeout) * time.Second
-
-	interval := mongoConfig.TotalCACertIntervalSeconds
-	if interval == 0 {
-		interval = 5 // 5 seconds by default
-	}
-
-	intervalCert := time.Duration(interval) * time.Second
-
-	// load CA certificate
-	caCert, err := pollTillCACertIsMountedSuccessfully(mongoConfig.ClientTLSCertConfig.CaCertPath,
-		totalCertTimeout, intervalCert)
+	tlsConfig, err := buildTLSConfig(mongoConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read CA certificate with error: %w", err)
-	}
-
-	// Build TLS config only when CA cert is available
-	var tlsConfig *tls.Config
-	if caCert != nil {
-		caCertPool := x509.NewCertPool()
-		if !caCertPool.AppendCertsFromPEM(caCert) {
-			return nil, fmt.Errorf("failed to append CA certificate to pool")
-		}
-
-		// Load client certificate and key. If the files don't exist, proceed
-		// with CA-only TLS rather than failing.
-		clientCert, err := tls.LoadX509KeyPair(mongoConfig.ClientTLSCertConfig.TlsCertPath,
-			mongoConfig.ClientTLSCertConfig.TlsKeyPath)
-		if err != nil {
-			if os.IsNotExist(err) {
-				slog.Warn("Client certificate or key not found, skipping mTLS",
-					"certPath", mongoConfig.ClientTLSCertConfig.TlsCertPath,
-					"keyPath", mongoConfig.ClientTLSCertConfig.TlsKeyPath)
-			} else {
-				return nil, fmt.Errorf("failed to load client certificate and key: %w", err)
-			}
-		}
-
-		tlsConfig = &tls.Config{
-			RootCAs:    caCertPool,
-			MinVersion: tls.VersionTLS12,
-		}
-		if err == nil {
-			tlsConfig.Certificates = []tls.Certificate{clientCert}
-		}
+		return nil, err
 	}
 
 	clientOpts := options.Client().ApplyURI(mongoConfig.URI)
@@ -559,6 +512,62 @@ func constructMongoClientOptions(
 	}
 
 	return clientOpts, nil
+}
+
+func buildTLSConfig(mongoConfig MongoDBConfig) (*tls.Config, error) {
+	timeout := mongoConfig.TotalCACertTimeoutSeconds
+	if timeout == 0 {
+		timeout = 600 // 10 minutes by default
+	}
+
+	totalCertTimeout := time.Duration(timeout) * time.Second
+
+	interval := mongoConfig.TotalCACertIntervalSeconds
+	if interval == 0 {
+		interval = 5 // 5 seconds by default
+	}
+
+	intervalCert := time.Duration(interval) * time.Second
+
+	caCert, err := pollTillCACertIsMountedSuccessfully(mongoConfig.ClientTLSCertConfig.CaCertPath,
+		totalCertTimeout, intervalCert)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA certificate with error: %w", err)
+	}
+
+	if caCert == nil {
+		return nil, nil
+	}
+
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("failed to append CA certificate to pool")
+	}
+
+	// Load client certificate and key. If the files don't exist, proceed
+	// with CA-only TLS rather than failing.
+	clientCert, err := tls.LoadX509KeyPair(mongoConfig.ClientTLSCertConfig.TlsCertPath,
+		mongoConfig.ClientTLSCertConfig.TlsKeyPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			slog.Warn("Client certificate or key not found, skipping mTLS",
+				"certPath", mongoConfig.ClientTLSCertConfig.TlsCertPath,
+				"keyPath", mongoConfig.ClientTLSCertConfig.TlsKeyPath)
+
+			return &tls.Config{
+				RootCAs:    caCertPool,
+				MinVersion: tls.VersionTLS12,
+			}, nil
+		}
+
+		return nil, fmt.Errorf("failed to load client certificate and key: %w", err)
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{clientCert},
+		RootCAs:      caCertPool,
+		MinVersion:   tls.VersionTLS12,
+	}, nil
 }
 
 // ConstructClientTLSConfig builds a TLS configuration from certificates at the
@@ -615,6 +624,7 @@ func pollTillCACertIsMountedSuccessfully(certPath string, timeoutInterval time.D
 		slog.Info("No CA cert path configured, TLS will be disabled")
 		return nil, nil
 	}
+
 	if !filepath.IsAbs(certPath) {
 		return nil, fmt.Errorf("CA cert path %q is not absolute — this is likely a misconfiguration. "+
 			"Use --tls-enabled=false to explicitly disable TLS, or provide an absolute cert mount path", certPath)


### PR DESCRIPTION
## Summary

<!-- Brief description of your changes -->

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional mTLS for datastore connections with graceful fallback to CA-only TLS when client certificates are missing.

* **Bug Fixes**
  * Drain skip override now immediately marks nodes as already drained.

* **Chores**
  * Improved config path normalization, TLS loading robustness, and minor formatting/lint annotations.

* **Tests**
  * E2E tests made more resilient to asynchronous cache timing by polling for expected state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->