### PR TITLE
fix: enable audit logging in janitor-provider (#1074)

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/janitor-provider/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor-provider/templates/deployment.yaml
@@ -44,6 +44,14 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "provider.serviceAccountName" . }}
+      {{- if .Values.global.auditLogging.enabled }}
+      securityContext:
+        fsGroup: 65532
+      {{- end }}
+      {{- if .Values.global.auditLogging.enabled }}
+      initContainers:
+        {{- include "nvsentinel.auditLogging.initContainer" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: janitor-provider
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default ((.Values.global).image).tag | default .Chart.AppVersion }}"
@@ -56,8 +64,15 @@ spec:
             - name: service
               containerPort: {{ .Values.service.port | default "50051" }}
           env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: JANITOR_PROVIDER_PORT
               value: {{ .Values.service.port | default 50051 | quote }}
+            {{- if .Values.global.auditLogging.enabled }}
+            {{- include "nvsentinel.auditLogging.envVars" . | nindent 12 }}
+            {{- end }}
             - name: METRICS_PORT
               value: {{ ((.Values.global).metricsPort) | default 2112 | quote }}
             # Cloud Service Provider configuration
@@ -165,8 +180,11 @@ spec:
             {{- end }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
-          {{- if or .Values.tls.enabled (and (eq (.Values.csp.provider | default "kind") "nebius") .Values.csp.nebius.serviceAccountKeySecret) }}
+          {{- if or .Values.global.auditLogging.enabled .Values.tls.enabled (and (eq (.Values.csp.provider | default "kind") "nebius") .Values.csp.nebius.serviceAccountKeySecret) }}
           volumeMounts:
+            {{- if .Values.global.auditLogging.enabled }}
+            {{- include "nvsentinel.auditLogging.volumeMount" . | nindent 12 }}
+            {{- end }}
             {{- if .Values.tls.enabled }}
             - name: tls-cert
               mountPath: {{ .Values.tls.certDir }}
@@ -178,8 +196,11 @@ spec:
               readOnly: true
             {{- end }}
           {{- end }}
-      {{- if or .Values.tls.enabled (and (eq (.Values.csp.provider | default "kind") "nebius") .Values.csp.nebius.serviceAccountKeySecret) }}
+      {{- if or .Values.global.auditLogging.enabled .Values.tls.enabled (and (eq (.Values.csp.provider | default "kind") "nebius") .Values.csp.nebius.serviceAccountKeySecret) }}
       volumes:
+        {{- if .Values.global.auditLogging.enabled }}
+        {{- include "nvsentinel.auditLogging.volume" . | nindent 8 }}
+        {{- end }}
         {{- if .Values.tls.enabled }}
         - name: tls-cert
           secret:

--- a/janitor-provider/main.go
+++ b/janitor-provider/main.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 
 	cspv1alpha1 "github.com/nvidia/nvsentinel/api/gen/go/csp/v1alpha1"
+	"github.com/nvidia/nvsentinel/commons/pkg/auditlogger"
 	"github.com/nvidia/nvsentinel/commons/pkg/logger"
 	"github.com/nvidia/nvsentinel/commons/pkg/server"
 	"github.com/nvidia/nvsentinel/janitor-provider/pkg/auth"
@@ -121,13 +122,24 @@ func (s *janitorProviderServer) SendTerminateSignal(
 }
 
 func main() {
+	os.Exit(realMain())
+}
+
+func realMain() int {
 	logger.SetDefaultStructuredLogger("janitor-provider", version)
 	slog.Info("Starting janitor-provider", "version", version, "commit", commit, "date", date)
 
+	if err := auditlogger.InitAuditLogger("janitor-provider"); err != nil {
+		slog.Warn("Failed to initialize audit logger", "error", err)
+	}
+	defer auditlogger.CloseAuditLogger() //nolint:errcheck
+
 	if err := run(); err != nil {
 		slog.Error("Failed to run", "error", err)
-		os.Exit(1)
+		return 1
 	}
+
+	return 0
 }
 
 func run() error {


### PR DESCRIPTION
## Summary

janitor-provider component was missing audit log initialization. As a result, it never created an audit log file, meaning
CSP API calls (reboot signals sent to GCP/AWS/Azure) were silently dropped from the audit trail.
This fix brings janitor-provider in line with all other components which already call InitAuditLogger on startup.

Changes:
- janitor-provider/main.go: call InitAuditLogger on startup and
  CloseAuditLogger on shutdown
- Helm deployment template: add POD_NAME env var (required for audit
  log filename), initContainer, securityContext (fsGroup), volumeMounts
  and hostPath volume, all gated behind global.auditLogging.enabled
  
 **Testing result-**
 Tested on GKE cluster tg220000-dgxc-runai-gcp-cmh-dev0 with global.auditLogging.enabled: true by injecting a GPU error (dcgmi test --inject --gpuid 0 -f 84 -v 0) to trigger a full remediation cycle.
_Before fix:_ 
No audit log file was created for janitor-provider under /var/log/nvsentinel/. CSP API calls were invisible in the audit trail.
_After fix:_ 
/var/log/nvsentinel/janitor-provider-7b675c7974-9cnks-audit.log was created on the node and contained:

 ```
 {"timestamp":"2026-03-24T09:33:38Z","component":"janitor-provider","method":"POST","url":"https://compute.googleapis.com/compute/v1/projects/proj-dgxc-runai-np-dev-mega/zones/us-east5-a/instances/gke-tg220000-dgxc-runai--customer-gpu-22dbdec4-hqqs/reset","response_code":403}
{"timestamp":"2026-03-24T09:33:38Z","component":"janitor-provider","method":"POST","url":"https://compute.googleapis.com/compute/v1/projects/proj-dgxc-runai-np-dev-mega/zones/us-east5-a/instances/gke-tg220000-dgxc-runai--customer-gpu-22dbdec4-hqqs/reset","response_code":403}
{"timestamp":"2026-03-24T12:17:35Z","component":"janitor-provider","method":"POST","url":"https://compute.googleapis.com/compute/v1/projects/proj-dgxc-runai-np-dev-mega/zones/us-east5-a/instances/gke-tg220000-dgxc-runai--customer-gpu-22dbdec4-hqqs/reset","response_code":403}
{"timestamp":"2026-03-24T12:17:35Z","component":"janitor-provider","method":"POST","url":"https://compute.googleapis.com/compute/v1/projects/proj-dgxc-runai-np-dev-mega/zones/us-east5-a/instances/gke-tg220000-dgxc-runai--customer-gpu-22dbdec4-hqqs/reset","response_code":403}
```


## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [x] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional audit logging support that can be enabled via configuration. When enabled, it initializes at startup and is cleanly shut down on exit.
  * Audit logging can add an optional initialization step, extra storage mounts, and environment variables (including the pod name) to the running container to capture metadata and events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->