### PR TITLE
fix: DrainRequest CR creation should be idempotent

### DIFF
--- a/node-drainer/pkg/customdrain/client.go
+++ b/node-drainer/pkg/customdrain/client.go
@@ -228,23 +228,7 @@ func (c *Client) GetCRStatus(ctx context.Context, crName string) (bool, bool, er
 		return false, false, fmt.Errorf("failed to get CR: %w", err)
 	}
 
-	conditions, found, err := unstructured.NestedSlice(cr.Object, "status", "conditions")
-	if err != nil {
-		return true, false, fmt.Errorf("failed to extract status.conditions: %w", err)
-	}
-
-	if !found {
-		return true, false, nil
-	}
-
-	for _, cond := range conditions {
-		condMap, ok := cond.(map[string]any)
-		if ok && c.matchesCondition(condMap) {
-			return true, true, nil
-		}
-	}
-
-	return true, false, nil
+	return true, c.isCRComplete(*cr), nil
 }
 
 func (c *Client) DeleteDrainCR(ctx context.Context, crName string) error {

--- a/node-drainer/pkg/customdrain/client.go
+++ b/node-drainer/pkg/customdrain/client.go
@@ -113,6 +113,7 @@ func (c *Client) CreateDrainCR(ctx context.Context, data TemplateData) (string, 
 	if labels == nil {
 		labels = make(map[string]string)
 	}
+
 	labels[NodeNameLabelKey] = data.HealthEvent.NodeName
 	cr.SetLabels(labels)
 

--- a/node-drainer/pkg/customdrain/client.go
+++ b/node-drainer/pkg/customdrain/client.go
@@ -109,6 +109,13 @@ func (c *Client) CreateDrainCR(ctx context.Context, data TemplateData) (string, 
 		cr.SetNamespace(c.config.Namespace)
 	}
 
+	labels := cr.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[NodeNameLabelKey] = data.HealthEvent.NodeName
+	cr.SetLabels(labels)
+
 	gvk := schema.GroupVersionKind{
 		Group:   c.config.ApiGroup,
 		Version: c.config.Version,
@@ -132,7 +139,7 @@ func (c *Client) CreateDrainCR(ctx context.Context, data TemplateData) (string, 
 	return crName, nil
 }
 
-func (c *Client) Exists(ctx context.Context, crName string) (bool, error) {
+func (c *Client) ExistsForNode(ctx context.Context, nodeName string) (bool, error) {
 	gvk := schema.GroupVersionKind{
 		Group:   c.config.ApiGroup,
 		Version: c.config.Version,
@@ -144,19 +151,17 @@ func (c *Client) Exists(ctx context.Context, crName string) (bool, error) {
 		return false, fmt.Errorf("failed to get REST mapping for %s: %w", gvk, err)
 	}
 
-	_, err = c.dynamicClient.
+	selector := fmt.Sprintf("%s=%s", NodeNameLabelKey, nodeName)
+
+	list, err := c.dynamicClient.
 		Resource(mapping.Resource).
 		Namespace(c.config.Namespace).
-		Get(ctx, crName, metav1.GetOptions{})
+		List(ctx, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
-		if errors.IsNotFound(err) {
-			return false, nil
-		}
-
-		return false, fmt.Errorf("failed to check CR existence: %w", err)
+		return false, fmt.Errorf("failed to list drain CRs for node %s: %w", nodeName, err)
 	}
 
-	return true, nil
+	return len(list.Items) > 0, nil
 }
 
 func (c *Client) matchesCondition(condMap map[string]any) bool {
@@ -168,7 +173,9 @@ func (c *Client) matchesCondition(condMap map[string]any) bool {
 		strings.EqualFold(condStatus, c.config.StatusConditionStatus)
 }
 
-func (c *Client) GetCRStatus(ctx context.Context, crName string) (bool, error) {
+// GetCRStatus checks if a CR exists and whether its status condition is met.
+// Returns (found, complete, error). found=false means the CR does not exist.
+func (c *Client) GetCRStatus(ctx context.Context, crName string) (bool, bool, error) {
 	gvk := schema.GroupVersionKind{
 		Group:   c.config.ApiGroup,
 		Version: c.config.Version,
@@ -177,7 +184,7 @@ func (c *Client) GetCRStatus(ctx context.Context, crName string) (bool, error) {
 
 	mapping, err := c.restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
-		return false, fmt.Errorf("failed to get REST mapping for %s: %w", gvk, err)
+		return false, false, fmt.Errorf("failed to get REST mapping for %s: %w", gvk, err)
 	}
 
 	cr, err := c.dynamicClient.
@@ -185,26 +192,30 @@ func (c *Client) GetCRStatus(ctx context.Context, crName string) (bool, error) {
 		Namespace(c.config.Namespace).
 		Get(ctx, crName, metav1.GetOptions{})
 	if err != nil {
-		return false, fmt.Errorf("failed to get CR: %w", err)
+		if errors.IsNotFound(err) {
+			return false, false, nil
+		}
+
+		return false, false, fmt.Errorf("failed to get CR: %w", err)
 	}
 
 	conditions, found, err := unstructured.NestedSlice(cr.Object, "status", "conditions")
 	if err != nil {
-		return false, fmt.Errorf("failed to extract status.conditions: %w", err)
+		return true, false, fmt.Errorf("failed to extract status.conditions: %w", err)
 	}
 
 	if !found {
-		return false, nil
+		return true, false, nil
 	}
 
 	for _, cond := range conditions {
 		condMap, ok := cond.(map[string]any)
 		if ok && c.matchesCondition(condMap) {
-			return true, nil
+			return true, true, nil
 		}
 	}
 
-	return false, nil
+	return true, false, nil
 }
 
 func (c *Client) DeleteDrainCR(ctx context.Context, crName string) error {

--- a/node-drainer/pkg/customdrain/client.go
+++ b/node-drainer/pkg/customdrain/client.go
@@ -140,7 +140,9 @@ func (c *Client) CreateDrainCR(ctx context.Context, data TemplateData) (string, 
 	return crName, nil
 }
 
-func (c *Client) ExistsForNode(ctx context.Context, nodeName string) (bool, error) {
+// ExistsForNode checks if any drain CR exists for the given node.
+// Returns (exists, drainComplete, error).
+func (c *Client) ExistsForNode(ctx context.Context, nodeName string) (bool, bool, error) {
 	gvk := schema.GroupVersionKind{
 		Group:   c.config.ApiGroup,
 		Version: c.config.Version,
@@ -149,7 +151,7 @@ func (c *Client) ExistsForNode(ctx context.Context, nodeName string) (bool, erro
 
 	mapping, err := c.restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
-		return false, fmt.Errorf("failed to get REST mapping for %s: %w", gvk, err)
+		return false, false, fmt.Errorf("failed to get REST mapping for %s: %w", gvk, err)
 	}
 
 	selector := fmt.Sprintf("%s=%s", NodeNameLabelKey, nodeName)
@@ -159,10 +161,36 @@ func (c *Client) ExistsForNode(ctx context.Context, nodeName string) (bool, erro
 		Namespace(c.config.Namespace).
 		List(ctx, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
-		return false, fmt.Errorf("failed to list drain CRs for node %s: %w", nodeName, err)
+		return false, false, fmt.Errorf("failed to list drain CRs for node %s: %w", nodeName, err)
 	}
 
-	return len(list.Items) > 0, nil
+	if len(list.Items) == 0 {
+		return false, false, nil
+	}
+
+	for _, item := range list.Items {
+		if !c.isCRComplete(item) {
+			return true, false, nil
+		}
+	}
+
+	return true, true, nil
+}
+
+func (c *Client) isCRComplete(cr unstructured.Unstructured) bool {
+	conditions, found, err := unstructured.NestedSlice(cr.Object, "status", "conditions")
+	if err != nil || !found {
+		return false
+	}
+
+	for _, cond := range conditions {
+		condMap, ok := cond.(map[string]any)
+		if ok && c.matchesCondition(condMap) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (c *Client) matchesCondition(condMap map[string]any) bool {

--- a/node-drainer/pkg/customdrain/client_integration_test.go
+++ b/node-drainer/pkg/customdrain/client_integration_test.go
@@ -158,8 +158,9 @@ func testStatusConditions(t *testing.T) {
 		Resource: "drainrequests",
 	}
 
-	isComplete, err := client.GetCRStatus(ctx, crName)
+	found, isComplete, err := client.GetCRStatus(ctx, crName)
 	require.NoError(t, err)
+	assert.True(t, found)
 	assert.False(t, isComplete)
 
 	cr, err := dynamicClient.Resource(gvr).Namespace("default").Get(ctx, crName, metav1.GetOptions{})
@@ -176,8 +177,9 @@ func testStatusConditions(t *testing.T) {
 	_, err = dynamicClient.Resource(gvr).Namespace("default").UpdateStatus(ctx, cr, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
-	isComplete, err = client.GetCRStatus(ctx, crName)
+	found, isComplete, err = client.GetCRStatus(ctx, crName)
 	require.NoError(t, err)
+	assert.True(t, found)
 	assert.False(t, isComplete)
 
 	cr, err = dynamicClient.Resource(gvr).Namespace("default").Get(ctx, crName, metav1.GetOptions{})
@@ -194,8 +196,9 @@ func testStatusConditions(t *testing.T) {
 	_, err = dynamicClient.Resource(gvr).Namespace("default").UpdateStatus(ctx, cr, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
-	isComplete, err = client.GetCRStatus(ctx, crName)
+	found, isComplete, err = client.GetCRStatus(ctx, crName)
 	require.NoError(t, err)
+	assert.True(t, found)
 	assert.False(t, isComplete)
 
 	cr, err = dynamicClient.Resource(gvr).Namespace("default").Get(ctx, crName, metav1.GetOptions{})
@@ -212,8 +215,9 @@ func testStatusConditions(t *testing.T) {
 	_, err = dynamicClient.Resource(gvr).Namespace("default").UpdateStatus(ctx, cr, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
-	isComplete, err = client.GetCRStatus(ctx, crName)
+	found, isComplete, err = client.GetCRStatus(ctx, crName)
 	require.NoError(t, err)
+	assert.True(t, found)
 	assert.True(t, isComplete, "Status check should be case-insensitive")
 
 }

--- a/node-drainer/pkg/customdrain/types.go
+++ b/node-drainer/pkg/customdrain/types.go
@@ -20,6 +20,8 @@ import (
 	"github.com/nvidia/nvsentinel/data-models/pkg/protos"
 )
 
+const NodeNameLabelKey = "nvsentinel.nvidia.com/node-name"
+
 type TemplateData struct {
 	HealthEvent *protos.HealthEvent
 	EventID     string

--- a/node-drainer/pkg/evaluator/evaluator.go
+++ b/node-drainer/pkg/evaluator/evaluator.go
@@ -83,6 +83,7 @@ func checkPreconditions(healthEvent model.HealthEventWithStatus) *DrainActionRes
 		healthEvent.HealthEvent.DrainOverrides.Skip {
 		slog.Info("DrainOverrides.Skip is true, skipping drain for node",
 			"node", nodeName)
+
 		return &DrainActionResult{Action: ActionMarkAlreadyDrained, Status: model.AlreadyDrained}
 	}
 

--- a/node-drainer/pkg/evaluator/evaluator.go
+++ b/node-drainer/pkg/evaluator/evaluator.go
@@ -343,11 +343,10 @@ func (e *NodeDrainEvaluator) evaluateCustomDrain(ctx context.Context, healthEven
 
 	crName := customdrain.GenerateCRName(nodeName, eventID)
 
-	exists, err := e.customDrainClient.Exists(ctx, crName)
+	nodeHasActiveCR, err := e.customDrainClient.ExistsForNode(ctx, nodeName)
 	if err != nil {
-		slog.Error("Failed to check if drain CR exists",
+		slog.Error("Failed to check if any drain CR exists for node",
 			"node", nodeName,
-			"crName", crName,
 			"error", err)
 
 		return &DrainActionResult{
@@ -356,7 +355,7 @@ func (e *NodeDrainEvaluator) evaluateCustomDrain(ctx context.Context, healthEven
 		}, nil
 	}
 
-	if !exists {
+	if !nodeHasActiveCR {
 		systemNamespaces := e.config.SystemNamespaces
 
 		namespaces, err := e.informers.GetNamespacesMatchingPattern(ctx, "*", systemNamespaces, nodeName)
@@ -375,12 +374,22 @@ func (e *NodeDrainEvaluator) evaluateCustomDrain(ctx context.Context, healthEven
 		}, nil
 	}
 
-	isComplete, err := e.customDrainClient.GetCRStatus(ctx, crName)
+	found, isComplete, err := e.customDrainClient.GetCRStatus(ctx, crName)
 	if err != nil {
 		slog.Error("Failed to get drain CR status",
 			"node", nodeName,
 			"crName", crName,
 			"error", err)
+
+		return &DrainActionResult{
+			Action:    ActionWait,
+			WaitDelay: customDrainPollInterval,
+		}, nil
+	}
+
+	if !found {
+		slog.Info("Another drain CR exists for this node, waiting",
+			"node", nodeName)
 
 		return &DrainActionResult{
 			Action:    ActionWait,

--- a/node-drainer/pkg/evaluator/evaluator.go
+++ b/node-drainer/pkg/evaluator/evaluator.go
@@ -344,7 +344,7 @@ func (e *NodeDrainEvaluator) evaluateCustomDrain(ctx context.Context, healthEven
 
 	crName := customdrain.GenerateCRName(nodeName, eventID)
 
-	nodeHasActiveCR, err := e.customDrainClient.ExistsForNode(ctx, nodeName)
+	nodeHasCR, nodeDrainComplete, err := e.customDrainClient.ExistsForNode(ctx, nodeName)
 	if err != nil {
 		slog.Error("Failed to check if any drain CR exists for node",
 			"node", nodeName,
@@ -356,7 +356,7 @@ func (e *NodeDrainEvaluator) evaluateCustomDrain(ctx context.Context, healthEven
 		}, nil
 	}
 
-	if !nodeHasActiveCR {
+	if !nodeHasCR {
 		systemNamespaces := e.config.SystemNamespaces
 
 		namespaces, err := e.informers.GetNamespacesMatchingPattern(ctx, "*", systemNamespaces, nodeName)
@@ -375,7 +375,7 @@ func (e *NodeDrainEvaluator) evaluateCustomDrain(ctx context.Context, healthEven
 		}, nil
 	}
 
-	found, isComplete, err := e.customDrainClient.GetCRStatus(ctx, crName)
+	crExists, isComplete, err := e.customDrainClient.GetCRStatus(ctx, crName)
 	if err != nil {
 		slog.Error("Failed to get drain CR status",
 			"node", nodeName,
@@ -388,8 +388,18 @@ func (e *NodeDrainEvaluator) evaluateCustomDrain(ctx context.Context, healthEven
 		}, nil
 	}
 
-	if !found {
-		slog.Info("Another drain CR exists for this node, waiting",
+	if !crExists {
+		if nodeDrainComplete {
+			slog.Info("Another drain CR completed for this node, marking as already drained",
+				"node", nodeName)
+
+			return &DrainActionResult{
+				Action: ActionMarkAlreadyDrained,
+				Status: model.AlreadyDrained,
+			}, nil
+		}
+
+		slog.Info("Another drain CR is in progress for this node, waiting",
 			"node", nodeName)
 
 		return &DrainActionResult{

--- a/node-drainer/pkg/evaluator/types.go
+++ b/node-drainer/pkg/evaluator/types.go
@@ -47,8 +47,8 @@ type InformersInterface interface {
 }
 
 type CustomDrainClientInterface interface {
-	Exists(ctx context.Context, crName string) (bool, error)
-	GetCRStatus(ctx context.Context, crName string) (bool, error)
+	ExistsForNode(ctx context.Context, nodeName string) (bool, error)
+	GetCRStatus(ctx context.Context, crName string) (found bool, complete bool, err error)
 }
 
 type DrainAction int

--- a/node-drainer/pkg/evaluator/types.go
+++ b/node-drainer/pkg/evaluator/types.go
@@ -47,7 +47,7 @@ type InformersInterface interface {
 }
 
 type CustomDrainClientInterface interface {
-	ExistsForNode(ctx context.Context, nodeName string) (bool, error)
+	ExistsForNode(ctx context.Context, nodeName string) (exists bool, drainComplete bool, err error)
 	GetCRStatus(ctx context.Context, crName string) (found bool, complete bool, err error)
 }
 

--- a/node-drainer/pkg/reconciler/reconciler_integration_test.go
+++ b/node-drainer/pkg/reconciler/reconciler_integration_test.go
@@ -1914,20 +1914,14 @@ func TestReconciler_CustomDrainMultipleEventsOnSameNode(t *testing.T) {
 	_, err = setup.dynamicClient.Resource(gvr).Namespace("default").Get(setup.ctx, crNameA, metav1.GetOptions{})
 	require.NoError(t, err, "DrainRequest for Event A should exist")
 
-	// Process Event B — should NOT create a CR because Event A's CR already exists for this node
+	// Process Event B while Event A's drain is still in progress — should wait
 	err = setup.reconciler.ProcessEventGeneric(setup.ctx, eventB, setup.mockDB, setup.healthEventStore, nodeName)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "waiting for retry delay",
-		"Event B should wait because another CR exists for this node")
+		"Event B should wait because another CR is in progress for this node")
 
 	_, err = setup.dynamicClient.Resource(gvr).Namespace("default").Get(setup.ctx, crNameB, metav1.GetOptions{})
-	require.True(t, errors.IsNotFound(err), "DrainRequest for Event B should NOT exist while Event A's CR is active")
-
-	// Retry Event A while CR is incomplete — should poll Event A's CR status
-	err = setup.reconciler.ProcessEventGeneric(setup.ctx, eventA, setup.mockDB, setup.healthEventStore, nodeName)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "waiting for retry delay",
-		"Event A should be waiting on its own CR")
+	require.True(t, errors.IsNotFound(err), "DrainRequest for Event B should NOT exist")
 
 	// Complete Event A's DrainRequest
 	crA, err := setup.dynamicClient.Resource(gvr).Namespace("default").Get(setup.ctx, crNameA, metav1.GetOptions{})
@@ -1945,6 +1939,13 @@ func TestReconciler_CustomDrainMultipleEventsOnSameNode(t *testing.T) {
 	_, err = setup.dynamicClient.Resource(gvr).Namespace("default").UpdateStatus(setup.ctx, crA, metav1.UpdateOptions{})
 	require.NoError(t, err)
 
+	// Process Event B again — Event A's CR is complete, so Event B should be marked AlreadyDrained
+	err = setup.reconciler.ProcessEventGeneric(setup.ctx, eventB, setup.mockDB, setup.healthEventStore, nodeName)
+	require.NoError(t, err, "Event B should be marked AlreadyDrained since the node's drain CR is complete")
+
+	_, err = setup.dynamicClient.Resource(gvr).Namespace("default").Get(setup.ctx, crNameB, metav1.GetOptions{})
+	require.True(t, errors.IsNotFound(err), "DrainRequest for Event B should NOT exist")
+
 	// Process Event A again — should detect completion and mark AlreadyDrained
 	err = setup.reconciler.ProcessEventGeneric(setup.ctx, eventA, setup.mockDB, setup.healthEventStore, nodeName)
 	require.NoError(t, err, "Event A should complete successfully after its CR is done")
@@ -1953,15 +1954,6 @@ func TestReconciler_CustomDrainMultipleEventsOnSameNode(t *testing.T) {
 		_, err := setup.dynamicClient.Resource(gvr).Namespace("default").Get(setup.ctx, crNameA, metav1.GetOptions{})
 		return errors.IsNotFound(err)
 	}, 10*time.Second, 500*time.Millisecond, "Event A's CR should be cleaned up")
-
-	// After Event A's CR is deleted, Event B should now be able to create its own CR
-	err = setup.reconciler.ProcessEventGeneric(setup.ctx, eventB, setup.mockDB, setup.healthEventStore, nodeName)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "waiting for custom drain CR to complete",
-		"Event B should now create its CR since Event A's CR was cleaned up")
-
-	_, err = setup.dynamicClient.Resource(gvr).Namespace("default").Get(setup.ctx, crNameB, metav1.GetOptions{})
-	require.NoError(t, err, "DrainRequest for Event B should now exist")
 }
 
 func TestReconciler_CustomDrainCRDNotFound(t *testing.T) {

--- a/node-drainer/pkg/reconciler/reconciler_integration_test.go
+++ b/node-drainer/pkg/reconciler/reconciler_integration_test.go
@@ -1914,19 +1914,20 @@ func TestReconciler_CustomDrainMultipleEventsOnSameNode(t *testing.T) {
 	_, err = setup.dynamicClient.Resource(gvr).Namespace("default").Get(setup.ctx, crNameA, metav1.GetOptions{})
 	require.NoError(t, err, "DrainRequest for Event A should exist")
 
-	// Process Event B — should create a separate DrainRequest CR
+	// Process Event B — should NOT create a CR because Event A's CR already exists for this node
 	err = setup.reconciler.ProcessEventGeneric(setup.ctx, eventB, setup.mockDB, setup.healthEventStore, nodeName)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "waiting for custom drain CR to complete")
+	assert.Contains(t, err.Error(), "waiting for retry delay",
+		"Event B should wait because another CR exists for this node")
 
 	_, err = setup.dynamicClient.Resource(gvr).Namespace("default").Get(setup.ctx, crNameB, metav1.GetOptions{})
-	require.NoError(t, err, "DrainRequest for Event B should exist")
+	require.True(t, errors.IsNotFound(err), "DrainRequest for Event B should NOT exist while Event A's CR is active")
 
-	// Retry Event A while CR is incomplete — should poll Event A's CR, not Event B's
+	// Retry Event A while CR is incomplete — should poll Event A's CR status
 	err = setup.reconciler.ProcessEventGeneric(setup.ctx, eventA, setup.mockDB, setup.healthEventStore, nodeName)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "waiting for retry delay",
-		"Event A should be waiting on its own CR, not trying to create a new one")
+		"Event A should be waiting on its own CR")
 
 	// Complete Event A's DrainRequest
 	crA, err := setup.dynamicClient.Resource(gvr).Namespace("default").Get(setup.ctx, crNameA, metav1.GetOptions{})
@@ -1953,9 +1954,14 @@ func TestReconciler_CustomDrainMultipleEventsOnSameNode(t *testing.T) {
 		return errors.IsNotFound(err)
 	}, 10*time.Second, 500*time.Millisecond, "Event A's CR should be cleaned up")
 
-	// Event B's CR should still exist independently
+	// After Event A's CR is deleted, Event B should now be able to create its own CR
+	err = setup.reconciler.ProcessEventGeneric(setup.ctx, eventB, setup.mockDB, setup.healthEventStore, nodeName)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "waiting for custom drain CR to complete",
+		"Event B should now create its CR since Event A's CR was cleaned up")
+
 	_, err = setup.dynamicClient.Resource(gvr).Namespace("default").Get(setup.ctx, crNameB, metav1.GetOptions{})
-	require.NoError(t, err, "Event B's CR should still exist — it hasn't been completed yet")
+	require.NoError(t, err, "DrainRequest for Event B should now exist")
 }
 
 func TestReconciler_CustomDrainCRDNotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

Node Drain should not create a new CR for a node if there is already an existing CR (be it either in progress state or completion state). It the existing CR is in progress state then `userpodevictionstatus` for the new node will be marked as `InProgress` and if the existing CR is already completed then the new event CR status about drain will be `AlreadyDrained`. 

## Testing
Scheduled a workload to block the drain:

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: sticky-workload-10
  namespace: slurm
  finalizers:
    - test.example.com/block-deletion
spec:
  nodeName: "be21d5aa-10"
  containers:
    - name: pause
      image: registry.k8s.io/pause:3.9
```
`
Injected couple of errors for a node

```
  [root@nvidia-device-plugin-daemonset-scgrx /]# chroot /host
# logger -p daemon.err "[6085126.134786] NVRM: Xid (PCI:0002:00:00): 79, pid=1582259, name=nvc:[driver], GPU has fallen off the bus."
# logger -p daemon.err "[6085126.134786] NVRM: Xid (PCI:0002:00:00): 79, pid=1582259, name=nvc:[driver], GPU has fallen off the b"   
# 
```


Verified that there is only one drain CR:

```
$ kg drainrequest -A | grep be21d5aa-10
nvsentinel   drain-be21d5aa-10-69ba13711b2cf7b0574ed8b2   32s

$ kg drainrequest -o yaml drain-be21d5aa-10-69ba13711b2cf7b0574ed8b2 -n nvsentinel
apiVersion: nvsentinel.nvidia.com/v1alpha1
kind: DrainRequest
metadata:
  creationTimestamp: "2026-03-18T02:52:33Z"
  finalizers:
  - nvsentinel.nvidia.com/slinky-drainer
  generation: 1
  labels:
    nvsentinel.nvidia.com/node-name: be21d5aa-10
  name: drain-be21d5aa-10-69ba13711b2cf7b0574ed8b2
  namespace: nvsentinel
  resourceVersion: "90860350"
  uid: dcbf7760-3caa-4ffc-ab59-64d21f83968a
spec:
  checkName: SysLogsXIDError
  entitiesImpacted:
  - type: PCI
    value: "0002:00:00"
  errorCode:
  - "79"
  healthEventID: 69ba13711b2cf7b0574ed8b2
  nodeName: be21d5aa-10
  podsToDrain:
    slurm:
    - sticky-workload-10
    - slurm-worker-cpu-hphqp
  reason: 'MESSAGE=[6085126.134786] NVRM: Xid (PCI:0002:00:00): 79, pid=1582259, name=nvc:[driver],
    GPU has fallen off the bus.'
  recommendedAction: RESTART_BM
```

Both health events are in `InProgress` state.

```
0 [direct: primary] HealthEventsDatabase> db.HealthEvents.find({"healthevent.agent": "syslog-health-monitor"})
[
  {
    _id: ObjectId('69ba13711b2cf7b0574ed8b2'),
    createdAt: ISODate('2026-03-18T02:52:33.672Z'),
    healthevent: {
      version: Long('1'),
      agent: 'syslog-health-monitor',
      componentclass: 'GPU',
      checkname: 'SysLogsXIDError',
      isfatal: true,
      ishealthy: false,
      message: 'MESSAGE=[6085126.134786] NVRM: Xid (PCI:0002:00:00): 79, pid=1582259, name=nvc:[driver], GPU has fallen off the bus.',
      recommendedaction: 24,
      errorcode: [ '79' ],
      entitiesimpacted: [ { entitytype: 'PCI', entityvalue: '0002:00:00' } ],
      metadata: {
        'nvidia.com/gpu.product': 'NVIDIA-B200',
        'nvidia.com/cuda.driver-version.major': '575',
        'nvidia.com/cuda.driver-version.minor': '57',
        'nvidia.com/cuda.driver-version.revision': '08',
        'nvidia.com/cuda.driver-version.full': '575.57.08',
        'nvidia.com/cuda.runtime-version.major': '12',
        'nvidia.com/cuda.runtime-version.minor': '9',
        'node.kubernetes.io/instance-type': 'k3s',
        'nvidia.com/cuda.runtime-version.full': '12.9',
        providerID: 'k3s://be21d5aa-10'
      },
      generatedtimestamp: { seconds: Long('1773802353'), nanos: 672251920 },
      nodename: 'be21d5aa-10',
      quarantineoverrides: null,
      drainoverrides: null,
      processingstrategy: 1,
      id: ''
    },
    healtheventstatus: {
      nodequarantined: 'Quarantined',
      userpodsevictionstatus: { status: 'InProgress' },
      faultremediated: null,
      quarantinefinishtimestamp: { seconds: Long('1773802353'), nanos: 739873231 }
    }
  },
  {
    _id: ObjectId('69ba13801b2cf7b0574ed8b3'),
    createdAt: ISODate('2026-03-18T02:52:48.650Z'),
    healthevent: {
      version: Long('1'),
      agent: 'syslog-health-monitor',
      componentclass: 'GPU',
      checkname: 'SysLogsXIDError',
      isfatal: true,
      ishealthy: false,
      message: 'MESSAGE=[6085126.134786] NVRM: Xid (PCI:0002:00:00): 79, pid=1582259, name=nvc:[driver], GPU has fallen off the b',
      recommendedaction: 24,
      errorcode: [ '79' ],
      entitiesimpacted: [ { entitytype: 'PCI', entityvalue: '0002:00:00' } ],
      metadata: {
        'nvidia.com/cuda.runtime-version.full': '12.9',
        providerID: 'k3s://be21d5aa-10',
        'node.kubernetes.io/instance-type': 'k3s',
        'nvidia.com/cuda.driver-version.minor': '57',
        'nvidia.com/cuda.driver-version.revision': '08',
        'nvidia.com/cuda.driver-version.major': '575',
        'nvidia.com/cuda.driver-version.full': '575.57.08',
        'nvidia.com/cuda.runtime-version.major': '12',
        'nvidia.com/gpu.product': 'NVIDIA-B200',
        'nvidia.com/cuda.runtime-version.minor': '9'
      },
      generatedtimestamp: { seconds: Long('1773802368'), nanos: 649798012 },
      nodename: 'be21d5aa-10',
      quarantineoverrides: null,
      drainoverrides: null,
      processingstrategy: 1,
      id: ''
    },
    healtheventstatus: {
      nodequarantined: 'AlreadyQuarantined',
      userpodsevictionstatus: { status: 'InProgress' },
      faultremediated: null,
      quarantinefinishtimestamp: { seconds: Long('1773802368'), nanos: 655180865 }
    }
  }
]
```


Patched the workload pod for manual drain:

```
kubectl patch pod sticky-workload-10 -n slurm --type=merge --subresource=status -p '{
  "status": {
    "conditions": [
      {
        "type": "SlurmNodeStateDrain",
        "status": "True"
      }
    ]
  }
}'
```


Drain completed:
```
$ kg drainrequest -n nvsentinel   drain-be21d5aa-10-69ba13711b2cf7b0574ed8b2 -o yaml
apiVersion: nvsentinel.nvidia.com/v1alpha1
kind: DrainRequest
metadata:
  creationTimestamp: "2026-03-18T02:52:33Z"
  deletionGracePeriodSeconds: 0
  deletionTimestamp: "2026-03-18T02:57:03Z"
  finalizers:
  - nvsentinel.nvidia.com/slinky-drainer
  generation: 2
  labels:
    nvsentinel.nvidia.com/node-name: be21d5aa-10
  name: drain-be21d5aa-10-69ba13711b2cf7b0574ed8b2
  namespace: nvsentinel
  resourceVersion: "90863383"
  uid: dcbf7760-3caa-4ffc-ab59-64d21f83968a
spec:
  checkName: SysLogsXIDError
  entitiesImpacted:
  - type: PCI
    value: "0002:00:00"
  errorCode:
  - "79"
  healthEventID: 69ba13711b2cf7b0574ed8b2
  nodeName: be21d5aa-10
  podsToDrain:
    slurm:
    - sticky-workload-10
    - slurm-worker-cpu-hphqp
  reason: 'MESSAGE=[6085126.134786] NVRM: Xid (PCI:0002:00:00): 79, pid=1582259, name=nvc:[driver],
    GPU has fallen off the bus.'
  recommendedAction: RESTART_BM
status:
  conditions:
  - lastTransitionTime: "2026-03-18T02:56:08Z"
    message: All Slinky pods drained successfully
    reason: DrainComplete
    status: "True"
    type: DrainComplete
```


Both events eventually went to drain completion state:
```
rs0 [direct: primary] HealthEventsDatabase> db.HealthEvents.find({"healthevent.agent": "syslog-health-monitor"})
[
  {
    _id: ObjectId('69ba13711b2cf7b0574ed8b2'),
    createdAt: ISODate('2026-03-18T02:52:33.672Z'),
    healthevent: {
      version: Long('1'),
      agent: 'syslog-health-monitor',
      componentclass: 'GPU',
      checkname: 'SysLogsXIDError',
      isfatal: true,
      ishealthy: false,
      message: 'MESSAGE=[6085126.134786] NVRM: Xid (PCI:0002:00:00): 79, pid=1582259, name=nvc:[driver], GPU has fallen off the bus.',
      recommendedaction: 24,
      errorcode: [ '79' ],
      entitiesimpacted: [ { entitytype: 'PCI', entityvalue: '0002:00:00' } ],
      metadata: {
        'nvidia.com/gpu.product': 'NVIDIA-B200',
        'nvidia.com/cuda.driver-version.major': '575',
        'nvidia.com/cuda.driver-version.minor': '57',
        'nvidia.com/cuda.driver-version.revision': '08',
        'nvidia.com/cuda.driver-version.full': '575.57.08',
        'nvidia.com/cuda.runtime-version.major': '12',
        'nvidia.com/cuda.runtime-version.minor': '9',
        'node.kubernetes.io/instance-type': 'k3s',
        'nvidia.com/cuda.runtime-version.full': '12.9',
        providerID: 'k3s://be21d5aa-10'
      },
      generatedtimestamp: { seconds: Long('1773802353'), nanos: 672251920 },
      nodename: 'be21d5aa-10',
      quarantineoverrides: null,
      drainoverrides: null,
      processingstrategy: 1,
      id: ''
    },
    healtheventstatus: {
      nodequarantined: 'Quarantined',
      userpodsevictionstatus: { status: 'AlreadyDrained', message: '' },
      faultremediated: null,
      quarantinefinishtimestamp: { seconds: Long('1773802353'), nanos: 739873231 },
      drainfinishtimestamp: { seconds: Long('1773802623'), nanos: 801126952 }
    }
  },
  {
    _id: ObjectId('69ba13801b2cf7b0574ed8b3'),
    createdAt: ISODate('2026-03-18T02:52:48.650Z'),
    healthevent: {
      version: Long('1'),
      agent: 'syslog-health-monitor',
      componentclass: 'GPU',
      checkname: 'SysLogsXIDError',
      isfatal: true,
      ishealthy: false,
      message: 'MESSAGE=[6085126.134786] NVRM: Xid (PCI:0002:00:00): 79, pid=1582259, name=nvc:[driver], GPU has fallen off the b',
      recommendedaction: 24,
      errorcode: [ '79' ],
      entitiesimpacted: [ { entitytype: 'PCI', entityvalue: '0002:00:00' } ],
      metadata: {
        'nvidia.com/cuda.runtime-version.full': '12.9',
        providerID: 'k3s://be21d5aa-10',
        'node.kubernetes.io/instance-type': 'k3s',
        'nvidia.com/cuda.driver-version.minor': '57',
        'nvidia.com/cuda.driver-version.revision': '08',
        'nvidia.com/cuda.driver-version.major': '575',
        'nvidia.com/cuda.driver-version.full': '575.57.08',
        'nvidia.com/cuda.runtime-version.major': '12',
        'nvidia.com/gpu.product': 'NVIDIA-B200',
        'nvidia.com/cuda.runtime-version.minor': '9'
      },
      generatedtimestamp: { seconds: Long('1773802368'), nanos: 649798012 },
      nodename: 'be21d5aa-10',
      quarantineoverrides: null,
      drainoverrides: null,
      processingstrategy: 1,
      id: ''
    },
    healtheventstatus: {
      nodequarantined: 'AlreadyQuarantined',
      userpodsevictionstatus: { status: 'AlreadyDrained', message: '' },
      faultremediated: null,
      quarantinefinishtimestamp: { seconds: Long('1773802368'), nanos: 655180865 },
      drainfinishtimestamp: { seconds: Long('1773802638'), nanos: 695808496 }
    }
  }
]
```

Verified after a while that we still have just one CR:
```
$ kg drainrequest -A | grep drain-be21d5aa-10
nvsentinel   drain-be21d5aa-10-69ba13711b2cf7b0574ed8b2   56m
```




## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drain requests are fully node-aware: only one active drain per node and drain payloads include per-node metadata.

* **Bug Fixes**
  * Status checks now report three states: not found, present-but-incomplete, and complete.
  * Improved retry/polling behavior: events wait and poll when a node’s drain exists but status isn’t yet discoverable; duplicate drain creation for the same node is avoided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->