### PR TITLE
feat: make UAT event timeout configurable via UAT_EVENT_TIMEOUT

### DIFF
--- a/tests/uat/tests.sh
+++ b/tests/uat/tests.sh
@@ -344,7 +344,7 @@ test_gpu_monitoring_dcgm() {
     kubectl exec -n gpu-operator "$dcgm_pod" -- dcgmi test --inject --gpuid 0 -f 240 -v 99999 # power watch error
 
     log "Waiting for node events to appear..."
-    local max_wait=30
+    local max_wait=${UAT_EVENT_TIMEOUT:-30}
     local waited=0
     while [[ $waited -lt $max_wait ]]; do
         power_event=$(kubectl get events --field-selector involvedObject.name="$gpu_node" -o json | jq -r '.items[] | select(.reason == "GpuPowerWatchIsNotHealthy") | .reason')
@@ -537,7 +537,7 @@ test_sxid_monitoring_syslog() {
     log "  - SXID 28002 (Non-fatal): Therm Warn Deactivated on Link $link_number"
     kubectl exec -n gpu-operator "$dcgm_pod" -- sh -c "echo '<3>nvidia-nvswitch0: SXid (PCI:${pci_id}): 28002, Non-fatal, Link ${link_number} Therm Warn Deactivated' > /dev/kmsg"
 
-    local max_wait=30
+    local max_wait=${UAT_EVENT_TIMEOUT:-30}
     local waited=0
     while [[ $waited -lt $max_wait ]]; do
         power_event=$(kubectl get events --field-selector involvedObject.name="$gpu_node" -o json | jq -r '.items[] | select(.reason == "SysLogsSXIDErrorIsNotHealthy") | .reason')


### PR DESCRIPTION
Allow the event-waiting loops in tests.sh to be configured via the UAT_EVENT_TIMEOUT env var (default: 30s), consistent with other UAT_*_TIMEOUT variables in the script.

In one of my uat test i noticed that 30s wait is causing a race. The test fails at `17:09:29` but event appears 2m later `2026-03-20T17:11:30`

```
[2026-03-20 17:08:52] Waiting for node events to appear...
[2026-03-20 17:09:29] Verifying node events are populated (non-fatal errors appear here)
[2026-03-20 17:09:29] ERROR: GpuPowerWatch event not found (non-fatal errors should create events)
```

--

```
kubectl  logs -n nvsentinel \
    platform-connectors-ckxdz --since=1h \
    | grep "GpuPowerWatch"

{"time":"2026-03-20T17:11:30.692619723Z","level":"INFO","msg":"Health events received","module":"platform-connectors","version":"v0.10.0","events":{"version":1,"events":[{"version":1,"agent":"gpu-health-monitor","componentClass":"GPU","checkName":"GpuPowerWatch","message":"Detected clocks event due to power violation in GPU 2. Monitor the power conditions. This GPU can still perform workload.","errorCode":["DCGM_FR_CLOCK_THROTTLE_POWER"],"entitiesImpacted":[{"entityType":"GPU","entityValue":"2"}],"generatedTimestamp":{"seconds":1774026690,"nanos":689464000},"nodeName":"<<>>","processingStrategy":1}]}}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Made event-polling timeout configurable in automated tests via an environment variable, allowing customization for longer or shorter waits in different environments while preserving the default 30-second behavior when unset. This improves test reliability and flexibility for varied execution contexts and CI conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->