### PR TITLE
feat: add OTEL tracing setup for fault-quarantine

### DIFF
--- a/commons/pkg/tracing/span_attributes.go
+++ b/commons/pkg/tracing/span_attributes.go
@@ -50,12 +50,12 @@ func AddHealthEventStatusAttributes(span trace.Span, healthEventStatus *pb.Healt
 		)
 	}
 
-	faultRemediated := false
+	faultRemediated := ""
 	if healthEventStatus.FaultRemediated != nil {
-		faultRemediated = healthEventStatus.FaultRemediated.GetValue()
+		faultRemediated = fmt.Sprintf("%t", healthEventStatus.FaultRemediated.GetValue())
 	}
 
-	attrs = append(attrs, attribute.Bool("health_event_status.fault_remediated", faultRemediated))
+	attrs = append(attrs, attribute.String("health_event_status.fault_remediated", faultRemediated))
 
 	span.SetAttributes(attrs...)
 }
@@ -93,6 +93,13 @@ func AddHealthEventAttributes(span trace.Span, event *pb.HealthEvent) {
 			attrs = append(attrs, attribute.String(fmt.Sprintf("health_event.entities_impacted.%s",
 				entity.EntityType), entity.EntityValue))
 		}
+	}
+
+	if event.QuarantineOverrides != nil {
+		attrs = append(attrs,
+			attribute.Bool("health_event.quarantine_overrides.force", event.QuarantineOverrides.Force),
+			attribute.Bool("health_event.quarantine_overrides.skip", event.QuarantineOverrides.Skip),
+		)
 	}
 
 	span.SetAttributes(attrs...)

--- a/commons/pkg/tracing/tracing.go
+++ b/commons/pkg/tracing/tracing.go
@@ -43,6 +43,10 @@ var (
 	tracer                  trace.Tracer
 )
 
+// Service name constants used across multiple modules for span-ID lookups.
+// For example, platform-connector's span ID is read by fault-quarantine,
+// event-exporter, and health-events-analyzer to establish parent-child
+// trace relationships.
 const (
 	ServicePlatformConnector = "platform-connector"
 	ServiceFaultQuarantine   = "fault-quarantine"

--- a/commons/pkg/tracing/tracing.go
+++ b/commons/pkg/tracing/tracing.go
@@ -43,6 +43,11 @@ var (
 	tracer                  trace.Tracer
 )
 
+const (
+	ServicePlatformConnector = "platform-connector"
+	ServiceFaultQuarantine   = "fault-quarantine"
+)
+
 // MetadataKeyTraceID is the key used to store the trace ID in the health event's
 // Metadata map. Platform-connector writes it at ingestion time so that all
 // downstream event consumers are linked to same trace.
@@ -51,12 +56,6 @@ const MetadataKeyTraceID = "trace_id"
 // defaultTraceID is the hex representation of the zero-value OpenTelemetry trace ID,
 // which is present when the context doesn't carry trace info.
 var defaultTraceID = trace.TraceID{}.String()
-
-const (
-	OperationStatusThrottled = "throttled"
-	OperationStatusCancelled = "cancelled"
-	OperationStatusSkipped   = "skipped"
-)
 
 // InitTracing initializes OpenTelemetry tracing with OTLP gRPC exporter.
 func InitTracing(serviceName string) error {
@@ -349,13 +348,4 @@ func RecordError(span trace.Span, err error, opts ...trace.EventOption) {
 // SpanFromContext returns the active span stored in ctx, or a no-op span if none exists.
 func SpanFromContext(ctx context.Context) trace.Span {
 	return trace.SpanFromContext(ctx)
-}
-
-// SetOperationStatus sets the standard operation status attribute on a span.
-func SetOperationStatus(span trace.Span, status string, service string) {
-	if span == nil {
-		return
-	}
-
-	span.SetAttributes(attribute.String(fmt.Sprintf("%s.operation.status", service), status))
 }

--- a/commons/pkg/tracing/tracing_test.go
+++ b/commons/pkg/tracing/tracing_test.go
@@ -110,8 +110,4 @@ func TestSpanHelpers(t *testing.T) {
 	t.Run("RecordError does not panic", func(t *testing.T) {
 		assert.NotPanics(t, func() { RecordError(span, assert.AnError) })
 	})
-
-	t.Run("SetOperationStatus nil span does not panic", func(t *testing.T) {
-		assert.NotPanics(t, func() { SetOperationStatus(nil, "success", "test_service") })
-	})
 }

--- a/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/deployment.yaml
@@ -163,6 +163,12 @@ spec:
               value: {{ $certMountPath }}
             {{- end }}
             {{- end }}
+            {{- if .Values.global.tracing.enabled }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.global.tracing.endpoint | quote }}
+            - name: OTEL_EXPORTER_OTLP_INSECURE
+              value: {{ .Values.global.tracing.insecure | quote }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ if .Values.global.datastore }}{{ .Release.Name }}-datastore-config{{ else }}mongodb-config{{ end }}

--- a/fault-quarantine/go.mod
+++ b/fault-quarantine/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/stretchr/testify v1.11.1
+	go.opentelemetry.io/otel v1.43.0
 	golang.org/x/exp v0.0.0-20251125195548-87e1e737ad39
 	golang.org/x/sync v0.20.0
 	google.golang.org/protobuf v1.36.11
@@ -80,7 +81,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo v0.67.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect
-	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect

--- a/fault-quarantine/main.go
+++ b/fault-quarantine/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/nvidia/nvsentinel/commons/pkg/flags"
 	"github.com/nvidia/nvsentinel/commons/pkg/logger"
 	"github.com/nvidia/nvsentinel/commons/pkg/server"
+	"github.com/nvidia/nvsentinel/commons/pkg/tracing"
 	"github.com/nvidia/nvsentinel/fault-quarantine/pkg/initializer"
 )
 
@@ -41,11 +42,16 @@ var (
 )
 
 func main() {
-	logger.SetDefaultStructuredLogger("fault-quarantine", version)
+	logger.SetDefaultStructuredLoggerWithTraceCorrelation("fault-quarantine", version)
 	slog.Info("Starting fault-quarantine", "version", version, "commit", commit, "date", date)
 
 	if err := auditlogger.InitAuditLogger("fault-quarantine"); err != nil {
 		slog.Warn("Failed to initialize audit logger", "error", err)
+	}
+
+	// Initialize OpenTelemetry tracing
+	if err := tracing.InitTracing(tracing.ServiceFaultQuarantine); err != nil {
+		slog.Warn("Failed to initialize tracing", "error", err)
 	}
 
 	if err := run(); err != nil {
@@ -60,6 +66,10 @@ func main() {
 
 	if err := auditlogger.CloseAuditLogger(); err != nil {
 		slog.Warn("Failed to close audit logger", "error", err)
+	}
+
+	if err := tracing.ShutdownTracing(context.Background()); err != nil {
+		slog.Warn("Failed to shutdown tracing", "error", err)
 	}
 }
 

--- a/fault-quarantine/pkg/breaker/breaker.go
+++ b/fault-quarantine/pkg/breaker/breaker.go
@@ -65,7 +65,7 @@ func NewSlidingWindowBreaker(ctx context.Context, cfg Config) (CircuitBreaker, e
 
 	err := cfg.K8sClient.EnsureCircuitBreakerConfigMap(ctx, cfg.ConfigMapName, cfg.ConfigMapNamespace, StateClosed)
 	if err != nil {
-		slog.Error("Error ensuring circuit breaker config map", "error", err)
+		slog.ErrorContext(ctx, "Error ensuring circuit breaker config map", "error", err)
 		return nil, fmt.Errorf("error ensuring circuit breaker config map: %w", err)
 	}
 
@@ -196,13 +196,13 @@ func (b *slidingWindowBreaker) IsTripped(ctx context.Context) (bool, error) {
 
 	totalNodes, err := b.getTotalNodesWithRetry(ctx)
 	if err != nil {
-		slog.Error("Failed to get total nodes after retries", "error", err)
+		slog.ErrorContext(ctx, "Failed to get total nodes after retries", "error", err)
 
 		return false, fmt.Errorf("failed to get total nodes after retries: %w", err)
 	}
 
 	if totalNodes == 0 {
-		slog.Error("Total nodes is still 0 after all retry attempts - cluster may have no GPU nodes")
+		slog.ErrorContext(ctx, "Total nodes is still 0 after all retry attempts - cluster may have no GPU nodes")
 		return false, fmt.Errorf("total nodes is 0 after retries")
 	}
 
@@ -217,7 +217,7 @@ func (b *slidingWindowBreaker) IsTripped(ctx context.Context) (bool, error) {
 
 	b.mu.Unlock()
 
-	slog.Debug("Recent cordoned nodes status",
+	slog.DebugContext(ctx, "Recent cordoned nodes status",
 		"recentCordonedNodes", recentCordonedNodes,
 		"totalNodes", totalNodes,
 		"tripPercentage", b.cfg.TripPercentage)
@@ -227,7 +227,7 @@ func (b *slidingWindowBreaker) IsTripped(ctx context.Context) (bool, error) {
 	if shouldTrip {
 		err := b.ForceState(ctx, StateTripped)
 		if err != nil {
-			slog.Error("Error forcing circuit breaker state to TRIPPED", "error", err)
+			slog.ErrorContext(ctx, "Error forcing circuit breaker state to TRIPPED", "error", err)
 			return true, fmt.Errorf("error forcing circuit breaker state to TRIPPED: %w", err)
 		}
 
@@ -252,11 +252,11 @@ func (b *slidingWindowBreaker) ForceState(ctx context.Context, s State) error {
 	err := b.cfg.K8sClient.WriteCircuitBreakerState(
 		ctx, b.cfg.ConfigMapName, b.cfg.ConfigMapNamespace, s)
 	if err != nil {
-		slog.Error("Error writing circuit breaker state", "error", err)
+		slog.ErrorContext(ctx, "Error writing circuit breaker state", "error", err)
 		return fmt.Errorf("error writing circuit breaker state: %w", err)
 	}
 
-	slog.Info("ForceState changed", "state", s)
+	slog.InfoContext(ctx, "ForceState changed", "state", s)
 
 	return nil
 }
@@ -316,7 +316,7 @@ func (b *slidingWindowBreaker) getTotalNodesWithRetry(ctx context.Context) (int,
 		}
 
 		if attempt == 0 {
-			slog.Info("Circuit breaker starting retries: NodeInformer cache may not be synced yet",
+			slog.InfoContext(ctx, "Circuit breaker starting retries: NodeInformer cache may not be synced yet",
 				"maxRetries", maxRetries)
 		}
 
@@ -383,7 +383,7 @@ func (b *slidingWindowBreaker) performRetryDelay(ctx context.Context, attempt, m
 	initialDelay, maxDelay time.Duration) error {
 	delay := b.calculateBackoffDelay(attempt, initialDelay, maxDelay)
 
-	slog.Debug("Circuit breaker retry; got 0 nodes, retrying (NodeInformer cache may still be syncing)",
+	slog.DebugContext(ctx, "Circuit breaker retry; got 0 nodes, retrying (NodeInformer cache may still be syncing)",
 		"attempt", attempt+1,
 		"maxRetries", maxRetries,
 		"delay", delay)
@@ -422,7 +422,7 @@ func (b *slidingWindowBreaker) logRetriesExhausted(ctx context.Context, maxRetri
 	initialDelay, maxDelay time.Duration) error {
 	actualNodes, err := b.cfg.K8sClient.GetTotalNodes(ctx)
 	if err != nil {
-		slog.Error(
+		slog.ErrorContext(ctx,
 			"Circuit breaker: All retry attempts exhausted; failed to get node count from Kubernetes API; pod will restart",
 			"maxRetries", maxRetries,
 			"error", err,
@@ -433,7 +433,7 @@ func (b *slidingWindowBreaker) logRetriesExhausted(ctx context.Context, maxRetri
 		return fmt.Errorf("%w: failed to get node count: %w", ErrRetryExhausted, err)
 	}
 
-	slog.Error("Circuit breaker: All retry attempts exhausted",
+	slog.ErrorContext(ctx, "Circuit breaker: All retry attempts exhausted",
 		"maxRetries", maxRetries,
 		"actualNodes", actualNodes,
 		"initialDelay", initialDelay,

--- a/fault-quarantine/pkg/eventwatcher/event_watcher.go
+++ b/fault-quarantine/pkg/eventwatcher/event_watcher.go
@@ -21,10 +21,12 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/nvidia/nvsentinel/commons/pkg/tracing"
 	"github.com/nvidia/nvsentinel/data-models/pkg/model"
 	"github.com/nvidia/nvsentinel/fault-quarantine/pkg/metrics"
 	"github.com/nvidia/nvsentinel/store-client/pkg/client"
 	"github.com/nvidia/nvsentinel/store-client/pkg/query"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type EventWatcher struct {
@@ -34,7 +36,7 @@ type EventWatcher struct {
 		ctx context.Context,
 		event *model.HealthEventWithStatus,
 	) *model.Status
-	fetchDocIDsFn                         func(nodeName string) []string
+	fetchDocIDsFn                         func(ctx context.Context, nodeName string) []string
 	unprocessedEventsMetricUpdateInterval time.Duration
 	lastProcessedObjectID                 LastProcessedObjectIDStore
 }
@@ -47,8 +49,8 @@ type LastProcessedObjectIDStore interface {
 type EventWatcherInterface interface {
 	Start(ctx context.Context) error
 	SetProcessEventCallback(callback func(ctx context.Context, event *model.HealthEventWithStatus) *model.Status)
-	SetFetchDocIDsFn(fn func(nodeName string) []string)
-	CancelLatestQuarantiningEvents(ctx context.Context, nodeName string) error
+	SetFetchDocIDsFn(fn func(ctx context.Context, nodeName string) []string)
+	CancelLatestQuarantiningEvents(ctx context.Context, nodeName string, reason string) error
 }
 
 func NewEventWatcher(
@@ -70,12 +72,12 @@ func (w *EventWatcher) SetProcessEventCallback(callback func(ctx context.Context
 	w.processEventCallback = callback
 }
 
-func (w *EventWatcher) SetFetchDocIDsFn(fn func(nodeName string) []string) {
+func (w *EventWatcher) SetFetchDocIDsFn(fn func(ctx context.Context, nodeName string) []string) {
 	w.fetchDocIDsFn = fn
 }
 
 func (w *EventWatcher) Start(ctx context.Context) error {
-	slog.Info("Starting event watcher")
+	slog.InfoContext(ctx, "Starting event watcher")
 
 	if w.changeStreamWatcher != nil {
 		w.changeStreamWatcher.Start(ctx)
@@ -91,11 +93,11 @@ func (w *EventWatcher) Start(ctx context.Context) error {
 	go func() {
 		err := w.watchEvents(ctx)
 		if err != nil {
-			slog.Error("Event watcher goroutine failed", "error", err)
+			slog.ErrorContext(ctx, "Event watcher goroutine failed", "error", err)
 
 			watchDoneCh <- err
 		} else {
-			slog.Error("Event watcher goroutine exited unexpectedly, event processing has stopped")
+			slog.ErrorContext(ctx, "Event watcher goroutine exited unexpectedly, event processing has stopped")
 
 			watchDoneCh <- fmt.Errorf("event watcher channel closed unexpectedly")
 		}
@@ -105,9 +107,9 @@ func (w *EventWatcher) Start(ctx context.Context) error {
 
 	select {
 	case <-ctx.Done():
-		slog.Info("Context cancelled, stopping event watcher")
+		slog.InfoContext(ctx, "Context cancelled, stopping event watcher")
 	case err := <-watchDoneCh:
-		slog.Error("Event watcher terminated unexpectedly, initiating shutdown", "error", err)
+		slog.ErrorContext(ctx, "Event watcher terminated unexpectedly, initiating shutdown", "error", err)
 		watchErr = fmt.Errorf("event watcher terminated: %w", err)
 	}
 
@@ -123,7 +125,8 @@ func (w *EventWatcher) watchEvents(ctx context.Context) error {
 		metrics.TotalEventsReceived.Inc()
 
 		if processErr := w.processEvent(ctx, event); processErr != nil {
-			slog.Error("Event processing failed, but still marking as processed to proceed ahead", "error", processErr)
+			slog.ErrorContext(ctx, "Event processing failed, but still marking as processed to proceed ahead",
+				"error", processErr)
 		}
 
 		// Extract the resume token from the event to avoid race condition
@@ -131,7 +134,7 @@ func (w *EventWatcher) watchEvents(ctx context.Context) error {
 		resumeToken := event.GetResumeToken()
 		if err := w.changeStreamWatcher.MarkProcessed(ctx, resumeToken); err != nil {
 			metrics.ProcessingErrors.WithLabelValues("mark_processed_error").Inc()
-			slog.Error("Failed to mark event as processed", "error", err)
+			slog.ErrorContext(ctx, "Failed to mark event as processed", "error", err)
 
 			return fmt.Errorf("failed to mark event as processed: %w", err)
 		}
@@ -150,7 +153,7 @@ func (w *EventWatcher) processEvent(ctx context.Context, event client.Event) err
 		return fmt.Errorf("failed to unmarshal event: %w", err)
 	}
 
-	slog.Debug("Processing event", "event", healthEventWithStatus)
+	slog.DebugContext(ctx, "Processing event", "event", healthEventWithStatus)
 
 	eventID, err := event.GetDocumentID()
 	if err != nil {
@@ -174,19 +177,37 @@ func (w *EventWatcher) processEvent(ctx context.Context, event client.Event) err
 
 	w.lastProcessedObjectID.StoreLastProcessedObjectID(eventID)
 
+	traceID := tracing.TraceIDFromMetadata(healthEventWithStatus.HealthEvent.GetMetadata())
+	parentSpanID := tracing.ParentSpanID(healthEventWithStatus.HealthEventStatus.SpanIds, tracing.ServicePlatformConnector)
+
+	// Short-lived span that marks the exact moment fault-quarantine received the
+	// event. It ends immediately so it appears in the trace backend before
+	// processing finishes, making it easy to see ingestion-to-processing latency.
+	ctx, receivedSpan := tracing.StartSpanWithLinkFromTraceContext(ctx, traceID,
+		parentSpanID, "fault_quarantine.event_received")
+	tracing.AddHealthEventStatusAttributes(receivedSpan, healthEventWithStatus.HealthEventStatus, eventID)
+
+	receivedSpan.End()
+
+	// Processing span wraps the callback and subsequent DB status update so they
+	// share the same trace context.
+	ctx, processSpan := tracing.StartSpan(ctx, "fault_quarantine.process_event")
+	defer processSpan.End()
+
 	startTime := time.Now()
 
 	var sourceDocIDs []string
 
 	if healthEventWithStatus.HealthEvent.GetIsHealthy() && w.fetchDocIDsFn != nil {
-		sourceDocIDs = w.fetchDocIDsFn(healthEventWithStatus.HealthEvent.GetNodeName())
+		sourceDocIDs = w.fetchDocIDsFn(ctx, healthEventWithStatus.HealthEvent.GetNodeName())
 	}
 
 	status := w.processEventCallback(ctx, &healthEventWithStatus)
+
 	if status != nil {
 		if err := w.updateNodeQuarantineStatus(ctx, recordUUID, status); err != nil {
 			metrics.ProcessingErrors.WithLabelValues("update_quarantine_status_error").Inc()
-			slog.Error("Failed to update node quarantine status", "error", err)
+			slog.ErrorContext(ctx, "Failed to update node quarantine status", "error", err)
 
 			return fmt.Errorf("failed to update node quarantine status: %w", err)
 		}
@@ -251,7 +272,7 @@ func (w *EventWatcher) emitRemediationDurationFromDocIDs(ctx context.Context, do
 
 	cursor, err := w.databaseClient.Find(lookupCtx, filter, nil)
 	if err != nil {
-		slog.Warn("emitRemediationDurationFromDocIDs: Find failed", "error", err)
+		slog.WarnContext(ctx, "emitRemediationDurationFromDocIDs: Find failed", "error", err)
 		return
 	}
 
@@ -260,12 +281,12 @@ func (w *EventWatcher) emitRemediationDurationFromDocIDs(ctx context.Context, do
 	for cursor.Next(lookupCtx) {
 		var doc remediationDoc
 		if err := cursor.Decode(&doc); err != nil {
-			slog.Warn("emitRemediationDurationFromDocIDs: Decode failed", "error", err)
+			slog.WarnContext(ctx, "emitRemediationDurationFromDocIDs: Decode failed", "error", err)
 			continue
 		}
 
 		if doc.HealthEvent.GeneratedTimestamp == nil {
-			slog.Warn("emitRemediationDurationFromDocIDs: generatedTimestamp missing",
+			slog.WarnContext(ctx, "emitRemediationDurationFromDocIDs: generatedTimestamp missing",
 				"node", doc.HealthEvent.NodeName)
 
 			continue
@@ -286,7 +307,7 @@ func (w *EventWatcher) emitRemediationDurationFromDocIDs(ctx context.Context, do
 	}
 
 	if err := cursor.Err(); err != nil {
-		slog.Warn("emitRemediationDurationFromDocIDs: cursor error", "error", err)
+		slog.WarnContext(ctx, "emitRemediationDurationFromDocIDs: cursor error", "error", err)
 	}
 }
 
@@ -356,14 +377,14 @@ func (w *EventWatcher) updateUnprocessedEventsMetric(ctx context.Context) {
 			if metricsWatcher, ok := w.changeStreamWatcher.(client.ChangeStreamMetrics); ok {
 				unprocessedCount, err := metricsWatcher.GetUnprocessedEventCount(ctx, objID)
 				if err != nil {
-					slog.Debug("Failed to get unprocessed event count", "error", err)
+					slog.DebugContext(ctx, "Failed to get unprocessed event count", "error", err)
 					continue
 				}
 
 				metrics.EventBacklogSize.Set(float64(unprocessedCount))
-				slog.Debug("Updated unprocessed events metric", "count", unprocessedCount, "afterObjectID", objID)
+				slog.DebugContext(ctx, "Updated unprocessed events metric", "count", unprocessedCount, "afterObjectID", objID)
 			} else {
-				slog.Debug("Change stream watcher does not support metrics")
+				slog.DebugContext(ctx, "Change stream watcher does not support metrics")
 				metrics.EventBacklogSize.Set(-1)
 			}
 		}
@@ -375,12 +396,23 @@ func (w *EventWatcher) updateNodeQuarantineStatus(
 	eventID string,
 	nodeQuarantinedStatus *model.Status,
 ) error {
-	err := client.UpdateHealthEventNodeQuarantineStatus(ctx, w.databaseClient, eventID, string(*nodeQuarantinedStatus))
+	// Create a span for the DB status update. This span's ID becomes the parent
+	// for downstream consumers (node-drainer) because the status write is the
+	// trigger point for their change stream.
+	spanCtx, dbSpan := tracing.StartSpan(ctx, "fault_quarantine.db.update_status")
+	defer dbSpan.End()
+
+	dbSpan.SetAttributes(
+		attribute.String("fault_quarantine.event.status", string(*nodeQuarantinedStatus)),
+	)
+
+	err := client.UpdateHealthEventNodeQuarantineStatus(spanCtx, w.databaseClient, eventID,
+		string(*nodeQuarantinedStatus), tracing.SpanIDFromSpan(dbSpan))
 	if err != nil {
 		return fmt.Errorf("error updating node quarantine status: %w", err)
 	}
 
-	slog.Info("Document updated with status", "id", eventID, "status", *nodeQuarantinedStatus)
+	slog.InfoContext(ctx, "Document updated with status", "id", eventID, "status", *nodeQuarantinedStatus)
 
 	return nil
 }
@@ -388,7 +420,16 @@ func (w *EventWatcher) updateNodeQuarantineStatus(
 func (w *EventWatcher) CancelLatestQuarantiningEvents(
 	ctx context.Context,
 	nodeName string,
+	reason string,
 ) error {
+	_, span := tracing.StartSpan(ctx, "fault_quarantine.cancel_latest_quarantining_events")
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.String("fault_quarantine.node_name", nodeName),
+		attribute.String("fault_quarantine.cancel.reason", reason),
+	)
+
 	// Find the latest Quarantined or UnQuarantined event to check current state of node
 	filter := query.New().Build(query.And(
 		query.Eq("healthevent.nodename", nodeName),
@@ -404,42 +445,65 @@ func (w *EventWatcher) CancelLatestQuarantiningEvents(
 		ID          string    `bson:"_id" json:"_id"`
 		CreatedAt   time.Time `bson:"createdAt" json:"createdAt"`
 		HealthEvent struct {
-			NodeName           string       `bson:"nodename" json:"nodeName"`
-			GeneratedTimestamp *dbTimestamp `bson:"generatedtimestamp" json:"generatedTimestamp"`
+			NodeName           string            `bson:"nodename" json:"nodeName"`
+			GeneratedTimestamp *dbTimestamp      `bson:"generatedtimestamp" json:"generatedTimestamp"`
+			Metadata           map[string]string `bson:"metadata" json:"metadata"`
 		} `bson:"healthevent" json:"healthEvent"`
 		HealthEventStatus struct {
-			NodeQuarantined           string       `bson:"nodequarantined" json:"nodeQuarantined"`
-			QuarantineFinishTimestamp *dbTimestamp `bson:"quarantinefinishtimestamp,omitempty" json:"quarantineFinishTimestamp"`
-			DrainFinishTimestamp      *dbTimestamp `bson:"drainfinishtimestamp,omitempty" json:"drainFinishTimestamp"`
+			NodeQuarantined           string            `bson:"nodequarantined" json:"nodeQuarantined"`
+			QuarantineFinishTimestamp *dbTimestamp      `bson:"quarantinefinishtimestamp,omitempty" json:"quarantineFinishTimestamp"` //nolint:lll
+			DrainFinishTimestamp      *dbTimestamp      `bson:"drainfinishtimestamp,omitempty" json:"drainFinishTimestamp"`
+			SpanIDs                   map[string]string `bson:"spanids"`
 		} `bson:"healtheventstatus" json:"healthEventStatus"`
 	}
 
 	result, err := w.databaseClient.FindOne(ctx, filter, findOptions)
 	if err != nil {
 		if errors.Is(err, client.ErrNoDocuments) {
-			slog.Warn("No quarantining/unquarantining events found for node", "node", nodeName)
+			slog.WarnContext(ctx, "No quarantining/unquarantining events found for node", "node", nodeName)
+
+			span.SetAttributes(
+				attribute.String("fault_quarantine.error.type", "no_quarantining_events_found"),
+				attribute.String("fault_quarantine.error.message", err.Error()),
+			)
 
 			return nil
 		}
 
-		slog.Error("Error finding latest quarantining event", "node", nodeName, "error", err)
+		slog.ErrorContext(ctx, "Error finding latest quarantining event", "node", nodeName, "error", err)
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("fault_quarantine.error.type", "error_finding_latest_quarantining_event"),
+			attribute.String("fault_quarantine.error.message", err.Error()),
+		)
 
 		return fmt.Errorf("error finding latest quarantining event for node %s: %w", nodeName, err)
 	}
 
 	if err := result.Decode(&latestEvent); err != nil {
 		if errors.Is(err, client.ErrNoDocuments) || client.IsNoDocumentsError(err) {
-			slog.Warn("No quarantining/unquarantining events found for node", "node", nodeName)
+			slog.WarnContext(ctx, "No quarantining/unquarantining events found for node", "node", nodeName)
+
+			span.SetAttributes(
+				attribute.String("fault_quarantine.error.type", "no_quarantining_events_found"),
+				attribute.String("fault_quarantine.error.message", err.Error()),
+			)
 
 			return nil
 		}
 
-		slog.Error("Error decoding latest event", "node", nodeName, "error", err)
+		slog.ErrorContext(ctx, "Error decoding latest event", "node", nodeName, "error", err)
+
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("fault_quarantine.error.type", "error_decoding_latest_quarantining_event"),
+			attribute.String("fault_quarantine.error.message", err.Error()),
+		)
 
 		return fmt.Errorf("error decoding latest quarantining event for node %s: %w", nodeName, err)
 	}
 
-	slog.Debug("Found latest event",
+	slog.DebugContext(ctx, "Found latest event",
 		"node", nodeName,
 		"eventID", latestEvent.ID,
 		"status", latestEvent.HealthEventStatus.NodeQuarantined)
@@ -447,10 +511,24 @@ func (w *EventWatcher) CancelLatestQuarantiningEvents(
 	// Only cancel if latest status is Quarantined (not if already UnQuarantined by healthy event)
 	if latestEvent.HealthEventStatus.NodeQuarantined == "" ||
 		latestEvent.HealthEventStatus.NodeQuarantined != string(model.Quarantined) {
-		slog.Debug("Latest event is not Quarantined, no events to cancel", "node", nodeName)
+		slog.InfoContext(ctx, "Latest event is not Quarantined, no events to cancel", "node", nodeName)
+
+		span.SetAttributes(
+			attribute.String("fault_quarantine.error.type", "latest_event_not_quarantined"),
+			attribute.String("fault_quarantine.error.message", "latest event is not Quarantined"),
+		)
 
 		return nil
 	}
+
+	latestTraceID := tracing.TraceIDFromMetadata(latestEvent.HealthEvent.Metadata)
+	platformConnectorSpanId := tracing.ParentSpanID(
+		latestEvent.HealthEventStatus.SpanIDs, tracing.ServicePlatformConnector)
+
+	ctx, eventSpan := tracing.StartSpanWithLinkFromTraceContext(
+		context.Background(), latestTraceID, platformConnectorSpanId,
+		"fault_quarantine.cancel_latest_quarantining_events")
+	defer eventSpan.End()
 
 	// Update all events from the current quarantine session (Quarantined + AlreadyQuarantined)
 	// This includes the first event and all subsequent events that occurred after it
@@ -469,10 +547,16 @@ func (w *EventWatcher) CancelLatestQuarantiningEvents(
 
 	updateResult, err := w.databaseClient.UpdateManyDocuments(ctx, updateFilter, update)
 	if err != nil {
+		tracing.RecordError(eventSpan, err)
+		eventSpan.SetAttributes(
+			attribute.String("fault_quarantine.error.type", "error_cancelling_quarantining_events"),
+			attribute.String("fault_quarantine.error.message", err.Error()),
+		)
+
 		return fmt.Errorf("error cancelling quarantining events for node %s: %w", nodeName, err)
 	}
 
-	slog.Info("Updated quarantining events to cancelled status",
+	slog.InfoContext(ctx, "Updated quarantining events to cancelled status",
 		"node", nodeName,
 		"firstEventId", latestEvent.ID,
 		"documentsUpdated", updateResult.ModifiedCount)
@@ -483,6 +567,11 @@ func (w *EventWatcher) CancelLatestQuarantiningEvents(
 		latestEvent.HealthEventStatus.QuarantineFinishTimestamp,
 		latestEvent.HealthEventStatus.DrainFinishTimestamp,
 		nodeName,
+	)
+
+	eventSpan.SetAttributes(
+		attribute.String("fault_quarantine.event.node_quarantined", string(model.Cancelled)),
+		attribute.String("fault_quarantine.event.reason", reason),
 	)
 
 	return nil

--- a/fault-quarantine/pkg/informer/k8s_client.go
+++ b/fault-quarantine/pkg/informer/k8s_client.go
@@ -84,19 +84,19 @@ func NewFaultQuarantineClient(kubeconfig string, dryRun bool,
 
 func (c *FaultQuarantineClient) EnsureCircuitBreakerConfigMap(ctx context.Context,
 	name, namespace string, initialStatus breaker.State) error {
-	slog.Info("Ensuring circuit breaker config map",
+	slog.InfoContext(ctx, "Ensuring circuit breaker config map",
 		"name", name, "namespace", namespace, "initialStatus", initialStatus)
 
 	cmClient := c.Clientset.CoreV1().ConfigMaps(namespace)
 
 	_, err := cmClient.Get(ctx, name, metav1.GetOptions{})
 	if err == nil {
-		slog.Info("Circuit breaker config map already exists", "name", name, "namespace", namespace)
+		slog.InfoContext(ctx, "Circuit breaker config map already exists", "name", name, "namespace", namespace)
 		return nil
 	}
 
 	if !errors.IsNotFound(err) {
-		slog.Error("Error getting circuit breaker config map", "name", name, "namespace", namespace, "error", err)
+		slog.ErrorContext(ctx, "Error getting circuit breaker config map", "name", name, "namespace", namespace, "error", err)
 		return fmt.Errorf("failed to get config map %s in namespace %s: %w", name, namespace, err)
 	}
 
@@ -110,7 +110,9 @@ func (c *FaultQuarantineClient) EnsureCircuitBreakerConfigMap(ctx context.Contex
 
 	_, err = cmClient.Create(ctx, cm, metav1.CreateOptions{})
 	if err != nil {
-		slog.Error("Error creating circuit breaker config map", "name", name, "namespace", namespace, "error", err)
+		slog.ErrorContext(ctx, "Error creating circuit breaker config map",
+			"name", name, "namespace", namespace, "error", err)
+
 		return fmt.Errorf("failed to create config map %s in namespace %s: %w", name, namespace, err)
 	}
 
@@ -123,7 +125,7 @@ func (c *FaultQuarantineClient) GetTotalNodes(ctx context.Context) (int, error) 
 		return 0, fmt.Errorf("failed to get node counts from informer: %w", err)
 	}
 
-	slog.Debug("Got total nodes from NodeInformer cache", "totalNodes", totalNodes)
+	slog.DebugContext(ctx, "Got total nodes from NodeInformer cache", "totalNodes", totalNodes)
 
 	return totalNodes, nil
 }
@@ -188,7 +190,7 @@ func isRetryableError(err error) bool {
 func (c *FaultQuarantineClient) ReadCircuitBreakerState(
 	ctx context.Context, name, namespace string,
 ) (breaker.State, error) {
-	slog.Info("Reading circuit breaker state from config map",
+	slog.InfoContext(ctx, "Reading circuit breaker state from config map",
 		"name", name, "namespace", namespace)
 
 	cm, err := c.Clientset.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
@@ -287,23 +289,23 @@ func (c *FaultQuarantineClient) QuarantineNodeAndSetAnnotations(
 ) error {
 	updateFn := func(node *v1.Node) error {
 		if len(taints) > 0 {
-			if err := c.applyTaints(node, taints, nodename); err != nil {
+			if err := c.applyTaints(ctx, node, taints, nodename); err != nil {
 				return fmt.Errorf("failed to apply taints to node %s: %w", nodename, err)
 			}
 		}
 
 		if isCordon {
-			if shouldSkip := c.handleCordon(node, nodename); shouldSkip {
+			if shouldSkip := c.handleCordon(ctx, node, nodename); shouldSkip {
 				return nil
 			}
 		}
 
 		if len(annotations) > 0 {
-			c.applyAnnotations(node, annotations, nodename)
+			c.applyAnnotations(ctx, node, annotations, nodename)
 		}
 
 		if len(labels) > 0 {
-			c.applyLabels(node, labels, nodename)
+			c.applyLabels(ctx, node, labels, nodename)
 		}
 
 		return nil
@@ -312,9 +314,11 @@ func (c *FaultQuarantineClient) QuarantineNodeAndSetAnnotations(
 	return c.UpdateNode(ctx, nodename, updateFn)
 }
 
-func (c *FaultQuarantineClient) applyTaints(node *v1.Node, taints []config.Taint, nodename string) error {
+func (c *FaultQuarantineClient) applyTaints(
+	ctx context.Context, node *v1.Node, taints []config.Taint, nodename string,
+) error {
 	if c.DryRunMode {
-		slog.Info("DryRun mode enabled, skipping taint application", "node", nodename)
+		slog.InfoContext(ctx, "DryRun mode enabled, skipping taint application", "node", nodename)
 		return nil
 	}
 
@@ -327,7 +331,7 @@ func (c *FaultQuarantineClient) applyTaints(node *v1.Node, taints []config.Taint
 		key := config.Taint{Key: taintConfig.Key, Value: taintConfig.Value, Effect: string(taintConfig.Effect)}
 
 		if _, exists := existingTaints[key]; !exists {
-			slog.Info("Tainting node", "node", nodename, "taintConfig", taintConfig)
+			slog.InfoContext(ctx, "Tainting node", "node", nodename, "taintConfig", taintConfig)
 			existingTaints[key] = v1.Taint{
 				Key:    taintConfig.Key,
 				Value:  taintConfig.Value,
@@ -344,18 +348,18 @@ func (c *FaultQuarantineClient) applyTaints(node *v1.Node, taints []config.Taint
 	return nil
 }
 
-func (c *FaultQuarantineClient) handleCordon(node *v1.Node, nodename string) bool {
+func (c *FaultQuarantineClient) handleCordon(ctx context.Context, node *v1.Node, nodename string) bool {
 	_, exist := node.Annotations[common.QuarantineHealthEventAnnotationKey]
 
 	if node.Spec.Unschedulable {
 		if exist {
-			slog.Info("Node already cordoned by FQM; skipping taint/annotation updates", "node", nodename)
+			slog.InfoContext(ctx, "Node already cordoned by FQM; skipping taint/annotation updates", "node", nodename)
 			return true
 		}
 
-		slog.Info("Node is cordoned manually; applying FQM taints/annotations", "node", nodename)
+		slog.InfoContext(ctx, "Node is cordoned manually; applying FQM taints/annotations", "node", nodename)
 	} else {
-		slog.Info("Cordoning node", "node", nodename)
+		slog.InfoContext(ctx, "Cordoning node", "node", nodename)
 
 		if !c.DryRunMode {
 			node.Spec.Unschedulable = true
@@ -365,24 +369,28 @@ func (c *FaultQuarantineClient) handleCordon(node *v1.Node, nodename string) boo
 	return false
 }
 
-func (c *FaultQuarantineClient) applyAnnotations(node *v1.Node, annotations map[string]string, nodename string) {
+func (c *FaultQuarantineClient) applyAnnotations(
+	ctx context.Context, node *v1.Node, annotations map[string]string, nodename string,
+) {
 	if node.Annotations == nil {
 		node.Annotations = make(map[string]string)
 	}
 
-	slog.Info("Setting annotations on node", "node", nodename, "annotations", annotations)
+	slog.InfoContext(ctx, "Setting annotations on node", "node", nodename, "annotations", annotations)
 
 	for annotationKey, annotationValue := range annotations {
 		node.Annotations[annotationKey] = annotationValue
 	}
 }
 
-func (c *FaultQuarantineClient) applyLabels(node *v1.Node, labels map[string]string, nodename string) {
+func (c *FaultQuarantineClient) applyLabels(
+	ctx context.Context, node *v1.Node, labels map[string]string, nodename string,
+) {
 	if node.Labels == nil {
 		node.Labels = make(map[string]string)
 	}
 
-	slog.Info("Adding labels on node", "node", nodename)
+	slog.InfoContext(ctx, "Adding labels on node", "node", nodename)
 
 	for k, v := range labels {
 		node.Labels[k] = v
@@ -399,23 +407,23 @@ func (c *FaultQuarantineClient) UnQuarantineNodeAndRemoveAnnotations(
 ) error {
 	updateFn := func(node *v1.Node) error {
 		if len(taints) > 0 {
-			if shouldReturn := c.removeTaints(node, taints, nodename); shouldReturn {
+			if shouldReturn := c.removeTaints(ctx, node, taints, nodename); shouldReturn {
 				return nil
 			}
 		}
 
-		c.handleUncordon(node, labels, nodename)
+		c.handleUncordon(ctx, node, labels, nodename)
 
 		if len(annotationKeys) > 0 {
 			for _, annotationKey := range annotationKeys {
-				slog.Info("Removing annotation key from node", "key", annotationKey, "node", nodename)
+				slog.InfoContext(ctx, "Removing annotation key from node", "key", annotationKey, "node", nodename)
 				delete(node.Annotations, annotationKey)
 			}
 		}
 
 		if len(labelsToRemove) > 0 {
 			for _, labelKey := range labelsToRemove {
-				slog.Info("Removing label key from node", "key", labelKey, "node", nodename)
+				slog.InfoContext(ctx, "Removing label key from node", "key", labelKey, "node", nodename)
 				delete(node.Labels, labelKey)
 			}
 		}
@@ -426,9 +434,11 @@ func (c *FaultQuarantineClient) UnQuarantineNodeAndRemoveAnnotations(
 	return c.UpdateNode(ctx, nodename, updateFn)
 }
 
-func (c *FaultQuarantineClient) removeTaints(node *v1.Node, taints []config.Taint, nodename string) bool {
+func (c *FaultQuarantineClient) removeTaints(
+	ctx context.Context, node *v1.Node, taints []config.Taint, nodename string,
+) bool {
 	if c.DryRunMode {
-		slog.Info("DryRun mode enabled, skipping taint removal", "node", nodename)
+		slog.InfoContext(ctx, "DryRun mode enabled, skipping taint removal", "node", nodename)
 		return false
 	}
 
@@ -448,7 +458,7 @@ func (c *FaultQuarantineClient) removeTaints(node *v1.Node, taints []config.Tain
 
 		found := taintsAlreadyPresentOnNodeMap[key]
 		if !found {
-			slog.Info("Node already does not have the taint", "node", nodename, "taint", taintConfig)
+			slog.InfoContext(ctx, "Node already does not have the taint", "node", nodename, "taint", taintConfig)
 		} else {
 			taintsToActuallyRemove = append(taintsToActuallyRemove, taintConfig)
 		}
@@ -458,24 +468,24 @@ func (c *FaultQuarantineClient) removeTaints(node *v1.Node, taints []config.Tain
 		return true
 	}
 
-	slog.Info("Untainting node", "node", nodename, "taints", taintsToActuallyRemove)
+	slog.InfoContext(ctx, "Untainting node", "node", nodename, "taints", taintsToActuallyRemove)
 
-	c.removeNodeTaints(node, taintsToActuallyRemove)
+	c.removeNodeTaints(ctx, node, taintsToActuallyRemove)
 
 	return false
 }
 
 func (c *FaultQuarantineClient) handleUncordon(
-	node *v1.Node, labels map[string]string, nodename string,
+	ctx context.Context, node *v1.Node, labels map[string]string, nodename string,
 ) {
-	slog.Info("Uncordoning node", "node", nodename)
+	slog.InfoContext(ctx, "Uncordoning node", "node", nodename)
 
 	if !c.DryRunMode {
 		node.Spec.Unschedulable = false
 	}
 
 	if len(labels) > 0 {
-		c.applyLabels(node, labels, nodename)
+		c.applyLabels(ctx, node, labels, nodename)
 
 		uncordonReason := node.Labels[c.cordonedReasonLabelKey]
 
@@ -542,9 +552,9 @@ func (c *FaultQuarantineClient) HandleManualUntaintCleanup(
 	return c.UpdateNode(ctx, nodename, updateFn)
 }
 
-func (c *FaultQuarantineClient) removeNodeTaints(node *v1.Node, taintsToRemove []config.Taint) {
+func (c *FaultQuarantineClient) removeNodeTaints(ctx context.Context, node *v1.Node, taintsToRemove []config.Taint) {
 	if c.DryRunMode {
-		slog.Info("DryRun mode enabled, skipping node taint removal")
+		slog.InfoContext(ctx, "DryRun mode enabled, skipping node taint removal")
 		return
 	}
 

--- a/fault-quarantine/pkg/informer/node_informer.go
+++ b/fault-quarantine/pkg/informer/node_informer.go
@@ -122,14 +122,14 @@ func (ni *NodeInformer) HasSynced() bool {
 
 // WaitForSync waits for the informer cache to sync with context cancellation support.
 func (ni *NodeInformer) WaitForSync(ctx context.Context) bool {
-	slog.Info("Waiting for NodeInformer cache to sync...")
+	slog.InfoContext(ctx, "Waiting for NodeInformer cache to sync...")
 
 	if ok := cache.WaitForCacheSync(ctx.Done(), ni.informerSynced); !ok {
-		slog.Warn("NodeInformer cache sync failed or context cancelled")
+		slog.WarnContext(ctx, "NodeInformer cache sync failed or context cancelled")
 		return false
 	}
 
-	slog.Info("NodeInformer cache synced")
+	slog.InfoContext(ctx, "NodeInformer cache synced")
 
 	return true
 }

--- a/fault-quarantine/pkg/initializer/init.go
+++ b/fault-quarantine/pkg/initializer/init.go
@@ -49,7 +49,7 @@ type Components struct {
 }
 
 func InitializeAll(ctx context.Context, params InitializationParams) (*Components, error) {
-	slog.Info("Starting fault quarantine module initialization")
+	slog.InfoContext(ctx, "Starting fault quarantine module initialization")
 
 	tokenConfig, err := storeconfig.TokenConfigFromEnv("fault-quarantine")
 	if err != nil {
@@ -71,7 +71,7 @@ func InitializeAll(ctx context.Context, params InitializationParams) (*Component
 	}
 
 	if params.DryRun {
-		slog.Info("Running in dry-run mode")
+		slog.InfoContext(ctx, "Running in dry-run mode")
 	}
 
 	k8sClient, err := informer.NewFaultQuarantineClient(params.KubeconfigPath, params.DryRun, 30*time.Minute)
@@ -79,7 +79,7 @@ func InitializeAll(ctx context.Context, params InitializationParams) (*Component
 		return nil, fmt.Errorf("error while initializing kubernetes client: %w", err)
 	}
 
-	slog.Info("Successfully initialized kubernetes client with embedded node informer")
+	slog.InfoContext(ctx, "Successfully initialized kubernetes client with embedded node informer")
 
 	circuitBreaker, err := setupCircuitBreaker(ctx, params, tomlCfg, k8sClient)
 	if err != nil {
@@ -101,7 +101,7 @@ func InitializeAll(ctx context.Context, params InitializationParams) (*Component
 		circuitBreaker,
 	)
 
-	slog.Info("Initialization completed successfully")
+	slog.InfoContext(ctx, "Initialization completed successfully")
 
 	return &Components{
 		Reconciler:      reconcilerInstance,
@@ -144,7 +144,7 @@ func setupCircuitBreaker(
 	k8sClient *informer.FaultQuarantineClient,
 ) (breaker.CircuitBreaker, error) {
 	if !params.CircuitBreakerEnabled {
-		slog.Info("Circuit breaker is disabled, skipping initialization")
+		slog.InfoContext(ctx, "Circuit breaker is disabled, skipping initialization")
 		return nil, nil
 	}
 
@@ -156,7 +156,7 @@ func setupCircuitBreaker(
 		return nil, fmt.Errorf("error while initializing circuit breaker: %w", err)
 	}
 
-	slog.Info("Successfully initialized circuit breaker")
+	slog.InfoContext(ctx, "Successfully initialized circuit breaker")
 
 	return cb, nil
 }
@@ -175,7 +175,7 @@ func initializeCircuitBreaker(
 		return nil, fmt.Errorf("invalid circuit breaker duration %q: %w", cbConfig.Duration, err)
 	}
 
-	slog.Info("Initializing circuit breaker",
+	slog.InfoContext(ctx, "Initializing circuit breaker",
 		"configMap", circuitBreakerName,
 		"namespace", namespace,
 		"percentage", cbConfig.Percentage,

--- a/fault-quarantine/pkg/reconciler/reconciler.go
+++ b/fault-quarantine/pkg/reconciler/reconciler.go
@@ -26,9 +26,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/nvidia/nvsentinel/commons/pkg/statemanager"
+	"github.com/nvidia/nvsentinel/commons/pkg/tracing"
 	"github.com/nvidia/nvsentinel/data-models/pkg/model"
 	"github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	"github.com/nvidia/nvsentinel/fault-quarantine/pkg/breaker"
@@ -42,6 +44,12 @@ import (
 	"github.com/nvidia/nvsentinel/store-client/pkg/client"
 	storeconfig "github.com/nvidia/nvsentinel/store-client/pkg/config"
 	"github.com/nvidia/nvsentinel/store-client/pkg/datastore"
+)
+
+const (
+	EventProcessingStatusSkipped         = "skipped"
+	EventProcessingStatusHalted          = "halted"
+	EventProcessingStatusPartialRecovery = "partial_recovery"
 )
 
 type ReconcilerConfig struct {
@@ -177,11 +185,11 @@ func (r *Reconciler) Start(ctx context.Context) error {
 
 	r.SetupNodeInformerCallbacks()
 
-	slog.Info("Starting node informer")
+	slog.InfoContext(ctx, "Starting node informer")
 
 	go func() {
 		if err := r.k8sClient.NodeInformer.Run(ctx.Done()); err != nil {
-			slog.Error("Node informer failed", "error", err)
+			slog.ErrorContext(ctx, "Node informer failed", "error", err)
 		}
 	}()
 
@@ -190,7 +198,7 @@ func (r *Reconciler) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to sync NodeInformer cache")
 	}
 
-	slog.Info("Node informer started and synced")
+	slog.InfoContext(ctx, "Node informer started and synced")
 
 	// Check circuit breaker state AFTER informer is synced (IsTripped needs node counts from informer)
 	if err := r.checkCircuitBreakerAtStartup(ctx); err != nil {
@@ -206,9 +214,9 @@ func (r *Reconciler) Start(ctx context.Context) error {
 
 	rulesetsConfig := r.buildRulesetsConfig()
 
-	r.precomputeTaintInitKeys(ruleSetEvals, rulesetsConfig)
+	r.precomputeTaintInitKeys(ctx, ruleSetEvals, rulesetsConfig)
 
-	r.initializeQuarantineMetrics()
+	r.initializeQuarantineMetrics(ctx)
 
 	r.eventWatcher.SetProcessEventCallback(
 		func(ctx context.Context, event *model.HealthEventWithStatus) *model.Status {
@@ -222,7 +230,7 @@ func (r *Reconciler) Start(ctx context.Context) error {
 		return fmt.Errorf("event watcher failed: %w", err)
 	}
 
-	slog.Info("Event watcher stopped, exiting fault-quarantine reconciler.")
+	slog.InfoContext(ctx, "Event watcher stopped, exiting fault-quarantine reconciler.")
 
 	return nil
 }
@@ -310,6 +318,7 @@ func (r *Reconciler) buildRulesetsConfig() rulesetsConfig {
 
 // precomputeTaintInitKeys pre-computes taint keys from rulesets for efficient map initialization
 func (r *Reconciler) precomputeTaintInitKeys(
+	ctx context.Context,
 	ruleSetEvals []evaluator.RuleSetEvaluatorIface,
 	rulesetsConfig rulesetsConfig,
 ) {
@@ -326,14 +335,14 @@ func (r *Reconciler) precomputeTaintInitKeys(
 		}
 	}
 
-	slog.Info("Pre-computed taint initialization keys", "count", len(r.taintInitKeys))
+	slog.InfoContext(ctx, "Pre-computed taint initialization keys", "count", len(r.taintInitKeys))
 }
 
 // initializeQuarantineMetrics initializes metrics for already quarantined nodes
-func (r *Reconciler) initializeQuarantineMetrics() {
+func (r *Reconciler) initializeQuarantineMetrics(ctx context.Context) {
 	totalNodes, quarantinedNodesMap, err := r.k8sClient.NodeInformer.GetNodeCounts()
 	if err != nil {
-		slog.Error("Failed to get initial node counts", "error", err)
+		slog.ErrorContext(ctx, "Failed to get initial node counts", "error", err)
 		return
 	}
 
@@ -341,7 +350,7 @@ func (r *Reconciler) initializeQuarantineMetrics() {
 		metrics.CurrentQuarantinedNodes.WithLabelValues(nodeName).Set(1)
 	}
 
-	slog.Info("Initial state", "totalNodes", totalNodes, "quarantinedNodes", len(quarantinedNodesMap),
+	slog.InfoContext(ctx, "Initial state", "totalNodes", totalNodes, "quarantinedNodes", len(quarantinedNodesMap),
 		"quarantinedNodesMap", quarantinedNodesMap)
 }
 
@@ -359,20 +368,20 @@ func (r *Reconciler) checkCircuitBreakerAtStartup(ctx context.Context) error {
 			return err
 		}
 
-		slog.Error("Error checking if circuit breaker is tripped", "error", err)
+		slog.ErrorContext(ctx, "Error checking if circuit breaker is tripped", "error", err)
 		<-ctx.Done()
 
 		return fmt.Errorf("circuit breaker check failed: %w", err)
 	}
 
 	if tripped {
-		slog.Error("Fault Quarantine circuit breaker is TRIPPED. Halting event dequeuing indefinitely.")
+		slog.ErrorContext(ctx, "Fault Quarantine circuit breaker is TRIPPED. Halting event dequeuing indefinitely.")
 		<-ctx.Done()
 
 		return fmt.Errorf("circuit breaker is TRIPPED at startup")
 	}
 
-	slog.Info("Listening for events on the channel...")
+	slog.InfoContext(ctx, "Listening for events on the channel...")
 
 	return nil
 }
@@ -384,26 +393,26 @@ func (r *Reconciler) handleCircuitBreakerCursorMode(ctx context.Context, dbClien
 
 	cursorMode, err := r.cb.GetCursorMode(ctx)
 	if err != nil {
-		slog.Error("Failed to read cursor mode, defaulting to RESUME", "error", err)
+		slog.ErrorContext(ctx, "Failed to read cursor mode, defaulting to RESUME", "error", err)
 		return fmt.Errorf("failed to read cursor mode: %w", err)
 	}
 
 	if cursorMode == breaker.CursorModeCreate {
-		slog.Info("Circuit breaker cursor is CREATE, deleting resume token to skip accumulated events")
+		slog.InfoContext(ctx, "Circuit breaker cursor is CREATE, deleting resume token to skip accumulated events")
 
 		if err := r.deleteResumeToken(ctx, dbClient); err != nil {
-			slog.Error("Failed to delete resume token", "error", err)
+			slog.ErrorContext(ctx, "Failed to delete resume token", "error", err)
 			return fmt.Errorf("failed to delete resume token: %w", err)
 		}
 
 		if err := r.cb.SetCursorMode(ctx, breaker.CursorModeResume); err != nil {
-			slog.Error("Failed to reset cursor to RESUME", "error", err)
+			slog.ErrorContext(ctx, "Failed to reset cursor to RESUME", "error", err)
 			return fmt.Errorf("failed to reset cursor to RESUME: %w", err)
 		}
 
-		slog.Info("Resume token deleted, will start from latest events")
+		slog.InfoContext(ctx, "Resume token deleted, will start from latest events")
 	} else {
-		slog.Info("Circuit breaker cursor is RESUME, will process accumulated events")
+		slog.InfoContext(ctx, "Circuit breaker cursor is RESUME, will process accumulated events")
 	}
 
 	return nil
@@ -425,7 +434,7 @@ func (r *Reconciler) deleteResumeToken(ctx context.Context, dbClient client.Data
 		return fmt.Errorf("failed to delete resume token: %w", err)
 	}
 
-	slog.Info("Successfully deleted resume token", "clientName", tokenConfig.ClientName)
+	slog.InfoContext(ctx, "Successfully deleted resume token", "clientName", tokenConfig.ClientName)
 
 	return nil
 }
@@ -437,20 +446,32 @@ func (r *Reconciler) ProcessEvent(
 	ruleSetEvals []evaluator.RuleSetEvaluatorIface,
 	rulesetsConfig rulesetsConfig,
 ) *model.Status {
+	span := tracing.SpanFromContext(ctx)
+
 	if shouldHalt := r.checkCircuitBreakerAndHalt(ctx); shouldHalt {
+		span.SetAttributes(attribute.String("fault_quarantine.event.processing_status", EventProcessingStatusHalted))
+
 		return nil
 	}
 
-	slog.Debug("Processing event", "checkName", event.HealthEvent.CheckName)
+	slog.DebugContext(ctx, "Processing event", "checkName", event.HealthEvent.CheckName)
 
 	isNodeQuarantined := r.handleEvent(ctx, event, ruleSetEvals, rulesetsConfig)
 
 	if isNodeQuarantined == nil {
-		slog.Debug("Skipped processing event for node, no status update needed", "node", event.HealthEvent.NodeName)
+		slog.DebugContext(ctx, "Skipped processing event for node, no status update needed",
+			"node", event.HealthEvent.NodeName)
+		span.SetAttributes(
+			attribute.String("fault_quarantine.event.processing_status", EventProcessingStatusSkipped),
+			attribute.String("fault_quarantine.skip.reason", "No status update needed"),
+		)
 	} else if *isNodeQuarantined == model.Quarantined ||
 		*isNodeQuarantined == model.UnQuarantined ||
 		*isNodeQuarantined == model.AlreadyQuarantined {
 		metrics.TotalEventsSuccessfullyProcessed.Inc()
+		span.SetAttributes(
+			attribute.String("fault_quarantine.event.processing_status", string(*isNodeQuarantined)),
+		)
 	}
 
 	return isNodeQuarantined
@@ -458,20 +479,33 @@ func (r *Reconciler) ProcessEvent(
 
 // checkCircuitBreakerAndHalt checks if circuit breaker is tripped and returns true if processing should halt
 func (r *Reconciler) checkCircuitBreakerAndHalt(ctx context.Context) bool {
+	span := tracing.SpanFromContext(ctx)
+
 	if !r.config.CircuitBreakerEnabled {
 		return false
 	}
 
 	tripped, err := r.cb.IsTripped(ctx)
 	if err != nil {
-		slog.Error("Error checking if circuit breaker is tripped", "error", err)
+		slog.ErrorContext(ctx, "Error checking if circuit breaker is tripped", "error", err)
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("fault_quarantine.error.type", "check_circuit_breaker_state_error"),
+			attribute.String("fault_quarantine.error.message", err.Error()),
+		)
 		<-ctx.Done()
 
 		return true
 	}
 
 	if tripped {
-		slog.Error("Circuit breaker TRIPPED. Halting event processing until restart and breaker reset.")
+		slog.ErrorContext(ctx, "Circuit breaker TRIPPED. Halting event processing until restart and breaker reset.")
+
+		span.SetAttributes(
+			attribute.String("fault_quarantine.circuit_breaker.state", "tripped"),
+			attribute.Bool("fault_quarantine.circuit_breaker.tripped", true),
+		)
+
 		<-ctx.Done()
 
 		return true
@@ -486,7 +520,10 @@ func (r *Reconciler) handleEvent(
 	ruleSetEvals []evaluator.RuleSetEvaluatorIface,
 	rulesetsConfig rulesetsConfig,
 ) *model.Status {
-	annotations, quarantineAnnotationExists := r.hasExistingQuarantine(event.HealthEvent.NodeName)
+	ctx, span := tracing.StartSpan(ctx, "fault_quarantine.handle_event")
+	defer span.End()
+
+	annotations, quarantineAnnotationExists := r.hasExistingQuarantine(ctx, event.HealthEvent.NodeName)
 
 	if quarantineAnnotationExists {
 		return r.handleAlreadyQuarantinedNode(ctx, event.HealthEvent, ruleSetEvals)
@@ -495,8 +532,12 @@ func (r *Reconciler) handleEvent(
 	// For healthy events, if there's no existing quarantine annotation,
 	// skip processing as there's no transition from unhealthy to healthy
 	if event.HealthEvent.IsHealthy {
-		slog.Info("Skipping healthy event for node as there's no existing quarantine annotation",
+		slog.InfoContext(ctx, "Skipping healthy event for node as there's no existing quarantine annotation",
 			"node", event.HealthEvent.NodeName, "event", event.HealthEvent)
+		span.SetAttributes(
+			attribute.String("fault_quarantine.event.processing_status", EventProcessingStatusSkipped),
+			attribute.String("fault_quarantine.skip.reason", "No existing quarantine annotation found for node"),
+		)
 
 		return nil
 	}
@@ -514,30 +555,38 @@ func (r *Reconciler) handleEvent(
 	var isCordoned atomic.Bool
 
 	r.evaluateRulesets(
-		event, ruleSetEvals, rulesetsConfig,
+		ctx, event, ruleSetEvals, rulesetsConfig,
 		taintAppliedMap, &labelsMap, &isCordoned, taintEffectPriorityMap,
 	)
 
 	taintsToBeApplied := r.collectTaintsToApply(taintAppliedMap)
 
-	annotationsMap := r.prepareAnnotations(taintsToBeApplied, &labelsMap, &isCordoned)
+	annotationsMap := r.prepareAnnotations(ctx, taintsToBeApplied, &labelsMap, &isCordoned)
 
 	isNodeQuarantined := len(taintsToBeApplied) > 0 || isCordoned.Load()
 
 	// In dry-run mode, always apply annotations for observability even if no actions would be taken
 	if !isNodeQuarantined && !r.config.DryRun {
+		span.SetAttributes(
+			attribute.String("fault_quarantine.event.processing_status", EventProcessingStatusSkipped),
+			attribute.String("fault_quarantine.skip.reason", "No quarantine actions required"),
+		)
+
 		return nil
 	}
 
-	status := r.applyQuarantine(ctx, event, annotations, taintsToBeApplied, annotationsMap, &labelsMap, &isCordoned)
+	status := r.applyQuarantine(
+		ctx, event, annotations, taintsToBeApplied,
+		annotationsMap, &labelsMap, &isCordoned,
+	)
 
 	return status
 }
 
-func (r *Reconciler) hasExistingQuarantine(nodeName string) (map[string]string, bool) {
-	annotations, err := r.getNodeQuarantineAnnotations(nodeName)
+func (r *Reconciler) hasExistingQuarantine(ctx context.Context, nodeName string) (map[string]string, bool) {
+	annotations, err := r.getNodeQuarantineAnnotations(ctx, nodeName)
 	if err != nil {
-		slog.Error("Failed to fetch annotations for node", "node", nodeName, "error", err)
+		slog.ErrorContext(ctx, "Failed to fetch annotations for node", "node", nodeName, "error", err)
 		return make(map[string]string), false
 	}
 
@@ -550,8 +599,8 @@ func (r *Reconciler) hasExistingQuarantine(nodeName string) (map[string]string, 
 	return annotations, exists && annotationVal != ""
 }
 
-func (r *Reconciler) sourceDocIDsFromAnnotation(nodeName string) []string {
-	healthEventsMap, _, err := r.getHealthEventsFromAnnotation(&protos.HealthEvent{NodeName: nodeName})
+func (r *Reconciler) sourceDocIDsFromAnnotation(ctx context.Context, nodeName string) []string {
+	healthEventsMap, _, err := r.getHealthEventsFromAnnotation(ctx, &protos.HealthEvent{NodeName: nodeName})
 
 	if err != nil || healthEventsMap == nil {
 		return nil
@@ -582,25 +631,49 @@ func (r *Reconciler) handleAlreadyQuarantinedNode(
 	event *protos.HealthEvent,
 	ruleSetEvals []evaluator.RuleSetEvaluatorIface,
 ) *model.Status {
-	healthEventsAnnotationMap, _, err := r.getHealthEventsFromAnnotation(event)
+	ctx, span := tracing.StartSpan(ctx, "fault_quarantine.handle_already_quarantined_node")
+	defer span.End()
+
+	healthEventsAnnotationMap, _, err := r.getHealthEventsFromAnnotation(ctx, event)
 
 	// Only propagate events to ND/FR if they will modify node annotations
 	// Returning nil prevents unnecessary MongoDB writes and downstream processing
 	switch {
 	case err != nil:
 		if errors.Is(err, errNoQuarantineAnnotation) {
+			tracing.RecordError(span, err)
+			span.SetAttributes(
+				attribute.String("fault_quarantine.error.type", "no_quarantine_annotations"),
+				attribute.String("fault_quarantine.error.message", err.Error()),
+			)
+
 			return nil
 		}
 
 		metrics.ProcessingErrors.WithLabelValues("get_node_annotations_error").Inc()
-		// Cannot proceed without valid annotation data
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("fault_quarantine.error.type", "get_node_annotations_error"),
+			attribute.String("fault_quarantine.error.message", err.Error()),
+		)
+
 		return nil
 	case event.IsHealthy:
 		_, hasExistingCheck := healthEventsAnnotationMap.GetEvent(event)
 		if !hasExistingCheck {
+			span.SetAttributes(
+				attribute.String("fault_quarantine.event.processing_status", EventProcessingStatusSkipped),
+				attribute.String("fault_quarantine.skip.reason", "No tracking check found for healthy event"),
+			)
+
 			return nil
 		}
 	case !r.isForceQuarantine(event) && !r.eventMatchesAnyRule(event, ruleSetEvals):
+		span.SetAttributes(
+			attribute.String("fault_quarantine.event.processing_status", EventProcessingStatusSkipped),
+			attribute.String("fault_quarantine.skip.reason", "No rules matched and no force quarantine override specified"),
+		)
+
 		return nil
 	}
 
@@ -610,6 +683,11 @@ func (r *Reconciler) handleAlreadyQuarantinedNode(
 	// Partial recovery: healthy event that doesn't fully unquarantine the node should
 	// not be propagated to ND/FR
 	if event.IsHealthy && stayQuarantined {
+		span.SetAttributes(
+			attribute.String("fault_quarantine.event.processing_status", EventProcessingStatusSkipped),
+			attribute.String("fault_quarantine.skip.reason", "Node is partially recovered"),
+		)
+
 		return nil
 	}
 
@@ -625,8 +703,9 @@ func (r *Reconciler) handleAlreadyQuarantinedNode(
 	return &status
 }
 
-// evaluateRulesets evaluates all rulesets against the health event in parallel
+// evaluateRulesets evaluates all rulesets against the health event in parallel.
 func (r *Reconciler) evaluateRulesets(
+	ctx context.Context,
 	event *model.HealthEventWithStatus,
 	ruleSetEvals []evaluator.RuleSetEvaluatorIface,
 	rulesetsConfig rulesetsConfig,
@@ -635,6 +714,9 @@ func (r *Reconciler) evaluateRulesets(
 	isCordoned *atomic.Bool,
 	taintEffectPriorityMap map[keyValTaint]int,
 ) {
+	ctx, span := tracing.StartSpan(ctx, "fault_quarantine.evaluate_rulesets")
+	defer span.End()
+
 	// Handle quarantine override (force quarantine without rule evaluation)
 	if event.HealthEvent.QuarantineOverrides != nil && event.HealthEvent.QuarantineOverrides.Force {
 		isCordoned.Store(true)
@@ -644,7 +726,7 @@ func (r *Reconciler) evaluateRulesets(
 		labelsMap.Store(r.cordonedReasonLabelKey,
 			formatCordonOrUncordonReasonValue(event.HealthEvent.Message, 63))
 
-		return
+		span.SetAttributes(attribute.String("fault_quarantine.ruleset.override", "force_quarantine"))
 	}
 
 	var wg sync.WaitGroup
@@ -655,7 +737,7 @@ func (r *Reconciler) evaluateRulesets(
 		go func(eval evaluator.RuleSetEvaluatorIface) {
 			defer wg.Done()
 
-			slog.Info("Handling event for ruleset", "event", event, "ruleset", eval.GetName())
+			slog.InfoContext(ctx, "Handling event for ruleset", "event", event, "ruleset", eval.GetName())
 
 			ruleEvaluatedResult, err := eval.Evaluate(event.HealthEvent)
 
@@ -664,7 +746,7 @@ func (r *Reconciler) evaluateRulesets(
 				r.handleSuccessfulRuleEvaluation(
 					eval, rulesetsConfig, labelsMap, isCordoned, taintAppliedMap, taintEffectPriorityMap)
 			case err != nil:
-				r.handleRuleEvaluationError(event.HealthEvent, eval.GetName(), err)
+				r.handleRuleEvaluationError(ctx, event.HealthEvent, eval.GetName(), err)
 			default:
 				metrics.RulesetEvaluations.WithLabelValues(eval.GetName(), metrics.StatusFailed).Inc()
 			}
@@ -731,11 +813,20 @@ func (r *Reconciler) updateTaintMaps(
 
 // handleRuleEvaluationError handles errors during rule evaluation
 func (r *Reconciler) handleRuleEvaluationError(
+	ctx context.Context,
 	event *protos.HealthEvent,
 	evalName string,
 	err error,
 ) {
-	slog.Error("Rule evaluation failed", "ruleset", evalName, "node", event.NodeName, "error", err)
+	_, span := tracing.StartSpan(ctx, "fault_quarantine.rule_evaluation_error")
+	defer span.End()
+
+	tracing.RecordError(span, err)
+	span.SetAttributes(
+		attribute.String("fault_quarantine.error.type", "rule_evaluation_error"),
+		attribute.String("fault_quarantine.error.message", err.Error()),
+	)
+	slog.ErrorContext(ctx, "Rule evaluation failed", "ruleset", evalName, "node", event.NodeName, "error", err)
 	metrics.ProcessingErrors.WithLabelValues("ruleset_evaluation_error").Inc()
 	metrics.RulesetEvaluations.WithLabelValues(evalName, metrics.StatusFailed).Inc()
 }
@@ -759,6 +850,7 @@ func (r *Reconciler) collectTaintsToApply(taintAppliedMap map[keyValTaint]string
 
 // prepareAnnotations prepares annotations and labels to be applied if any
 func (r *Reconciler) prepareAnnotations(
+	ctx context.Context,
 	taintsToBeApplied []config.Taint,
 	labelsMap *sync.Map,
 	isCordoned *atomic.Bool,
@@ -768,7 +860,7 @@ func (r *Reconciler) prepareAnnotations(
 	if len(taintsToBeApplied) > 0 {
 		taintsJsonStr, err := json.Marshal(taintsToBeApplied)
 		if err != nil {
-			slog.Error("Failed to marshal taints for annotation", "error", err)
+			slog.ErrorContext(ctx, "Failed to marshal taints for annotation", "error", err)
 		} else {
 			annotationsMap[common.QuarantineHealthEventAppliedTaintsAnnotationKey] = string(taintsJsonStr)
 		}
@@ -799,51 +891,67 @@ func (r *Reconciler) applyQuarantine(
 	labelsMap *sync.Map,
 	isCordoned *atomic.Bool,
 ) *model.Status {
+	ctx, span := tracing.StartSpan(ctx, "fault_quarantine.apply_quarantine")
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.Bool("fault_quarantine.action.cordon", isCordoned.Load()),
+		attribute.Bool("fault_quarantine.action.taint", len(taintsToBeApplied) > 0),
+		attribute.Int("fault_quarantine.action.taint_count", len(taintsToBeApplied)),
+	)
+
 	r.recordCordonEventInCircuitBreaker(event)
 
 	healthEvents := healthEventsAnnotation.NewHealthEventsAnnotationMap()
 	updated := healthEvents.AddOrUpdateEvent(event.HealthEvent)
 
 	if !updated {
-		slog.Info("Health event already exists for node, skipping quarantine", "node", event.HealthEvent.NodeName)
+		slog.InfoContext(ctx, "Health event already exists for node, skipping quarantine", "node", event.HealthEvent.NodeName)
+		span.SetAttributes(
+			attribute.String("fault_quarantine.event.processing_status", EventProcessingStatusSkipped),
+			attribute.String("fault_quarantine.skip.reason", "Health event already exists for node"),
+		)
 
 		return nil
 	}
 
 	if err := r.addHealthEventAnnotation(healthEvents, annotationsMap); err != nil {
-		slog.Error("Failed to add health event annotation", "error", err, "node", event.HealthEvent.NodeName)
+		slog.ErrorContext(ctx, "Failed to add health event annotation", "error", err, "node", event.HealthEvent.NodeName)
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("fault_quarantine.error.type", "add_health_event_annotation_error"),
+			attribute.String("fault_quarantine.error.message", err.Error()),
+		)
 
 		return nil
 	}
 
-	slog.Debug("Added health event annotation successfully", "node", event.HealthEvent.NodeName)
+	slog.DebugContext(ctx, "Added health event annotation successfully", "node", event.HealthEvent.NodeName)
 
 	// Remove manual uncordon annotation if present before applying new quarantine
 	if err := r.cleanupManualUncordonAnnotation(ctx, event.HealthEvent.NodeName, annotations); err != nil {
-		slog.Error("Failed to cleanup manual uncordon annotation",
+		slog.ErrorContext(ctx, "Failed to cleanup manual uncordon annotation",
 			"error", err, "node", event.HealthEvent.NodeName)
 		metrics.ProcessingErrors.WithLabelValues("cleanup_manual_uncordon_annotation_error").Inc()
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("fault_quarantine.error.type", "cleanup_manual_uncordon_annotation_error"),
+			attribute.String("fault_quarantine.error.message", err.Error()),
+		)
 
 		return nil
 	}
 
 	if !r.config.CircuitBreakerEnabled {
-		slog.Info("Circuit breaker is disabled, proceeding with quarantine action without protection",
+		slog.InfoContext(ctx, "Circuit breaker is disabled, proceeding with quarantine action without protection",
 			"node", event.HealthEvent.NodeName)
 	}
 
-	// Convert sync.Map to regular map for K8s API call
-	labels := make(map[string]string)
+	labels := syncMapToStringMap(labelsMap)
 
-	labelsMap.Range(func(key, value any) bool {
-		if strKey, ok := key.(string); ok {
-			if strValue, ok := value.(string); ok {
-				labels[strKey] = strValue
-			}
-		}
+	span.SetAttributes(attribute.Bool("fault_quarantine.labels_applied", len(labels) > 0))
 
-		return true
-	})
+	span.SetAttributes(attribute.Bool("fault_quarantine.annotation_applied", len(annotationsMap) > 0))
 
 	err := r.k8sClient.QuarantineNodeAndSetAnnotations(
 		ctx,
@@ -854,19 +962,40 @@ func (r *Reconciler) applyQuarantine(
 		labels,
 	)
 	if err != nil {
-		slog.Error("Failed to taint and cordon node", "node", event.HealthEvent.NodeName, "error", err)
+		slog.ErrorContext(ctx, "Failed to taint and cordon node", "node", event.HealthEvent.NodeName, "error", err)
 		metrics.ProcessingErrors.WithLabelValues("taint_and_cordon_error").Inc()
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("fault_quarantine.error.type", "taint_and_cordon_error"),
+			attribute.String("fault_quarantine.error.message", err.Error()),
+		)
 
 		return nil
 	}
 
-	slog.Debug("QuarantineNodeAndSetAnnotations completed successfully", "node", event.HealthEvent.NodeName)
+	slog.DebugContext(ctx, "QuarantineNodeAndSetAnnotations completed successfully", "node", event.HealthEvent.NodeName)
 
 	r.updateQuarantineMetrics(event.HealthEvent.NodeName, taintsToBeApplied, isCordoned)
 
 	status := model.Quarantined
 
 	return &status
+}
+
+func syncMapToStringMap(m *sync.Map) map[string]string {
+	result := make(map[string]string)
+
+	m.Range(func(key, value any) bool {
+		if strKey, ok := key.(string); ok {
+			if strValue, ok := value.(string); ok {
+				result[strKey] = strValue
+			}
+		}
+
+		return true
+	})
+
+	return result
 }
 
 // recordCordonEventInCircuitBreaker records a cordon event in the circuit breaker if enabled
@@ -942,7 +1071,7 @@ func (r *Reconciler) handleUnhealthyEventOnQuarantinedNode(
 	healthEventsAnnotationMap *healthEventsAnnotation.HealthEventsAnnotationMap,
 ) bool {
 	if !r.isForceQuarantine(event) && !r.eventMatchesAnyRule(event, ruleSetEvals) {
-		slog.Info("Unhealthy event on node doesn't match any rules, skipping annotation update",
+		slog.InfoContext(ctx, "Unhealthy event on node doesn't match any rules, skipping annotation update",
 			"checkName", event.CheckName, "node", event.NodeName)
 
 		return true
@@ -951,15 +1080,15 @@ func (r *Reconciler) handleUnhealthyEventOnQuarantinedNode(
 	added := healthEventsAnnotationMap.AddOrUpdateEvent(event)
 
 	if added {
-		slog.Info("Added entity failures for check on node",
+		slog.InfoContext(ctx, "Added entity failures for check on node",
 			"checkName", event.CheckName, "node", event.NodeName, "totalTrackedEntities", healthEventsAnnotationMap.Count())
 
 		if err := r.addEventToAnnotation(ctx, event); err != nil {
-			slog.Error("Failed to update health events annotation", "error", err)
+			slog.ErrorContext(ctx, "Failed to update health events annotation", "error", err)
 			return true
 		}
 	} else {
-		slog.Debug("All entities already tracked for check on node",
+		slog.DebugContext(ctx, "All entities already tracked for check on node",
 			"checkName", event.CheckName, "node", event.NodeName)
 	}
 
@@ -971,9 +1100,18 @@ func (r *Reconciler) handleQuarantinedNode(
 	event *protos.HealthEvent,
 	ruleSetEvals []evaluator.RuleSetEvaluatorIface,
 ) bool {
-	healthEventsAnnotationMap, annotations, err := r.getHealthEventsFromAnnotation(event)
+	ctx, span := tracing.StartSpan(ctx, "fault_quarantine.handle_quarantined_node")
+	defer span.End()
+
+	healthEventsAnnotationMap, annotations, err := r.getHealthEventsFromAnnotation(ctx, event)
 	if err != nil {
 		metrics.ProcessingErrors.WithLabelValues("get_node_annotations_error").Inc()
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("fault_quarantine.error.type", "get_node_annotations_error"),
+			attribute.String("fault_quarantine.error.message", err.Error()),
+		)
+
 		return !errors.Is(err, errNoQuarantineAnnotation)
 	}
 
@@ -984,9 +1122,14 @@ func (r *Reconciler) handleQuarantinedNode(
 	}
 
 	if !hasExistingCheck {
-		slog.Debug("Received healthy event for untracked check (other checks may still be failing)",
+		slog.DebugContext(ctx, "Received healthy event for untracked check (other checks may still be failing)",
 			"check", event.CheckName,
 			"node", event.NodeName)
+
+		span.SetAttributes(
+			attribute.String("fault_quarantine.event.processing_status", EventProcessingStatusSkipped),
+			attribute.String("fault_quarantine.skip.reason", "Received healthy event for untracked check"),
+		)
 
 		return true
 	}
@@ -996,58 +1139,87 @@ func (r *Reconciler) handleQuarantinedNode(
 	removedCount := healthEventsAnnotationMap.RemoveEvent(event)
 
 	if removedCount > 0 {
-		slog.Info("Removed recovered entities for check on node",
+		slog.InfoContext(ctx, "Removed recovered entities for check on node",
 			"removedCount", removedCount,
 			"check", event.CheckName,
 			"node", event.NodeName,
 			"remainingEntities", healthEventsAnnotationMap.Count())
 	} else {
-		slog.Debug("No matching entities to remove for check on node",
+		slog.DebugContext(ctx, "No matching entities to remove for check on node",
 			"check", event.CheckName,
 			"node", event.NodeName)
 	}
 
 	updatedHealthEventsMap, err := r.removeEventFromAnnotation(ctx, event)
 	if err != nil {
-		slog.Error("Failed to update health events annotation after recovery", "error", err)
+		slog.ErrorContext(ctx, "Failed to update health events annotation after recovery", "error", err)
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("fault_quarantine.error.type", "update_health_events_annotation_error"),
+			attribute.String("fault_quarantine.error.message", err.Error()),
+		)
+
 		return true
 	}
 
 	if updatedHealthEventsMap.IsEmpty() {
-		slog.Info("All health checks recovered for node, proceeding with uncordon",
+		slog.InfoContext(ctx, "All health checks recovered for node, proceeding with uncordon",
 			"node", event.NodeName)
 
 		isUncordoned, err := r.performUncordon(ctx, event, annotations)
 		if err != nil {
-			slog.Error("Failed to uncordon node", "error", err, "node", event.NodeName)
+			slog.ErrorContext(ctx, "Failed to uncordon node", "error", err, "node", event.NodeName)
 			metrics.ProcessingErrors.WithLabelValues("uncordon_error").Inc()
+			tracing.RecordError(span, err)
+			span.SetAttributes(
+				attribute.String("fault_quarantine.error.type", "uncordon_error"),
+				attribute.String("fault_quarantine.error.message", err.Error()),
+			)
 		}
 
 		return isUncordoned
 	}
 
-	slog.Info("Node remains quarantined with failing checks",
+	slog.InfoContext(ctx, "Node remains quarantined with failing checks",
 		"node", event.NodeName,
 		"failingChecksCount", updatedHealthEventsMap.Count(),
 		"checks", updatedHealthEventsMap.GetAllCheckNames())
+
+	span.SetAttributes(
+		attribute.String("fault_quarantine.event.processing_status", EventProcessingStatusPartialRecovery),
+		attribute.Int("fault_quarantine.remaining_failing_checks", updatedHealthEventsMap.Count()),
+	)
 
 	return true
 }
 
 func (r *Reconciler) getHealthEventsFromAnnotation(
+	ctx context.Context,
 	event *protos.HealthEvent,
 ) (*healthEventsAnnotation.HealthEventsAnnotationMap, map[string]string, error) {
-	annotations, err := r.getNodeQuarantineAnnotations(event.NodeName)
+	ctx, span := tracing.StartSpan(ctx, "fault_quarantine.get_health_events_from_annotation")
+	defer span.End()
+
+	annotations, err := r.getNodeQuarantineAnnotations(ctx, event.NodeName)
 	if err != nil {
-		slog.Error("Failed to get node annotations for node", "node", event.NodeName, "error", err)
+		slog.ErrorContext(ctx, "Failed to get node annotations for node", "node", event.NodeName, "error", err)
 		metrics.ProcessingErrors.WithLabelValues("get_node_annotations_error").Inc()
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("fault_quarantine.error.type", "get_node_annotations_error"),
+			attribute.String("fault_quarantine.error.message", err.Error()),
+		)
 
 		return nil, nil, fmt.Errorf("failed to get annotations: %w", err)
 	}
 
 	quarantineAnnotationStr, exists := annotations[common.QuarantineHealthEventAnnotationKey]
 	if !exists || quarantineAnnotationStr == "" {
-		slog.Info("No quarantine annotation found for node", "node", event.NodeName)
+		slog.InfoContext(ctx, "No quarantine annotation found for node", "node", event.NodeName)
+		span.SetAttributes(attribute.String("fault_quarantine.event.processing_status", EventProcessingStatusSkipped),
+			attribute.String("fault_quarantine.skip.reason", "No existing quarantine annotation found for node"),
+		)
+
 		return nil, nil, errNoQuarantineAnnotation
 	}
 
@@ -1059,11 +1231,17 @@ func (r *Reconciler) getHealthEventsFromAnnotation(
 		var singleHealthEvent protos.HealthEvent
 
 		if err2 := json.Unmarshal([]byte(quarantineAnnotationStr), &singleHealthEvent); err2 == nil {
-			slog.Info("Found old format annotation for node, converting locally", "node", event.NodeName)
+			slog.InfoContext(ctx, "Found old format annotation for node, converting locally", "node", event.NodeName)
 
 			healthEventsMap = *healthEventsAnnotation.NewHealthEventsAnnotationMap()
 			healthEventsMap.AddOrUpdateEvent(&singleHealthEvent)
 		} else {
+			tracing.RecordError(span, err)
+			span.SetAttributes(
+				attribute.String("fault_quarantine.error.type", "unmarshal_annotation_error"),
+				attribute.String("fault_quarantine.error.message", err.Error()),
+			)
+
 			return nil, nil, fmt.Errorf("failed to unmarshal annotation for node %s: %w", event.NodeName, err)
 		}
 	}
@@ -1097,7 +1275,8 @@ func (r *Reconciler) addEventToAnnotation(
 
 		added := healthEventsMap.AddOrUpdateEvent(event)
 		if !added {
-			slog.Debug("Event already exists for node, no annotation update needed", "node", event.NodeName)
+			slog.DebugContext(ctx, "Event already exists for node, no annotation update needed", "node", event.NodeName)
+
 			return nil
 		}
 
@@ -1108,7 +1287,8 @@ func (r *Reconciler) addEventToAnnotation(
 
 		node.Annotations[common.QuarantineHealthEventAnnotationKey] = string(annotationBytes)
 
-		slog.Debug("Added/updated event for node", "node", event.NodeName, "totalEntityLevelEvents", healthEventsMap.Count())
+		slog.DebugContext(ctx, "Added/updated event for node",
+			"node", event.NodeName, "totalEntityLevelEvents", healthEventsMap.Count())
 
 		return nil
 	}
@@ -1122,18 +1302,23 @@ func (r *Reconciler) removeEventFromAnnotation(
 	ctx context.Context,
 	event *protos.HealthEvent,
 ) (*healthEventsAnnotation.HealthEventsAnnotationMap, error) {
+	ctx, span := tracing.StartSpan(ctx, "fault_quarantine.remove_event_from_annotation")
+	defer span.End()
+
 	// Capture the updated map based on the ACTUAL state after removal
 	updatedMap := healthEventsAnnotation.NewHealthEventsAnnotationMap()
 
 	updateFn := func(node *corev1.Node) error {
 		if node.Annotations == nil {
 			updatedMap = healthEventsAnnotation.NewHealthEventsAnnotationMap()
+
 			return nil
 		}
 
 		existingAnnotation, exists := node.Annotations[common.QuarantineHealthEventAnnotationKey]
 		if !exists || existingAnnotation == "" {
 			updatedMap = healthEventsAnnotation.NewHealthEventsAnnotationMap()
+
 			return nil
 		}
 
@@ -1149,7 +1334,8 @@ func (r *Reconciler) removeEventFromAnnotation(
 
 		removed := healthEventsMap.RemoveEvent(event)
 		if removed == 0 {
-			slog.Debug("No matching entities to remove for node, no annotation update needed", "node", event.NodeName)
+			slog.DebugContext(ctx, "No matching entities to remove for node, no annotation update needed",
+				"node", event.NodeName)
 
 			updatedMap = healthEventsMap
 
@@ -1163,7 +1349,8 @@ func (r *Reconciler) removeEventFromAnnotation(
 
 		node.Annotations[common.QuarantineHealthEventAnnotationKey] = string(annotationBytes)
 
-		slog.Debug("Removed entities for node", "node", event.NodeName, "remainingEntityLevelEvents", healthEventsMap.Count())
+		slog.DebugContext(ctx, "Removed entities for node",
+			"node", event.NodeName, "remainingEntityLevelEvents", healthEventsMap.Count())
 
 		updatedMap = healthEventsMap
 
@@ -1171,6 +1358,13 @@ func (r *Reconciler) removeEventFromAnnotation(
 	}
 
 	err := r.k8sClient.UpdateNode(ctx, event.NodeName, updateFn)
+	if err != nil {
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("fault_quarantine.error.type", "update_node_error"),
+			attribute.String("fault_quarantine.error.message", err.Error()),
+		)
+	}
 
 	return updatedMap, err
 }
@@ -1180,7 +1374,10 @@ func (r *Reconciler) performUncordon(
 	event *protos.HealthEvent,
 	annotations map[string]string,
 ) (bool, error) {
-	slog.Info("All entities recovered for check - proceeding with uncordon",
+	ctx, span := tracing.StartSpan(ctx, "fault_quarantine.perform_uncordon")
+	defer span.End()
+
+	slog.InfoContext(ctx, "All entities recovered for check - proceeding with uncordon",
 		"check", event.CheckName,
 		"node", event.NodeName)
 
@@ -1188,23 +1385,35 @@ func (r *Reconciler) performUncordon(
 	taintsToBeRemoved, annotationsToBeRemoved, isUnCordon, labelsMap, err := r.prepareUncordonParams(
 		event, annotations)
 	if err != nil {
-		slog.Error("Failed to prepare uncordon params for node", "node", event.NodeName, "error", err)
+		slog.ErrorContext(ctx, "Failed to prepare uncordon params for node", "node", event.NodeName, "error", err)
+
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("fault_quarantine.error.type", "prepare_uncordon_params_error"),
+			attribute.String("fault_quarantine.error.message", err.Error()),
+		)
+
 		return true, fmt.Errorf("failed to prepare uncordon params for node %s: %w", event.NodeName, err)
 	}
 
 	if len(taintsToBeRemoved) == 0 && !isUnCordon {
+		span.SetAttributes(attribute.String("fault_quarantine.event.processing_status", EventProcessingStatusSkipped),
+			attribute.String("fault_quarantine.skip.reason", "No quarantine taints or annotations present to remove"),
+		)
+
 		return false, nil
 	}
 
 	if !isUnCordon {
-		slog.Warn("Node is not cordoned but has quarantine taints/annotations, proceeding with cleanup",
+		slog.WarnContext(ctx, "Node is not cordoned but has quarantine taints/annotations, proceeding with cleanup",
 			"node", event.NodeName)
 	}
 
 	annotationsToBeRemoved = append(annotationsToBeRemoved, common.QuarantineHealthEventAnnotationKey)
 
 	if !r.config.CircuitBreakerEnabled {
-		slog.Info("Circuit breaker is disabled, proceeding with unquarantine action for node", "node", event.NodeName)
+		slog.InfoContext(ctx, "Circuit breaker is disabled, proceeding with unquarantine action for node",
+			"node", event.NodeName)
 	}
 
 	labelsToRemove := []string{
@@ -1222,13 +1431,23 @@ func (r *Reconciler) performUncordon(
 		labelsToRemove,
 		labelsMap,
 	); err != nil {
-		slog.Error("Failed to untaint and uncordon node", "node", event.NodeName, "error", err)
+		slog.ErrorContext(ctx, "Failed to untaint and uncordon node", "node", event.NodeName, "error", err)
 		metrics.ProcessingErrors.WithLabelValues("untaint_and_uncordon_error").Inc()
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("fault_quarantine.error.type", "untaint_and_uncordon_error"),
+			attribute.String("fault_quarantine.error.message", err.Error()),
+		)
 
 		return true, fmt.Errorf("failed to untaint and uncordon node %s: %w", event.NodeName, err)
 	}
 
-	r.updateUncordonMetrics(event.NodeName, taintsToBeRemoved, isUnCordon)
+	r.updateUncordonMetrics(ctx, event.NodeName, taintsToBeRemoved, isUnCordon)
+
+	span.SetAttributes(
+		attribute.Bool("fault_quarantine.action.uncordon", isUnCordon),
+		attribute.Bool("fault_quarantine.taints.removed", len(taintsToBeRemoved) > 0),
+	)
 
 	return false, nil
 }
@@ -1272,13 +1491,14 @@ func (r *Reconciler) prepareUncordonParams(
 }
 
 func (r *Reconciler) updateUncordonMetrics(
+	ctx context.Context,
 	nodeName string,
 	taintsToBeRemoved []config.Taint,
 	isUnCordon bool,
 ) {
 	metrics.TotalNodesUnquarantined.WithLabelValues(nodeName).Inc()
 	metrics.CurrentQuarantinedNodes.WithLabelValues(nodeName).Set(0)
-	slog.Info("Set currentQuarantinedNodes to 0 for unquarantined node", "node", nodeName)
+	slog.InfoContext(ctx, "Set currentQuarantinedNodes to 0 for unquarantined node", "node", nodeName)
 
 	for _, taint := range taintsToBeRemoved {
 		metrics.TaintsRemoved.WithLabelValues(taint.Key, taint.Effect).Inc()
@@ -1303,7 +1523,7 @@ func formatCordonOrUncordonReasonValue(input string, length int) string {
 }
 
 // getNodeQuarantineAnnotations retrieves quarantine annotations from the informer cache
-func (r *Reconciler) getNodeQuarantineAnnotations(nodeName string) (map[string]string, error) {
+func (r *Reconciler) getNodeQuarantineAnnotations(ctx context.Context, nodeName string) (map[string]string, error) {
 	node, err := r.k8sClient.NodeInformer.GetNode(nodeName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get node from cache: %w", err)
@@ -1326,7 +1546,7 @@ func (r *Reconciler) getNodeQuarantineAnnotations(nodeName string) (map[string]s
 		}
 	}
 
-	slog.Debug("Retrieved quarantine annotations for node from informer cache", "node", nodeName)
+	slog.DebugContext(ctx, "Retrieved quarantine annotations for node from informer cache", "node", nodeName)
 
 	return quarantineAnnotations, nil
 }
@@ -1334,16 +1554,17 @@ func (r *Reconciler) getNodeQuarantineAnnotations(nodeName string) (map[string]s
 func (r *Reconciler) cleanupManualUncordonAnnotation(ctx context.Context, nodeName string,
 	annotations map[string]string) error {
 	if _, hasManualUncordon := annotations[common.QuarantinedNodeUncordonedManuallyAnnotationKey]; hasManualUncordon {
-		slog.Info("Removing manual uncordon annotation from node before applying new quarantine", "node", nodeName)
+		slog.InfoContext(ctx, "Removing manual uncordon annotation from node before applying new quarantine",
+			"node", nodeName)
 
 		updateFn := func(node *corev1.Node) error {
 			if node.Annotations == nil {
-				slog.Debug("Node has no annotations, manual uncordon annotation already absent", "node", nodeName)
+				slog.DebugContext(ctx, "Node has no annotations, manual uncordon annotation already absent", "node", nodeName)
 				return nil
 			}
 
 			if _, exists := node.Annotations[common.QuarantinedNodeUncordonedManuallyAnnotationKey]; !exists {
-				slog.Debug("Manual uncordon annotation already removed from node", "node", nodeName)
+				slog.DebugContext(ctx, "Manual uncordon annotation already removed from node", "node", nodeName)
 				return nil
 			}
 
@@ -1353,7 +1574,7 @@ func (r *Reconciler) cleanupManualUncordonAnnotation(ctx context.Context, nodeNa
 		}
 
 		if err := r.k8sClient.UpdateNode(ctx, nodeName, updateFn); err != nil {
-			slog.Error("Failed to remove manual uncordon annotation from node", "node", nodeName, "error", err)
+			slog.ErrorContext(ctx, "Failed to remove manual uncordon annotation from node", "node", nodeName, "error", err)
 			return fmt.Errorf("failed to remove manual uncordon annotation from node %s: %w", nodeName, err)
 		}
 	}
@@ -1363,13 +1584,25 @@ func (r *Reconciler) cleanupManualUncordonAnnotation(ctx context.Context, nodeNa
 
 // handleManualUncordon handles the case when a node is manually uncordoned while having FQ annotations
 func (r *Reconciler) handleManualUncordon(nodeName string) error {
-	annotations, err := r.getNodeQuarantineAnnotations(nodeName)
+	ctx, span := tracing.StartSpan(context.Background(), "fault_quarantine.manual_uncordon")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("fault_quarantine.node_name", nodeName))
+
+	annotations, err := r.getNodeQuarantineAnnotations(ctx, nodeName)
 	if err != nil {
-		slog.Error("Failed to get node annotations", "node", nodeName, "error", err)
+		slog.ErrorContext(ctx, "Failed to get node annotations", "node", nodeName, "error", err)
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("fault_quarantine.error.type", "get_node_annotations_error"),
+			attribute.String("fault_quarantine.error.message", err.Error()),
+		)
+
 		return fmt.Errorf("failed to get annotations for manually uncordoned node %s: %w", nodeName, err)
 	}
 
-	slog.Debug("Retrieved node annotations for manual uncordon", "node", nodeName, "annotationCount", len(annotations))
+	slog.DebugContext(ctx, "Retrieved node annotations for manual uncordon",
+		"node", nodeName, "annotationCount", len(annotations))
 
 	annotationsToRemove := []string{}
 
@@ -1386,13 +1619,11 @@ func (r *Reconciler) handleManualUncordon(nodeName string) error {
 		annotationsToRemove = append(annotationsToRemove, common.QuarantineHealthEventIsCordonedAnnotationKey)
 	}
 
-	slog.Debug("Prepared annotations to remove", "node", nodeName, "count", len(annotationsToRemove))
+	slog.DebugContext(ctx, "Prepared annotations to remove", "node", nodeName, "count", len(annotationsToRemove))
 
 	newAnnotations := map[string]string{
 		common.QuarantinedNodeUncordonedManuallyAnnotationKey: common.QuarantinedNodeUncordonedManuallyAnnotationValue,
 	}
-
-	ctx := context.Background()
 
 	if err := r.k8sClient.HandleManualUncordonCleanup(
 		ctx,
@@ -1401,47 +1632,70 @@ func (r *Reconciler) handleManualUncordon(nodeName string) error {
 		newAnnotations,
 		[]string{statemanager.NVSentinelStateLabelKey},
 	); err != nil {
-		slog.Error("Failed to clean up manually uncordoned node", "node", nodeName, "error", err)
+		slog.ErrorContext(ctx, "Failed to clean up manually uncordoned node", "node", nodeName, "error", err)
 		metrics.ProcessingErrors.WithLabelValues("manual_uncordon_cleanup_error").Inc()
+
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("fault_quarantine.error.type", "manual_uncordon_cleanup_error"),
+			attribute.String("fault_quarantine.error.message", err.Error()),
+		)
 
 		return fmt.Errorf("failed to clean up manually uncordoned node %s: %w", nodeName, err)
 	}
 
-	slog.Debug("Successfully completed K8s cleanup for manual uncordon", "node", nodeName)
+	slog.DebugContext(ctx, "Successfully completed K8s cleanup for manual uncordon", "node", nodeName)
 
-	slog.Info("Set currentQuarantinedNodes to 0 for manually uncordoned node", "node", nodeName)
+	slog.InfoContext(ctx, "Set currentQuarantinedNodes to 0 for manually uncordoned node", "node", nodeName)
 	metrics.CurrentQuarantinedNodes.WithLabelValues(nodeName).Set(0)
 	metrics.TotalNodesManuallyUncordoned.WithLabelValues(nodeName).Inc()
 
 	// Cancel latest quarantining events (if eventWatcher is available)
 	if r.eventWatcher != nil {
-		slog.Debug("Calling CancelLatestQuarantiningEvents for manual uncordon", "node", nodeName)
+		slog.DebugContext(ctx, "Calling CancelLatestQuarantiningEvents for manual uncordon", "node", nodeName)
 
-		if err := r.eventWatcher.CancelLatestQuarantiningEvents(ctx, nodeName); err != nil {
-			slog.Error("Failed to cancel latest quarantining events for manually uncordoned node",
+		if err := r.eventWatcher.CancelLatestQuarantiningEvents(ctx, nodeName, "Manual uncordoning detected"); err != nil {
+			slog.ErrorContext(ctx, "Failed to cancel latest quarantining events for manually uncordoned node",
 				"node", nodeName, "error", err)
 			metrics.ProcessingErrors.WithLabelValues("mongodb_cancel_quarantine_error").Inc()
+			tracing.RecordError(span, err)
+			span.SetAttributes(
+				attribute.String("fault_quarantine.error.type", "mongodb_cancel_quarantine_error"),
+				attribute.String("fault_quarantine.error.message", err.Error()),
+			)
 		} else {
-			slog.Debug("Successfully cancelled latest quarantining events", "node", nodeName)
+			slog.DebugContext(ctx, "Successfully cancelled latest quarantining events", "node", nodeName)
 		}
 	} else {
-		slog.Warn("eventWatcher is NIL - cannot cancel quarantining events in database", "node", nodeName)
+		slog.WarnContext(ctx, "eventWatcher is NIL - cannot cancel quarantining events in database", "node", nodeName)
 	}
 
-	slog.Info("Successfully completed manual uncordon handling", "node", nodeName)
+	slog.InfoContext(ctx, "Successfully completed manual uncordon handling", "node", nodeName)
 
 	return nil
 }
 
 // handleManualUntaint handles the case when a node is manually untainted while having FQ annotations
 func (r *Reconciler) handleManualUntaint(nodeName string) error {
-	annotations, err := r.getNodeQuarantineAnnotations(nodeName)
+	ctx, span := tracing.StartSpan(context.Background(), "fault_quarantine.manual_untaint")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("fault_quarantine.node_name", nodeName))
+
+	annotations, err := r.getNodeQuarantineAnnotations(ctx, nodeName)
 	if err != nil {
-		slog.Error("Failed to get node annotations", "node", nodeName, "error", err)
+		slog.ErrorContext(ctx, "Failed to get node annotations", "node", nodeName, "error", err)
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("fault_quarantine.error.type", "get_node_annotations_error"),
+			attribute.String("fault_quarantine.error.message", err.Error()),
+		)
+
 		return fmt.Errorf("failed to get annotations for manually untainted node %s: %w", nodeName, err)
 	}
 
-	slog.Debug("Retrieved node annotations for manual untaint", "node", nodeName, "annotationCount", len(annotations))
+	slog.DebugContext(ctx, "Retrieved node annotations for manual untaint",
+		"node", nodeName, "annotationCount", len(annotations))
 
 	annotationsToRemove := []string{}
 
@@ -1457,13 +1711,11 @@ func (r *Reconciler) handleManualUntaint(nodeName string) error {
 		annotationsToRemove = append(annotationsToRemove, common.QuarantineHealthEventIsCordonedAnnotationKey)
 	}
 
-	slog.Debug("Prepared annotations to remove", "node", nodeName, "count", len(annotationsToRemove))
+	slog.DebugContext(ctx, "Prepared annotations to remove", "node", nodeName, "count", len(annotationsToRemove))
 
 	newAnnotations := map[string]string{
 		common.QuarantinedNodeIsUntaintedManuallyAnnotationKey: common.QuarantinedNodeIsUntaintedManuallyAnnotationValue,
 	}
-
-	ctx := context.Background()
 
 	if err := r.k8sClient.HandleManualUntaintCleanup(
 		ctx,
@@ -1472,33 +1724,43 @@ func (r *Reconciler) handleManualUntaint(nodeName string) error {
 		newAnnotations,
 		[]string{statemanager.NVSentinelStateLabelKey},
 	); err != nil {
-		slog.Error("Failed to clean up manually untainted node", "node", nodeName, "error", err)
+		slog.ErrorContext(ctx, "Failed to clean up manually untainted node", "node", nodeName, "error", err)
 		metrics.ProcessingErrors.WithLabelValues("manual_untaint_cleanup_error").Inc()
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("fault_quarantine.error.type", "manual_untaint_cleanup_error"),
+			attribute.String("fault_quarantine.error.message", err.Error()),
+		)
 
 		return fmt.Errorf("failed to clean up manually untainted node %s: %w", nodeName, err)
 	}
 
-	slog.Debug("Successfully completed K8s cleanup for manual untaint", "node", nodeName)
+	slog.DebugContext(ctx, "Successfully completed K8s cleanup for manual untaint", "node", nodeName)
 
 	// Reset the quarantine gauge metric since the node is no longer quarantined
 	metrics.CurrentQuarantinedNodes.WithLabelValues(nodeName).Set(0)
 	metrics.TotalNodesManuallyUntainted.WithLabelValues(nodeName).Inc()
-	slog.Info("Set currentQuarantinedNodes to 0 after manual untaint", "node", nodeName)
+	slog.InfoContext(ctx, "Set currentQuarantinedNodes to 0 after manual untaint", "node", nodeName)
 
 	// Cancel latest quarantining events (if eventWatcher is available)
 	if r.eventWatcher != nil {
-		slog.Debug("Calling CancelLatestQuarantiningEvents for manual untaint", "node", nodeName)
+		slog.DebugContext(ctx, "Calling CancelLatestQuarantiningEvents for manual untaint", "node", nodeName)
 
-		if err := r.eventWatcher.CancelLatestQuarantiningEvents(ctx, nodeName); err != nil {
-			slog.Error("Failed to cancel latest quarantining events for manually untainted node",
+		if err := r.eventWatcher.CancelLatestQuarantiningEvents(ctx, nodeName, "Manual untainting detected"); err != nil {
+			slog.ErrorContext(ctx, "Failed to cancel latest quarantining events for manually untainted node",
 				"node", nodeName, "error", err)
 			metrics.ProcessingErrors.WithLabelValues("mongodb_cancel_quarantine_error").Inc()
+			tracing.RecordError(span, err)
+			span.SetAttributes(
+				attribute.String("fault_quarantine.error.type", "mongodb_cancel_quarantine_error"),
+				attribute.String("fault_quarantine.error.message", err.Error()),
+			)
 		} else {
-			slog.Debug("Successfully cancelled latest quarantining events", "node", nodeName)
+			slog.DebugContext(ctx, "Successfully cancelled latest quarantining events", "node", nodeName)
 		}
 	}
 
-	slog.Info("Successfully completed manual untaint handling", "node", nodeName)
+	slog.InfoContext(ctx, "Successfully completed manual untaint handling", "node", nodeName)
 
 	return nil
 }

--- a/fault-quarantine/pkg/reconciler/reconciler.go
+++ b/fault-quarantine/pkg/reconciler/reconciler.go
@@ -894,12 +894,6 @@ func (r *Reconciler) applyQuarantine(
 	ctx, span := tracing.StartSpan(ctx, "fault_quarantine.apply_quarantine")
 	defer span.End()
 
-	span.SetAttributes(
-		attribute.Bool("fault_quarantine.action.cordon", isCordoned.Load()),
-		attribute.Bool("fault_quarantine.action.taint", len(taintsToBeApplied) > 0),
-		attribute.Int("fault_quarantine.action.taint_count", len(taintsToBeApplied)),
-	)
-
 	r.recordCordonEventInCircuitBreaker(event)
 
 	healthEvents := healthEventsAnnotation.NewHealthEventsAnnotationMap()
@@ -948,10 +942,6 @@ func (r *Reconciler) applyQuarantine(
 	}
 
 	labels := syncMapToStringMap(labelsMap)
-
-	span.SetAttributes(attribute.Bool("fault_quarantine.labels_applied", len(labels) > 0))
-
-	span.SetAttributes(attribute.Bool("fault_quarantine.annotation_applied", len(annotationsMap) > 0))
 
 	err := r.k8sClient.QuarantineNodeAndSetAnnotations(
 		ctx,

--- a/fault-quarantine/pkg/reconciler/reconciler_e2e_test.go
+++ b/fault-quarantine/pkg/reconciler/reconciler_e2e_test.go
@@ -340,9 +340,9 @@ func setupE2EReconcilerWithOptions(t *testing.T, ctx context.Context, cfg E2ERec
 		}
 	}
 
-	r.precomputeTaintInitKeys(ruleSetEvals, rulesetsConfig)
+	r.precomputeTaintInitKeys(context.Background(), ruleSetEvals, rulesetsConfig)
 
-	r.initializeQuarantineMetrics()
+	r.initializeQuarantineMetrics(context.Background())
 
 	// Create mock watcher
 	mockWatcher := testutils.NewMockChangeStreamWatcher()
@@ -531,8 +531,8 @@ func runReconcilerAndQuarantineNode(
 			}
 		}
 
-		r.precomputeTaintInitKeys(ruleSetEvals, rulesetsConfig)
-		r.initializeQuarantineMetrics()
+		r.precomputeTaintInitKeys(context.Background(), ruleSetEvals, rulesetsConfig)
+		r.initializeQuarantineMetrics(context.Background())
 
 		mockWatcher := testutils.NewMockChangeStreamWatcher()
 
@@ -620,7 +620,7 @@ func verifyUnquarantineLabels(t *testing.T, node *corev1.Node) {
 
 // MockEventWatcher is a test mock for EventWatcherInterface that can simulate various scenarios
 type MockEventWatcher struct {
-	CancelLatestQuarantiningEventsFn func(ctx context.Context, nodeName string) error
+	CancelLatestQuarantiningEventsFn func(ctx context.Context, nodeName string, reason string) error
 	ProcessEventCallbackFn           func(ctx context.Context, event *model.HealthEventWithStatus) *model.Status
 	StartFn                          func(ctx context.Context) error
 }
@@ -636,11 +636,11 @@ func (m *MockEventWatcher) SetProcessEventCallback(callback func(ctx context.Con
 	m.ProcessEventCallbackFn = callback
 }
 
-func (m *MockEventWatcher) SetFetchDocIDsFn(_ func(nodeName string) []string) {}
+func (m *MockEventWatcher) SetFetchDocIDsFn(_ func(ctx context.Context, nodeName string) []string) {}
 
-func (m *MockEventWatcher) CancelLatestQuarantiningEvents(ctx context.Context, nodeName string) error {
+func (m *MockEventWatcher) CancelLatestQuarantiningEvents(ctx context.Context, nodeName string, reason string) error {
 	if m.CancelLatestQuarantiningEventsFn != nil {
-		return m.CancelLatestQuarantiningEventsFn(ctx, nodeName)
+		return m.CancelLatestQuarantiningEventsFn(ctx, nodeName, reason)
 	}
 	// Default behavior: simulate MongoDB document not found (returns nil as per the real implementation)
 	return nil
@@ -3870,1237 +3870,1237 @@ func TestE2E_UnhealthyEventNotMatchingRulesNotPropagated(t *testing.T) {
 	assert.Equal(t, 1, healthEventsMap.Count(), "Should still have only GpuXidError tracked")
 }
 
-// // TestE2E_ManualUncordonWithCancellation tests that manual uncordon triggers proper cleanup
-// func TestE2E_ManualUncordonWithCancellation(t *testing.T) {
-// 	ctx, cancel := context.WithTimeout(e2eTestContext, 30*time.Second)
-// 	defer cancel()
-
-// 	nodeName := testutils.GenerateTestNodeName("e2e-manual-uncordon")
-// 	createE2ETestNode(ctx, t, nodeName, nil, nil, nil, false)
-// 	defer func() {
-// 		_ = e2eTestClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
-// 	}()
-
-// 	tomlConfig := config.TomlConfig{
-// 		LabelPrefix: "k8s.nvidia.com/",
-// 		RuleSets: []config.RuleSet{
-// 			{
-// 				Name:     "gpu-xid-errors",
-// 				Version:  "1",
-// 				Priority: 10,
-// 				Match: config.Match{
-// 					Any: []config.Rule{
-// 						{Kind: "HealthEvent", Expression: "event.checkName == 'GpuXidError' && event.isFatal == true"},
-// 					},
-// 				},
-// 				Taint:  config.Taint{Key: "nvidia.com/gpu-xid-error", Value: "true", Effect: "NoSchedule"},
-// 				Cordon: config.Cordon{ShouldCordon: true},
-// 			},
-// 		},
-// 	}
-
-// 	_, mockWatcher, getStatus, _ := setupE2EReconciler(t, ctx, tomlConfig, nil)
-
-// 	beforeManualUncordon := getCounterVecValue(t, metrics.TotalNodesManuallyUncordoned, nodeName)
-// 	beforeCurrentQuarantined := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
-
-// 	t.Log("Sending unhealthy event to quarantine node")
-// 	eventID1 := generateTestID()
-// 	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(
-// 		eventID1,
-// 		nodeName,
-// 		"GpuXidError",
-// 		false,
-// 		true,
-// 		[]*protos.Entity{{EntityType: "GPU", EntityValue: "0"}},
-// 		model.StatusInProgress,
-// 	)}
-
-// 	t.Log("Waiting for node to be quarantined")
-// 	require.Eventually(t, func() bool {
-// 		status := getStatus(eventID1)
-// 		return status != nil && *status == model.Quarantined
-// 	}, statusCheckTimeout, statusCheckPollInterval, "Status should be Quarantined")
-
-// 	require.Eventually(t, func() bool {
-// 		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 		return err == nil && node.Spec.Unschedulable
-// 	}, eventuallyTimeout, eventuallyPollInterval, "Node should be quarantined")
-
-// 	t.Log("Manually uncordon the node")
-// 	quarantinedNode, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 	require.NoError(t, err)
-// 	quarantinedNode.Spec.Unschedulable = false
-// 	_, err = e2eTestClient.CoreV1().Nodes().Update(ctx, quarantinedNode, metav1.UpdateOptions{})
-// 	require.NoError(t, err)
-
-// 	t.Log("Verify manual uncordon cleanup")
-// 	require.Eventually(t, func() bool {
-// 		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 		if err != nil {
-// 			return false
-// 		}
-
-// 		return node.Annotations[common.QuarantinedNodeUncordonedManuallyAnnotationKey] == common.QuarantinedNodeUncordonedManuallyAnnotationValue &&
-// 			node.Annotations[common.QuarantineHealthEventAnnotationKey] == ""
-// 	}, eventuallyTimeout, eventuallyPollInterval, "Manual uncordon should clean up annotations")
-
-// 	t.Log("Verify manual uncordon metric incremented")
-// 	afterManualUncordon := getCounterVecValue(t, metrics.TotalNodesManuallyUncordoned, nodeName)
-// 	assert.Equal(t, beforeManualUncordon+1, afterManualUncordon, "TotalNodesManuallyUncordoned should increment")
-
-// 	t.Log("Verify current quarantined nodes gauge updated")
-// 	afterCurrentQuarantined := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
-// 	assert.Equal(t, float64(0), afterCurrentQuarantined, "CurrentQuarantinedNodes should be 0")
-// 	assert.GreaterOrEqual(t, beforeCurrentQuarantined, float64(0), "Gauge should have been set before")
-// }
-
-// // TestE2E_ManualUncordonMultipleEvents tests that manual uncordon works with multiple events on the same node
-// func TestE2E_ManualUncordonMultipleEvents(t *testing.T) {
-// 	ctx, cancel := context.WithTimeout(e2eTestContext, 30*time.Second)
-// 	defer cancel()
-
-// 	nodeName := testutils.GenerateTestNodeName("e2e-manual-multi")
-// 	createE2ETestNode(ctx, t, nodeName, nil, nil, nil, false)
-// 	defer func() {
-// 		_ = e2eTestClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
-// 	}()
-
-// 	tomlConfig := config.TomlConfig{
-// 		LabelPrefix: "k8s.nvidia.com/",
-// 		RuleSets: []config.RuleSet{
-// 			{
-// 				Name:     "gpu-xid-errors",
-// 				Version:  "1",
-// 				Priority: 10,
-// 				Match: config.Match{
-// 					Any: []config.Rule{
-// 						{Kind: "HealthEvent", Expression: "event.checkName == 'GpuXidError'"},
-// 					},
-// 				},
-// 				Taint:  config.Taint{Key: "nvidia.com/gpu-xid-error", Value: "true", Effect: "NoSchedule"},
-// 				Cordon: config.Cordon{ShouldCordon: true},
-// 			},
-// 		},
-// 	}
-
-// 	_, mockWatcher, getStatus, _ := setupE2EReconciler(t, ctx, tomlConfig, nil)
-
-// 	t.Log("Send first unhealthy event (Quarantined)")
-// 	eventID1 := generateTestID()
-// 	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(
-// 		eventID1,
-// 		nodeName,
-// 		"GpuXidError",
-// 		false,
-// 		true,
-// 		[]*protos.Entity{{EntityType: "GPU", EntityValue: "0"}},
-// 		model.StatusInProgress,
-// 	)}
-
-// 	require.Eventually(t, func() bool {
-// 		status := getStatus(eventID1)
-// 		return status != nil && *status == model.Quarantined
-// 	}, statusCheckTimeout, statusCheckPollInterval, "First event should be Quarantined")
-
-// 	t.Log("Send second unhealthy event (AlreadyQuarantined)")
-// 	eventID2 := generateTestID()
-// 	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(
-// 		eventID2,
-// 		nodeName,
-// 		"GpuXidError",
-// 		false,
-// 		true,
-// 		[]*protos.Entity{{EntityType: "GPU", EntityValue: "1"}},
-// 		model.StatusInProgress,
-// 	)}
-
-// 	require.Eventually(t, func() bool {
-// 		status := getStatus(eventID2)
-// 		return status != nil && *status == model.AlreadyQuarantined
-// 	}, statusCheckTimeout, statusCheckPollInterval, "Second event should be Quarantined")
-
-// 	t.Log("Send third unhealthy event (AlreadyQuarantined)")
-// 	eventID3 := generateTestID()
-// 	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(
-// 		eventID3,
-// 		nodeName,
-// 		"GpuXidError",
-// 		false,
-// 		true,
-// 		[]*protos.Entity{{EntityType: "GPU", EntityValue: "2"}},
-// 		model.StatusInProgress,
-// 	)}
-
-// 	require.Eventually(t, func() bool {
-// 		status := getStatus(eventID3)
-// 		return status != nil && *status == model.AlreadyQuarantined
-// 	}, statusCheckTimeout, statusCheckPollInterval, "Third event should be AlreadyQuarantined")
-
-// 	t.Log("Manually uncordon the node")
-// 	quarantinedNode, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 	require.NoError(t, err)
-// 	quarantinedNode.Spec.Unschedulable = false
-// 	_, err = e2eTestClient.CoreV1().Nodes().Update(ctx, quarantinedNode, metav1.UpdateOptions{})
-// 	require.NoError(t, err)
-
-// 	t.Log("Verify manual uncordon annotation is set")
-// 	require.Eventually(t, func() bool {
-// 		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 		if err != nil {
-// 			return false
-// 		}
-// 		return node.Annotations[common.QuarantinedNodeUncordonedManuallyAnnotationKey] == common.QuarantinedNodeUncordonedManuallyAnnotationValue
-// 	}, eventuallyTimeout, eventuallyPollInterval, "Manual uncordon annotation should be set")
-
-// 	t.Log("Verify quarantine annotation cleared")
-// 	require.Eventually(t, func() bool {
-// 		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 		if err != nil {
-// 			return false
-// 		}
-// 		return node.Annotations[common.QuarantineHealthEventAnnotationKey] == ""
-// 	}, eventuallyTimeout, eventuallyPollInterval, "Quarantine annotation should be cleared")
-// }
-
-// // TestE2E_ConcurrentHealthyEvents_WithDelayedInformer verifies that the reconciler correctly
-// // uncordons a node when multiple health checks recover simultaneously, even when the informer
-// // cache is stale.
-// //
-// // SCENARIO:
-// // A node has two different failing health checks. Both checks recover at the same time,
-// // generating two healthy events that are processed concurrently. Each event:
-// //   - Reads the node state from the informer cache
-// //   - Removes its own check from the annotation
-// //   - Decides whether to uncordon based on remaining checks
-// //
-// // CHALLENGE:
-// // When both events read the cache before either update propagates back, they both see
-// // stale data showing "the other check is still failing." The reconciler must handle this
-// // correctly and ensure the node is uncordoned when all checks have actually recovered.
-// //
-// // TEST STRATEGY:
-// // We inject a 500ms delay into the informer's watch connection, simulating real-world
-// // cache lag due to network latency or API server load. The delay is toggled:
-// //   - DISABLED during setup: allows normal operation to quarantine the node
-// //   - ENABLED during trigger: forces concurrent events to see stale cache
-// func TestE2E_ConcurrentHealthyEvents_WithDelayedInformer(t *testing.T) {
-// 	// This test requires its own envtest instance with a custom transport wrapper
-// 	testEnv := &envtest.Environment{}
-// 	restConfig, err := testEnv.Start()
-// 	require.NoError(t, err, "Failed to start test environment")
-
-// 	// Start with delay DISABLED - we need normal operation during setup phase
-// 	delayedRT := &delayedWatchRoundTripper{
-// 		watchDelay: 500 * time.Millisecond,
-// 		enabled:    false,
-// 	}
-
-// 	stopCh := make(chan struct{})
-
-// 	// Shutdown order matters: disable delay first (unblocks any pending reads), then stop
-// 	// informer (closes watch connection), then stop envtest (can now shut down cleanly)
-// 	defer func() {
-// 		delayedRT.SetEnabled(false)
-// 		close(stopCh)
-// 		if err := testEnv.Stop(); err != nil {
-// 			t.Logf("Warning: Failed to stop test environment: %v", err)
-// 		}
-// 	}()
-
-// 	// Wrap the transport to delay only watch requests (informer cache sync)
-// 	// Regular GET/POST/PUT/DELETE requests are unaffected
-// 	restConfig.Wrap(func(rt http.RoundTripper) http.RoundTripper {
-// 		delayedRT.delegate = rt
-// 		return delayedRT
-// 	})
-
-// 	k8sClient, err := kubernetes.NewForConfig(restConfig)
-// 	require.NoError(t, err, "Failed to create k8s client")
-
-// 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-// 	defer cancel()
-
-// 	nodeName := "concurrent-recovery-" + generateShortTestID()
-// 	node := &corev1.Node{
-// 		ObjectMeta: metav1.ObjectMeta{Name: nodeName},
-// 		Spec:       corev1.NodeSpec{Unschedulable: false},
-// 		Status:     corev1.NodeStatus{Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}}},
-// 	}
-// 	_, err = k8sClient.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
-// 	require.NoError(t, err, "Failed to create test node")
-// 	defer func() {
-// 		_ = k8sClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
-// 	}()
-
-// 	tomlConfig := config.TomlConfig{
-// 		LabelPrefix: "k8s.nvidia.com/",
-// 		RuleSets: []config.RuleSet{{
-// 			Name:     "gpu-fatal-errors",
-// 			Version:  "1",
-// 			Priority: 10,
-// 			Match:    config.Match{Any: []config.Rule{{Kind: "HealthEvent", Expression: "event.isFatal == true"}}},
-// 			Taint:    config.Taint{Key: "nvidia.com/gpu-error", Value: "true", Effect: "NoSchedule"},
-// 			Cordon:   config.Cordon{ShouldCordon: true},
-// 		}},
-// 	}
-
-// 	// Resync period of 0 disables periodic re-listing. The informer only updates via watch
-// 	// events, not by periodically fetching all nodes. This ensures cache staleness is controlled
-// 	// solely by our delayed watch transport.
-// 	nodeInformer, err := informer.NewNodeInformer(k8sClient, 0)
-// 	require.NoError(t, err)
-
-// 	fqClient := &informer.FaultQuarantineClient{
-// 		Clientset:    k8sClient,
-// 		DryRunMode:   false,
-// 		NodeInformer: nodeInformer,
-// 	}
-
-// 	go func() { _ = nodeInformer.Run(stopCh) }()
-
-// 	require.Eventually(t, nodeInformer.HasSynced, 10*time.Second, 100*time.Millisecond, "NodeInformer should sync")
-
-// 	ruleSetEvals, err := evaluator.InitializeRuleSetEvaluators(tomlConfig.RuleSets, fqClient.NodeInformer)
-// 	require.NoError(t, err)
-
-// 	r := NewReconciler(ReconcilerConfig{TomlConfig: tomlConfig}, fqClient, nil)
-// 	r.SetLabelKeys(tomlConfig.LabelPrefix)
-// 	fqClient.SetLabelKeys(r.cordonedReasonLabelKey, r.uncordonedReasonLabelKey)
-
-// 	rulesetsConfig := rulesetsConfig{
-// 		TaintConfigMap:     make(map[string]*config.Taint),
-// 		CordonConfigMap:    make(map[string]bool),
-// 		RuleSetPriorityMap: make(map[string]int),
-// 	}
-// 	for _, rs := range tomlConfig.RuleSets {
-// 		if rs.Taint.Key != "" {
-// 			rulesetsConfig.TaintConfigMap[rs.Name] = &rs.Taint
-// 		}
-// 		if rs.Cordon.ShouldCordon {
-// 			rulesetsConfig.CordonConfigMap[rs.Name] = true
-// 		}
-// 		if rs.Priority > 0 {
-// 			rulesetsConfig.RuleSetPriorityMap[rs.Name] = rs.Priority
-// 		}
-// 	}
-
-// 	r.precomputeTaintInitKeys(ruleSetEvals, rulesetsConfig)
-// 	fqClient.NodeInformer.SetOnManualUncordonCallback(r.handleManualUncordon)
-
-// 	mockWatcher := testutils.NewMockChangeStreamWatcher()
-// 	t.Cleanup(func() { close(mockWatcher.EventsChan) })
-
-// 	go func() {
-// 		for event := range mockWatcher.Events() {
-// 			var healthEventWithStatus model.HealthEventWithStatus
-// 			if err := event.UnmarshalDocument(&healthEventWithStatus); err != nil {
-// 				continue
-// 			}
-// 			r.ProcessEvent(ctx, &healthEventWithStatus, ruleSetEvals, rulesetsConfig)
-// 		}
-// 	}()
-
-// 	// === SETUP: Quarantine node with TWO different checks ===
-// 	t.Log("Setup: Quarantining node with two checks")
-
-// 	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(
-// 		generateTestID(), nodeName, "GpuInforomWatch", false, true,
-// 		[]*protos.Entity{{EntityType: "GPU", EntityValue: "0"}}, model.StatusInProgress,
-// 	)}
-
-// 	require.Eventually(t, func() bool {
-// 		n, _ := k8sClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 		return n.Spec.Unschedulable
-// 	}, 10*time.Second, 100*time.Millisecond, "Node should be quarantined")
-
-// 	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(
-// 		generateTestID(), nodeName, "GpuDcgmConnectivityFailure", false, true,
-// 		[]*protos.Entity{}, model.StatusInProgress,
-// 	)}
-
-// 	require.Eventually(t, func() bool {
-// 		n, _ := k8sClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 		var m healthEventsAnnotation.HealthEventsAnnotationMap
-// 		if err := json.Unmarshal([]byte(n.Annotations[common.QuarantineHealthEventAnnotationKey]), &m); err != nil {
-// 			return false
-// 		}
-// 		return m.Count() == 2
-// 	}, 10*time.Second, 100*time.Millisecond, "Both checks should be tracked")
-
-// 	// === TRIGGER: Process both healthy events CONCURRENTLY with delayed watch ===
-// 	t.Log("Trigger: Enabling watch delay and processing healthy events concurrently")
-
-// 	// From this point, every informer cache update is delayed by 500ms. Any K8s API update
-// 	// the reconciler makes won't be visible in the cache until well after both events finish.
-// 	delayedRT.SetEnabled(true)
-
-// 	// Recovery events for both checks - these will be processed simultaneously
-// 	eventA := &model.HealthEventWithStatus{
-// 		HealthEvent: &protos.HealthEvent{
-// 			Version: 1, Agent: "gpu-health-monitor", ComponentClass: "GPU",
-// 			CheckName: "GpuDcgmConnectivityFailure", IsHealthy: true, IsFatal: false,
-// 			EntitiesImpacted: []*protos.Entity{}, NodeName: nodeName,
-// 		},
-// 	}
-
-// 	eventB := &model.HealthEventWithStatus{
-// 		HealthEvent: &protos.HealthEvent{
-// 			Version: 1, Agent: "gpu-health-monitor", ComponentClass: "GPU",
-// 			CheckName: "GpuInforomWatch", IsHealthy: true, IsFatal: false,
-// 			EntitiesImpacted: []*protos.Entity{{EntityType: "GPU", EntityValue: "0"}}, NodeName: nodeName,
-// 		},
-// 	}
-
-// 	var wg sync.WaitGroup
-// 	wg.Add(2)
-
-// 	// startBarrier ensures both goroutines begin at exactly the same instant. Both block
-// 	// on receiving from this channel; closing the channel unblocks all receivers simultaneously.
-// 	// This maximizes overlap between the two ProcessEvent calls, guaranteeing they both read
-// 	// the cache before either has a chance to see the other's updates.
-// 	startBarrier := make(chan struct{})
-
-// 	go func() {
-// 		defer wg.Done()
-// 		<-startBarrier
-// 		r.ProcessEvent(ctx, eventA, ruleSetEvals, rulesetsConfig)
-// 	}()
-
-// 	go func() {
-// 		defer wg.Done()
-// 		<-startBarrier
-// 		r.ProcessEvent(ctx, eventB, ruleSetEvals, rulesetsConfig)
-// 	}()
-
-// 	close(startBarrier)
-// 	wg.Wait()
-
-// 	// === VERIFY: Node should be fully recovered ===
-// 	delayedRT.SetEnabled(false)
-
-// 	// Read directly from API server (not cache) to get the true final state
-// 	finalNode, err := k8sClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 	require.NoError(t, err)
-
-// 	annotation := finalNode.Annotations[common.QuarantineHealthEventAnnotationKey]
-// 	isStillCordoned := finalNode.Spec.Unschedulable
-
-// 	t.Logf("Final state: annotation=%q, stillCordoned=%v", annotation, isStillCordoned)
-
-// 	// Verify annotation is empty - both events successfully removed their checks
-// 	var healthEventsMap healthEventsAnnotation.HealthEventsAnnotationMap
-// 	annotationIsEmpty := annotation == "" || annotation == "[]"
-// 	if !annotationIsEmpty && annotation != "" {
-// 		if err := json.Unmarshal([]byte(annotation), &healthEventsMap); err == nil {
-// 			annotationIsEmpty = healthEventsMap.IsEmpty()
-// 		}
-// 	}
-
-// 	require.True(t, annotationIsEmpty, "Annotation should be empty after both checks recovered, got: %s", annotation)
-
-// 	// With all checks recovered (empty annotation), node must be uncordoned
-// 	require.False(t, isStillCordoned,
-// 		"Node should be uncordoned when all health checks have recovered. "+
-// 			"The reconciler must correctly handle concurrent recovery events even with stale cache.")
-
-// 	require.Empty(t, finalNode.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey])
-
-// 	fqTaintCount := 0
-// 	for _, taint := range finalNode.Spec.Taints {
-// 		if taint.Key == "nvidia.com/gpu-error" {
-// 			fqTaintCount++
-// 		}
-// 	}
-// 	require.Equal(t, 0, fqTaintCount, "FQ taints should be removed")
-// }
-
-// // TestE2E_StaleAnnotationOnRestart test verifies that stale annotation and taints are cleaned up
-// // on restart if node has been manually uncordoned before the FQ pod restarted:
-// // SCENARIO:
-// // 1. FQ reconciler is running and taints + cordons a node due to a health event
-// // 2. Reconciler pod crashes or stops running (simulating OOM, cluster upgrade, etc.)
-// // 3. While reconciler is down, operator manually removes taints and uncordons the node
-// // 4. Reconciler pod restarts
-// // Expected: Reconciler should detect stale annotations (annotation + taints present but node not cordoned/tainted)
-// // and clean them up, ensuring metrics are correctly initialized to 0.
-// func TestE2E_StaleAnnotationOnRestart_TaintsAndCordon(t *testing.T) {
-// 	ctx, cancel := context.WithTimeout(e2eTestContext, 30*time.Second)
-// 	defer cancel()
-
-// 	nodeName := "stale-annotation-test-node-" + generateShortTestID()
-
-// 	// Create a clean node initially
-// 	createE2ETestNode(ctx, t, nodeName, nil, nil, nil, false)
-// 	defer func() {
-// 		_ = e2eTestClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
-// 	}()
-
-// 	tomlConfig := config.TomlConfig{
-// 		LabelPrefix: "k8s.nvidia.com/",
-// 		RuleSets: []config.RuleSet{
-// 			{
-// 				Name:     "gpu-xid-errors",
-// 				Version:  "1",
-// 				Priority: 10,
-// 				Match: config.Match{
-// 					Any: []config.Rule{
-// 						{Kind: "HealthEvent", Expression: "event.checkName == 'GpuXidError'"},
-// 					},
-// 				},
-// 				Taint:  config.Taint{Key: "nvidia.com/gpu-xid-error", Value: "true", Effect: "NoSchedule"},
-// 				Cordon: config.Cordon{ShouldCordon: true},
-// 			},
-// 		},
-// 	}
-
-// 	// Step 1: Start reconciler and let it taint and cordon the node
-// 	t.Log("Step 1: Starting reconciler and sending health event to taint and cordon node")
-// 	runReconcilerAndQuarantineNode(t, ctx, nodeName, tomlConfig, func(t *testing.T, node *corev1.Node) bool {
-// 		hasHealthEvent := node.Annotations[common.QuarantineHealthEventAnnotationKey] != ""
-// 		hasAppliedTaintsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey] != ""
-// 		hasCordonAnnotation := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey] == "True"
-// 		isCordoned := node.Spec.Unschedulable
-
-// 		hasFQTaint := false
-// 		for _, taint := range node.Spec.Taints {
-// 			if taint.Key == "nvidia.com/gpu-xid-error" {
-// 				hasFQTaint = true
-// 				break
-// 			}
-// 		}
-
-// 		t.Logf("Node quarantined check: hasHealthEvent=%v, hasAppliedTaintsAnnotation=%v, hasCordonAnnotation=%v, isCordoned=%v, hasFQTaint=%v",
-// 			hasHealthEvent, hasAppliedTaintsAnnotation, hasCordonAnnotation, isCordoned, hasFQTaint)
-// 		return hasHealthEvent && hasAppliedTaintsAnnotation && hasCordonAnnotation && isCordoned && hasFQTaint
-// 	})
-
-// 	// Step 2: Manually remove taints and uncordon the node
-// 	t.Log("Step 2: Manually removing taints and uncordoning the node while reconciler is down")
-// 	node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 	require.NoError(t, err)
-
-// 	// Remove FQ taints
-// 	filteredTaints := []corev1.Taint{}
-// 	for _, taint := range node.Spec.Taints {
-// 		if taint.Key != "nvidia.com/gpu-xid-error" && taint.Key != "node.kubernetes.io/unschedulable" {
-// 			filteredTaints = append(filteredTaints, taint)
-// 		}
-// 	}
-// 	node.Spec.Taints = filteredTaints
-// 	node.Spec.Unschedulable = false
-
-// 	_, err = e2eTestClient.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
-// 	require.NoError(t, err)
-
-// 	t.Log("Verifying node is manually untainted/uncordoned but stale annotations remain")
-// 	require.Eventually(t, func() bool {
-// 		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 		if err != nil {
-// 			return false
-// 		}
-// 		hasHealthEvent := node.Annotations[common.QuarantineHealthEventAnnotationKey] != ""
-// 		hasAppliedTaintsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey] != ""
-// 		isNotCordoned := !node.Spec.Unschedulable
-
-// 		hasFQTaint := false
-// 		for _, taint := range node.Spec.Taints {
-// 			if taint.Key == "nvidia.com/gpu-xid-error" {
-// 				hasFQTaint = true
-// 				break
-// 			}
-// 		}
-
-// 		t.Logf("Stale state check: hasHealthEvent=%v, hasAppliedTaintsAnnotation=%v, isNotCordoned=%v, hasFQTaint=%v",
-// 			hasHealthEvent, hasAppliedTaintsAnnotation, isNotCordoned, hasFQTaint)
-// 		return hasHealthEvent && hasAppliedTaintsAnnotation && isNotCordoned && !hasFQTaint
-// 	}, eventuallyTimeout, eventuallyPollInterval, "Node should be untainted/uncordoned but have stale annotations")
-
-// 	// Step 3: Restart reconciler - it should detect and clean up stale annotations
-// 	t.Log("Step 3: Setting up reconciler - simulating pod restart with stale annotation")
-// 	setupE2EReconciler(t, ctx, tomlConfig, nil)
-
-// 	t.Log("Verifying stale annotations are cleaned up")
-// 	require.Eventually(t, func() bool {
-// 		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 		if err != nil {
-// 			return false
-// 		}
-
-// 		// Stale annotations should be removed
-// 		annotationRemoved := node.Annotations[common.QuarantineHealthEventAnnotationKey] == ""
-// 		appliedTaintsRemoved := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey] == ""
-// 		cordonedAnnotationRemoved := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey] == ""
-// 		labelRemoved := node.Labels[statemanager.NVSentinelStateLabelKey] == ""
-
-// 		fqTaintCount := 0
-// 		for _, taint := range node.Spec.Taints {
-// 			if taint.Key == "nvidia.com/gpu-xid-error" {
-// 				fqTaintCount++
-// 			}
-// 		}
-
-// 		return annotationRemoved &&
-// 			appliedTaintsRemoved &&
-// 			cordonedAnnotationRemoved &&
-// 			labelRemoved &&
-// 			fqTaintCount == 0 &&
-// 			!node.Spec.Unschedulable
-// 	}, eventuallyTimeout, eventuallyPollInterval, "Stale annotations should be cleaned up on restart")
-
-// 	t.Log("Verifying metric is correctly initialized to 0 (not 1)")
-// 	gaugeValue := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
-// 	assert.Equal(t, float64(0), gaugeValue, "CurrentQuarantinedNodes should be 0 after cleaning stale annotation")
-// }
-
-// // TestE2E_StaleAnnotationOnRestart_CordonOnly tests stale annotation is cleaned up on restart if node has been manually uncordoned before the FQ pod restarted:
-// // SCENARIO:
-// // 1. FQ reconciler is running and cordons a node due to a health event (no taints, cordon-only)
-// // 2. Reconciler pod crashes or stops running (simulating OOM, cluster upgrade, etc.)
-// // 3. While reconciler is down, operator manually uncordons the node
-// // 4. Reconciler pod restarts
-// // Expected: Reconciler should detect stale annotations (annotation says cordoned but node is not cordoned)
-// // and clean them up, ensuring metrics are correctly initialized to 0.
-// func TestE2E_StaleAnnotationOnRestart_CordonOnly(t *testing.T) {
-// 	ctx, cancel := context.WithTimeout(e2eTestContext, 30*time.Second)
-// 	defer cancel()
-
-// 	nodeName := "stale-cordon-only-node-" + generateShortTestID()
-
-// 	// Create a clean node initially
-// 	createE2ETestNode(ctx, t, nodeName, nil, nil, nil, false)
-// 	defer func() {
-// 		_ = e2eTestClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
-// 	}()
-
-// 	tomlConfig := config.TomlConfig{
-// 		LabelPrefix: "k8s.nvidia.com/",
-// 		RuleSets: []config.RuleSet{
-// 			{
-// 				Name:     "gpu-xid-errors",
-// 				Version:  "1",
-// 				Priority: 10,
-// 				Match: config.Match{
-// 					Any: []config.Rule{
-// 						{Kind: "HealthEvent", Expression: "event.checkName == 'GpuXidError'"},
-// 					},
-// 				},
-// 				Cordon: config.Cordon{ShouldCordon: true}, // Cordon-only, no taints
-// 			},
-// 		},
-// 	}
-
-// 	// Step 1: Start reconciler and let it cordon the node (no taints)
-// 	t.Log("Step 1: Starting reconciler and sending health event to cordon node")
-// 	runReconcilerAndQuarantineNode(t, ctx, nodeName, tomlConfig, func(t *testing.T, node *corev1.Node) bool {
-// 		hasHealthEvent := node.Annotations[common.QuarantineHealthEventAnnotationKey] != ""
-// 		hasCordonAnnotation := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey] == "True"
-// 		isCordoned := node.Spec.Unschedulable
-// 		t.Logf("Node cordoned check: hasHealthEvent=%v, hasCordonAnnotation=%v, isCordoned=%v",
-// 			hasHealthEvent, hasCordonAnnotation, isCordoned)
-// 		return hasHealthEvent && hasCordonAnnotation && isCordoned
-// 	})
-
-// 	// Step 2: Manually uncordon the node (simulating kubectl uncordon)
-// 	t.Log("Step 2: Manually uncordoning the node while reconciler is down")
-// 	node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 	require.NoError(t, err)
-// 	node.Spec.Unschedulable = false
-// 	_, err = e2eTestClient.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
-// 	require.NoError(t, err)
-
-// 	t.Log("Verifying node is manually uncordoned but stale annotations remain")
-// 	require.Eventually(t, func() bool {
-// 		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 		if err != nil {
-// 			return false
-// 		}
-// 		hasHealthEvent := node.Annotations[common.QuarantineHealthEventAnnotationKey] != ""
-// 		hasCordonAnnotation := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey] == "True"
-// 		isNotCordoned := !node.Spec.Unschedulable
-// 		t.Logf("Stale state check: hasHealthEvent=%v, hasCordonAnnotation=%v, isNotCordoned=%v",
-// 			hasHealthEvent, hasCordonAnnotation, isNotCordoned)
-// 		return hasHealthEvent && hasCordonAnnotation && isNotCordoned
-// 	}, eventuallyTimeout, eventuallyPollInterval, "Node should be uncordoned but have stale annotations")
-
-// 	// Step 3: Restart reconciler - it should detect and clean up stale annotations
-// 	t.Log("Step 3: Setting up reconciler - simulating pod restart with stale cordon annotation")
-// 	_, _, _, _ = setupE2EReconciler(t, ctx, tomlConfig, nil)
-
-// 	t.Log("Verifying stale cordon annotations were cleaned up during reconciler startup")
-// 	require.Eventually(t, func() bool {
-// 		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 		if err != nil {
-// 			return false
-// 		}
-
-// 		annotationRemoved := node.Annotations[common.QuarantineHealthEventAnnotationKey] == ""
-// 		cordonedAnnotationRemoved := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey] == ""
-// 		labelRemoved := node.Labels[statemanager.NVSentinelStateLabelKey] == ""
-
-// 		return annotationRemoved &&
-// 			cordonedAnnotationRemoved &&
-// 			labelRemoved &&
-// 			!node.Spec.Unschedulable
-// 	}, eventuallyTimeout, eventuallyPollInterval, "Stale cordon annotations should be cleaned up")
-
-// 	t.Log("Verifying metric is correctly initialized to 0 (not 1)")
-// 	gaugeValue := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
-// 	assert.Equal(t, float64(0), gaugeValue, "CurrentQuarantinedNodes should be 0 after cleaning stale annotation")
-// }
-
-// // TestE2E_StaleAnnotationOnRestart_TaintsOnly test verifies that stale annotation and taints are cleaned up
-// // on restart when node was manually untainted and uncordoned while reconciler was down:
-// // SCENARIO:
-// // 1. FQ reconciler is running and taints + cordons a node due to a health event
-// // 2. Reconciler pod crashes or stops running (simulating OOM, cluster upgrade, etc.)
-// // 3. While reconciler is down, operator manually removes taints and uncordons the node
-// // 4. Reconciler pod restarts
-// // Expected: Reconciler should detect stale annotations (health event + appliedTaints annotations exist but node is not tainted/cordoned)
-// // and clean them up, ensuring metrics are correctly initialized to 0.
-// func TestE2E_StaleAnnotationOnRestart_TaintsOnly(t *testing.T) {
-// 	ctx, cancel := context.WithTimeout(e2eTestContext, 30*time.Second)
-// 	defer cancel()
-
-// 	nodeName := "stale-taints-node-" + generateShortTestID()
-
-// 	// Create a clean node initially
-// 	createE2ETestNode(ctx, t, nodeName, nil, nil, nil, false)
-// 	defer func() {
-// 		_ = e2eTestClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
-// 	}()
-
-// 	tomlConfig := config.TomlConfig{
-// 		LabelPrefix: "k8s.nvidia.com/",
-// 		RuleSets: []config.RuleSet{
-// 			{
-// 				Name:     "gpu-xid-errors",
-// 				Version:  "1",
-// 				Priority: 10,
-// 				Match: config.Match{
-// 					Any: []config.Rule{
-// 						{Kind: "HealthEvent", Expression: "event.checkName == 'GpuXidError'"},
-// 					},
-// 				},
-// 				Taint:  config.Taint{Key: "nvidia.com/gpu-xid-error", Value: "true", Effect: "NoSchedule"},
-// 				Cordon: config.Cordon{ShouldCordon: true},
-// 			},
-// 		},
-// 	}
-
-// 	// Step 1: Start reconciler and let it taint and cordon the node
-// 	t.Log("Step 1: Starting reconciler and sending health event to taint and cordon node")
-// 	runReconcilerAndQuarantineNode(t, ctx, nodeName, tomlConfig, func(t *testing.T, node *corev1.Node) bool {
-// 		hasHealthEvent := node.Annotations[common.QuarantineHealthEventAnnotationKey] != ""
-// 		hasAppliedTaintsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey] != ""
-// 		isCordoned := node.Spec.Unschedulable
-
-// 		hasFQTaint := false
-// 		for _, taint := range node.Spec.Taints {
-// 			if taint.Key == "nvidia.com/gpu-xid-error" {
-// 				hasFQTaint = true
-// 				break
-// 			}
-// 		}
-
-// 		t.Logf("Node tainted check: hasHealthEvent=%v, hasAppliedTaintsAnnotation=%v, isCordoned=%v, hasFQTaint=%v",
-// 			hasHealthEvent, hasAppliedTaintsAnnotation, isCordoned, hasFQTaint)
-// 		return hasHealthEvent && hasAppliedTaintsAnnotation && isCordoned && hasFQTaint
-// 	})
-
-// 	// Step 2: Manually remove taints and uncordon the node (simulating kubectl uncordon + manual taint removal)
-// 	t.Log("Step 2: Manually removing taints and uncordoning the node while reconciler is down")
-// 	node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 	require.NoError(t, err)
-
-// 	// Remove FQ taints
-// 	filteredTaints := []corev1.Taint{}
-// 	for _, taint := range node.Spec.Taints {
-// 		if taint.Key != "nvidia.com/gpu-xid-error" && taint.Key != "node.kubernetes.io/unschedulable" {
-// 			filteredTaints = append(filteredTaints, taint)
-// 		}
-// 	}
-// 	node.Spec.Taints = filteredTaints
-// 	node.Spec.Unschedulable = false
-
-// 	_, err = e2eTestClient.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
-// 	require.NoError(t, err)
-
-// 	t.Log("Verifying node is manually untainted/uncordoned but stale annotations remain")
-// 	require.Eventually(t, func() bool {
-// 		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 		if err != nil {
-// 			return false
-// 		}
-// 		hasHealthEvent := node.Annotations[common.QuarantineHealthEventAnnotationKey] != ""
-// 		hasAppliedTaintsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey] != ""
-// 		isNotCordoned := !node.Spec.Unschedulable
-
-// 		hasFQTaint := false
-// 		for _, taint := range node.Spec.Taints {
-// 			if taint.Key == "nvidia.com/gpu-xid-error" {
-// 				hasFQTaint = true
-// 				break
-// 			}
-// 		}
-
-// 		t.Logf("Stale state check: hasHealthEvent=%v, hasAppliedTaintsAnnotation=%v, isNotCordoned=%v, hasFQTaint=%v",
-// 			hasHealthEvent, hasAppliedTaintsAnnotation, isNotCordoned, hasFQTaint)
-// 		return hasHealthEvent && hasAppliedTaintsAnnotation && isNotCordoned && !hasFQTaint
-// 	}, eventuallyTimeout, eventuallyPollInterval, "Node should be untainted/uncordoned but have stale annotations")
-
-// 	// Step 3: Restart reconciler - it should detect and clean up stale annotations
-// 	t.Log("Step 3: Restarting reconciler - should detect and clean up stale annotations")
-// 	_, _, _, _ = setupE2EReconciler(t, ctx, tomlConfig, nil)
-
-// 	t.Log("Verifying stale annotations were cleaned up during reconciler startup")
-// 	require.Eventually(t, func() bool {
-// 		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 		if err != nil {
-// 			return false
-// 		}
-
-// 		annotationRemoved := node.Annotations[common.QuarantineHealthEventAnnotationKey] == ""
-// 		appliedTaintsRemoved := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey] == ""
-// 		cordonAnnotationRemoved := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey] == ""
-// 		labelRemoved := node.Labels[statemanager.NVSentinelStateLabelKey] == ""
-
-// 		fqTaintCount := 0
-// 		for _, taint := range node.Spec.Taints {
-// 			if taint.Key == "nvidia.com/gpu-xid-error" {
-// 				fqTaintCount++
-// 			}
-// 		}
-
-// 		t.Logf("Cleanup check: annotationRemoved=%v, appliedTaintsRemoved=%v, cordonAnnotationRemoved=%v, labelRemoved=%v, fqTaintCount=%d, isUnschedulable=%v",
-// 			annotationRemoved, appliedTaintsRemoved, cordonAnnotationRemoved, labelRemoved, fqTaintCount, node.Spec.Unschedulable)
-
-// 		return annotationRemoved &&
-// 			appliedTaintsRemoved &&
-// 			cordonAnnotationRemoved &&
-// 			labelRemoved &&
-// 			fqTaintCount == 0 &&
-// 			!node.Spec.Unschedulable
-// 	}, eventuallyTimeout, eventuallyPollInterval, "Stale annotations should be cleaned up after detecting manual untaint/uncordon")
-
-// 	t.Log("Verifying metric is correctly initialized to 0 (not 1)")
-// 	gaugeValue := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
-// 	assert.Equal(t, float64(0), gaugeValue, "CurrentQuarantinedNodes should be 0 after cleaning stale annotations for manually untainted/uncordoned node")
-// }
-
-// // TestE2E_ManualUncordonWithMissingMongoDoc tests :
-// // SCENARIO:
-// // Node was cordoned by fault-quarantine and taints along with annotations are applied.
-// // Cluster upgrade was done where PVC were deleted.
-// // After upgrade when FQ restarts,
-// // if node is manually uncordoned and MongoDB document is missing (e.g., DB was reset),
-// // FQ should handle this gracefully with a warning (not error) and still update metrics correctly.
-// func TestE2E_ManualUncordonWithMissingMongoDoc(t *testing.T) {
-// 	ctx, cancel := context.WithTimeout(e2eTestContext, 20*time.Second)
-// 	defer cancel()
-
-// 	nodeName := "test-node-" + generateShortTestID()
-
-// 	// Simulate post-upgrade state: node was cordoned before upgrade
-// 	existingEvent := &protos.HealthEvent{
-// 		NodeName:       nodeName,
-// 		Agent:          "gpu-health-monitor",
-// 		CheckName:      "GpuXidError",
-// 		ComponentClass: "GPU",
-// 		Version:        1,
-// 		IsHealthy:      false,
-// 		EntitiesImpacted: []*protos.Entity{
-// 			{EntityType: "GPU", EntityValue: "0"},
-// 		},
-// 	}
-
-// 	existingMap := healthEventsAnnotation.NewHealthEventsAnnotationMap()
-// 	existingMap.AddOrUpdateEvent(existingEvent)
-// 	existingBytes, err := json.Marshal(existingMap)
-// 	require.NoError(t, err)
-
-// 	annotations := map[string]string{
-// 		common.QuarantineHealthEventAnnotationKey:              string(existingBytes),
-// 		common.QuarantineHealthEventAppliedTaintsAnnotationKey: `[{"Key":"nvidia.com/gpu-xid-error","Value":"true","Effect":"NoSchedule"}]`,
-// 		common.QuarantineHealthEventIsCordonedAnnotationKey:    "True",
-// 	}
-
-// 	labels := map[string]string{
-// 		statemanager.NVSentinelStateLabelKey: string(statemanager.QuarantinedLabelValue),
-// 	}
-
-// 	taints := []corev1.Taint{
-// 		{Key: "nvidia.com/gpu-xid-error", Value: "true", Effect: "NoSchedule"},
-// 	}
-
-// 	createE2ETestNode(ctx, t, nodeName, annotations, labels, taints, true)
-// 	defer func() {
-// 		_ = e2eTestClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
-// 	}()
-
-// 	tomlConfig := config.TomlConfig{
-// 		LabelPrefix: "k8s.nvidia.com/",
-// 	}
-
-// 	t.Log("Setting up reconciler after simulated upgrade with eventWatcher")
-// 	r, _, _, _ := setupE2EReconciler(t, ctx, tomlConfig, nil)
-// 	mockEventWatcher := &MockEventWatcher{}
-// 	mockEventWatcher.CancelLatestQuarantiningEventsFn = func(ctx context.Context, nodeName string) error {
-// 		return fmt.Errorf("error decoding latest quarantining event for node %s: mongo: no documents in result", nodeName)
-// 	}
-// 	mockEventWatcher.ProcessEventCallbackFn = func(ctx context.Context, event *model.HealthEventWithStatus) *model.Status {
-// 		return nil
-// 	}
-// 	mockEventWatcher.StartFn = func(ctx context.Context) error {
-// 		return nil
-// 	}
-
-// 	r.eventWatcher = mockEventWatcher
-
-// 	require.Eventually(t, func() bool {
-// 		node, err := r.k8sClient.NodeInformer.GetNode(nodeName)
-// 		return err == nil && node != nil && node.Spec.Unschedulable
-// 	}, eventuallyTimeout, eventuallyPollInterval, "Informer should see the initially quarantined node")
-
-// 	beforeManualUncordon := getCounterVecValue(t, metrics.TotalNodesManuallyUncordoned, nodeName)
-// 	beforeCurrentQuarantined := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
-
-// 	t.Log("Manually uncordon node (simulating operator action after upgrade)")
-// 	quarantinedNode, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 	require.NoError(t, err)
-// 	quarantinedNode.Spec.Unschedulable = false
-// 	_, err = e2eTestClient.CoreV1().Nodes().Update(ctx, quarantinedNode, metav1.UpdateOptions{})
-// 	require.NoError(t, err)
-
-// 	t.Log("Verifying manual uncordon cleanup completes successfully")
-// 	require.Eventually(t, func() bool {
-// 		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 		if err != nil {
-// 			return false
-// 		}
-
-// 		// Manual uncordon annotation should be set
-// 		hasManualUncordonAnnotation := node.Annotations[common.QuarantinedNodeUncordonedManuallyAnnotationKey] == common.QuarantinedNodeUncordonedManuallyAnnotationValue
-
-// 		// FQ annotations should be cleaned up
-// 		annotationRemoved := node.Annotations[common.QuarantineHealthEventAnnotationKey] == ""
-// 		appliedTaintsRemoved := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey] == ""
-// 		cordonedAnnotationRemoved := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey] == ""
-
-// 		// FQ taints should remain (manual uncordon only removes annotations, not taints)
-// 		hasFQTaint := false
-// 		for _, taint := range node.Spec.Taints {
-// 			if taint.Key == "nvidia.com/gpu-xid-error" {
-// 				hasFQTaint = true
-// 				break
-// 			}
-// 		}
-
-// 		// Node should be uncordoned
-// 		isUncordoned := !node.Spec.Unschedulable
-
-// 		return hasManualUncordonAnnotation &&
-// 			annotationRemoved &&
-// 			appliedTaintsRemoved &&
-// 			cordonedAnnotationRemoved &&
-// 			hasFQTaint && // FQ taint should remain (manual uncordon doesn't remove taints)
-// 			isUncordoned // node should be uncordoned
-// 	}, eventuallyTimeout, eventuallyPollInterval, "Manual uncordon should complete cleanup even without MongoDB doc")
-
-// 	t.Log("Verifying metrics are correctly updated despite missing MongoDB document")
-// 	afterManualUncordon := getCounterVecValue(t, metrics.TotalNodesManuallyUncordoned, nodeName)
-// 	assert.Equal(t, beforeManualUncordon+1, afterManualUncordon, "TotalNodesManuallyUncordoned should increment")
-
-// 	afterCurrentQuarantined := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
-// 	assert.Equal(t, float64(0), afterCurrentQuarantined, "CurrentQuarantinedNodes should be 0")
-// 	assert.GreaterOrEqual(t, beforeCurrentQuarantined, float64(0), "Gauge should have been initialized before")
-// }
-
-// // TestE2ECordonAndTaint_ManualUntaint tests:
-// // SCENARIO:
-// // Node was cordoned by fault-quarantine and taints along with annotations are applied.
-// // Node is manually untainted by the operator.
-// // FQ should detect the manual untaint and clean up the FQ state.
-// func TestE2ECordonAndTaint_ManualUntaint(t *testing.T) {
-// 	ctx, cancel := context.WithTimeout(e2eTestContext, 20*time.Second)
-// 	defer cancel()
-
-// 	nodeName := "test-node-" + generateShortTestID()
-
-// 	// Create a clean node initially
-// 	createE2ETestNode(ctx, t, nodeName, nil, nil, nil, false)
-// 	defer func() {
-// 		_ = e2eTestClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
-// 	}()
-
-// 	tomlConfig := config.TomlConfig{
-// 		LabelPrefix: "k8s.nvidia.com/",
-// 		RuleSets: []config.RuleSet{
-// 			{
-// 				Name:     "gpu-xid-errors",
-// 				Version:  "1",
-// 				Priority: 10,
-// 				Match: config.Match{
-// 					Any: []config.Rule{
-// 						{Kind: "HealthEvent", Expression: "event.checkName == 'GpuXidError'"},
-// 					},
-// 				},
-// 				Taint:  config.Taint{Key: "nvidia.com/gpu-xid-error", Value: "true", Effect: "NoSchedule"},
-// 				Cordon: config.Cordon{ShouldCordon: true},
-// 			},
-// 		},
-// 	}
-
-// 	// Step 1: Start reconciler and let it taint and cordon the node
-// 	t.Log("Step 1: Starting reconciler and sending health event to taint and cordon node")
-// 	_, mockWatcher, _, _ := setupE2EReconciler(t, ctx, tomlConfig, nil)
-
-// 	// Send health event to quarantine the node
-// 	eventID := generateTestID()
-// 	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(
-// 		eventID,
-// 		nodeName,
-// 		"GpuXidError",
-// 		false, // unhealthy
-// 		false,
-// 		[]*protos.Entity{{EntityType: "GPU", EntityValue: "0"}},
-// 		model.StatusInProgress,
-// 	)}
-
-// 	// Wait for node to be quarantined
-// 	t.Log("Waiting for FQ to quarantine the node")
-// 	require.Eventually(t, func() bool {
-// 		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 		if err != nil {
-// 			return false
-// 		}
-// 		hasHealthEvent := node.Annotations[common.QuarantineHealthEventAnnotationKey] != ""
-// 		hasAppliedTaintsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey] != ""
-// 		isCordoned := node.Spec.Unschedulable
-
-// 		hasFQTaint := false
-// 		for _, taint := range node.Spec.Taints {
-// 			if taint.Key == "nvidia.com/gpu-xid-error" {
-// 				hasFQTaint = true
-// 				break
-// 			}
-// 		}
-
-// 		t.Logf("Node tainted check: hasHealthEvent=%v, hasAppliedTaintsAnnotation=%v, isCordoned=%v, hasFQTaint=%v",
-// 			hasHealthEvent, hasAppliedTaintsAnnotation, isCordoned, hasFQTaint)
-// 		return hasHealthEvent && hasAppliedTaintsAnnotation && isCordoned && hasFQTaint
-// 	}, eventuallyTimeout, eventuallyPollInterval, "Node should be quarantined by FQ")
-
-// 	// Reconciler and mockWatcher remain running for subsequent test steps
-
-// 	// Capture metric values before manual untaint
-// 	beforeManualUntaint := getCounterVecValue(t, metrics.TotalNodesManuallyUntainted, nodeName)
-// 	beforeCurrentQuarantined := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
-
-// 	t.Log("Step 2: Manually remove the taint from the node")
-// 	quarantinedNode, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 	require.NoError(t, err)
-
-// 	// Remove the FQ taint manually
-// 	updatedTaints := []corev1.Taint{}
-// 	for _, taint := range quarantinedNode.Spec.Taints {
-// 		if taint.Key != "nvidia.com/gpu-xid-error" {
-// 			updatedTaints = append(updatedTaints, taint)
-// 		}
-// 	}
-// 	quarantinedNode.Spec.Taints = updatedTaints
-
-// 	_, err = e2eTestClient.CoreV1().Nodes().Update(ctx, quarantinedNode, metav1.UpdateOptions{})
-// 	require.NoError(t, err)
-
-// 	t.Log("Step 3:Verify manual untaint is detected and FQ state cleaned up")
-// 	require.Eventually(t, func() bool {
-// 		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 		if err != nil {
-// 			return false
-// 		}
-
-// 		// Manual untaint annotation should be set
-// 		hasManualUntaintAnnotation := node.Annotations[common.QuarantinedNodeIsUntaintedManuallyAnnotationKey] == common.QuarantinedNodeIsUntaintedManuallyAnnotationValue
-
-// 		// FQ annotations should be cleaned up
-// 		_, hasQuarantineAnnotation := node.Annotations[common.QuarantineHealthEventAnnotationKey]
-// 		_, hasAppliedTaintsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey]
-// 		_, hasCordonedAnnotation := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey]
-
-// 		// State label should be removed
-// 		_, hasStateLabel := node.Labels[statemanager.NVSentinelStateLabelKey]
-
-// 		// Check that FQ taint is removed (manually removed by test)
-// 		hasFQTaint := false
-// 		for _, taint := range node.Spec.Taints {
-// 			if taint.Key == "nvidia.com/gpu-xid-error" {
-// 				hasFQTaint = true
-// 				break
-// 			}
-// 		}
-
-// 		// Node should still be cordoned (manual untaint only removes taints, not the cordon)
-// 		isCordoned := node.Spec.Unschedulable
-
-// 		// Note: Manual untaint only removes taints and annotations, not the cordon.
-// 		// The node should still be cordoned.
-// 		return hasManualUntaintAnnotation &&
-// 			!hasQuarantineAnnotation &&
-// 			!hasAppliedTaintsAnnotation &&
-// 			!hasCordonedAnnotation &&
-// 			!hasFQTaint && // FQ taint should be removed
-// 			isCordoned && // node should still be cordoned
-// 			!hasStateLabel
-// 	}, eventuallyTimeout, eventuallyPollInterval, "Manual untaint should clean up FQ state")
-
-// 	t.Log("Verify metrics are correctly updated")
-// 	afterManualUntaint := getCounterVecValue(t, metrics.TotalNodesManuallyUntainted, nodeName)
-// 	assert.Equal(t, beforeManualUntaint+1, afterManualUntaint, "TotalNodesManuallyUntainted should increment")
-
-// 	afterCurrentQuarantined := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
-// 	assert.Equal(t, float64(0), afterCurrentQuarantined, "CurrentQuarantinedNodes should be 0")
-// 	assert.GreaterOrEqual(t, beforeCurrentQuarantined, float64(0), "Gauge should have been initialized before")
-// }
-
-// // TestE2ECordonAndTaint_ManualUncordon tests:
-// // SCENARIO:
-// // Node was cordoned by fault-quarantine and taints along with annotations are applied.
-// // Node is manually uncordoned by the operator.
-// // FQ should detect the manual uncordon and clean up the FQ state.
-// func TestE2ECordonAndTaint_ManualUncordon(t *testing.T) {
-// 	ctx, cancel := context.WithTimeout(e2eTestContext, 20*time.Second)
-// 	defer cancel()
-
-// 	nodeName := "test-node-" + generateShortTestID()
-
-// 	// Create a clean node initially
-// 	createE2ETestNode(ctx, t, nodeName, nil, nil, nil, false)
-// 	defer func() {
-// 		_ = e2eTestClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
-// 	}()
-
-// 	tomlConfig := config.TomlConfig{
-// 		LabelPrefix: "k8s.nvidia.com/",
-// 		RuleSets: []config.RuleSet{
-// 			{
-// 				Name:     "gpu-xid-errors",
-// 				Version:  "1",
-// 				Priority: 10,
-// 				Match: config.Match{
-// 					Any: []config.Rule{
-// 						{Kind: "HealthEvent", Expression: "event.checkName == 'GpuXidError'"},
-// 					},
-// 				},
-// 				Taint:  config.Taint{Key: "nvidia.com/gpu-xid-error", Value: "true", Effect: "NoSchedule"},
-// 				Cordon: config.Cordon{ShouldCordon: true},
-// 			},
-// 		},
-// 	}
-
-// 	// Step 1: Start reconciler and let it taint and cordon the node
-// 	t.Log("Step 1: Starting reconciler and sending health event to taint and cordon node")
-// 	_, mockWatcher, _, _ := setupE2EReconciler(t, ctx, tomlConfig, nil)
-
-// 	// Send health event to quarantine the node
-// 	eventID := generateTestID()
-// 	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(
-// 		eventID,
-// 		nodeName,
-// 		"GpuXidError",
-// 		false, // unhealthy
-// 		false,
-// 		[]*protos.Entity{{EntityType: "GPU", EntityValue: "0"}},
-// 		model.StatusInProgress,
-// 	)}
-
-// 	// Wait for node to be quarantined
-// 	t.Log("Waiting for FQ to quarantine the node")
-// 	require.Eventually(t, func() bool {
-// 		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 		if err != nil {
-// 			return false
-// 		}
-// 		hasHealthEvent := node.Annotations[common.QuarantineHealthEventAnnotationKey] != ""
-// 		hasAppliedTaintsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey] != ""
-// 		isCordoned := node.Spec.Unschedulable
-
-// 		hasFQTaint := false
-// 		for _, taint := range node.Spec.Taints {
-// 			if taint.Key == "nvidia.com/gpu-xid-error" {
-// 				hasFQTaint = true
-// 				break
-// 			}
-// 		}
-
-// 		t.Logf("Node tainted check: hasHealthEvent=%v, hasAppliedTaintsAnnotation=%v, isCordoned=%v, hasFQTaint=%v",
-// 			hasHealthEvent, hasAppliedTaintsAnnotation, isCordoned, hasFQTaint)
-// 		return hasHealthEvent && hasAppliedTaintsAnnotation && isCordoned && hasFQTaint
-// 	}, eventuallyTimeout, eventuallyPollInterval, "Node should be quarantined by FQ")
-
-// 	// Reconciler and mockWatcher remain running for subsequent test steps
-
-// 	// Capture metric values before manual uncordon
-// 	beforeManualUncordon := getCounterVecValue(t, metrics.TotalNodesManuallyUncordoned, nodeName)
-// 	beforeCurrentQuarantined := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
-
-// 	t.Log("Manually uncordon the node")
-// 	quarantinedNode, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 	require.NoError(t, err)
-
-// 	// Uncordon the node manually
-// 	quarantinedNode.Spec.Unschedulable = false
-
-// 	_, err = e2eTestClient.CoreV1().Nodes().Update(ctx, quarantinedNode, metav1.UpdateOptions{})
-// 	require.NoError(t, err)
-
-// 	t.Log("Verify manual uncordon is detected and FQ state cleaned up")
-// 	require.Eventually(t, func() bool {
-// 		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-// 		if err != nil {
-// 			return false
-// 		}
-
-// 		// Manual uncordon annotation should be set
-// 		hasManualUncordonAnnotation := node.Annotations[common.QuarantinedNodeUncordonedManuallyAnnotationKey] == common.QuarantinedNodeUncordonedManuallyAnnotationValue
-
-// 		// FQ annotations should be cleaned up
-// 		_, hasQuarantineAnnotation := node.Annotations[common.QuarantineHealthEventAnnotationKey]
-// 		_, hasAppliedTaintsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey]
-// 		_, hasCordonedAnnotation := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey]
-
-// 		// State label should be removed
-// 		_, hasStateLabel := node.Labels[statemanager.NVSentinelStateLabelKey]
-
-// 		// Check that FQ taint remains (manual uncordon only removes cordon, not taints)
-// 		hasFQTaint := false
-// 		for _, taint := range node.Spec.Taints {
-// 			if taint.Key == "nvidia.com/gpu-xid-error" {
-// 				hasFQTaint = true
-// 				break
-// 			}
-// 		}
-
-// 		// Node should be uncordoned
-// 		isUncordoned := !node.Spec.Unschedulable
-
-// 		return hasManualUncordonAnnotation &&
-// 			!hasQuarantineAnnotation &&
-// 			!hasAppliedTaintsAnnotation &&
-// 			!hasCordonedAnnotation &&
-// 			hasFQTaint && // FQ taint should remain (manual uncordon doesn't remove taints)
-// 			isUncordoned && // node should be uncordoned
-// 			!hasStateLabel
-// 	}, eventuallyTimeout, eventuallyPollInterval, "Manual uncordon should clean up FQ state")
-
-// 	t.Log("Verify metrics are correctly updated")
-// 	afterManualUncordon := getCounterVecValue(t, metrics.TotalNodesManuallyUncordoned, nodeName)
-// 	assert.Equal(t, beforeManualUncordon+1, afterManualUncordon, "TotalNodesManuallyUncordoned should increment")
-
-// 	afterCurrentQuarantined := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
-// 	assert.Equal(t, float64(0), afterCurrentQuarantined, "CurrentQuarantinedNodes should be 0")
-// 	assert.GreaterOrEqual(t, beforeCurrentQuarantined, float64(0), "Gauge should have been initialized before")
-// }
+// TestE2E_ManualUncordonWithCancellation tests that manual uncordon triggers proper cleanup
+func TestE2E_ManualUncordonWithCancellation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(e2eTestContext, 30*time.Second)
+	defer cancel()
+
+	nodeName := testutils.GenerateTestNodeName("e2e-manual-uncordon")
+	createE2ETestNode(ctx, t, nodeName, nil, nil, nil, false)
+	defer func() {
+		_ = e2eTestClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
+	}()
+
+	tomlConfig := config.TomlConfig{
+		LabelPrefix: "k8s.nvidia.com/",
+		RuleSets: []config.RuleSet{
+			{
+				Name:     "gpu-xid-errors",
+				Version:  "1",
+				Priority: 10,
+				Match: config.Match{
+					Any: []config.Rule{
+						{Kind: "HealthEvent", Expression: "event.checkName == 'GpuXidError' && event.isFatal == true"},
+					},
+				},
+				Taint:  config.Taint{Key: "nvidia.com/gpu-xid-error", Value: "true", Effect: "NoSchedule"},
+				Cordon: config.Cordon{ShouldCordon: true},
+			},
+		},
+	}
+
+	_, mockWatcher, getStatus, _ := setupE2EReconciler(t, ctx, tomlConfig, nil)
+
+	beforeManualUncordon := getCounterVecValue(t, metrics.TotalNodesManuallyUncordoned, nodeName)
+	beforeCurrentQuarantined := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
+
+	t.Log("Sending unhealthy event to quarantine node")
+	eventID1 := generateTestID()
+	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(
+		eventID1,
+		nodeName,
+		"GpuXidError",
+		false,
+		true,
+		[]*protos.Entity{{EntityType: "GPU", EntityValue: "0"}},
+		model.StatusInProgress,
+	)}
+
+	t.Log("Waiting for node to be quarantined")
+	require.Eventually(t, func() bool {
+		status := getStatus(eventID1)
+		return status != nil && *status == model.Quarantined
+	}, statusCheckTimeout, statusCheckPollInterval, "Status should be Quarantined")
+
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		return err == nil && node.Spec.Unschedulable
+	}, eventuallyTimeout, eventuallyPollInterval, "Node should be quarantined")
+
+	t.Log("Manually uncordon the node")
+	quarantinedNode, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	require.NoError(t, err)
+	quarantinedNode.Spec.Unschedulable = false
+	_, err = e2eTestClient.CoreV1().Nodes().Update(ctx, quarantinedNode, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	t.Log("Verify manual uncordon cleanup")
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+
+		return node.Annotations[common.QuarantinedNodeUncordonedManuallyAnnotationKey] == common.QuarantinedNodeUncordonedManuallyAnnotationValue &&
+			node.Annotations[common.QuarantineHealthEventAnnotationKey] == ""
+	}, eventuallyTimeout, eventuallyPollInterval, "Manual uncordon should clean up annotations")
+
+	t.Log("Verify manual uncordon metric incremented")
+	afterManualUncordon := getCounterVecValue(t, metrics.TotalNodesManuallyUncordoned, nodeName)
+	assert.Equal(t, beforeManualUncordon+1, afterManualUncordon, "TotalNodesManuallyUncordoned should increment")
+
+	t.Log("Verify current quarantined nodes gauge updated")
+	afterCurrentQuarantined := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
+	assert.Equal(t, float64(0), afterCurrentQuarantined, "CurrentQuarantinedNodes should be 0")
+	assert.GreaterOrEqual(t, beforeCurrentQuarantined, float64(0), "Gauge should have been set before")
+}
+
+// TestE2E_ManualUncordonMultipleEvents tests that manual uncordon works with multiple events on the same node
+func TestE2E_ManualUncordonMultipleEvents(t *testing.T) {
+	ctx, cancel := context.WithTimeout(e2eTestContext, 30*time.Second)
+	defer cancel()
+
+	nodeName := testutils.GenerateTestNodeName("e2e-manual-multi")
+	createE2ETestNode(ctx, t, nodeName, nil, nil, nil, false)
+	defer func() {
+		_ = e2eTestClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
+	}()
+
+	tomlConfig := config.TomlConfig{
+		LabelPrefix: "k8s.nvidia.com/",
+		RuleSets: []config.RuleSet{
+			{
+				Name:     "gpu-xid-errors",
+				Version:  "1",
+				Priority: 10,
+				Match: config.Match{
+					Any: []config.Rule{
+						{Kind: "HealthEvent", Expression: "event.checkName == 'GpuXidError'"},
+					},
+				},
+				Taint:  config.Taint{Key: "nvidia.com/gpu-xid-error", Value: "true", Effect: "NoSchedule"},
+				Cordon: config.Cordon{ShouldCordon: true},
+			},
+		},
+	}
+
+	_, mockWatcher, getStatus, _ := setupE2EReconciler(t, ctx, tomlConfig, nil)
+
+	t.Log("Send first unhealthy event (Quarantined)")
+	eventID1 := generateTestID()
+	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(
+		eventID1,
+		nodeName,
+		"GpuXidError",
+		false,
+		true,
+		[]*protos.Entity{{EntityType: "GPU", EntityValue: "0"}},
+		model.StatusInProgress,
+	)}
+
+	require.Eventually(t, func() bool {
+		status := getStatus(eventID1)
+		return status != nil && *status == model.Quarantined
+	}, statusCheckTimeout, statusCheckPollInterval, "First event should be Quarantined")
+
+	t.Log("Send second unhealthy event (AlreadyQuarantined)")
+	eventID2 := generateTestID()
+	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(
+		eventID2,
+		nodeName,
+		"GpuXidError",
+		false,
+		true,
+		[]*protos.Entity{{EntityType: "GPU", EntityValue: "1"}},
+		model.StatusInProgress,
+	)}
+
+	require.Eventually(t, func() bool {
+		status := getStatus(eventID2)
+		return status != nil && *status == model.AlreadyQuarantined
+	}, statusCheckTimeout, statusCheckPollInterval, "Second event should be Quarantined")
+
+	t.Log("Send third unhealthy event (AlreadyQuarantined)")
+	eventID3 := generateTestID()
+	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(
+		eventID3,
+		nodeName,
+		"GpuXidError",
+		false,
+		true,
+		[]*protos.Entity{{EntityType: "GPU", EntityValue: "2"}},
+		model.StatusInProgress,
+	)}
+
+	require.Eventually(t, func() bool {
+		status := getStatus(eventID3)
+		return status != nil && *status == model.AlreadyQuarantined
+	}, statusCheckTimeout, statusCheckPollInterval, "Third event should be AlreadyQuarantined")
+
+	t.Log("Manually uncordon the node")
+	quarantinedNode, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	require.NoError(t, err)
+	quarantinedNode.Spec.Unschedulable = false
+	_, err = e2eTestClient.CoreV1().Nodes().Update(ctx, quarantinedNode, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	t.Log("Verify manual uncordon annotation is set")
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return node.Annotations[common.QuarantinedNodeUncordonedManuallyAnnotationKey] == common.QuarantinedNodeUncordonedManuallyAnnotationValue
+	}, eventuallyTimeout, eventuallyPollInterval, "Manual uncordon annotation should be set")
+
+	t.Log("Verify quarantine annotation cleared")
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return node.Annotations[common.QuarantineHealthEventAnnotationKey] == ""
+	}, eventuallyTimeout, eventuallyPollInterval, "Quarantine annotation should be cleared")
+}
+
+// TestE2E_ConcurrentHealthyEvents_WithDelayedInformer verifies that the reconciler correctly
+// uncordons a node when multiple health checks recover simultaneously, even when the informer
+// cache is stale.
+//
+// SCENARIO:
+// A node has two different failing health checks. Both checks recover at the same time,
+// generating two healthy events that are processed concurrently. Each event:
+//   - Reads the node state from the informer cache
+//   - Removes its own check from the annotation
+//   - Decides whether to uncordon based on remaining checks
+//
+// CHALLENGE:
+// When both events read the cache before either update propagates back, they both see
+// stale data showing "the other check is still failing." The reconciler must handle this
+// correctly and ensure the node is uncordoned when all checks have actually recovered.
+//
+// TEST STRATEGY:
+// We inject a 500ms delay into the informer's watch connection, simulating real-world
+// cache lag due to network latency or API server load. The delay is toggled:
+//   - DISABLED during setup: allows normal operation to quarantine the node
+//   - ENABLED during trigger: forces concurrent events to see stale cache
+func TestE2E_ConcurrentHealthyEvents_WithDelayedInformer(t *testing.T) {
+	// This test requires its own envtest instance with a custom transport wrapper
+	testEnv := &envtest.Environment{}
+	restConfig, err := testEnv.Start()
+	require.NoError(t, err, "Failed to start test environment")
+
+	// Start with delay DISABLED - we need normal operation during setup phase
+	delayedRT := &delayedWatchRoundTripper{
+		watchDelay: 500 * time.Millisecond,
+		enabled:    false,
+	}
+
+	stopCh := make(chan struct{})
+
+	// Shutdown order matters: disable delay first (unblocks any pending reads), then stop
+	// informer (closes watch connection), then stop envtest (can now shut down cleanly)
+	defer func() {
+		delayedRT.SetEnabled(false)
+		close(stopCh)
+		if err := testEnv.Stop(); err != nil {
+			t.Logf("Warning: Failed to stop test environment: %v", err)
+		}
+	}()
+
+	// Wrap the transport to delay only watch requests (informer cache sync)
+	// Regular GET/POST/PUT/DELETE requests are unaffected
+	restConfig.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		delayedRT.delegate = rt
+		return delayedRT
+	})
+
+	k8sClient, err := kubernetes.NewForConfig(restConfig)
+	require.NoError(t, err, "Failed to create k8s client")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	nodeName := "concurrent-recovery-" + generateShortTestID()
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+		Spec:       corev1.NodeSpec{Unschedulable: false},
+		Status:     corev1.NodeStatus{Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}}},
+	}
+	_, err = k8sClient.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
+	require.NoError(t, err, "Failed to create test node")
+	defer func() {
+		_ = k8sClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
+	}()
+
+	tomlConfig := config.TomlConfig{
+		LabelPrefix: "k8s.nvidia.com/",
+		RuleSets: []config.RuleSet{{
+			Name:     "gpu-fatal-errors",
+			Version:  "1",
+			Priority: 10,
+			Match:    config.Match{Any: []config.Rule{{Kind: "HealthEvent", Expression: "event.isFatal == true"}}},
+			Taint:    config.Taint{Key: "nvidia.com/gpu-error", Value: "true", Effect: "NoSchedule"},
+			Cordon:   config.Cordon{ShouldCordon: true},
+		}},
+	}
+
+	// Resync period of 0 disables periodic re-listing. The informer only updates via watch
+	// events, not by periodically fetching all nodes. This ensures cache staleness is controlled
+	// solely by our delayed watch transport.
+	nodeInformer, err := informer.NewNodeInformer(k8sClient, 0)
+	require.NoError(t, err)
+
+	fqClient := &informer.FaultQuarantineClient{
+		Clientset:    k8sClient,
+		DryRunMode:   false,
+		NodeInformer: nodeInformer,
+	}
+
+	go func() { _ = nodeInformer.Run(stopCh) }()
+
+	require.Eventually(t, nodeInformer.HasSynced, 10*time.Second, 100*time.Millisecond, "NodeInformer should sync")
+
+	ruleSetEvals, err := evaluator.InitializeRuleSetEvaluators(tomlConfig.RuleSets, fqClient.NodeInformer)
+	require.NoError(t, err)
+
+	r := NewReconciler(ReconcilerConfig{TomlConfig: tomlConfig}, fqClient, nil)
+	r.SetLabelKeys(tomlConfig.LabelPrefix)
+	fqClient.SetLabelKeys(r.cordonedReasonLabelKey, r.uncordonedReasonLabelKey)
+
+	rulesetsConfig := rulesetsConfig{
+		TaintConfigMap:     make(map[string]*config.Taint),
+		CordonConfigMap:    make(map[string]bool),
+		RuleSetPriorityMap: make(map[string]int),
+	}
+	for _, rs := range tomlConfig.RuleSets {
+		if rs.Taint.Key != "" {
+			rulesetsConfig.TaintConfigMap[rs.Name] = &rs.Taint
+		}
+		if rs.Cordon.ShouldCordon {
+			rulesetsConfig.CordonConfigMap[rs.Name] = true
+		}
+		if rs.Priority > 0 {
+			rulesetsConfig.RuleSetPriorityMap[rs.Name] = rs.Priority
+		}
+	}
+
+	r.precomputeTaintInitKeys(context.Background(), ruleSetEvals, rulesetsConfig)
+	fqClient.NodeInformer.SetOnManualUncordonCallback(r.handleManualUncordon)
+
+	mockWatcher := testutils.NewMockChangeStreamWatcher()
+	t.Cleanup(func() { close(mockWatcher.EventsChan) })
+
+	go func() {
+		for event := range mockWatcher.Events() {
+			var healthEventWithStatus model.HealthEventWithStatus
+			if err := event.UnmarshalDocument(&healthEventWithStatus); err != nil {
+				continue
+			}
+			r.ProcessEvent(ctx, &healthEventWithStatus, ruleSetEvals, rulesetsConfig)
+		}
+	}()
+
+	// === SETUP: Quarantine node with TWO different checks ===
+	t.Log("Setup: Quarantining node with two checks")
+
+	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(
+		generateTestID(), nodeName, "GpuInforomWatch", false, true,
+		[]*protos.Entity{{EntityType: "GPU", EntityValue: "0"}}, model.StatusInProgress,
+	)}
+
+	require.Eventually(t, func() bool {
+		n, _ := k8sClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		return n.Spec.Unschedulable
+	}, 10*time.Second, 100*time.Millisecond, "Node should be quarantined")
+
+	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(
+		generateTestID(), nodeName, "GpuDcgmConnectivityFailure", false, true,
+		[]*protos.Entity{}, model.StatusInProgress,
+	)}
+
+	require.Eventually(t, func() bool {
+		n, _ := k8sClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		var m healthEventsAnnotation.HealthEventsAnnotationMap
+		if err := json.Unmarshal([]byte(n.Annotations[common.QuarantineHealthEventAnnotationKey]), &m); err != nil {
+			return false
+		}
+		return m.Count() == 2
+	}, 10*time.Second, 100*time.Millisecond, "Both checks should be tracked")
+
+	// === TRIGGER: Process both healthy events CONCURRENTLY with delayed watch ===
+	t.Log("Trigger: Enabling watch delay and processing healthy events concurrently")
+
+	// From this point, every informer cache update is delayed by 500ms. Any K8s API update
+	// the reconciler makes won't be visible in the cache until well after both events finish.
+	delayedRT.SetEnabled(true)
+
+	// Recovery events for both checks - these will be processed simultaneously
+	eventA := &model.HealthEventWithStatus{
+		HealthEvent: &protos.HealthEvent{
+			Version: 1, Agent: "gpu-health-monitor", ComponentClass: "GPU",
+			CheckName: "GpuDcgmConnectivityFailure", IsHealthy: true, IsFatal: false,
+			EntitiesImpacted: []*protos.Entity{}, NodeName: nodeName,
+		},
+	}
+
+	eventB := &model.HealthEventWithStatus{
+		HealthEvent: &protos.HealthEvent{
+			Version: 1, Agent: "gpu-health-monitor", ComponentClass: "GPU",
+			CheckName: "GpuInforomWatch", IsHealthy: true, IsFatal: false,
+			EntitiesImpacted: []*protos.Entity{{EntityType: "GPU", EntityValue: "0"}}, NodeName: nodeName,
+		},
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// startBarrier ensures both goroutines begin at exactly the same instant. Both block
+	// on receiving from this channel; closing the channel unblocks all receivers simultaneously.
+	// This maximizes overlap between the two ProcessEvent calls, guaranteeing they both read
+	// the cache before either has a chance to see the other's updates.
+	startBarrier := make(chan struct{})
+
+	go func() {
+		defer wg.Done()
+		<-startBarrier
+		r.ProcessEvent(ctx, eventA, ruleSetEvals, rulesetsConfig)
+	}()
+
+	go func() {
+		defer wg.Done()
+		<-startBarrier
+		r.ProcessEvent(ctx, eventB, ruleSetEvals, rulesetsConfig)
+	}()
+
+	close(startBarrier)
+	wg.Wait()
+
+	// === VERIFY: Node should be fully recovered ===
+	delayedRT.SetEnabled(false)
+
+	// Read directly from API server (not cache) to get the true final state
+	finalNode, err := k8sClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	annotation := finalNode.Annotations[common.QuarantineHealthEventAnnotationKey]
+	isStillCordoned := finalNode.Spec.Unschedulable
+
+	t.Logf("Final state: annotation=%q, stillCordoned=%v", annotation, isStillCordoned)
+
+	// Verify annotation is empty - both events successfully removed their checks
+	var healthEventsMap healthEventsAnnotation.HealthEventsAnnotationMap
+	annotationIsEmpty := annotation == "" || annotation == "[]"
+	if !annotationIsEmpty && annotation != "" {
+		if err := json.Unmarshal([]byte(annotation), &healthEventsMap); err == nil {
+			annotationIsEmpty = healthEventsMap.IsEmpty()
+		}
+	}
+
+	require.True(t, annotationIsEmpty, "Annotation should be empty after both checks recovered, got: %s", annotation)
+
+	// With all checks recovered (empty annotation), node must be uncordoned
+	require.False(t, isStillCordoned,
+		"Node should be uncordoned when all health checks have recovered. "+
+			"The reconciler must correctly handle concurrent recovery events even with stale cache.")
+
+	require.Empty(t, finalNode.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey])
+
+	fqTaintCount := 0
+	for _, taint := range finalNode.Spec.Taints {
+		if taint.Key == "nvidia.com/gpu-error" {
+			fqTaintCount++
+		}
+	}
+	require.Equal(t, 0, fqTaintCount, "FQ taints should be removed")
+}
+
+// TestE2E_StaleAnnotationOnRestart test verifies that stale annotation and taints are cleaned up
+// on restart if node has been manually uncordoned before the FQ pod restarted:
+// SCENARIO:
+// 1. FQ reconciler is running and taints + cordons a node due to a health event
+// 2. Reconciler pod crashes or stops running (simulating OOM, cluster upgrade, etc.)
+// 3. While reconciler is down, operator manually removes taints and uncordons the node
+// 4. Reconciler pod restarts
+// Expected: Reconciler should detect stale annotations (annotation + taints present but node not cordoned/tainted)
+// and clean them up, ensuring metrics are correctly initialized to 0.
+func TestE2E_StaleAnnotationOnRestart_TaintsAndCordon(t *testing.T) {
+	ctx, cancel := context.WithTimeout(e2eTestContext, 30*time.Second)
+	defer cancel()
+
+	nodeName := "stale-annotation-test-node-" + generateShortTestID()
+
+	// Create a clean node initially
+	createE2ETestNode(ctx, t, nodeName, nil, nil, nil, false)
+	defer func() {
+		_ = e2eTestClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
+	}()
+
+	tomlConfig := config.TomlConfig{
+		LabelPrefix: "k8s.nvidia.com/",
+		RuleSets: []config.RuleSet{
+			{
+				Name:     "gpu-xid-errors",
+				Version:  "1",
+				Priority: 10,
+				Match: config.Match{
+					Any: []config.Rule{
+						{Kind: "HealthEvent", Expression: "event.checkName == 'GpuXidError'"},
+					},
+				},
+				Taint:  config.Taint{Key: "nvidia.com/gpu-xid-error", Value: "true", Effect: "NoSchedule"},
+				Cordon: config.Cordon{ShouldCordon: true},
+			},
+		},
+	}
+
+	// Step 1: Start reconciler and let it taint and cordon the node
+	t.Log("Step 1: Starting reconciler and sending health event to taint and cordon node")
+	runReconcilerAndQuarantineNode(t, ctx, nodeName, tomlConfig, func(t *testing.T, node *corev1.Node) bool {
+		hasHealthEvent := node.Annotations[common.QuarantineHealthEventAnnotationKey] != ""
+		hasAppliedTaintsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey] != ""
+		hasCordonAnnotation := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey] == "True"
+		isCordoned := node.Spec.Unschedulable
+
+		hasFQTaint := false
+		for _, taint := range node.Spec.Taints {
+			if taint.Key == "nvidia.com/gpu-xid-error" {
+				hasFQTaint = true
+				break
+			}
+		}
+
+		t.Logf("Node quarantined check: hasHealthEvent=%v, hasAppliedTaintsAnnotation=%v, hasCordonAnnotation=%v, isCordoned=%v, hasFQTaint=%v",
+			hasHealthEvent, hasAppliedTaintsAnnotation, hasCordonAnnotation, isCordoned, hasFQTaint)
+		return hasHealthEvent && hasAppliedTaintsAnnotation && hasCordonAnnotation && isCordoned && hasFQTaint
+	})
+
+	// Step 2: Manually remove taints and uncordon the node
+	t.Log("Step 2: Manually removing taints and uncordoning the node while reconciler is down")
+	node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	// Remove FQ taints
+	filteredTaints := []corev1.Taint{}
+	for _, taint := range node.Spec.Taints {
+		if taint.Key != "nvidia.com/gpu-xid-error" && taint.Key != "node.kubernetes.io/unschedulable" {
+			filteredTaints = append(filteredTaints, taint)
+		}
+	}
+	node.Spec.Taints = filteredTaints
+	node.Spec.Unschedulable = false
+
+	_, err = e2eTestClient.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	t.Log("Verifying node is manually untainted/uncordoned but stale annotations remain")
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		hasHealthEvent := node.Annotations[common.QuarantineHealthEventAnnotationKey] != ""
+		hasAppliedTaintsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey] != ""
+		isNotCordoned := !node.Spec.Unschedulable
+
+		hasFQTaint := false
+		for _, taint := range node.Spec.Taints {
+			if taint.Key == "nvidia.com/gpu-xid-error" {
+				hasFQTaint = true
+				break
+			}
+		}
+
+		t.Logf("Stale state check: hasHealthEvent=%v, hasAppliedTaintsAnnotation=%v, isNotCordoned=%v, hasFQTaint=%v",
+			hasHealthEvent, hasAppliedTaintsAnnotation, isNotCordoned, hasFQTaint)
+		return hasHealthEvent && hasAppliedTaintsAnnotation && isNotCordoned && !hasFQTaint
+	}, eventuallyTimeout, eventuallyPollInterval, "Node should be untainted/uncordoned but have stale annotations")
+
+	// Step 3: Restart reconciler - it should detect and clean up stale annotations
+	t.Log("Step 3: Setting up reconciler - simulating pod restart with stale annotation")
+	setupE2EReconciler(t, ctx, tomlConfig, nil)
+
+	t.Log("Verifying stale annotations are cleaned up")
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+
+		// Stale annotations should be removed
+		annotationRemoved := node.Annotations[common.QuarantineHealthEventAnnotationKey] == ""
+		appliedTaintsRemoved := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey] == ""
+		cordonedAnnotationRemoved := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey] == ""
+		labelRemoved := node.Labels[statemanager.NVSentinelStateLabelKey] == ""
+
+		fqTaintCount := 0
+		for _, taint := range node.Spec.Taints {
+			if taint.Key == "nvidia.com/gpu-xid-error" {
+				fqTaintCount++
+			}
+		}
+
+		return annotationRemoved &&
+			appliedTaintsRemoved &&
+			cordonedAnnotationRemoved &&
+			labelRemoved &&
+			fqTaintCount == 0 &&
+			!node.Spec.Unschedulable
+	}, eventuallyTimeout, eventuallyPollInterval, "Stale annotations should be cleaned up on restart")
+
+	t.Log("Verifying metric is correctly initialized to 0 (not 1)")
+	gaugeValue := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
+	assert.Equal(t, float64(0), gaugeValue, "CurrentQuarantinedNodes should be 0 after cleaning stale annotation")
+}
+
+// TestE2E_StaleAnnotationOnRestart_CordonOnly tests stale annotation is cleaned up on restart if node has been manually uncordoned before the FQ pod restarted:
+// SCENARIO:
+// 1. FQ reconciler is running and cordons a node due to a health event (no taints, cordon-only)
+// 2. Reconciler pod crashes or stops running (simulating OOM, cluster upgrade, etc.)
+// 3. While reconciler is down, operator manually uncordons the node
+// 4. Reconciler pod restarts
+// Expected: Reconciler should detect stale annotations (annotation says cordoned but node is not cordoned)
+// and clean them up, ensuring metrics are correctly initialized to 0.
+func TestE2E_StaleAnnotationOnRestart_CordonOnly(t *testing.T) {
+	ctx, cancel := context.WithTimeout(e2eTestContext, 30*time.Second)
+	defer cancel()
+
+	nodeName := "stale-cordon-only-node-" + generateShortTestID()
+
+	// Create a clean node initially
+	createE2ETestNode(ctx, t, nodeName, nil, nil, nil, false)
+	defer func() {
+		_ = e2eTestClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
+	}()
+
+	tomlConfig := config.TomlConfig{
+		LabelPrefix: "k8s.nvidia.com/",
+		RuleSets: []config.RuleSet{
+			{
+				Name:     "gpu-xid-errors",
+				Version:  "1",
+				Priority: 10,
+				Match: config.Match{
+					Any: []config.Rule{
+						{Kind: "HealthEvent", Expression: "event.checkName == 'GpuXidError'"},
+					},
+				},
+				Cordon: config.Cordon{ShouldCordon: true}, // Cordon-only, no taints
+			},
+		},
+	}
+
+	// Step 1: Start reconciler and let it cordon the node (no taints)
+	t.Log("Step 1: Starting reconciler and sending health event to cordon node")
+	runReconcilerAndQuarantineNode(t, ctx, nodeName, tomlConfig, func(t *testing.T, node *corev1.Node) bool {
+		hasHealthEvent := node.Annotations[common.QuarantineHealthEventAnnotationKey] != ""
+		hasCordonAnnotation := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey] == "True"
+		isCordoned := node.Spec.Unschedulable
+		t.Logf("Node cordoned check: hasHealthEvent=%v, hasCordonAnnotation=%v, isCordoned=%v",
+			hasHealthEvent, hasCordonAnnotation, isCordoned)
+		return hasHealthEvent && hasCordonAnnotation && isCordoned
+	})
+
+	// Step 2: Manually uncordon the node (simulating kubectl uncordon)
+	t.Log("Step 2: Manually uncordoning the node while reconciler is down")
+	node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	require.NoError(t, err)
+	node.Spec.Unschedulable = false
+	_, err = e2eTestClient.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	t.Log("Verifying node is manually uncordoned but stale annotations remain")
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		hasHealthEvent := node.Annotations[common.QuarantineHealthEventAnnotationKey] != ""
+		hasCordonAnnotation := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey] == "True"
+		isNotCordoned := !node.Spec.Unschedulable
+		t.Logf("Stale state check: hasHealthEvent=%v, hasCordonAnnotation=%v, isNotCordoned=%v",
+			hasHealthEvent, hasCordonAnnotation, isNotCordoned)
+		return hasHealthEvent && hasCordonAnnotation && isNotCordoned
+	}, eventuallyTimeout, eventuallyPollInterval, "Node should be uncordoned but have stale annotations")
+
+	// Step 3: Restart reconciler - it should detect and clean up stale annotations
+	t.Log("Step 3: Setting up reconciler - simulating pod restart with stale cordon annotation")
+	_, _, _, _ = setupE2EReconciler(t, ctx, tomlConfig, nil)
+
+	t.Log("Verifying stale cordon annotations were cleaned up during reconciler startup")
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+
+		annotationRemoved := node.Annotations[common.QuarantineHealthEventAnnotationKey] == ""
+		cordonedAnnotationRemoved := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey] == ""
+		labelRemoved := node.Labels[statemanager.NVSentinelStateLabelKey] == ""
+
+		return annotationRemoved &&
+			cordonedAnnotationRemoved &&
+			labelRemoved &&
+			!node.Spec.Unschedulable
+	}, eventuallyTimeout, eventuallyPollInterval, "Stale cordon annotations should be cleaned up")
+
+	t.Log("Verifying metric is correctly initialized to 0 (not 1)")
+	gaugeValue := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
+	assert.Equal(t, float64(0), gaugeValue, "CurrentQuarantinedNodes should be 0 after cleaning stale annotation")
+}
+
+// TestE2E_StaleAnnotationOnRestart_TaintsOnly test verifies that stale annotation and taints are cleaned up
+// on restart when node was manually untainted and uncordoned while reconciler was down:
+// SCENARIO:
+// 1. FQ reconciler is running and taints + cordons a node due to a health event
+// 2. Reconciler pod crashes or stops running (simulating OOM, cluster upgrade, etc.)
+// 3. While reconciler is down, operator manually removes taints and uncordons the node
+// 4. Reconciler pod restarts
+// Expected: Reconciler should detect stale annotations (health event + appliedTaints annotations exist but node is not tainted/cordoned)
+// and clean them up, ensuring metrics are correctly initialized to 0.
+func TestE2E_StaleAnnotationOnRestart_TaintsOnly(t *testing.T) {
+	ctx, cancel := context.WithTimeout(e2eTestContext, 30*time.Second)
+	defer cancel()
+
+	nodeName := "stale-taints-node-" + generateShortTestID()
+
+	// Create a clean node initially
+	createE2ETestNode(ctx, t, nodeName, nil, nil, nil, false)
+	defer func() {
+		_ = e2eTestClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
+	}()
+
+	tomlConfig := config.TomlConfig{
+		LabelPrefix: "k8s.nvidia.com/",
+		RuleSets: []config.RuleSet{
+			{
+				Name:     "gpu-xid-errors",
+				Version:  "1",
+				Priority: 10,
+				Match: config.Match{
+					Any: []config.Rule{
+						{Kind: "HealthEvent", Expression: "event.checkName == 'GpuXidError'"},
+					},
+				},
+				Taint:  config.Taint{Key: "nvidia.com/gpu-xid-error", Value: "true", Effect: "NoSchedule"},
+				Cordon: config.Cordon{ShouldCordon: true},
+			},
+		},
+	}
+
+	// Step 1: Start reconciler and let it taint and cordon the node
+	t.Log("Step 1: Starting reconciler and sending health event to taint and cordon node")
+	runReconcilerAndQuarantineNode(t, ctx, nodeName, tomlConfig, func(t *testing.T, node *corev1.Node) bool {
+		hasHealthEvent := node.Annotations[common.QuarantineHealthEventAnnotationKey] != ""
+		hasAppliedTaintsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey] != ""
+		isCordoned := node.Spec.Unschedulable
+
+		hasFQTaint := false
+		for _, taint := range node.Spec.Taints {
+			if taint.Key == "nvidia.com/gpu-xid-error" {
+				hasFQTaint = true
+				break
+			}
+		}
+
+		t.Logf("Node tainted check: hasHealthEvent=%v, hasAppliedTaintsAnnotation=%v, isCordoned=%v, hasFQTaint=%v",
+			hasHealthEvent, hasAppliedTaintsAnnotation, isCordoned, hasFQTaint)
+		return hasHealthEvent && hasAppliedTaintsAnnotation && isCordoned && hasFQTaint
+	})
+
+	// Step 2: Manually remove taints and uncordon the node (simulating kubectl uncordon + manual taint removal)
+	t.Log("Step 2: Manually removing taints and uncordoning the node while reconciler is down")
+	node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	// Remove FQ taints
+	filteredTaints := []corev1.Taint{}
+	for _, taint := range node.Spec.Taints {
+		if taint.Key != "nvidia.com/gpu-xid-error" && taint.Key != "node.kubernetes.io/unschedulable" {
+			filteredTaints = append(filteredTaints, taint)
+		}
+	}
+	node.Spec.Taints = filteredTaints
+	node.Spec.Unschedulable = false
+
+	_, err = e2eTestClient.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	t.Log("Verifying node is manually untainted/uncordoned but stale annotations remain")
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		hasHealthEvent := node.Annotations[common.QuarantineHealthEventAnnotationKey] != ""
+		hasAppliedTaintsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey] != ""
+		isNotCordoned := !node.Spec.Unschedulable
+
+		hasFQTaint := false
+		for _, taint := range node.Spec.Taints {
+			if taint.Key == "nvidia.com/gpu-xid-error" {
+				hasFQTaint = true
+				break
+			}
+		}
+
+		t.Logf("Stale state check: hasHealthEvent=%v, hasAppliedTaintsAnnotation=%v, isNotCordoned=%v, hasFQTaint=%v",
+			hasHealthEvent, hasAppliedTaintsAnnotation, isNotCordoned, hasFQTaint)
+		return hasHealthEvent && hasAppliedTaintsAnnotation && isNotCordoned && !hasFQTaint
+	}, eventuallyTimeout, eventuallyPollInterval, "Node should be untainted/uncordoned but have stale annotations")
+
+	// Step 3: Restart reconciler - it should detect and clean up stale annotations
+	t.Log("Step 3: Restarting reconciler - should detect and clean up stale annotations")
+	_, _, _, _ = setupE2EReconciler(t, ctx, tomlConfig, nil)
+
+	t.Log("Verifying stale annotations were cleaned up during reconciler startup")
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+
+		annotationRemoved := node.Annotations[common.QuarantineHealthEventAnnotationKey] == ""
+		appliedTaintsRemoved := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey] == ""
+		cordonAnnotationRemoved := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey] == ""
+		labelRemoved := node.Labels[statemanager.NVSentinelStateLabelKey] == ""
+
+		fqTaintCount := 0
+		for _, taint := range node.Spec.Taints {
+			if taint.Key == "nvidia.com/gpu-xid-error" {
+				fqTaintCount++
+			}
+		}
+
+		t.Logf("Cleanup check: annotationRemoved=%v, appliedTaintsRemoved=%v, cordonAnnotationRemoved=%v, labelRemoved=%v, fqTaintCount=%d, isUnschedulable=%v",
+			annotationRemoved, appliedTaintsRemoved, cordonAnnotationRemoved, labelRemoved, fqTaintCount, node.Spec.Unschedulable)
+
+		return annotationRemoved &&
+			appliedTaintsRemoved &&
+			cordonAnnotationRemoved &&
+			labelRemoved &&
+			fqTaintCount == 0 &&
+			!node.Spec.Unschedulable
+	}, eventuallyTimeout, eventuallyPollInterval, "Stale annotations should be cleaned up after detecting manual untaint/uncordon")
+
+	t.Log("Verifying metric is correctly initialized to 0 (not 1)")
+	gaugeValue := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
+	assert.Equal(t, float64(0), gaugeValue, "CurrentQuarantinedNodes should be 0 after cleaning stale annotations for manually untainted/uncordoned node")
+}
+
+// TestE2E_ManualUncordonWithMissingMongoDoc tests :
+// SCENARIO:
+// Node was cordoned by fault-quarantine and taints along with annotations are applied.
+// Cluster upgrade was done where PVC were deleted.
+// After upgrade when FQ restarts,
+// if node is manually uncordoned and MongoDB document is missing (e.g., DB was reset),
+// FQ should handle this gracefully with a warning (not error) and still update metrics correctly.
+func TestE2E_ManualUncordonWithMissingMongoDoc(t *testing.T) {
+	ctx, cancel := context.WithTimeout(e2eTestContext, 20*time.Second)
+	defer cancel()
+
+	nodeName := "test-node-" + generateShortTestID()
+
+	// Simulate post-upgrade state: node was cordoned before upgrade
+	existingEvent := &protos.HealthEvent{
+		NodeName:       nodeName,
+		Agent:          "gpu-health-monitor",
+		CheckName:      "GpuXidError",
+		ComponentClass: "GPU",
+		Version:        1,
+		IsHealthy:      false,
+		EntitiesImpacted: []*protos.Entity{
+			{EntityType: "GPU", EntityValue: "0"},
+		},
+	}
+
+	existingMap := healthEventsAnnotation.NewHealthEventsAnnotationMap()
+	existingMap.AddOrUpdateEvent(existingEvent)
+	existingBytes, err := json.Marshal(existingMap)
+	require.NoError(t, err)
+
+	annotations := map[string]string{
+		common.QuarantineHealthEventAnnotationKey:              string(existingBytes),
+		common.QuarantineHealthEventAppliedTaintsAnnotationKey: `[{"Key":"nvidia.com/gpu-xid-error","Value":"true","Effect":"NoSchedule"}]`,
+		common.QuarantineHealthEventIsCordonedAnnotationKey:    "True",
+	}
+
+	labels := map[string]string{
+		statemanager.NVSentinelStateLabelKey: string(statemanager.QuarantinedLabelValue),
+	}
+
+	taints := []corev1.Taint{
+		{Key: "nvidia.com/gpu-xid-error", Value: "true", Effect: "NoSchedule"},
+	}
+
+	createE2ETestNode(ctx, t, nodeName, annotations, labels, taints, true)
+	defer func() {
+		_ = e2eTestClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
+	}()
+
+	tomlConfig := config.TomlConfig{
+		LabelPrefix: "k8s.nvidia.com/",
+	}
+
+	t.Log("Setting up reconciler after simulated upgrade with eventWatcher")
+	r, _, _, _ := setupE2EReconciler(t, ctx, tomlConfig, nil)
+	mockEventWatcher := &MockEventWatcher{}
+	mockEventWatcher.CancelLatestQuarantiningEventsFn = func(ctx context.Context, nodeName string, reason string) error {
+		return fmt.Errorf("error decoding latest quarantining event for node %s: mongo: no documents in result", nodeName)
+	}
+	mockEventWatcher.ProcessEventCallbackFn = func(ctx context.Context, event *model.HealthEventWithStatus) *model.Status {
+		return nil
+	}
+	mockEventWatcher.StartFn = func(ctx context.Context) error {
+		return nil
+	}
+
+	r.eventWatcher = mockEventWatcher
+
+	require.Eventually(t, func() bool {
+		node, err := r.k8sClient.NodeInformer.GetNode(nodeName)
+		return err == nil && node != nil && node.Spec.Unschedulable
+	}, eventuallyTimeout, eventuallyPollInterval, "Informer should see the initially quarantined node")
+
+	beforeManualUncordon := getCounterVecValue(t, metrics.TotalNodesManuallyUncordoned, nodeName)
+	beforeCurrentQuarantined := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
+
+	t.Log("Manually uncordon node (simulating operator action after upgrade)")
+	quarantinedNode, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	require.NoError(t, err)
+	quarantinedNode.Spec.Unschedulable = false
+	_, err = e2eTestClient.CoreV1().Nodes().Update(ctx, quarantinedNode, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	t.Log("Verifying manual uncordon cleanup completes successfully")
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+
+		// Manual uncordon annotation should be set
+		hasManualUncordonAnnotation := node.Annotations[common.QuarantinedNodeUncordonedManuallyAnnotationKey] == common.QuarantinedNodeUncordonedManuallyAnnotationValue
+
+		// FQ annotations should be cleaned up
+		annotationRemoved := node.Annotations[common.QuarantineHealthEventAnnotationKey] == ""
+		appliedTaintsRemoved := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey] == ""
+		cordonedAnnotationRemoved := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey] == ""
+
+		// FQ taints should remain (manual uncordon only removes annotations, not taints)
+		hasFQTaint := false
+		for _, taint := range node.Spec.Taints {
+			if taint.Key == "nvidia.com/gpu-xid-error" {
+				hasFQTaint = true
+				break
+			}
+		}
+
+		// Node should be uncordoned
+		isUncordoned := !node.Spec.Unschedulable
+
+		return hasManualUncordonAnnotation &&
+			annotationRemoved &&
+			appliedTaintsRemoved &&
+			cordonedAnnotationRemoved &&
+			hasFQTaint && // FQ taint should remain (manual uncordon doesn't remove taints)
+			isUncordoned // node should be uncordoned
+	}, eventuallyTimeout, eventuallyPollInterval, "Manual uncordon should complete cleanup even without MongoDB doc")
+
+	t.Log("Verifying metrics are correctly updated despite missing MongoDB document")
+	afterManualUncordon := getCounterVecValue(t, metrics.TotalNodesManuallyUncordoned, nodeName)
+	assert.Equal(t, beforeManualUncordon+1, afterManualUncordon, "TotalNodesManuallyUncordoned should increment")
+
+	afterCurrentQuarantined := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
+	assert.Equal(t, float64(0), afterCurrentQuarantined, "CurrentQuarantinedNodes should be 0")
+	assert.GreaterOrEqual(t, beforeCurrentQuarantined, float64(0), "Gauge should have been initialized before")
+}
+
+// TestE2ECordonAndTaint_ManualUntaint tests:
+// SCENARIO:
+// Node was cordoned by fault-quarantine and taints along with annotations are applied.
+// Node is manually untainted by the operator.
+// FQ should detect the manual untaint and clean up the FQ state.
+func TestE2ECordonAndTaint_ManualUntaint(t *testing.T) {
+	ctx, cancel := context.WithTimeout(e2eTestContext, 20*time.Second)
+	defer cancel()
+
+	nodeName := "test-node-" + generateShortTestID()
+
+	// Create a clean node initially
+	createE2ETestNode(ctx, t, nodeName, nil, nil, nil, false)
+	defer func() {
+		_ = e2eTestClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
+	}()
+
+	tomlConfig := config.TomlConfig{
+		LabelPrefix: "k8s.nvidia.com/",
+		RuleSets: []config.RuleSet{
+			{
+				Name:     "gpu-xid-errors",
+				Version:  "1",
+				Priority: 10,
+				Match: config.Match{
+					Any: []config.Rule{
+						{Kind: "HealthEvent", Expression: "event.checkName == 'GpuXidError'"},
+					},
+				},
+				Taint:  config.Taint{Key: "nvidia.com/gpu-xid-error", Value: "true", Effect: "NoSchedule"},
+				Cordon: config.Cordon{ShouldCordon: true},
+			},
+		},
+	}
+
+	// Step 1: Start reconciler and let it taint and cordon the node
+	t.Log("Step 1: Starting reconciler and sending health event to taint and cordon node")
+	_, mockWatcher, _, _ := setupE2EReconciler(t, ctx, tomlConfig, nil)
+
+	// Send health event to quarantine the node
+	eventID := generateTestID()
+	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(
+		eventID,
+		nodeName,
+		"GpuXidError",
+		false, // unhealthy
+		false,
+		[]*protos.Entity{{EntityType: "GPU", EntityValue: "0"}},
+		model.StatusInProgress,
+	)}
+
+	// Wait for node to be quarantined
+	t.Log("Waiting for FQ to quarantine the node")
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		hasHealthEvent := node.Annotations[common.QuarantineHealthEventAnnotationKey] != ""
+		hasAppliedTaintsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey] != ""
+		isCordoned := node.Spec.Unschedulable
+
+		hasFQTaint := false
+		for _, taint := range node.Spec.Taints {
+			if taint.Key == "nvidia.com/gpu-xid-error" {
+				hasFQTaint = true
+				break
+			}
+		}
+
+		t.Logf("Node tainted check: hasHealthEvent=%v, hasAppliedTaintsAnnotation=%v, isCordoned=%v, hasFQTaint=%v",
+			hasHealthEvent, hasAppliedTaintsAnnotation, isCordoned, hasFQTaint)
+		return hasHealthEvent && hasAppliedTaintsAnnotation && isCordoned && hasFQTaint
+	}, eventuallyTimeout, eventuallyPollInterval, "Node should be quarantined by FQ")
+
+	// Reconciler and mockWatcher remain running for subsequent test steps
+
+	// Capture metric values before manual untaint
+	beforeManualUntaint := getCounterVecValue(t, metrics.TotalNodesManuallyUntainted, nodeName)
+	beforeCurrentQuarantined := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
+
+	t.Log("Step 2: Manually remove the taint from the node")
+	quarantinedNode, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	// Remove the FQ taint manually
+	updatedTaints := []corev1.Taint{}
+	for _, taint := range quarantinedNode.Spec.Taints {
+		if taint.Key != "nvidia.com/gpu-xid-error" {
+			updatedTaints = append(updatedTaints, taint)
+		}
+	}
+	quarantinedNode.Spec.Taints = updatedTaints
+
+	_, err = e2eTestClient.CoreV1().Nodes().Update(ctx, quarantinedNode, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	t.Log("Step 3:Verify manual untaint is detected and FQ state cleaned up")
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+
+		// Manual untaint annotation should be set
+		hasManualUntaintAnnotation := node.Annotations[common.QuarantinedNodeIsUntaintedManuallyAnnotationKey] == common.QuarantinedNodeIsUntaintedManuallyAnnotationValue
+
+		// FQ annotations should be cleaned up
+		_, hasQuarantineAnnotation := node.Annotations[common.QuarantineHealthEventAnnotationKey]
+		_, hasAppliedTaintsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey]
+		_, hasCordonedAnnotation := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey]
+
+		// State label should be removed
+		_, hasStateLabel := node.Labels[statemanager.NVSentinelStateLabelKey]
+
+		// Check that FQ taint is removed (manually removed by test)
+		hasFQTaint := false
+		for _, taint := range node.Spec.Taints {
+			if taint.Key == "nvidia.com/gpu-xid-error" {
+				hasFQTaint = true
+				break
+			}
+		}
+
+		// Node should still be cordoned (manual untaint only removes taints, not the cordon)
+		isCordoned := node.Spec.Unschedulable
+
+		// Note: Manual untaint only removes taints and annotations, not the cordon.
+		// The node should still be cordoned.
+		return hasManualUntaintAnnotation &&
+			!hasQuarantineAnnotation &&
+			!hasAppliedTaintsAnnotation &&
+			!hasCordonedAnnotation &&
+			!hasFQTaint && // FQ taint should be removed
+			isCordoned && // node should still be cordoned
+			!hasStateLabel
+	}, eventuallyTimeout, eventuallyPollInterval, "Manual untaint should clean up FQ state")
+
+	t.Log("Verify metrics are correctly updated")
+	afterManualUntaint := getCounterVecValue(t, metrics.TotalNodesManuallyUntainted, nodeName)
+	assert.Equal(t, beforeManualUntaint+1, afterManualUntaint, "TotalNodesManuallyUntainted should increment")
+
+	afterCurrentQuarantined := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
+	assert.Equal(t, float64(0), afterCurrentQuarantined, "CurrentQuarantinedNodes should be 0")
+	assert.GreaterOrEqual(t, beforeCurrentQuarantined, float64(0), "Gauge should have been initialized before")
+}
+
+// TestE2ECordonAndTaint_ManualUncordon tests:
+// SCENARIO:
+// Node was cordoned by fault-quarantine and taints along with annotations are applied.
+// Node is manually uncordoned by the operator.
+// FQ should detect the manual uncordon and clean up the FQ state.
+func TestE2ECordonAndTaint_ManualUncordon(t *testing.T) {
+	ctx, cancel := context.WithTimeout(e2eTestContext, 20*time.Second)
+	defer cancel()
+
+	nodeName := "test-node-" + generateShortTestID()
+
+	// Create a clean node initially
+	createE2ETestNode(ctx, t, nodeName, nil, nil, nil, false)
+	defer func() {
+		_ = e2eTestClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
+	}()
+
+	tomlConfig := config.TomlConfig{
+		LabelPrefix: "k8s.nvidia.com/",
+		RuleSets: []config.RuleSet{
+			{
+				Name:     "gpu-xid-errors",
+				Version:  "1",
+				Priority: 10,
+				Match: config.Match{
+					Any: []config.Rule{
+						{Kind: "HealthEvent", Expression: "event.checkName == 'GpuXidError'"},
+					},
+				},
+				Taint:  config.Taint{Key: "nvidia.com/gpu-xid-error", Value: "true", Effect: "NoSchedule"},
+				Cordon: config.Cordon{ShouldCordon: true},
+			},
+		},
+	}
+
+	// Step 1: Start reconciler and let it taint and cordon the node
+	t.Log("Step 1: Starting reconciler and sending health event to taint and cordon node")
+	_, mockWatcher, _, _ := setupE2EReconciler(t, ctx, tomlConfig, nil)
+
+	// Send health event to quarantine the node
+	eventID := generateTestID()
+	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(
+		eventID,
+		nodeName,
+		"GpuXidError",
+		false, // unhealthy
+		false,
+		[]*protos.Entity{{EntityType: "GPU", EntityValue: "0"}},
+		model.StatusInProgress,
+	)}
+
+	// Wait for node to be quarantined
+	t.Log("Waiting for FQ to quarantine the node")
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		hasHealthEvent := node.Annotations[common.QuarantineHealthEventAnnotationKey] != ""
+		hasAppliedTaintsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey] != ""
+		isCordoned := node.Spec.Unschedulable
+
+		hasFQTaint := false
+		for _, taint := range node.Spec.Taints {
+			if taint.Key == "nvidia.com/gpu-xid-error" {
+				hasFQTaint = true
+				break
+			}
+		}
+
+		t.Logf("Node tainted check: hasHealthEvent=%v, hasAppliedTaintsAnnotation=%v, isCordoned=%v, hasFQTaint=%v",
+			hasHealthEvent, hasAppliedTaintsAnnotation, isCordoned, hasFQTaint)
+		return hasHealthEvent && hasAppliedTaintsAnnotation && isCordoned && hasFQTaint
+	}, eventuallyTimeout, eventuallyPollInterval, "Node should be quarantined by FQ")
+
+	// Reconciler and mockWatcher remain running for subsequent test steps
+
+	// Capture metric values before manual uncordon
+	beforeManualUncordon := getCounterVecValue(t, metrics.TotalNodesManuallyUncordoned, nodeName)
+	beforeCurrentQuarantined := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
+
+	t.Log("Manually uncordon the node")
+	quarantinedNode, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	// Uncordon the node manually
+	quarantinedNode.Spec.Unschedulable = false
+
+	_, err = e2eTestClient.CoreV1().Nodes().Update(ctx, quarantinedNode, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	t.Log("Verify manual uncordon is detected and FQ state cleaned up")
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+
+		// Manual uncordon annotation should be set
+		hasManualUncordonAnnotation := node.Annotations[common.QuarantinedNodeUncordonedManuallyAnnotationKey] == common.QuarantinedNodeUncordonedManuallyAnnotationValue
+
+		// FQ annotations should be cleaned up
+		_, hasQuarantineAnnotation := node.Annotations[common.QuarantineHealthEventAnnotationKey]
+		_, hasAppliedTaintsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey]
+		_, hasCordonedAnnotation := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey]
+
+		// State label should be removed
+		_, hasStateLabel := node.Labels[statemanager.NVSentinelStateLabelKey]
+
+		// Check that FQ taint remains (manual uncordon only removes cordon, not taints)
+		hasFQTaint := false
+		for _, taint := range node.Spec.Taints {
+			if taint.Key == "nvidia.com/gpu-xid-error" {
+				hasFQTaint = true
+				break
+			}
+		}
+
+		// Node should be uncordoned
+		isUncordoned := !node.Spec.Unschedulable
+
+		return hasManualUncordonAnnotation &&
+			!hasQuarantineAnnotation &&
+			!hasAppliedTaintsAnnotation &&
+			!hasCordonedAnnotation &&
+			hasFQTaint && // FQ taint should remain (manual uncordon doesn't remove taints)
+			isUncordoned && // node should be uncordoned
+			!hasStateLabel
+	}, eventuallyTimeout, eventuallyPollInterval, "Manual uncordon should clean up FQ state")
+
+	t.Log("Verify metrics are correctly updated")
+	afterManualUncordon := getCounterVecValue(t, metrics.TotalNodesManuallyUncordoned, nodeName)
+	assert.Equal(t, beforeManualUncordon+1, afterManualUncordon, "TotalNodesManuallyUncordoned should increment")
+
+	afterCurrentQuarantined := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
+	assert.Equal(t, float64(0), afterCurrentQuarantined, "CurrentQuarantinedNodes should be 0")
+	assert.GreaterOrEqual(t, beforeCurrentQuarantined, float64(0), "Gauge should have been initialized before")
+}
 
 // delayedWatchRoundTripper intercepts HTTP requests made by the Kubernetes client.
 //
@@ -5742,7 +5742,7 @@ func TestSourceDocIDsFromAnnotation(t *testing.T) {
 				return err == nil
 			}, eventuallyTimeout, statusCheckPollInterval, "informer should observe test node")
 
-			ids := r.sourceDocIDsFromAnnotation(nodeName)
+			ids := r.sourceDocIDsFromAnnotation(ctx, nodeName)
 			assert.ElementsMatch(t, tc.expectedIDs, ids)
 		})
 	}

--- a/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
@@ -186,7 +186,7 @@ func (m *MockHealthEventStore) FindHealthEventsByStatus(ctx context.Context, sta
 	return nil, nil
 }
 
-func (m *MockHealthEventStore) UpdateNodeQuarantineStatus(ctx context.Context, eventID string, status datastore.Status) error {
+func (m *MockHealthEventStore) UpdateNodeQuarantineStatus(ctx context.Context, eventID string, status datastore.Status, spanID string) error {
 	return nil
 }
 

--- a/platform-connectors/go.sum
+++ b/platform-connectors/go.sum
@@ -31,7 +31,6 @@ github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=

--- a/platform-connectors/pkg/connectors/store/store_connector.go
+++ b/platform-connectors/pkg/connectors/store/store_connector.go
@@ -34,10 +34,6 @@ import (
 	"github.com/nvidia/nvsentinel/store-client/pkg/factory"
 )
 
-const (
-	ServicePlatformConnector = "platform-connector"
-)
-
 type DatabaseStoreConnector struct {
 	// databaseClient is the database-agnostic client
 	databaseClient client.DatabaseClient
@@ -223,7 +219,7 @@ func (r *DatabaseStoreConnector) insertHealthEvents(
 			HealthEventStatus: &protos.HealthEventStatus{
 				UserPodsEvictionStatus: &protos.OperationStatus{},
 				SpanIds: map[string]string{
-					ServicePlatformConnector: tracing.SpanIDFromSpan(eventSpan),
+					tracing.ServicePlatformConnector: tracing.SpanIDFromSpan(eventSpan),
 				},
 			},
 		}

--- a/store-client/pkg/client/convenience.go
+++ b/store-client/pkg/client/convenience.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/nvidia/nvsentinel/commons/pkg/tracing"
 	"github.com/nvidia/nvsentinel/store-client/pkg/config"
 	"github.com/nvidia/nvsentinel/store-client/pkg/datastore/providers/mongodb/watcher"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -38,7 +39,7 @@ func UpdateHealthEventStatus(ctx context.Context, client DatabaseClient, eventID
 // UpdateHealthEventNodeQuarantineStatus updates the node quarantine status
 // Used by fault-quarantine-module
 func UpdateHealthEventNodeQuarantineStatus(ctx context.Context, client DatabaseClient,
-	eventID string, status string) error {
+	eventID string, status string, spanID string) error {
 	fields := map[string]interface{}{
 		"healtheventstatus.nodequarantined": status,
 	}
@@ -46,6 +47,8 @@ func UpdateHealthEventNodeQuarantineStatus(ctx context.Context, client DatabaseC
 	if status == "Quarantined" || status == "AlreadyQuarantined" {
 		fields["healtheventstatus.quarantinefinishtimestamp"] = timestamppb.Now()
 	}
+
+	fields["healtheventstatus.spanids."+tracing.ServiceFaultQuarantine] = spanID
 
 	return client.UpdateDocumentStatusFields(ctx, eventID, fields)
 }

--- a/store-client/pkg/datastore/behavioral_contract_test.go
+++ b/store-client/pkg/datastore/behavioral_contract_test.go
@@ -132,8 +132,8 @@ func (m *MockHealthEventStore) FindHealthEventsByStatus(ctx context.Context, sta
 	return args.Get(0).([]datastore.HealthEventWithStatus), args.Error(1)
 }
 
-func (m *MockHealthEventStore) UpdateNodeQuarantineStatus(ctx context.Context, eventID string, status datastore.Status) error {
-	args := m.Called(ctx, eventID, status)
+func (m *MockHealthEventStore) UpdateNodeQuarantineStatus(ctx context.Context, eventID string, status datastore.Status, spanID string) error {
+	args := m.Called(ctx, eventID, status, spanID)
 	return args.Error(0)
 }
 

--- a/store-client/pkg/datastore/interfaces.go
+++ b/store-client/pkg/datastore/interfaces.go
@@ -77,7 +77,7 @@ type HealthEventStore interface {
 	UpdateHealthEventsByQuery(ctx context.Context, queryBuilder QueryBuilder, updateBuilder UpdateBuilder) error
 
 	// Convenience methods for common operations
-	UpdateNodeQuarantineStatus(ctx context.Context, eventID string, status Status) error
+	UpdateNodeQuarantineStatus(ctx context.Context, eventID string, status Status, spanID string) error
 	UpdatePodEvictionStatus(ctx context.Context, eventID string, status OperationStatus) error
 	UpdateRemediationStatus(ctx context.Context, eventID string, status interface{}) error
 

--- a/store-client/pkg/datastore/providers/mongodb/health_store.go
+++ b/store-client/pkg/datastore/providers/mongodb/health_store.go
@@ -228,10 +228,10 @@ func (h *MongoHealthEventStore) FindHealthEventsByStatus(ctx context.Context,
 
 // UpdateNodeQuarantineStatus updates node quarantine status
 func (h *MongoHealthEventStore) UpdateNodeQuarantineStatus(ctx context.Context, eventID string,
-	status datastore.Status) error {
+	status datastore.Status, spanID string) error {
 	// Use the convenience function from our existing implementation
 	return client.UpdateHealthEventNodeQuarantineStatus(ctx, h.databaseClient, eventID,
-		string(status))
+		string(status), spanID)
 }
 
 // UpdatePodEvictionStatus updates pod eviction status

--- a/store-client/pkg/datastore/providers/postgresql/health_events.go
+++ b/store-client/pkg/datastore/providers/postgresql/health_events.go
@@ -664,15 +664,24 @@ func (p *PostgreSQLHealthEventStore) FindHealthEventsByStatus(
 
 // UpdateNodeQuarantineStatus updates node quarantine status for a specific event
 func (p *PostgreSQLHealthEventStore) UpdateNodeQuarantineStatus(
-	ctx context.Context, eventID string, status datastore.Status,
+	ctx context.Context, eventID string, status datastore.Status, spanID string,
 ) error {
 	// PostgreSQL stores health event status in BOTH table columns AND the JSONB document.
 	// We must update BOTH to keep them in sync for aggregation pipelines to work correctly.
+	//nolint:dupword // SQL query uses nested jsonb_set calls
 	query := `
 		UPDATE health_events
 		SET node_quarantined = $1,
 		    document = jsonb_set(
-		        document,
+		        jsonb_set(
+		            CASE
+		                WHEN document #> '{healtheventstatus,spanids}' IS NULL
+		                THEN jsonb_set(document, '{healtheventstatus,spanids}', '{}'::jsonb)
+		                ELSE document
+		            END,
+		            '{healtheventstatus,spanids,fault-quarantine}',
+		            to_jsonb($3::text)
+		        ),
 		        '{healtheventstatus,nodequarantined}',
 		        to_jsonb($1::text)
 		    ),
@@ -680,7 +689,7 @@ func (p *PostgreSQLHealthEventStore) UpdateNodeQuarantineStatus(
 		WHERE id = $2
 	`
 
-	result, err := p.db.ExecContext(ctx, query, string(status), eventID)
+	result, err := p.db.ExecContext(ctx, query, string(status), eventID, spanID)
 	if err != nil {
 		return fmt.Errorf("failed to update node quarantine status: %w", err)
 	}


### PR DESCRIPTION
## Summary

<!-- Brief description of your changes -->

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


### Testing
Tested out the following cases in fault-quarantine using the tilt and dev cluster.
1. Cordoned the node by injecting the fatal error. The fault-quarantine spans were linked correctly to the root trace and to parent span.

<img width="1137" height="326" alt="cordoned-3" src="https://github.com/user-attachments/assets/ed14d80d-4f43-459e-a9e5-a2d6c2506539" />

Details like taints applied, annotations applied, labels applied were tracked through span attributes.

<img width="1046" height="507" alt="cordoned-4" src="https://github.com/user-attachments/assets/243da46e-6798-4b87-810d-86a4d857660d" />

<img width="1071" height="540" alt="cordoned-1" src="https://github.com/user-attachments/assets/95332853-70da-445c-9b20-73c77d324d04" />

2. Uncordoned the node by injecting healthy event. Tracked every operation like what labels/annotations/taints were removed. 

<img width="1146" height="570" alt="full-recovery-uncordoning" src="https://github.com/user-attachments/assets/bcc7fc0a-1779-436d-9953-2f094670444b" />

Tracked the final status updated in db for the received event  

<img width="1068" height="306" alt="full-recovery-uncordoning-1" src="https://github.com/user-attachments/assets/b33411f9-02bf-4e2e-b29b-6055695f50d5" />

3. Tracked the manual uncordoning and untainting which led to cancel the breakfix pipeline.

<img width="1140" height="396" alt="manual-uncordoning-1" src="https://github.com/user-attachments/assets/7f32efc1-49f9-42d3-a4a3-fc965728424c" />

<img width="1139" height="408" alt="manual-uncordoning-2" src="https://github.com/user-attachments/assets/21c6c37e-d26e-45f2-a0a5-8ebb2339dd00" />

4. Separate trace was created when manual uncordon/untaint was detected. Below is an example of negative case when cancel breakfix was triggered but no document was found in DB

<img width="1174" height="434" alt="no-event-found-to-cancel" src="https://github.com/user-attachments/assets/a2386c3b-6f80-4418-9345-a222ddfac8e0" />

4.  Tracked if received event caused partial recovery of node.

<img width="1158" height="593" alt="partial-recovery" src="https://github.com/user-attachments/assets/f0bdd12b-47f1-465c-8fb1-9c2210f3b17c" />

6. Tracked if received event caused the circuit breaker to trip. Spans were generated when event processing continued after manually closing the circuit breaker.

<img width="935" height="310" alt="Screenshot 2026-04-06 at 3 22 00 PM" src="https://github.com/user-attachments/assets/699c8cf8-e9fe-4dfa-abf3-c408a1fdc5f1" />

7. Tracked when event was skipped as no ruleset matched.

<img width="1153" height="667" alt="no-ruleset-evaluated-0" src="https://github.com/user-attachments/assets/615a5296-994d-495d-82f4-40508071da06" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenTelemetry tracing across services for improved end-to-end observability.
  * Trace-correlated structured logs for better debugging and request tracing.

* **Infrastructure**
  * Kubernetes templates now support OTLP exporter env variables to enable tracing.

* **Bug Fixes**
  * Fault remediation status now emits as a string (consistent format) for downstream consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->