### PR TITLE
metadata-collector: make kubelet host configurable via KUBELET_HOST env var

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/metadata-collector/templates/daemonset.yaml
+++ b/distros/kubernetes/nvsentinel/charts/metadata-collector/templates/daemonset.yaml
@@ -58,6 +58,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+            {{- if .Values.kubeletHost }}
+            - name: KUBELET_HOST
+              {{- toYaml .Values.kubeletHost | nindent 14 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/distros/kubernetes/nvsentinel/charts/metadata-collector/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/metadata-collector/values.yaml
@@ -29,3 +29,19 @@ resources:
 
 # Runtime class name for the pod. If empty or not set, the field will be omitted.
 runtimeClassName: "nvidia"
+
+# Override the kubelet host used by the pod device mapper. When unset (default),
+# the metadata-collector connects to localhost. Set this to a valid Kubernetes
+# env var spec to override. On clusters where kubelet binds to the node's
+# primary IP instead of 0.0.0.0, use the Downward API:
+#
+#   kubeletHost:
+#     valueFrom:
+#       fieldRef:
+#         fieldPath: status.hostIP
+#
+# A static value also works:
+#
+#   kubeletHost:
+#     value: "10.0.0.1"
+kubeletHost: {}

--- a/metadata-collector/pkg/mapper/httpsclient.go
+++ b/metadata-collector/pkg/mapper/httpsclient.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -31,9 +32,10 @@ import (
 
 const (
 	kubeSecurePort      = "10250"
-	kubeletHostName     = "localhost"
+	defaultKubeletHost  = "localhost"
+	kubeletHostEnvVar   = "KUBELET_HOST"
 	bearerTokenPath     = "/var/run/secrets/kubernetes.io/serviceaccount/token" //nolint:gosec // not a credential
-	listPodsURLTemplate = "https://%s:%s/pods"
+	listPodsURLTemplate = "https://%s/pods"
 )
 
 type KubeletHTTPSClient interface {
@@ -64,25 +66,32 @@ func NewKubeletHTTPSClient(ctx context.Context) (KubeletHTTPSClient, error) {
 		ResponseHeaderTimeout: 30 * time.Second,
 	}
 
+	kubeletHost := os.Getenv(kubeletHostEnvVar)
+	if kubeletHost == "" {
+		kubeletHost = defaultKubeletHost
+	}
+
 	return &kubeletHTTPSClient{
 		ctx:              ctx,
 		httpRoundTripper: transport,
 		bearerTokenPath:  bearerTokenPath,
-		listPodsURI:      fmt.Sprintf(listPodsURLTemplate, kubeletHostName, kubeSecurePort),
+		listPodsURI:      fmt.Sprintf(listPodsURLTemplate, net.JoinHostPort(kubeletHost, kubeSecurePort)),
 	}, nil
 }
 
 /*
-This function calls the /pods Kubelet endpoint on localhost skipping Kubelet server certificate validation for TLS
+This function calls the /pods Kubelet endpoint skipping Kubelet server certificate validation for TLS
 while passing a service account token for authN and authZ.
+
+- Kubelet host: by default the client connects to localhost, which works when kubelet binds to 0.0.0.0. On clusters
+where kubelet binds to the node's primary IP, set the KUBELET_HOST environment variable to the node's IP. The Helm
+chart injects this via the Kubernetes Downward API (status.hostIP).
 
 - Insecure TLS justification: by default, Kubelet serving certificates are signed by the same certificate authority as
 the kube-apiserver. As a result, the CA mounted in the pod file system at file path
 /var/run/secrets/kubernetes.io/serviceaccount/ca.crt can be used against either server. However, this server certificate
-only has a valid SAN for the node's primary IP and not localhost. To prevent needing to lookup the node's primary IP
-via the K8s API or leveraging a HostPath volume, we will call the server listening on localhost and skip certificate
-validation. The metadata-collector already runs with HostNetwork=true so the localhost interface will match the same one
-that the Kubelet is serving on.
+only has a valid SAN for the node's primary IP and not localhost. We skip certificate validation to handle both cases.
+The metadata-collector already runs with HostNetwork=true.
 
 - Kubelet AuthN + AuthZ: Kubelet's can optionally enabled authentication with a bearer token that is validated via a
 TokenReview and authorization that is validated via a SubjectAccessReview. To ensure that our metadata-collector pod

--- a/metadata-collector/pkg/mapper/httpsclient_test.go
+++ b/metadata-collector/pkg/mapper/httpsclient_test.go
@@ -557,3 +557,36 @@ func TestListPodsWithUnmarshalError(t *testing.T) {
 	_, err := client.ListPods()
 	assert.Error(t, err)
 }
+
+func TestNewKubeletHTTPSClientHostResolution(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostEnv  string
+		expected string
+	}{
+		{
+			name:     "empty env defaults to localhost",
+			hostEnv:  "",
+			expected: "https://localhost:10250/pods",
+		},
+		{
+			name:     "IPv4 host",
+			hostEnv:  "192.168.1.100",
+			expected: "https://192.168.1.100:10250/pods",
+		},
+		{
+			name:     "IPv6 host is bracketed",
+			hostEnv:  "fd00::1",
+			expected: "https://[fd00::1]:10250/pods",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(kubeletHostEnvVar, tc.hostEnv)
+			client, err := NewKubeletHTTPSClient(context.Background())
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, client.(*kubeletHTTPSClient).listPodsURI)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1096

## Problem

The metadata-collector hardcodes the kubelet endpoint as `localhost:10250`. This fails on clusters where kubelet binds to the node's primary IP instead of `0.0.0.0`, causing all metadata-collector pods to crash-loop:

```
dial tcp 127.0.0.1:10250: connect: connection refused
```

This is common on bare-metal Kubernetes clusters where the kubelet config sets `address` to the node IP.

## Fix

- Read kubelet host from the `KUBELET_HOST` environment variable, falling back to `localhost` for backward compatibility
- Inject `KUBELET_HOST` in the Helm chart daemonset template via the Kubernetes Downward API (`status.hostIP`), which provides the correct node IP on every node automatically
- Use `net.JoinHostPort` for correct IPv6 address bracketing

## Testing

- Table-driven tests covering default (localhost), IPv4, and IPv6 hosts
- All existing tests pass unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Helm chart adds a configurable kubelet host override for the metadata collector, allowing non-default kubelet endpoints (node primary IPs, custom hosts). Defaults to localhost when not set; supports IPv4 and IPv6.
* **Tests**
  * Added unit tests validating host-resolution and request URI construction for empty, IPv4, and IPv6 host cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->