### PR TITLE
fix: make preflight chart consistent with other subcharts

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/_helpers.tpl
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/_helpers.tpl
@@ -25,16 +25,7 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 */}}
 {{- define "preflight.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+{{- "preflight" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*

--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/_helpers.tpl
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/_helpers.tpl
@@ -18,7 +18,7 @@ limitations under the License.
 Expand the name of the chart.
 */}}
 {{- define "preflight.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*

--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/configmap.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "preflight.fullname" . }}-config
+  name: {{ include "preflight.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "preflight.labels" . | nindent 4 }}
@@ -75,14 +75,18 @@ data:
       {{- end }}
     initContainers:
       {{- $extraEnv := .Values.ncclAllreduceExtraEnv | default list }}
+      {{- $globalTag := ((.Values.global).image).tag | default "" }}
+      {{- $appVersion := .Chart.AppVersion }}
       {{- $result := list }}
       {{- range .Values.initContainers }}
-      {{- if and (eq .name "preflight-nccl-allreduce") $extraEnv }}
       {{- $container := deepCopy . }}
-      {{- $_ := set $container "env" (concat (.env | default list) $extraEnv) }}
-      {{- $result = append $result $container }}
-      {{- else }}
-      {{- $result = append $result . }}
+      {{- if or $globalTag $appVersion }}
+      {{- $repo := index (splitList ":" $container.image) 0 }}
+      {{- $_ := set $container "image" (printf "%s:%s" $repo ($globalTag | default $appVersion)) }}
       {{- end }}
+      {{- if and (eq .name "preflight-nccl-allreduce") $extraEnv }}
+      {{- $_ := set $container "env" (concat (.env | default list) $extraEnv) }}
+      {{- end }}
+      {{- $result = append $result $container }}
       {{- end }}
       {{- toYaml $result | nindent 6 }}

--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/configmap.yaml
@@ -80,10 +80,8 @@ data:
       {{- $result := list }}
       {{- range .Values.initContainers }}
       {{- $container := deepCopy . }}
-      {{- if or $globalTag $appVersion }}
-      {{- $repo := index (splitList ":" $container.image) 0 }}
-      {{- $_ := set $container "image" (printf "%s:%s" $repo ($globalTag | default $appVersion)) }}
-      {{- end }}
+      {{- $tag := $container.image.tag | default $globalTag | default $appVersion }}
+      {{- $_ := set $container "image" (printf "%s:%s" $container.image.repository $tag) }}
       {{- if and (eq .name "preflight-nccl-allreduce") $extraEnv }}
       {{- $_ := set $container "env" (concat (.env | default list) $extraEnv) }}
       {{- end }}

--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
             secretName: {{ include "preflight.certSecretName" . }}
         - name: config
           configMap:
-            name: {{ include "preflight.fullname" . }}-config
+            name: {{ include "preflight.fullname" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: {{ include "preflight.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default ((.Values.global).image).tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --port={{ .Values.webhook.port }}

--- a/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
@@ -17,7 +17,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/nvidia/nvsentinel/preflight
   pullPolicy: IfNotPresent
-  tag: "latest"
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""

--- a/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
@@ -20,8 +20,6 @@ image:
   tag: ""
 
 imagePullSecrets: []
-nameOverride: ""
-fullnameOverride: ""
 
 serviceAccount:
   create: true

--- a/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
@@ -101,7 +101,9 @@ dcgm:
 
 initContainers:
   - name: preflight-dcgm-diag
-    image: ghcr.io/nvidia/nvsentinel/preflight-dcgm-diag:latest
+    image:
+      repository: ghcr.io/nvidia/nvsentinel/preflight-dcgm-diag
+      tag: ""
     volumeMounts:
       - name: nvsentinel-socket
         mountPath: /var/run
@@ -110,9 +112,11 @@ initContainers:
     #   limits:
     #     memory: 512Mi
 
-  # # NCCL loopback test - validates intra-node GPU-to-GPU communication (NVLink/PCIe)
+  # NCCL loopback test - validates intra-node GPU-to-GPU communication (NVLink/PCIe)
   - name: preflight-nccl-loopback
-    image: ghcr.io/nvidia/nvsentinel/preflight-nccl-loopback:latest
+    image:
+      repository: ghcr.io/nvidia/nvsentinel/preflight-nccl-loopback
+      tag: ""
     env:
       - name: BW_THRESHOLD_GBPS
       # Minimum acceptable bus bandwidth
@@ -133,7 +137,9 @@ initContainers:
   # NCCL all-reduce test - validates multi-node GPU communication
   # Requires gangCoordination.enabled=true and gang-aware scheduler (Volcano, Kueue, etc.)
   - name: preflight-nccl-allreduce
-    image: ghcr.io/nvidia/nvsentinel/preflight-nccl-allreduce:latest
+    image:
+      repository: ghcr.io/nvidia/nvsentinel/preflight-nccl-allreduce
+      tag: ""
     securityContext:
       capabilities:
         add: ["IPC_LOCK"]  # Required for RDMA memory registration

--- a/distros/kubernetes/nvsentinel/values-tilt.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt.yaml
@@ -121,7 +121,9 @@ preflight:
     diagLevel: 3
   initContainers:
     - name: preflight-dcgm-diag
-      image: busybox:latest
+      image:
+        repository: busybox
+        tag: latest
       command: ["/bin/sh", "-c"]
       args: ["echo 'preflight-dcgm-diag: no real GPU, exiting ok'; exit 0"]
 

--- a/tests/helpers/preflight.go
+++ b/tests/helpers/preflight.go
@@ -34,7 +34,7 @@ const (
 	PreflightNamespaceLabel    = "nvsentinel.nvidia.com/preflight"
 	PreflightNamespaceLabelVal = "enabled"
 	PreflightDCGMDiagName      = "preflight-dcgm-diag"
-	PreflightConfigMapName     = "nvsentinel-preflight-config"
+	PreflightConfigMapName     = "preflight"
 	PreflightConfigKey         = "config.yaml"
 
 	GangConfigMapLabelManagedBy = "nvsentinel.nvidia.com/managed-by"

--- a/tilt/Tiltfile
+++ b/tilt/Tiltfile
@@ -229,10 +229,10 @@ cert_manager_objects = [
 ]
 if preflight_enabled:
     cert_manager_objects.extend([
-        'nvsentinel-preflight-webhook-cert:certificate',
-        'nvsentinel-preflight-ca:certificate',
-        'nvsentinel-preflight-selfsigned:issuer',
-        'nvsentinel-preflight-ca-issuer:issuer',
+        'preflight-webhook-cert:certificate',
+        'preflight-ca:certificate',
+        'preflight-selfsigned:issuer',
+        'preflight-ca-issuer:issuer',
     ])
 if use_postgresql:
     cert_manager_objects.extend([


### PR DESCRIPTION
## Summary

1. Add fallback of using global values image tag for preflight deployment and the init containers -- consistent with other subcharts
2. Use consistent naming for templates i.e. `nvsentinel-preflight-config` -> `preflight`

### Template generation testing:
```
$ helm template test-release distros/kubernetes/nvsentinel/charts/preflight -s templates/configmap.yaml --set global.image.tag=v2.5.0 2>&1 | grep -A2 'image:'
      - image: ghcr.io/nvidia/nvsentinel/preflight-dcgm-diag:v2.5.0
        name: preflight-dcgm-diag
        volumeMounts:
--
        image: ghcr.io/nvidia/nvsentinel/preflight-nccl-loopback:v2.5.0
        name: preflight-nccl-loopback
        volumeMounts:
--
        image: ghcr.io/nvidia/nvsentinel/preflight-nccl-allreduce:v2.5.0
        name: preflight-nccl-allreduce
        securityContext:


$ helm template test-release distros/kubernetes/nvsentinel/charts/preflight -s templates/configmap.yaml 2>&1 | grep -A2 'image:'
      - image: ghcr.io/nvidia/nvsentinel/preflight-dcgm-diag:1.0.0
        name: preflight-dcgm-diag
        volumeMounts:
--
        image: ghcr.io/nvidia/nvsentinel/preflight-nccl-loopback:1.0.0
        name: preflight-nccl-loopback
        volumeMounts:
--
        image: ghcr.io/nvidia/nvsentinel/preflight-nccl-allreduce:1.0.0
        name: preflight-nccl-allreduce
        securityContext:
```

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Kubernetes resource names standardized to "preflight" (fullname/name templates simplified; removed overrides/suffixes).
  * Image tag resolution now prefers explicit container tag, then global tag, then chart appVersion.
  * Init containers: image fields rewritten to use repository+tag; env concatenation remains targeted to the NCCL allreduce container.
  * Default main image tag cleared (no longer "latest").

* **Tests**
  * E2E expectations updated to use the new ConfigMap/resource name.

* **Chores**
  * Local dev config updated to use new certificate/issuer names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->