### PR TITLE
feat: add OpenShift service-ca support as alternative to cert-manager

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/janitor/templates/certificate-metrics.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/templates/certificate-metrics.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-{{- if .Values.metrics.tls.enabled }}
+{{- if and .Values.metrics.tls.enabled (ne .Values.webhook.certProvider "openshift-service-ca") }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/distros/kubernetes/nvsentinel/charts/janitor/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/templates/deployment.yaml
@@ -126,6 +126,9 @@ spec:
         {{- if .Values.metrics.tls.enabled }}
         - name: metrics-certs
           secret:
+            {{- if eq .Values.webhook.certProvider "openshift-service-ca" }}
+            secretName: {{ include "janitor.fullname" . }}-webhook-cert
+            {{- else }}
             secretName: {{ include "janitor.fullname" . }}-metrics-cert
             items:
               - key: ca.crt
@@ -134,6 +137,7 @@ spec:
                 path: tls.crt
               - key: tls.key
                 path: tls.key
+            {{- end }}
             defaultMode: 420
         {{- end }}
         {{- if and .Values.config.cspProvider .Values.config.cspProvider.tls .Values.config.cspProvider.tls.enabled }}

--- a/distros/kubernetes/nvsentinel/charts/janitor/templates/issuer.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/templates/issuer.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- if ne .Values.webhook.certProvider "openshift-service-ca" }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -21,4 +22,5 @@ metadata:
     {{- include "janitor.labels" . | nindent 4 }}
 spec:
   selfSigned: {}
+{{- end }}
 

--- a/distros/kubernetes/nvsentinel/charts/janitor/templates/service.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/templates/service.yaml
@@ -17,6 +17,10 @@ metadata:
   name: {{ include "janitor.fullname" . }}
   labels:
     {{- include "janitor.labels" . | nindent 4 }}
+{{- if eq .Values.webhook.certProvider "openshift-service-ca" }}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: {{ include "janitor.fullname" . }}-webhook-cert
+{{- end }}
 spec:
   type: ClusterIP
   selector:

--- a/distros/kubernetes/nvsentinel/charts/janitor/templates/webhook.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/templates/webhook.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+{{- if ne .Values.webhook.certProvider "openshift-service-ca" }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -32,6 +33,7 @@ spec:
   issuerRef:
     name: {{ .Values.webhook.certIssuer | default "selfsigned-issuer" }}
     kind: Issuer
+{{- end }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -40,7 +42,11 @@ metadata:
   labels:
     {{- include "janitor.labels" . | nindent 4 }}
   annotations:
+{{- if eq .Values.webhook.certProvider "openshift-service-ca" }}
+    service.beta.openshift.io/inject-cabundle: "true"
+{{- else }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "janitor.fullname" . }}-webhook-cert
+{{- end }}
 webhooks:
   - name: vrebootnode-v1alpha1.kb.io
     clientConfig:

--- a/distros/kubernetes/nvsentinel/charts/janitor/values.schema.json
+++ b/distros/kubernetes/nvsentinel/charts/janitor/values.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "webhook": {
+      "type": "object",
+      "properties": {
+        "certProvider": {
+          "type": "string",
+          "title": "Certificate provider for webhook TLS",
+          "description": "Use \"cert-manager\" for cert-manager CRDs or \"openshift-service-ca\" for OpenShift service-ca-operator",
+          "default": "cert-manager",
+          "enum": ["cert-manager", "openshift-service-ca"]
+        }
+      }
+    }
+  }
+}

--- a/distros/kubernetes/nvsentinel/charts/janitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/values.yaml
@@ -188,6 +188,12 @@ webhook:
   # Cert-manager issuer to use for webhook certificate
   # Janitor creates its own self-signed issuer
   certIssuer: "janitor-selfsigned-issuer"
+  # Certificate provider: "cert-manager" or "openshift-service-ca"
+  # Use "openshift-service-ca" on OpenShift to use the built-in service-ca-operator
+  # instead of cert-manager for webhook TLS certificate management.
+  # Example:
+  # certProvider: openshift-service-ca
+  certProvider: cert-manager
 
 # Metrics Configuration
 metrics:

--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/ca-certificate.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/ca-certificate.yaml
@@ -14,7 +14,7 @@
 
 # CA Certificate - long-lived, used to sign webhook certificates
 # This is what inject-ca-from should reference for stable CA rotation
-{{- if .Values.webhook.createIssuer }}
+{{- if and .Values.webhook.createIssuer (ne .Values.webhook.certProvider "openshift-service-ca") }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/ca-issuer.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/ca-issuer.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # CA Issuer - issues webhook certificates using the CA certificate
-{{- if .Values.webhook.createIssuer }}
+{{- if and .Values.webhook.createIssuer (ne .Values.webhook.certProvider "openshift-service-ca") }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:

--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/certificate.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/certificate.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # TLS Certificate for webhook, issued by CA Issuer for proper rotation support
+{{- if ne .Values.webhook.certProvider "openshift-service-ca" }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -38,3 +39,4 @@ spec:
     {{- end }}
     kind: Issuer
     group: cert-manager.io
+{{- end }}

--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/mutatingwebhook.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/mutatingwebhook.yaml
@@ -18,6 +18,9 @@ metadata:
   labels:
     {{- include "preflight.labels" . | nindent 4 }}
   annotations:
+{{- if eq .Values.webhook.certProvider "openshift-service-ca" }}
+    service.beta.openshift.io/inject-cabundle: "true"
+{{- else }}
     # cert-manager injects the CA bundle from the CA certificate (not the leaf cert)
     # This ensures stable CA across leaf certificate rotations
     {{- if .Values.webhook.createIssuer }}
@@ -25,6 +28,7 @@ metadata:
     {{- else }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ .Values.webhook.caCertificateName }}
     {{- end }}
+{{- end }}
 webhooks:
   - name: {{ include "preflight.webhookName" . }}
     clientConfig:

--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/selfsigned-issuer.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/selfsigned-issuer.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Bootstrap self-signed issuer - only used to create the CA certificate
-{{- if .Values.webhook.createIssuer }}
+{{- if and .Values.webhook.createIssuer (ne .Values.webhook.certProvider "openshift-service-ca") }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:

--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/service.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/service.yaml
@@ -19,6 +19,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "preflight.labels" . | nindent 4 }}
+{{- if eq .Values.webhook.certProvider "openshift-service-ca" }}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: {{ include "preflight.certSecretName" . }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/distros/kubernetes/nvsentinel/charts/preflight/values.schema.json
+++ b/distros/kubernetes/nvsentinel/charts/preflight/values.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "webhook": {
+      "type": "object",
+      "properties": {
+        "certProvider": {
+          "type": "string",
+          "title": "Certificate provider for webhook TLS",
+          "description": "Use \"cert-manager\" for cert-manager CRDs or \"openshift-service-ca\" for OpenShift service-ca-operator",
+          "default": "cert-manager",
+          "enum": ["cert-manager", "openshift-service-ca"]
+        }
+      }
+    }
+  }
+}

--- a/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
@@ -80,6 +80,12 @@ webhook:
   # Only used when createIssuer=false
   certIssuer: ""
   caCertificateName: ""
+  # Certificate provider: "cert-manager" or "openshift-service-ca"
+  # Use "openshift-service-ca" on OpenShift to use the built-in service-ca-operator
+  # instead of cert-manager for webhook TLS certificate management.
+  # Example:
+  # certProvider: openshift-service-ca
+  certProvider: cert-manager
 
 # Local fallback values - global.dcgm takes precedence when set
 dcgm:


### PR DESCRIPTION
## Summary

Add `webhook.certProvider` value (`"cert-manager"` or `"openshift-service-ca"`) to janitor and preflight subcharts, enabling NVSentinel to run on OpenShift Container Platform without requiring cert-manager.

When set to `"openshift-service-ca"`:
- cert-manager CRDs (Issuer, Certificate) are not rendered
- Services get `service.beta.openshift.io/serving-cert-secret-name` annotation for automatic TLS Secret generation
- Webhook configurations get `service.beta.openshift.io/inject-cabundle: "true"` for CA bundle injection

No changes to Deployments or Go code — they already mount Secrets by name and read `tls.crt`/`tls.key` from the filesystem.

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [x] Janitor
- [x] Other: Preflight

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

### Verification

**Default behavior preserved** (`certProvider: cert-manager`):
- `helm template` renders all cert-manager CRDs (Issuer, Certificate) identically to before

**OpenShift service-ca mode** (`certProvider: openshift-service-ca`):
- `helm template --set webhook.certProvider=openshift-service-ca` renders zero `cert-manager.io` references
- Service has `service.beta.openshift.io/serving-cert-secret-name` annotation
- Webhook config has `service.beta.openshift.io/inject-cabundle: "true"` annotation
- Secret names in Service annotations match Deployment volume mounts:
  - Janitor: `janitor-webhook-cert`
  - Preflight: `<fullname>-webhook-tls`

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add support for OpenShift service CA as an alternative certificate provider for webhook TLS.

* **Configuration**
  * New webhook.certProvider setting (default: `cert-manager`) to choose `cert-manager` or `openshift-service-ca`.
  * JSON schemas added to validate the new value.

* **Behavior Changes**
  * Selecting `openshift-service-ca` omits cert-manager TLS resources, injects OpenShift CA annotations into Services and webhook configs, and uses the service CA secret for webhook/metrics volumes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->