### PR TITLE
feat: add MongoDB Atlas support via system TLS and URI passthrough

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/deployment.yaml
@@ -154,6 +154,11 @@ spec:
             - configMapRef:
                 name: {{ if .Values.global.datastore }}{{ .Release.Name }}-datastore-config{{ else }}mongodb-config{{ end }}
                 optional: true
+            {{- if and .Values.global.datastore .Values.global.datastore.uriSecretName }}
+            - secretRef:
+                name: {{ .Values.global.datastore.uriSecretName }}
+                optional: false
+            {{- end }}
 
         - name: maintenance-notifier
           image: "{{ .Values.quarantineTriggerEngine.image.repository }}:{{ .Values.image.tag | default ((.Values.global).image).tag | default .Chart.AppVersion }}"
@@ -221,6 +226,11 @@ spec:
             - configMapRef:
                 name: {{ if .Values.global.datastore }}{{ .Release.Name }}-datastore-config{{ else }}mongodb-config{{ end }}
                 optional: true
+            {{- if and .Values.global.datastore .Values.global.datastore.uriSecretName }}
+            - secretRef:
+                name: {{ .Values.global.datastore.uriSecretName }}
+                optional: false
+            {{- end }}
       restartPolicy: Always
       {{- with (((.Values.global).systemNodeSelector) | default .Values.nodeSelector) }}
       nodeSelector:

--- a/distros/kubernetes/nvsentinel/charts/event-exporter/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/event-exporter/templates/deployment.yaml
@@ -143,6 +143,11 @@ spec:
             - configMapRef:
                 name: {{ if .Values.global.datastore }}{{ .Release.Name }}-datastore-config{{ else }}mongodb-config{{ end }}
                 optional: true
+            {{- if and .Values.global.datastore .Values.global.datastore.uriSecretName }}
+            - secretRef:
+                name: {{ .Values.global.datastore.uriSecretName }}
+                optional: false
+            {{- end }}
       volumes:
       - name: config-volume
         configMap:

--- a/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/deployment.yaml
@@ -164,6 +164,11 @@ spec:
             - configMapRef:
                 name: {{ if .Values.global.datastore }}{{ .Release.Name }}-datastore-config{{ else }}mongodb-config{{ end }}
                 optional: true
+            {{- if and .Values.global.datastore .Values.global.datastore.uriSecretName }}
+            - secretRef:
+                name: {{ .Values.global.datastore.uriSecretName }}
+                optional: false
+            {{- end }}
       volumes:
       - name: config-volume
         configMap:

--- a/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-remediation/templates/deployment.yaml
@@ -164,6 +164,11 @@ spec:
             - configMapRef:
                 name: {{ if .Values.global.datastore }}{{ .Release.Name }}-datastore-config{{ else }}mongodb-config{{ end }}
                 optional: true
+            {{- if and .Values.global.datastore .Values.global.datastore.uriSecretName }}
+            - secretRef:
+                name: {{ .Values.global.datastore.uriSecretName }}
+                optional: false
+            {{- end }}
       volumes:
       {{- if .Values.clientCertMountPath }}
       {{- if and .Values.global.datastore (eq .Values.global.datastore.provider "postgresql") }}

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
@@ -143,6 +143,11 @@ spec:
             - configMapRef:
                 name: {{ if .Values.global.datastore }}{{ .Release.Name }}-datastore-config{{ else }}mongodb-config{{ end }}
                 optional: true
+            {{- if and .Values.global.datastore .Values.global.datastore.uriSecretName }}
+            - secretRef:
+                name: {{ .Values.global.datastore.uriSecretName }}
+                optional: false
+            {{- end }}
       volumes:
       - name: config-volume
         configMap:

--- a/distros/kubernetes/nvsentinel/charts/node-drainer/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/node-drainer/templates/deployment.yaml
@@ -165,6 +165,11 @@ spec:
             - configMapRef:
                 name: {{ if .Values.global.datastore }}{{ .Release.Name }}-datastore-config{{ else }}mongodb-config{{ end }}
                 optional: true
+            {{- if and .Values.global.datastore .Values.global.datastore.uriSecretName }}
+            - secretRef:
+                name: {{ .Values.global.datastore.uriSecretName }}
+                optional: false
+            {{- end }}
       volumes:
       - name: config-volume
         configMap:

--- a/distros/kubernetes/nvsentinel/templates/configmap-datastore.yaml
+++ b/distros/kubernetes/nvsentinel/templates/configmap-datastore.yaml
@@ -81,6 +81,11 @@ data:
   # Legacy MongoDB environment variables for backward compatibility
   # These are set for all providers to support legacy code paths that still use the old config system
   {{- if eq .Values.global.datastore.provider "mongodb" }}
+  {{- if .Values.global.datastore.connection.uri }}
+  # Direct URI provided (e.g. MongoDB Atlas mongodb+srv://...). Password should be
+  # supplied via global.datastore.uriSecret to avoid storing credentials in a ConfigMap.
+  MONGODB_URI: {{ .Values.global.datastore.connection.uri | quote }}
+  {{- else }}
   {{- $mongodbURI := printf "mongodb://%s:%d/" .Values.global.datastore.connection.host (int (.Values.global.datastore.connection.port | default 27017)) }}
   {{- if .Values.global.datastore.connection.extraParams }}
   {{- $params := list }}
@@ -90,6 +95,8 @@ data:
   {{- $mongodbURI = printf "%s?%s" $mongodbURI (join "&" $params) }}
   {{- end }}
   MONGODB_URI: {{ $mongodbURI | quote }}
+  {{- end }}
+  MONGODB_USE_SYSTEM_TLS: {{ .Values.global.datastore.useSystemTLS | default false | quote }}
   {{- else }}
   # For non-MongoDB datastores, set empty MongoDB URI
   MONGODB_URI: ""

--- a/distros/kubernetes/nvsentinel/values.yaml
+++ b/distros/kubernetes/nvsentinel/values.yaml
@@ -31,6 +31,28 @@ global:
   #     host: "mongodb"
   #     port: 27017
   #     database: "nvsentinel"
+  #
+  #   # MongoDB Atlas / external MongoDB: set uri directly instead of host/port.
+  #   # The URI must include credentials. To avoid storing the password in a
+  #   # ConfigMap, create a Secret and reference it via uriSecret below instead.
+  #   # Example (SRV):
+  #   #   uri: "mongodb+srv://nvsentinel:<password>@cluster.mongodb.net/"
+  #   # Example (standard):
+  #   #   uri: "mongodb://nvsentinel:<password>@host1:27017,host2:27017/?replicaSet=rs0&authSource=admin"
+  #
+  #   # Set to true when connecting to MongoDB Atlas or any deployment that uses
+  #   # publicly trusted TLS certificates (Let's Encrypt, DigiCert, etc.).
+  #   # Removes the need to mount custom CA cert files in pods.
+  #   useSystemTLS: false
+  #
+  #   # Name of a Kubernetes Secret whose keys are injected as env vars into all
+  #   # datastore-consuming pods. Use this to supply MONGODB_URI without storing
+  #   # the password in a ConfigMap.
+  #   # Create the secret with:
+  #   #   kubectl create secret generic <name> \
+  #   #     --from-literal=MONGODB_URI='mongodb+srv://user:pass@cluster.mongodb.net/'
+  #   uriSecretName: ""
+  #
   #   certificates:
   #     secretName: "mongo-app-client-cert-secret"  # Secret containing client certificates
   #     certKey: "tls.crt"      # Key for client certificate (default: tls.crt)

--- a/node-drainer/pkg/reconciler/reconciler_integration_test.go
+++ b/node-drainer/pkg/reconciler/reconciler_integration_test.go
@@ -162,6 +162,10 @@ func (m *mockDatabaseConfig) GetAppName() string {
 	return "node-drainer"
 }
 
+func (m *mockDatabaseConfig) GetUseSystemTLS() bool {
+	return false
+}
+
 // mockCertConfig is a simple mock implementation for testing
 type mockCertConfig struct{}
 

--- a/store-client/pkg/adapter/legacy_adapter.go
+++ b/store-client/pkg/adapter/legacy_adapter.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/nvidia/nvsentinel/commons/pkg/stringutil"
 	"github.com/nvidia/nvsentinel/store-client/pkg/config"
 	"github.com/nvidia/nvsentinel/store-client/pkg/datastore"
 )
@@ -141,6 +142,10 @@ func (l *LegacyDatabaseConfigAdapter) GetTimeoutConfig() config.TimeoutConfig {
 
 func (l *LegacyDatabaseConfigAdapter) GetAppName() string {
 	return os.Getenv("APP_NAME")
+}
+
+func (l *LegacyDatabaseConfigAdapter) GetUseSystemTLS() bool {
+	return stringutil.IsTruthyValue(os.Getenv(config.EnvMongoDBUseSystemTLS))
 }
 
 // LegacyCertConfigAdapter adapts DataStoreConfig certificate configuration

--- a/store-client/pkg/client/convenience.go
+++ b/store-client/pkg/client/convenience.go
@@ -84,6 +84,7 @@ func ConvertToMongoDBConfig(dbConfig config.DatabaseConfig) MongoDBConfig {
 		TotalCACertIntervalSeconds:       dbConfig.GetTimeoutConfig().GetCACertIntervalSeconds(),
 		ChangeStreamRetryDeadlineSeconds: dbConfig.GetTimeoutConfig().GetChangeStreamRetryDeadlineSeconds(),
 		ChangeStreamRetryIntervalSeconds: dbConfig.GetTimeoutConfig().GetChangeStreamRetryIntervalSeconds(),
+		UseSystemTLS:                     dbConfig.GetUseSystemTLS(),
 	}
 }
 

--- a/store-client/pkg/client/mongodb_client.go
+++ b/store-client/pkg/client/mongodb_client.go
@@ -344,6 +344,7 @@ func NewMongoDBClient(ctx context.Context, dbConfig config.DatabaseConfig) (*Mon
 		ChangeStreamRetryDeadlineSeconds: dbConfig.GetTimeoutConfig().GetChangeStreamRetryDeadlineSeconds(),
 		ChangeStreamRetryIntervalSeconds: dbConfig.GetTimeoutConfig().GetChangeStreamRetryIntervalSeconds(),
 		AppName:                          dbConfig.GetAppName(),
+		UseSystemTLS:                     dbConfig.GetUseSystemTLS(),
 	}
 
 	// Initialize certificate watcher if rotation is enabled

--- a/store-client/pkg/config/env_loader.go
+++ b/store-client/pkg/config/env_loader.go
@@ -32,6 +32,9 @@ type DatabaseConfig interface {
 	GetCertConfig() CertificateConfig
 	GetTimeoutConfig() TimeoutConfig
 	GetAppName() string
+	// GetUseSystemTLS returns true when the client should use the system CA trust
+	// store instead of custom CA cert files (e.g. when connecting to MongoDB Atlas).
+	GetUseSystemTLS() bool
 }
 
 // CertificateConfig holds TLS certificate configuration
@@ -70,6 +73,10 @@ const (
 	EnvChangeStreamRetryIntervalSeconds = "CHANGE_STREAM_RETRY_INTERVAL_SECONDS"
 	// Certificate rotation configuration
 	EnvMongoDBEnableCertRotation = "MONGODB_ENABLE_CERT_ROTATION"
+	// EnvMongoDBUseSystemTLS instructs the client to use the system CA trust store
+	// instead of custom CA cert files. Set to "true" when connecting to MongoDB Atlas
+	// or other deployments that use publicly trusted certificates.
+	EnvMongoDBUseSystemTLS = "MONGODB_USE_SYSTEM_TLS"
 )
 
 // Default values that match existing module defaults for backward compatibility
@@ -115,6 +122,7 @@ type StandardDatabaseConfig struct {
 	certConfig     CertificateConfig
 	timeoutConfig  TimeoutConfig
 	appName        string
+	useSystemTLS   bool
 }
 
 // StandardCertificateConfig implements CertificateConfig
@@ -254,6 +262,7 @@ func NewDatabaseConfigWithCollection(
 		certConfig:     certConfig,
 		timeoutConfig:  timeoutConfig,
 		appName:        os.Getenv("APP_NAME"),
+		useSystemTLS:   stringutil.IsTruthyValue(os.Getenv(EnvMongoDBUseSystemTLS)),
 	}, nil
 }
 
@@ -501,6 +510,10 @@ func (c *StandardDatabaseConfig) GetTimeoutConfig() TimeoutConfig {
 
 func (c *StandardDatabaseConfig) GetAppName() string {
 	return c.appName
+}
+
+func (c *StandardDatabaseConfig) GetUseSystemTLS() bool {
+	return c.useSystemTLS
 }
 
 func (c *StandardCertificateConfig) GetCertPath() string {

--- a/store-client/pkg/datastore/providers/mongodb/watcher/watch_store.go
+++ b/store-client/pkg/datastore/providers/mongodb/watcher/watch_store.go
@@ -645,24 +645,29 @@ func constructMongoClientOptions(
 	}
 
 	// Only set TLS when TLS config was successfully built.
-	// Only set X.509 auth when client certificate is available (CA-only
-	// TLS should not attempt X.509 auth since there's no client cert).
-	// When certificate rotation is enabled, the client certificate is
-	// provided dynamically via GetClientCertificate rather than the
-	// Certificates slice.
-	if tlsConfig != nil {
-		clientOpts.SetTLSConfig(tlsConfig)
-
-		if len(tlsConfig.Certificates) > 0 || tlsConfig.GetClientCertificate != nil {
-			credential := options.Credential{
-				AuthMechanism: "MONGODB-X509",
-				AuthSource:    "$external",
-			}
-			clientOpts.SetAuth(credential)
-		}
-	}
+	applyTLSConfig(clientOpts, tlsConfig)
 
 	return clientOpts, nil
+}
+
+// applyTLSConfig sets TLS and X.509 auth on clientOpts when tlsConfig is non-nil.
+// X.509 auth is only set when a client certificate is available (CA-only TLS
+// should not attempt X.509 auth). When certificate rotation is enabled, the
+// client certificate is provided dynamically via GetClientCertificate rather
+// than the Certificates slice.
+func applyTLSConfig(clientOpts *options.ClientOptions, tlsConfig *tls.Config) {
+	if tlsConfig == nil {
+		return
+	}
+	clientOpts.SetTLSConfig(tlsConfig)
+
+	if len(tlsConfig.Certificates) > 0 || tlsConfig.GetClientCertificate != nil {
+		credential := options.Credential{
+			AuthMechanism: "MONGODB-X509",
+			AuthSource:    "$external",
+		}
+		clientOpts.SetAuth(credential)
+	}
 }
 
 // constructSystemTLSConfig creates a TLS config that trusts the system CA pool.

--- a/store-client/pkg/datastore/providers/mongodb/watcher/watch_store.go
+++ b/store-client/pkg/datastore/providers/mongodb/watcher/watch_store.go
@@ -63,6 +63,11 @@ type MongoDBConfig struct {
 	CertWatcher *certwatcher.CertWatcher
 	// AppName is used to identify the client in MongoDB connection tracking
 	AppName string
+	// UseSystemTLS instructs the client to use the system CA trust store instead of
+	// custom CA cert files. Use this when connecting to MongoDB Atlas or any deployment
+	// that uses publicly trusted certificates (e.g. Let's Encrypt, DigiCert).
+	// When true, no CA cert file is required and X.509 client auth is not attempted.
+	UseSystemTLS bool
 }
 
 // TokenConfig holds the token-specific configuration.
@@ -603,13 +608,23 @@ func constructMongoClientOptions(
 		tlsConfig *tls.Config
 		err       error
 	)
-	// Use CertWatcher if provided for automatic client certificate rotation
-	if mongoConfig.CertWatcher != nil {
+
+	switch {
+	case mongoConfig.UseSystemTLS:
+		// Use the system CA trust store — no cert files required.
+		// Credentials (e.g. SCRAM username/password) are encoded in the URI.
+		tlsConfig, err = constructSystemTLSConfig()
+		if err != nil {
+			return nil, err
+		}
+	case mongoConfig.CertWatcher != nil:
+		// Dynamic TLS with automatic client certificate rotation.
 		tlsConfig, err = constructDynamicTLSConfig(mongoConfig)
 		if err != nil {
 			return nil, err
 		}
-	} else {
+	default:
+		// Static TLS loaded from cert files on disk.
 		tlsConfig, err = constructStaticTLSConfig(mongoConfig)
 		if err != nil {
 			return nil, err
@@ -648,6 +663,23 @@ func constructMongoClientOptions(
 	}
 
 	return clientOpts, nil
+}
+
+// constructSystemTLSConfig creates a TLS config that trusts the system CA pool.
+// Used when connecting to deployments with publicly trusted certificates (e.g. MongoDB Atlas).
+// No client certificate is loaded, so X.509 mutual auth is not performed.
+func constructSystemTLSConfig() (*tls.Config, error) {
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load system CA cert pool: %w", err)
+	}
+
+	slog.Info("Using system CA trust store for TLS configuration")
+
+	return &tls.Config{
+		RootCAs:    pool,
+		MinVersion: tls.VersionTLS12,
+	}, nil
 }
 
 func constructDynamicTLSConfig(mongoConfig MongoDBConfig) (*tls.Config, error) {


### PR DESCRIPTION
Adds MONGODB_USE_SYSTEM_TLS support so NVSentinel can connect to MongoDB Atlas (and any deployment using publicly trusted certificates) without requiring custom CA cert files mounted in pods.

Go changes:
- New MONGODB_USE_SYSTEM_TLS env var: when true, uses x509.SystemCertPool() instead of loading CA certs from disk, skipping X.509 client auth
- Added GetUseSystemTLS() to DatabaseConfig interface and all implementations
- Wired UseSystemTLS through MongoDBConfig, NewMongoDBClient, and ConvertToMongoDBConfig

Helm changes:
- configmap-datastore.yaml: supports global.datastore.connection.uri for direct URI passthrough (e.g. mongodb+srv://), emits MONGODB_USE_SYSTEM_TLS
- values.yaml: documents uri, useSystemTLS, and uriSecretName options
- All 6 datastore-consuming deployment templates: inject optional Secret via envFrom when global.datastore.uriSecretName is set, keeping passwords out of ConfigMaps

Usage with Atlas:
  kubectl create secret generic nvsentinel-atlas-uri \ --from-literal=MONGODB_URI='mongodb+srv://user:pass@cluster.mongodb.net/' helm upgrade nvsentinel ... \ --set global.datastore.provider=mongodb \ --set global.datastore.connection.database=nvsentinel \ --set global.datastore.useSystemTLS=true \ --set global.datastore.uriSecretName=nvsentinel-atlas-uri

## Summary

<!-- Brief description of your changes -->

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for a full MongoDB connection URI and optional injection via Kubernetes Secret.
  * Option to use system-trusted TLS for MongoDB connections.
  * Deployments will conditionally require the configured datastore secret when a secret name is provided.

* **Documentation**
  * Added commented Helm guidance for MongoDB URI, system TLS, and secret name.

* **Tests**
  * Updated test mocks to include the system-TLS flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->