### PR TITLE
fix: allow GPUReset CR deletion for deleted nodes

### DIFF
--- a/.versions.yaml
+++ b/.versions.yaml
@@ -44,7 +44,7 @@ go_tools:
   golangci_lint: 'v2.5.0'
   gotestsum: 'v1.13.0'
   gocover_cobertura: 'v1.4.0'
-  setup_envtest: 'latest'
+  setup_envtest: 'v0.0.0-20260119123727-a2de7e94d2dd'
   goimports: 'v0.30.0'
   crane: 'v0.20.2'
 

--- a/fault-quarantine/Makefile
+++ b/fault-quarantine/Makefile
@@ -26,17 +26,17 @@ IS_KO_MODULE := 1
 # fault-quarantine specific settings
 CLEAN_EXTRA_FILES := fault-quarantine
 
-# Test setup commands for kubebuilder envtest
-TEST_SETUP_COMMANDS := \
-	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest && \
-	eval $$(setup-envtest use --use-env -p env) &&
-
 # =============================================================================
 # INCLUDE SHARED DEFINITIONS
 # =============================================================================
 
 include ../make/common.mk
 include ../make/go.mk
+
+# Test setup commands for kubebuilder envtest
+TEST_SETUP_COMMANDS := \
+	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(SETUP_ENVTEST_VERSION) && \
+	eval $$(setup-envtest use --use-env -p env) &&
 
 # =============================================================================
 # DEFAULT TARGET

--- a/janitor/pkg/controller/gpureset_controller.go
+++ b/janitor/pkg/controller/gpureset_controller.go
@@ -537,10 +537,30 @@ func (r *GPUResetReconciler) restoreServices(ctx context.Context, gr *v1alpha1.G
 
 	nodeName := gr.Spec.NodeName
 	managerName := r.serviceManager.Name
+	nodeExists := true
 
-	if len(r.serviceManager.Spec.Apps) == 0 {
-		log.V(1).Info("GPU services manager has no apps specified, skipping service restoration", "manager",
-			managerName, "node", nodeName)
+	node, err := r.getNode(nodeName)
+	if err != nil {
+		// The restoreServices logic is called during GPUReset reconciling and during GPUReset CR deletion. In both
+		// cases, if the corresponding node doesn't exist, we will consider ServicesRestored as successful with reason
+		// skipped.
+		if !apierrors.IsNotFound(err) {
+			log.V(1).Info("Failed to get node for service restoration, will retry", "node", nodeName, "error", err)
+			return ctrl.Result{}, fmt.Errorf("failed to get node %s for service restoration: %w", nodeName, err)
+		}
+
+		nodeExists = false
+	}
+
+	if len(r.serviceManager.Spec.Apps) == 0 || !nodeExists {
+		if len(r.serviceManager.Spec.Apps) == 0 {
+			log.V(1).Info("GPU services manager has no apps specified, skipping service restoration", "manager",
+				managerName, "node", nodeName)
+		}
+
+		if !nodeExists {
+			log.V(1).Info("Node no longer exists, skipping service restoration", "node", nodeName)
+		}
 
 		if err := r.updateCondition(ctx, gr, v1alpha1.ServicesRestored, metav1.ConditionTrue, v1alpha1.ReasonSkipped,
 			"No services manager configured, or has no managed services specified"); err != nil {
@@ -572,12 +592,6 @@ func (r *GPUResetReconciler) restoreServices(ctx context.Context, gr *v1alpha1.G
 
 		return r.reconcileTerminalFailure(ctx, gr, v1alpha1.ReasonRestoreTimeoutExceeded,
 			fmt.Sprintf("failed to restore %s managed services within the timeout period", managerName))
-	}
-
-	node, err := r.getNode(nodeName)
-	if err != nil {
-		log.V(1).Info("Failed to get node for service restoration, will retry", "node", nodeName, "error", err)
-		return ctrl.Result{}, fmt.Errorf("failed to get node %s for service restoration: %w", nodeName, err)
 	}
 
 	nodeToUpdate := node.DeepCopy()
@@ -628,8 +642,6 @@ func (r *GPUResetReconciler) restoreServices(ctx context.Context, gr *v1alpha1.G
 			v1alpha1.ReasonServiceRestoreSucceeded, fmt.Sprintf("%s managed services are Ready", managerName)); err != nil {
 			return ctrl.Result{}, err
 		}
-
-		return ctrl.Result{}, nil
 	}
 
 	return ctrl.Result{}, nil

--- a/janitor/pkg/controller/gpureset_controller_test.go
+++ b/janitor/pkg/controller/gpureset_controller_test.go
@@ -341,6 +341,143 @@ var _ = Describe("GPUReset Controller", func() {
 		})
 	})
 
+	Context("Successful workflow with GPU Service Manager when node is deleted", func() {
+		var nodeName = "success-test-node-deleted"
+		var resetName = "success-test-reset-node-deleted"
+		var typeNamespacedName = types.NamespacedName{Name: resetName}
+		var node *corev1.Node
+
+		BeforeEach(func() {
+			By("Creating a test node")
+			node = &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: nodeName, Labels: make(map[string]string)}}
+			Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			By("Cleaning up resources")
+			if err := k8sClient.Delete(ctx, node); err != nil && !apierrors.IsNotFound(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+			reset := &v1alpha1.GPUReset{ObjectMeta: metav1.ObjectMeta{Name: resetName}}
+			if err := k8sClient.Delete(ctx, reset); err != nil && !apierrors.IsNotFound(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+			var jobList batchv1.JobList
+			Expect(k8sClient.List(ctx, &jobList)).To(Succeed())
+			for _, job := range jobList.Items {
+				if strings.HasPrefix(job.Name, resetName) {
+					if err := k8sClient.Delete(ctx, &job, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !apierrors.IsNotFound(err) {
+						Expect(err).NotTo(HaveOccurred())
+					}
+				}
+			}
+		})
+
+		It("should reconcile a GPUReset through all states successfully when node is deleted", func() {
+			By("Creating a new GPUReset resource")
+			reset := &v1alpha1.GPUReset{
+				ObjectMeta: metav1.ObjectMeta{Name: resetName},
+				Spec: v1alpha1.GPUResetSpec{
+					NodeName: nodeName,
+					Selector: &v1alpha1.GPUSelector{
+						UUIDs: []string{"GPU-a1b2c3d4-e5f6-a7b8-c9d0-e1f2a3b4c5d6"},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, reset)).To(Succeed())
+
+			By("Waiting for the status to be initialized")
+			var updatedReset v1alpha1.GPUReset
+			Eventually(func(g Gomega) {
+				_, _ = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, &updatedReset)).To(Succeed())
+				g.Expect(meta.FindStatusCondition(updatedReset.Status.Conditions, string(v1alpha1.Ready))).NotTo(BeNil())
+				g.Expect(updatedReset.Status.Phase).To(Equal(v1alpha1.ResetPending))
+			}, "10s", "250ms").Should(Succeed())
+			Expect(controllerutil.ContainsFinalizer(&updatedReset, gpuResetFinalizer)).To(BeTrue())
+
+			By("Waiting for the reset to be scheduled")
+			Eventually(func(g Gomega) {
+				_, _ = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, &updatedReset)).To(Succeed())
+				g.Expect(meta.IsStatusConditionTrue(updatedReset.Status.Conditions, string(v1alpha1.Ready))).To(BeTrue())
+				g.Expect(updatedReset.Status.Phase).To(Equal(v1alpha1.ResetPending))
+			}, "10s", "250ms").Should(Succeed())
+			Expect(meta.FindStatusCondition(updatedReset.Status.Conditions, string(v1alpha1.Ready)).Reason).To(Equal(string(v1alpha1.ReasonReadyForReset)))
+
+			By("Waiting for services to be torn down")
+			Eventually(func(g Gomega) {
+				_, _ = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, &updatedReset)).To(Succeed())
+				g.Expect(meta.IsStatusConditionTrue(updatedReset.Status.Conditions, string(v1alpha1.ServicesTornDown))).To(BeTrue())
+			}, "10s", "250ms").Should(Succeed())
+
+			By("Waiting for the reset job to be created")
+			Eventually(func(g Gomega) {
+				_, _ = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, &updatedReset)).To(Succeed())
+				g.Expect(updatedReset.Status.JobRef).NotTo(BeNil())
+				g.Expect(meta.IsStatusConditionTrue(updatedReset.Status.Conditions, string(v1alpha1.ServicesTornDown))).To(BeTrue())
+				g.Expect(updatedReset.Status.Phase).To(Equal(v1alpha1.ResetInProgress))
+
+				// wait for the job to exist
+				jobKey := types.NamespacedName{Name: updatedReset.Status.JobRef.Name, Namespace: updatedReset.Status.JobRef.Namespace}
+				var createdJob batchv1.Job
+				g.Expect(k8sClient.Get(ctx, jobKey, &createdJob)).To(Succeed())
+
+				cond := meta.FindStatusCondition(updatedReset.Status.Conditions, string(v1alpha1.ResetJobCreated))
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+				g.Expect(cond.Reason).To(Equal(string(v1alpha1.ReasonResetJobCreationSucceeded)))
+			}, "10s", "250ms").Should(Succeed())
+			Expect(meta.FindStatusCondition(updatedReset.Status.Conditions, string(v1alpha1.ResetJobCreated)).Reason).To(Equal(string(v1alpha1.ReasonResetJobCreationSucceeded)))
+
+			By("Simulating the job succeeding")
+			var createdJob batchv1.Job
+			jobKey := types.NamespacedName{Name: updatedReset.Status.JobRef.Name, Namespace: updatedReset.Status.JobRef.Namespace}
+			Expect(k8sClient.Get(ctx, jobKey, &createdJob)).To(Succeed())
+			createdJob.Status.Succeeded = 1
+			Expect(k8sClient.Status().Update(ctx, &createdJob)).To(Succeed())
+
+			By("Waiting for the job to be marked as completed")
+			Eventually(func(g Gomega) {
+				_, _ = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, &updatedReset)).To(Succeed())
+				g.Expect(meta.IsStatusConditionTrue(updatedReset.Status.Conditions, string(v1alpha1.ResetJobCompleted))).To(BeTrue())
+				g.Expect(updatedReset.Status.Phase).To(Equal(v1alpha1.ResetInProgress))
+			}, "10s", "250ms").Should(Succeed())
+			Expect(meta.FindStatusCondition(updatedReset.Status.Conditions, string(v1alpha1.ResetJobCompleted)).Reason).To(Equal(string(v1alpha1.ReasonResetJobSucceeded)))
+
+			By("Deleting the node resource mid-workflow")
+			Expect(k8sClient.Delete(ctx, node)).To(Succeed())
+
+			By("Waiting for services to be restored")
+			Eventually(func(g Gomega) {
+				_, _ = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, &updatedReset)).To(Succeed())
+				g.Expect(meta.IsStatusConditionTrue(updatedReset.Status.Conditions, string(v1alpha1.ServicesRestored))).To(BeTrue())
+				g.Expect(updatedReset.Status.Phase).To(Equal(v1alpha1.ResetInProgress))
+			}, "10s", "250ms").Should(Succeed())
+			Expect(meta.FindStatusCondition(updatedReset.Status.Conditions, string(v1alpha1.ServicesRestored)).Reason).To(Equal(string(v1alpha1.ReasonSkipped)))
+
+			By("Waiting for the reset to be marked as complete")
+			Eventually(func(g Gomega) {
+				_, _ = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, &updatedReset)).To(Succeed())
+				g.Expect(updatedReset.Status.CompletionTime).NotTo(BeNil())
+				g.Expect(meta.IsStatusConditionTrue(updatedReset.Status.Conditions, string(v1alpha1.Complete))).To(BeTrue())
+				g.Expect(updatedReset.Status.Phase).To(Equal(v1alpha1.ResetSucceeded))
+			}, "10s", "250ms").Should(Succeed())
+			Expect(meta.FindStatusCondition(updatedReset.Status.Conditions, string(v1alpha1.Complete)).Reason).To(Equal(string(v1alpha1.ReasonGPUResetSucceeded)))
+		})
+	})
+
 	Context("Successful Workflow without GPU Service Manager (no-op service teardown/restoration)", func() {
 		var nodeName = "noop-test-node"
 		var resetName = "noop-test-reset"
@@ -1193,6 +1330,48 @@ var _ = Describe("GPUReset Controller", func() {
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, &updatedNode)).To(Succeed())
 			Expect(updatedNode.Labels["nvidia.com/gpu.deploy.device-plugin"]).To(Equal("true"))
 		})
+
+		It("should allow GPUReset deletion if node is deleted", func() {
+			reset := &v1alpha1.GPUReset{
+				ObjectMeta: metav1.ObjectMeta{Name: resetName},
+				Spec: v1alpha1.GPUResetSpec{
+					NodeName: nodeName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, reset)).To(Succeed())
+
+			By("Reconciling until services are torn down")
+			Eventually(func(g Gomega) {
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+				g.Expect(err).NotTo(HaveOccurred())
+
+				var updatedReset v1alpha1.GPUReset
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, &updatedReset)).To(Succeed())
+				g.Expect(meta.IsStatusConditionTrue(updatedReset.Status.Conditions, string(v1alpha1.ServicesTornDown))).To(BeTrue())
+			}, "10s", "250ms").Should(Succeed())
+
+			By("Verifying services are disabled")
+			var updatedNode corev1.Node
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, &updatedNode)).To(Succeed())
+			Expect(updatedNode.Labels["nvidia.com/gpu.deploy.device-plugin"]).To(Equal("false"))
+
+			By("Deleting node mid-workflow")
+			Expect(k8sClient.Delete(ctx, node)).To(Succeed())
+
+			By("Deleting the GPUReset resource mid-workflow")
+			Expect(k8sClient.Delete(ctx, reset)).To(Succeed())
+
+			By("Reconciling until the resource is fully deleted")
+			Eventually(func(g Gomega) {
+				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+				g.Expect(err).NotTo(HaveOccurred())
+
+				var deletedReset v1alpha1.GPUReset
+				err = k8sClient.Get(ctx, typeNamespacedName, &deletedReset)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}, "10s", "250ms").Should(Succeed())
+		})
+
 	})
 
 	Context("Metrics", func() {

--- a/janitor/pkg/webhook/v1alpha1/janitor_webhook.go
+++ b/janitor/pkg/webhook/v1alpha1/janitor_webhook.go
@@ -374,7 +374,7 @@ func (v *JanitorCustomValidator) ValidateCreate(ctx context.Context, obj runtime
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for all Janitor CRD types.
-// nolint:cyclop,lll
+// nolint:cyclop,lll,gocognit
 func (v *JanitorCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	var (
 		objName        string
@@ -382,6 +382,8 @@ func (v *JanitorCustomValidator) ValidateUpdate(ctx context.Context, oldObj, new
 		nodeName       string
 		oldNodeName    string
 	)
+
+	allowDeletedNode := false
 
 	switch typedObj := newObj.(type) {
 	case *janitordgxcnvidiacomv1alpha1.RebootNode:
@@ -441,12 +443,18 @@ func (v *JanitorCustomValidator) ValidateUpdate(ctx context.Context, oldObj, new
 			}
 		}
 
+		// The gpu-reset-controller needs to be able to issue an update request to remove the
+		// janitor.dgxc.nvidia.com/finalizer whether the current node exists or not. Note that the delete webhook
+		// handler for GPUReset CRs already allows the initial delete request to succeed if the corresponding node
+		// is deleted.
+		allowDeletedNode = true
+
 	default:
 		return nil, fmt.Errorf("expected a Janitor CR object but got %T", newObj)
 	}
 
 	// Validate node existence for CRs that reference nodes
-	if nodeName != "" {
+	if len(nodeName) != 0 && !allowDeletedNode {
 		if err := v.validateNodeExists(ctx, nodeName); err != nil {
 			janitorWebhookLog.Info(
 				"Node validation failed", // nolint:lll

--- a/janitor/pkg/webhook/v1alpha1/janitor_webhook_test.go
+++ b/janitor/pkg/webhook/v1alpha1/janitor_webhook_test.go
@@ -265,6 +265,33 @@ var _ = Describe("Janitor Webhook", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("node 'non-existent-node' does not exist in the cluster"))
 		})
+
+		It("Should accept GPUReset updates when node does not exist", func() {
+			oldObj := &janitordgxcnvidiacomv1alpha1.GPUReset{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gpu-reset",
+				},
+				Spec: janitordgxcnvidiacomv1alpha1.GPUResetSpec{
+					NodeName: "non-existent-node",
+					Selector: &janitordgxcnvidiacomv1alpha1.GPUSelector{
+						UUIDs: []string{"test-uuid"},
+					},
+				},
+			}
+			newObj := &janitordgxcnvidiacomv1alpha1.GPUReset{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-gpu-reset",
+				},
+				Spec: janitordgxcnvidiacomv1alpha1.GPUResetSpec{
+					NodeName: "non-existent-node",
+					Selector: &janitordgxcnvidiacomv1alpha1.GPUSelector{
+						UUIDs: []string{"test-uuid"},
+					},
+				},
+			}
+			_, err := validator.ValidateUpdate(ctx, oldObj, newObj)
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
 
 	Context("Existing resource verification", func() {

--- a/plugins/slinky-drainer/Makefile
+++ b/plugins/slinky-drainer/Makefile
@@ -6,6 +6,9 @@ IMG ?= $(IMAGE_NAME):$(IMAGE_TAG)
 
 CONTROLLER_GEN ?= $(shell go env GOPATH)/bin/controller-gen
 
+include ../../make/common.mk
+include ../../make/go.mk
+
 .PHONY: help
 help:
 	@echo "Available targets:"
@@ -71,7 +74,7 @@ undeploy:
 clean:
 	rm -rf bin/ dist/ slinky-drainer
 
-SETUP_ENVTEST_COMMAND := go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest && \
+SETUP_ENVTEST_COMMAND := go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(SETUP_ENVTEST_VERSION) && \
 	eval $$(setup-envtest use --use-env -p env) &&
 
 .PHONY: test


### PR DESCRIPTION
## Summary
Currently, GPUReset CRs fail to be deleted if their corresponding node has been deleted. Deleted GPUReset CRs will stay in terminating status and need to have its finalizer manually removed because the RestoreServices logic exercised prior to finalizer removal by the controller fails if the corresponding node is deleted. Additionally, this issue also causes in-progress GPUReset CRs to fail their ServicesRestored stage. In summary, we will gracefully handle the node object not existing in restoreServices which covers the 2 cases:
1. GPUReset reconciling: if the node object is deleted during reconciling, we will allow the CR to progress from ServicesRestored with reason skipped -> Complete. Note that finalizer removal requires an update GPUReset CR request which is intercepted by the webhook. We need to allow update requests to GPUResets with non-existent nodes in this case.
2. GPUReset deletion: if the node object is deleted prior to GPUReset deletion, we will allow the CR to progress from Terminating -> ServicesRestored with reason skipped

## Testing
Added unit tests for the 2 cases describe above and confirmed that the tests initially failed before this fix:
```
Summarizing 2 Failures:
  [FAIL] GPUReset Controller Successful workflow with GPU Service Manager when node is deleted [It] should reconcile a GPUReset through all states successfully when node is deleted
  /Users/nherz/go/NVSentinel2/NVSentinel/janitor/pkg/controller/gpureset_controller_test.go:466
  [FAIL] GPUReset Controller Finalizer [It] should allow GPUReset deletion if node is deleted
  /Users/nherz/go/NVSentinel2/NVSentinel/janitor/pkg/controller/gpureset_controller_test.go:1457
```
After fix:
```
% make test
Running tests on janitor...
go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest && eval $(setup-envtest use --use-env -p env) && \
        gotestsum --junitfile report.xml -- -race  ./... -coverprofile=coverage.txt -covermode atomic -coverpkg=github.com/nvidia/nvsentinel/janitor/...
✓  pkg/client (cached) (coverage: 1.0% of statements in github.com/nvidia/nvsentinel/janitor/...)
✓  pkg/config (cached) (coverage: 5.7% of statements in github.com/nvidia/nvsentinel/janitor/...)
✓  api/v1alpha1 (cached) (coverage: 2.4% of statements in github.com/nvidia/nvsentinel/janitor/...)
∅  . (776ms) (coverage: 0.0% of statements)
✓  pkg/distributedlock (cached) (coverage: 5.1% of statements in github.com/nvidia/nvsentinel/janitor/...)
✓  pkg/webhook/v1alpha1 (cached) (coverage: 12.9% of statements in github.com/nvidia/nvsentinel/janitor/...)
✓  pkg/gpuservices (cached) (coverage: 1.0% of statements in github.com/nvidia/nvsentinel/janitor/...)
✓  pkg/metrics (cached) (coverage: 0.4% of statements in github.com/nvidia/nvsentinel/janitor/...)
✓  pkg/controller (35.133s) (coverage: 48.1% of statements in github.com/nvidia/nvsentinel/janitor/...)

DONE 84 tests in 40.154s
```
Manual Kind testing showing that a GPUReset CR can now successfully be removed from manual deletion:
```
% kubectl create -f gpureset.yaml
gpureset.janitor.dgxc.nvidia.com/gpureset-sample created

% kubectl get gpureset gpureset-sample
NAME              NODE                STATUS      AGE
gpureset-sample   nvsentinel-worker   Succeeded   42s

kubectl delete gpureset gpureset-sample
gpureset.janitor.dgxc.nvidia.com "gpureset-sample" deleted

kubectl get gpureset gpureset-sample
Error from server (NotFound): gpuresets.janitor.dgxc.nvidia.com "gpureset-sample" not found
```
Janitor logs showing finalizer removal:
```
{"time":"2026-03-17T21:58:16.080979345Z","level":"INFO","msg":"Validation for Janitor CR upon deletion","module":"janitor","version":"dev","logger":"janitor-webhook","type":"GPUReset","name":"gpureset-sample"}
{"time":"2026-03-17T21:58:16.084884345Z","level":"INFO","msg":"Running finalizer to restore managed services before deletion","module":"janitor","version":"dev","controller":"gpureset","controllerGroup":"janitor.dgxc.nvidia.com","controllerKind":"GPUReset","GPUReset":{"name":"gpureset-sample"},"namespace":"","name":"gpureset-sample","reconcileID":"1ce469ee-a450-437e-a25f-19146dc52be7","manager":"gpu-operator","node":"nvsentinel-worker"}
{"time":"2026-03-17T21:58:16.091530429Z","level":"INFO","msg":"Managed service restoration complete, removing finalizer","module":"janitor","version":"dev","controller":"gpureset","controllerGroup":"janitor.dgxc.nvidia.com","controllerKind":"GPUReset","GPUReset":{"name":"gpureset-sample"},"namespace":"","name":"gpureset-sample","reconcileID":"1ce469ee-a450-437e-a25f-19146dc52be7","manager":"gpu-operator","node":"nvsentinel-worker"}
{"time":"2026-03-17T21:58:16.094139595Z","level":"ERROR","msg":"Reconciler error","module":"janitor","version":"dev","controller":"gpureset","controllerGroup":"janitor.dgxc.nvidia.com","controllerKind":"GPUReset","GPUReset":{"name":"gpureset-sample"},"namespace":"","name":"gpureset-sample","reconcileID":"1ce469ee-a450-437e-a25f-19146dc52be7","err":"failed to remove finalizer from gpureset-sample: Operation cannot be fulfilled on gpuresets.janitor.dgxc.nvidia.com \"gpureset-sample\": the object has been modified; please apply your changes to the latest version and try again"}
{"time":"2026-03-17T21:58:16.094306095Z","level":"INFO","msg":"Managed service restoration complete, removing finalizer","module":"janitor","version":"dev","controller":"gpureset","controllerGroup":"janitor.dgxc.nvidia.com","controllerKind":"GPUReset","GPUReset":{"name":"gpureset-sample"},"namespace":"","name":"gpureset-sample","reconcileID":"2fb7f0cb-a3f9-481d-97eb-cbed3303f738","manager":"gpu-operator","node":"nvsentinel-worker"}
{"time":"2026-03-17T21:58:16.095978429Z","level":"INFO","msg":"Validation for Janitor CR upon update","module":"janitor","version":"dev","logger":"janitor-webhook","type":"GPUReset","name":"gpureset-sample"}
```

## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [X] Janitor
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cleaner handling when the target node is deleted during a GPU reset: service restoration is skipped gracefully with clearer logging and the workflow completes reliably.
  * Validator adjusted so GPU reset updates are allowed even if the referenced node no longer exists.

* **Tests**
  * Added end-to-end tests covering node deletion mid-GPU-reset, including finalizer, job lifecycle, and cleanup scenarios.

* **Chores**
  * Pinned a tooling version in project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->