### PR TITLE
fix: race with helm hooks

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/mongodb-store/templates/jobs.yaml
+++ b/distros/kubernetes/nvsentinel/charts/mongodb-store/templates/jobs.yaml
@@ -58,8 +58,6 @@ metadata:
   name: create-mongodb-database
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   activeDeadlineSeconds: 600
   template:


### PR DESCRIPTION
## Summary

The database job will need to be created along with the rest of the resources, using a post-hook would block helm installs using `--wait` since helm would wait for the resources to be ready, but the resources need the hook to become ready

## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [X] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [ ] Documentation updated (if needed)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MongoDB store job configuration to remove automatic execution during deployment operations. The MongoDB job is now managed as a standard Kubernetes workload for improved operational consistency and control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->