### PR TITLE
fix: prevent DCGM connectivity error on gpu-health-monitor start-up

### DIFF
--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/dcgm.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/dcgm.py
@@ -294,6 +294,10 @@ class DCGMWatcher:
 
         # Initial DCGM handle and monitoring setup
         while not exit.is_set():
+            # Wait for poll interval to allow DCGM initialization
+            log.debug("Waiting till next cycle")
+            exit.wait(self._poll_interval_seconds)
+
             with metrics.overall_reconcile_loop_time.time():
                 if dcgm_handle is None:
                     try:
@@ -322,9 +326,6 @@ class DCGMWatcher:
                             types.CallbackInterface.health_event_occurred.__name__,
                             [health_status, gpu_ids],
                         )
-
-            log.debug("Waiting till next cycle")
-            exit.wait(self._poll_interval_seconds)
 
         # Cleanup on exit
         self._cleanup_dcgm_resources(dcgm_group, dcgm_handle)


### PR DESCRIPTION
## Summary

It's possible for the gpu-health-monitor to emit a DCGM_CONNECTIVITY_ERROR event on initial start-up. The nvidia-dcgm daemonset will be deployed to nodes which have the nvidia.com/gpu.deploy.dcgm=true label which is added by gpu-operator. Additionally, the gpu-health-monitor pod will be deployed to nodes which have the nvsentinel.dgxc.nvidia.com/dcgm.version=4.x label. This label is added by the labeler component in NVSentinel if the node has a nvidia-dcgm pod. Note that the labeler does not check for readiness of the nvidia-dcgm pod before deploying the gpu-health-monitor.

Cases that result in a DCGM_CONNECTIVITY_ERROR:
1. gpu-operator init containers: the gpu-operator goes through its init container start-up sequence either on initial deployment or after a reboot. The nvidia-dcgm pod be recreated from the k8s-driver-manager and then it will be pending on its init container until the driver + container-toolkit are initialized. The labeler only checks for nvidia-dcgm pod existence and not readiness. It will add the nvsentinel.dgxc.nvidia.com/dcgm.version=4.x to deploy the gpu-health-monitor even if the nvidia-dcgm is waiting on its init container. Note that on node reboots, we should expect that the gpu-health-monitor is recreated alongside the nvidia-dcgm (which itself is stuck in pending due to driver re-installation).
2. nvidia-dcgm and gpu-health-monitor pods are both deleted and recreated: in this case, the new gpu-health-monitor pod runs into a connectivity error without an active DCGM handle which results in the unhealthy event being generated on start-up (compared to the case below where we have 1 additional attempt after the poll period if the pod previously had a DCGM handle). This occurs on the first loop iteration here: https://github.com/NVIDIA/NVSentinel/blob/main/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/dcgm.py#L304
```
% kubectl delete pods gpu-health-monitor-dcgm-4.x-4zntw -n nvsentinel && kubectl delete pods nvidia-dcgm-w27vl -n gpu-operator
pod "gpu-health-monitor-dcgm-4.x-4zntw" deleted from nvsentinel namespace
pod "nvidia-dcgm-w27vl" deleted from gpu-operator namespace

% kubectl logs gpu-health-monitor-dcgm-4.x-xwpkl -n nvsentinel
...
{"event": "Error getting DCGM handle: The connection to the host engine is not valid any longer", "level": "error", "timestamp": "2026-03-18T22:51:04.575491Z", "module": "gpu-health-monitor", "version": "0.1.0"}
{"event": "DCGM connectivity failure detected, sending GpuDcgmConnectivityFailure health event", "level": "error", "timestamp": "2026-03-18T22:51:04.576664Z", "module": "gpu-health-monitor", "version": "0.1.0"}
{"event": "GPU metadata loaded from /var/lib/nvsentinel/gpu_metadata.json: 8 GPUs, chassis_serial=absent", "level": "info", "timestamp": "2026-03-18T22:51:04.576949Z", "module": "gpu-health-monitor", "version": "0.1.0"}
{"event": "Updated cache for key GpuDcgmConnectivityFailure|DCGM|ALL after successful send", "level": "info", "timestamp": "2026-03-18T22:51:04.581135Z", "module": "gpu-health-monitor", "version": "0.1.0"}
{"event": "DCGM k8s service enabled. Using nvidia-dcgm.gpu-operator.svc:5555", "level": "info", "timestamp": "2026-03-18T22:51:19.577026Z", "module": "gpu-health-monitor", "version": "0.1.0"}
{"event": "Successfully created DCGM handle", "level": "info", "timestamp": "2026-03-18T22:51:19.582133Z", "module": "gpu-health-monitor", "version": "0.1.0"}
```

Cases that DO NOT result in a DCGM_CONNECTIVITY_ERROR:

3. nvidia-dcgm pod is deleted only: the pod is recreated quick enough by the daemonset-controller that the node-labeler does not update the target node's labels and the gpu-health-monitor pod is not recreated. Note that a connectivity error does occur, however, it occurs after the DCGM handle was successfully initiated so an unhealthy DCGM_CONNECTIVITY_ERROR event is not sent. The gpu-health-monitor pod is able to re-initialize its DCGM handle to the new nvidia-dcgm pod after its 15s polling period to avoid the unhealthy event (which would occur if on the next iteration it could still not re-connect to DCGM): https://github.com/NVIDIA/NVSentinel/blob/main/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/dcgm.py#L313.

```
% kubectl delete pod nvidia-dcgm-6jx5z -n gpu-operator
pod "nvidia-dcgm-6jx5z" deleted from gpu-operator namespace

% kubectl logs gpu-health-monitor-dcgm-4.x-4zntw -n nvsentinel
...
{"event": "Unexpected error during DCGM health check: The connection to the host engine is not valid any longer. Indicating connectivity failure.", "level": "error", "timestamp": "2026-03-18T22:36:51.713074Z", "module": "gpu-health-monitor", "version": "0.1.0"}
{"event": "DCGM connectivity failure detected", "level": "warning", "timestamp": "2026-03-18T22:36:51.713415Z", "module": "gpu-health-monitor", "version": "0.1.0"}
{"event": "Error cleaning up DCGM handle: The connection to the host engine is not valid any longer", "level": "error", "timestamp": "2026-03-18T22:36:51.713637Z", "module": "gpu-health-monitor", "version": "0.1.0"}
{"event": "DCGM k8s service enabled. Using nvidia-dcgm.gpu-operator.svc:5555", "level": "info", "timestamp": "2026-03-18T22:37:06.713961Z", "module": "gpu-health-monitor", "version": "0.1.0"}
{"event": "Successfully created DCGM handle", "level": "info", "timestamp": "2026-03-18T22:37:06.716785Z", "module": "gpu-health-monitor", "version": "0.1.0"}
```

Note that case 2 above is exactly what happens during GPU resets where a DCGM_CONNECTIVITY_ERROR can occur after Janitor re-enables the gpu-operator services which result in nvidia-dcgm + gpu-health-monitor starting concurrently. Specifically this occurs when Janitor restores the nvidia.com/gpu.deploy.dcgm=true label on the node and then the NVSentinel labeler restores the nvsentinel.dgxc.nvidia.com/dcgm.version=4.x label. Case 1 also occurs on reboots where gpu-operator components have to go through its start-up sequence after a driver pod restart. In both cases 1 and 2, this will keep the node cordoned (or even may re-cordon the node) after the initial unhealthy event which required a reboot or GPU reset because it results in a new unhealthy event for the DCGM_CONNECTIVITY_ERROR. 

For reboot, the node would have been already been fully drained and its state would go to remediation-failed with a CONTACT_SUPPORT event until DCGM recovers and the node is uncordoned. For a reset, the node would only have previously been partially drained of pods so its likely that the DCGM_CONNECTIVITY_ERROR event will trigger a full drain and be stuck in draining until DCGM recovers and the node is uncordoned. This isn't a problem today because the fleet only has the AllowCompletion mode. If we introduce ImmediateEvict or DeleteAfterTimeout, it's possible that we would cause workload impact as a side effect of a GPU reset. As a result, we need to prevent the DCGM connectivity error specifically for GPU reset. 

GOALS:
1. Ensure DCGM_CONNECTIVITY_ERRORs do not occur as a side effect of GPU resets. In other words, we're trying to avoid these errors when the nvidia-dcgm and gpu-health-monitor pod are created concurrently (not during the gpu-operator start-up sequence).
2. Keep DCGM_CONNECTIVITY_ERRORs as a signal for node readiness. Preventing DCGM_CONNECTIVITY_ERRORs during reboots or during the initial gpu-operator deployment is out of scope of this change. Note that checking for nvidia-dcgm pod readiness (making sure it passed its init container and is reporting as ready) could help prevent us from deploying the gpu-health-monitor and generating this unhealthy event, however, we would lose health check coverage for when we use DCGM as a proxy for driver health.

Implementation options:

1. [CHOSEN] Introduce a start-up delay to gpu-health-monitor to allow nvidia-dcgm to initialize if they start-up concurrently. This is similar to how case 3 above does not result in a connectivity error.
2. Onboard the gpu-health-monitor to the Janitor service tear down logic so that it removes both nvidia-dcgm and gpu-health-monitor. We already have equivalent behavior today because the node-label will mirror Janitor's actions and add/remove the gpu-health-monitor in response to Janitor's label modification. What we could do is add a delay between when Janitor re-enables nvidia-dcgm and  gpu-health-monitor. However, this would add significant complexity to the Janitor tear down logic and make 2 components (Janitor + labeler) responsible for DCGM readiness.
5. Do nothing and tolerate the unhealthy DCGM connectivity error. This would only be acceptable if we never wanted to support the ImmediateEvict mode or even the DeleteAfterTimeout mode with a short timeout (that's less than the DCGM connectivity delay on start-up).

#### Testing

The DCGM_CONNECTIVITY_ERROR occurs in small percentage of GPU resets when the nvidia-dcgm and gpu-health-monitor start concurrently. When triggering GPU resets on a test cluster, it occurred on roughly 2/10 tests and the connectivity issue recovered on the next poll period 15s later. Here are logs from a GPU reset which hit the DCGM_CONNECTIVITY_ERROR:
```
{"event": "DCGM k8s service enabled. Using nvidia-dcgm.gpu-operator.svc:5555", "level": "info", "timestamp": "2026-03-18T20:13:16.490981Z", "module": "gpu-health-monitor", "version": "0.1.0"}
{"event": "Error creating DCGM handle: The connection to the host engine is not valid any longer", "level": "error", "timestamp": "2026-03-18T20:13:21.510855Z", "module": "gpu-health-monitor", "version": "0.1.0"}
{"event": "Error getting DCGM handle: 'NoneType' object has no attribute 'GetSystem'", "level": "error", "timestamp": "2026-03-18T20:13:21.511012Z", "module": "gpu-health-monitor", "version": "0.1.0"}
{"event": "DCGM connectivity failure detected, sending GpuDcgmConnectivityFailure health event", "level": "error", "timestamp": "2026-03-18T20:13:21.511378Z", "module": "gpu-health-monitor", "version": "0.1.0"}
{"event": "GPU metadata loaded from /var/lib/nvsentinel/gpu_metadata.json: 8 GPUs, chassis_serial=absent", "level": "info", "timestamp": "2026-03-18T20:13:21.511631Z", "module": "gpu-health-monitor", "version": "0.1.0"}
{"event": "Updated cache for key GpuDcgmConnectivityFailure|DCGM|ALL after successful send", "level": "info", "timestamp": "2026-03-18T20:13:21.516712Z", "module": "gpu-health-monitor", "version": "0.1.0"}
{"event": "DCGM k8s service enabled. Using nvidia-dcgm.gpu-operator.svc:5555", "level": "info", "timestamp": "2026-03-18T20:13:36.511725Z", "module": "gpu-health-monitor", "version": "0.1.0"}
{"event": "Successfully created DCGM handle", "level": "info", "timestamp": "2026-03-18T20:13:36.513493Z", "module": "gpu-health-monitor", "version": "0.1.0"}
```

## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [X] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted GPU health monitor polling timing so the wait now occurs at the start of each monitoring cycle instead of at the end.
  * Ensures consistent poll intervals across all cycles, including the first iteration, improving predictability of health checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->