### PR TITLE
feat: add objectSelector support to preflight webhook

### DIFF
--- a/.github/actions/setup-ci-env/action.yml
+++ b/.github/actions/setup-ci-env/action.yml
@@ -48,6 +48,7 @@ runs:
         echo "goimports_version=$(yq '.go_tools.goimports' .versions.yaml)" >> $GITHUB_OUTPUT
         echo "crane_version=$(yq '.go_tools.crane' .versions.yaml)" >> $GITHUB_OUTPUT
         echo "helm_version=$(yq '.testing_tools.helm' .versions.yaml)" >> $GITHUB_OUTPUT
+        echo "helm_unittest_version=$(yq '.testing_tools.helm_unittest' .versions.yaml)" >> $GITHUB_OUTPUT
 
     - name: Install base dependencies
       shell: bash
@@ -94,6 +95,11 @@ runs:
       shell: bash
       run: |
         helm plugin install https://github.com/chartmuseum/helm-push || echo "Helm push plugin may already be installed"
+
+    - name: Install Helm unittest plugin
+      shell: bash
+      run: |
+        helm plugin install https://github.com/helm-unittest/helm-unittest --version ${{ steps.versions.outputs.helm_unittest_version }} || echo "Helm unittest plugin may already be installed"
 
     - name: Set up Go
       uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -104,6 +104,10 @@ jobs:
         if: matrix.component == 'helm-charts'
         run: make helm-lint
 
+      - name: Run Helm Chart Unit Tests
+        if: matrix.component == 'helm-charts'
+        run: make helm-test
+
   health-monitors-lint-test:
     if: github.repository == 'nvidia/nvsentinel'
     runs-on: linux-amd64-cpu16

--- a/.versions.yaml
+++ b/.versions.yaml
@@ -73,6 +73,7 @@ container_tools:
 testing_tools:
   kind: '0.30.0'
   helm: 'v3.19.2'
+  helm_unittest: 'v1.0.3'
   kwok: 'v0.7.0'
   kwok_chart: '0.2.0'  # KWOK Helm chart version (different from app version)
   ctlptl: '0.8.43'

--- a/Makefile
+++ b/Makefile
@@ -513,6 +513,24 @@ helm-lint:
 	done
 	@echo "✅ All Helm charts validated successfully"
 
+# Helm chart unit tests
+.PHONY: helm-test
+helm-test:
+	@echo "🧪 Running Helm chart unit tests..."
+	@if ! helm plugin list | grep -q unittest; then \
+		echo "❌ Error: helm-unittest plugin not found. Install with: helm plugin install https://github.com/helm-unittest/helm-unittest"; \
+		exit 1; \
+	fi
+	@for chart_dir in distros/kubernetes/nvsentinel/charts/*/; do \
+		if [[ -d "$$chart_dir/tests" ]]; then \
+			chart_name=$$(basename "$$chart_dir"); \
+			echo "Running unit tests for chart: $$chart_name"; \
+			helm unittest "$$chart_dir" || exit 1; \
+			echo ""; \
+		fi; \
+	done
+	@echo "✅ All Helm chart unit tests passed"
+
 # Log collector lint (shell script)
 .PHONY: log-collector-lint
 log-collector-lint: ## Lint shell scripts in log collector

--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/mutatingwebhook.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/mutatingwebhook.yaml
@@ -55,3 +55,7 @@ webhooks:
       matchExpressions:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+    {{- with .Values.objectSelector }}
+    objectSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}

--- a/distros/kubernetes/nvsentinel/charts/preflight/tests/mutatingwebhook_test.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/tests/mutatingwebhook_test.yaml
@@ -1,0 +1,49 @@
+suite: mutatingwebhook
+templates:
+  - templates/mutatingwebhook.yaml
+tests:
+  - it: should not render objectSelector when empty
+    asserts:
+      - isKind:
+          of: MutatingWebhookConfiguration
+      - notExists:
+          path: webhooks[0].objectSelector
+
+  - it: should render objectSelector with matchLabels
+    set:
+      objectSelector:
+        matchLabels:
+          nvsentinel.nvidia.com/preflight: "enabled"
+    asserts:
+      - equal:
+          path: webhooks[0].objectSelector.matchLabels
+          value:
+            nvsentinel.nvidia.com/preflight: "enabled"
+
+  - it: should render objectSelector with matchExpressions
+    set:
+      objectSelector:
+        matchExpressions:
+          - key: nvsentinel.nvidia.com/preflight
+            operator: In
+            values:
+              - "enabled"
+              - "true"
+    asserts:
+      - equal:
+          path: webhooks[0].objectSelector.matchExpressions[0].key
+          value: nvsentinel.nvidia.com/preflight
+      - equal:
+          path: webhooks[0].objectSelector.matchExpressions[0].operator
+          value: In
+
+  - it: should always render namespaceSelector regardless of objectSelector
+    set:
+      objectSelector:
+        matchLabels:
+          app: test
+    asserts:
+      - exists:
+          path: webhooks[0].namespaceSelector
+      - exists:
+          path: webhooks[0].objectSelector

--- a/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
@@ -302,5 +302,12 @@ namespaceSelector:
   matchLabels:
     nvsentinel.nvidia.com/preflight: "enabled"
 
+# Pod-level opt-in filtering (empty = no objectSelector emitted, all pods matched)
+# Example: target only pods with a specific label:
+#   objectSelector:
+#     matchLabels:
+#       nvsentinel.nvidia.com/preflight: "enabled"
+objectSelector: {}
+
 networkPolicy:
   enabled: true

--- a/docs/configuration/preflight.md
+++ b/docs/configuration/preflight.md
@@ -265,6 +265,31 @@ For DRA / device claims mirrored into init containers, see [ADR-026 §DRA Integr
 | Gang discovery | `preflight.gangDiscovery` |
 | Gang coordination (timeouts, topology, mounts) | `preflight.gangCoordination` |
 | Namespace selector for the webhook | `preflight.namespaceSelector` |
+| Pod-level selector for the webhook | `preflight.objectSelector` |
+
+## Object selector (pod-level filtering)
+
+By default the webhook intercepts all GPU pods in labeled namespaces. To further restrict which pods are intercepted, set `objectSelector` with standard Kubernetes label selectors. When empty (`{}`), no `objectSelector` is emitted and all pods in matching namespaces are intercepted.
+
+Example — only intercept pods explicitly labeled for preflight:
+
+```yaml
+objectSelector:
+  matchLabels:
+    nvsentinel.nvidia.com/preflight: "enabled"
+```
+
+`matchExpressions` are also supported:
+
+```yaml
+objectSelector:
+  matchExpressions:
+    - key: nvsentinel.nvidia.com/preflight
+      operator: In
+      values: ["enabled", "true"]
+```
+
+This is useful when you want namespace-wide opt-in via `namespaceSelector` but only run preflight on specific workloads within those namespaces.
 
 Full defaults and comments: `distros/kubernetes/nvsentinel/charts/preflight/values.yaml`.
 

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -22,7 +22,7 @@ If a preflight check fails, the pod stays in `Init:Error`, a health event enters
 Preflight runs as a Deployment with a mutating admission webhook:
 
 1. **Namespace opt-in**: Label namespaces with `nvsentinel.nvidia.com/preflight=enabled`
-2. **Pod admission**: When a GPU pod is created in a labeled namespace, the webhook intercepts the request
+2. **Pod admission**: When a GPU pod is created in a labeled namespace, the webhook intercepts the request. Optionally, an `objectSelector` can further restrict which pods are intercepted based on pod labels
 3. **Init container injection**: The webhook prepends diagnostic init containers to the pod spec
 4. **Checks run**: Init containers execute sequentially before the main workload starts
 5. **Health reporting**: Each check reports results as health events via the Platform Connector (gRPC over Unix domain socket)
@@ -68,6 +68,7 @@ Key configuration areas:
 | `preflight.gangCoordination` | Multi-node coordination timeouts, NCCL topology, extra mounts |
 | `preflight.webhook` | TLS, failure policy, cert provider |
 | `preflight.namespaceSelector` | Which namespaces the webhook applies to |
+| `preflight.objectSelector` | Which pods the webhook applies to (label-based filtering within selected namespaces) |
 
 For detailed configuration including per-check env vars, fabric-specific NCCL setup, and gang discovery examples, see [Preflight configuration](./configuration/preflight.md).
 


### PR DESCRIPTION
## Summary
- Add `objectSelector` support to the preflight `MutatingWebhookConfiguration`, enabling pod-level opt-in filtering alongside the existing namespace-level selection
- Default is `{}` (no objectSelector emitted), so existing behavior is unchanged
- Users can target specific pods via labels, e.g. `objectSelector.matchLabels: {nvsentinel.nvidia.com/preflight: "enabled"}`

## Test plan
- [x] `helm template` with default values — verify no `objectSelector` block in rendered webhook
- [x] `helm template` with `objectSelector.matchLabels` set — verify `objectSelector` renders correctly
- [x] Deploy to test cluster and confirm webhook only intercepts labeled pods when objectSelector is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional objectSelector to scope the mutating webhook to pods by label; empty = applies to all pods within selected namespaces.
* **Tests**
  * Added unit tests validating webhook rendering for objectSelector (matchLabels and matchExpressions) and confirming namespaceSelector behavior.
* **Chores**
  * Added a helm-test Make target, CI step to run chart unit tests, and pinned helm-unittest tool version.
* **Documentation**
  * Documented preflight.objectSelector usage with examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->