### PR TITLE
feat: PreflightProfile CRD for per-pod check configuration and gang fail-fast

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/preflight/crds/nvsentinel.nvidia.com_preflightprofiles.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/crds/nvsentinel.nvidia.com_preflightprofiles.yaml
@@ -1,0 +1,94 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: preflightprofiles.nvsentinel.nvidia.com
+spec:
+  group: nvsentinel.nvidia.com
+  names:
+    kind: PreflightProfile
+    listKind: PreflightProfileList
+    plural: preflightprofiles
+    singular: preflightprofile
+    shortNames:
+      - pfp
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: >-
+            PreflightProfile defines per-pod overrides for preflight init
+            container configuration. Pods reference a profile via the
+            nvsentinel.nvidia.com/preflight-profile annotation.
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              description: Desired preflight configuration overrides.
+              properties:
+                initContainers:
+                  type: array
+                  description: >-
+                    List of init container overrides. Each entry matches a
+                    chart-level init container by name and can enable/disable
+                    it or override its environment variables.
+                  items:
+                    type: object
+                    required:
+                      - name
+                    properties:
+                      name:
+                        type: string
+                        description: >-
+                          Name of the init container to configure. Must match
+                          a container name defined in the Helm chart's
+                          initContainers list.
+                      enabled:
+                        type: boolean
+                        description: >-
+                          Whether this init container should be injected.
+                          Defaults to true if omitted.
+                      env:
+                        type: array
+                        description: >-
+                          Environment variable overrides for this init
+                          container. Protected env vars (NODE_NAME,
+                          PLATFORM_CONNECTOR_SOCKET, etc.) cannot be
+                          overridden.
+                        items:
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              type: string
+                              description: Environment variable name.
+                            value:
+                              type: string
+                              description: Environment variable value.
+      additionalPrinterColumns:
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp

--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/clusterrole.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/clusterrole.yaml
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.gangCoordination.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -20,16 +19,22 @@ metadata:
   labels:
     {{- include "preflight.labels" . | nindent 4 }}
 rules:
+  # PreflightProfile CRD access
+  - apiGroups: ["nvsentinel.nvidia.com"]
+    resources: ["preflightprofiles"]
+    verbs: ["get", "list", "watch"]
+
+  {{- if .Values.gangCoordination.enabled }}
   # Core resources for gang discovery
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
-  
+
   # ConfigMaps for gang coordination
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  
+
   # Gang discovery API - dynamically generated based on gangDiscovery config
   {{- if .Values.gangDiscovery.podGroupGVR }}
   # PodGroup-based scheduler ({{ .Values.gangDiscovery.name | default "custom" }})
@@ -41,5 +46,4 @@ rules:
     resources: ["workloads"]
   {{- end }}
     verbs: ["get", "list", "watch"]
-
-{{- end }}
+  {{- end }}

--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/clusterrolebinding.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/clusterrolebinding.yaml
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.gangCoordination.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -27,5 +26,3 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "preflight.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
-{{- end }}
-

--- a/docs/configuration/preflight.md
+++ b/docs/configuration/preflight.md
@@ -310,6 +310,39 @@ Full defaults and comments: `distros/kubernetes/nvsentinel/charts/preflight/valu
 
 Tilt development often trims init containers to DCGM-only; see `distros/kubernetes/nvsentinel/values-tilt.yaml`.
 
+## Per-pod check configuration (PreflightProfile CRD)
+
+The `PreflightProfile` CRD (`nvsentinel.nvidia.com/v1alpha1`) lets workload owners customise which preflight checks run and override their environment variables on a per-pod basis, without changing the cluster-wide Helm defaults.
+
+Create a profile in the workload namespace:
+
+```yaml
+apiVersion: nvsentinel.nvidia.com/v1alpha1
+kind: PreflightProfile
+metadata:
+  name: fast-check
+  namespace: training
+spec:
+  initContainers:
+    - name: preflight-dcgm-diag
+      enabled: true
+      env:
+        - name: DCGM_DIAG_LEVEL
+          value: "1"
+    - name: preflight-nccl-allreduce
+      enabled: false
+```
+
+Reference it from a pod via annotation:
+
+```yaml
+metadata:
+  annotations:
+    nvsentinel.nvidia.com/preflight-profile: "fast-check"
+```
+
+The webhook merges the profile with chart-level defaults. Protected env vars (`NODE_NAME`, `PLATFORM_CONNECTOR_SOCKET`, etc.) cannot be overridden by profiles. If the referenced profile does not exist, the webhook falls back to chart defaults (fail-closed). See [ADR-034](../designs/034-preflight-pod-config.md) for full design details.
+
 ## Observability
 
 - Webhook pod: liveness/readiness probes use `/healthz` on the webhook port.

--- a/docs/designs/034-preflight-pod-config.md
+++ b/docs/designs/034-preflight-pod-config.md
@@ -169,23 +169,21 @@ missing peer to join the NCCL communicator).
 
 ### Data flow
 
-1. **Webhook** writes each pod's enabled-checks list and a hash of its
-   allreduce configuration into the gang ConfigMap peer line:
+1. **Controller** writes each pod's PreflightProfile name into the gang
+   ConfigMap peer line:
 
    ```
-   pod-0;10.0.0.1;0;preflight-nccl-allreduce,preflight-dcgm;abc123
-   pod-1;10.0.0.2;1;preflight-nccl-allreduce,preflight-dcgm;abc123
+   pod-0;10.0.0.1;0;full-diagnostics
+   pod-1;10.0.0.2;1;full-diagnostics
    ```
 
-   Fields 4 and 5 are optional for backward compatibility.
+   Field 4 (profile name) is optional for backward compatibility.
 
-2. **Init container** calls `gang_config.validate_peers("preflight-nccl-allreduce")`
-   before launching torchrun.
+2. **Init container** calls `gang_config.validate_peers()` before launching
+   torchrun.
 
 3. **Validation** checks:
-   - Every peer has the check in its checks list (old-format peers without
-     the field are skipped with a warning).
-   - All peers share the same `allreduce_config` hash.
+   - All peers reference the same PreflightProfile CRD (or all use defaults).
 
 4. **On mismatch**: the init container logs the error, reports
    `GANG_CONFIG_ERROR` to the platform connector, and exits immediately

--- a/docs/designs/034-preflight-pod-config.md
+++ b/docs/designs/034-preflight-pod-config.md
@@ -1,0 +1,221 @@
+# ADR-034: Per-Pod Preflight Configuration via PreflightProfile CRD
+
+## Context
+
+NVSentinel's preflight webhook injects GPU diagnostic init containers into
+pods that request GPU resources. Today the set of checks, their environment
+variables, and enabled/disabled state are configured at the Helm chart level
+and apply uniformly to every intercepted pod in a namespace.
+
+Real clusters need more flexibility:
+
+- **Fast-check profiles** for interactive jobs (DCGM level 1 only, skip NCCL).
+- **Full-diagnostics profiles** for batch training (DCGM level 3 + NCCL
+  all-reduce).
+- **NCCL-only profiles** when DCGM diagnostics are handled externally.
+- Per-workload bandwidth thresholds or message sizes.
+
+A multi-layer configuration model lets platform teams set safe defaults at
+the chart level while allowing workload owners to override per pod.
+
+## Problem
+
+1. Operators cannot tune preflight checks per workload without creating
+   separate namespaces or Helm releases.
+2. Gang-coordinated checks (NCCL all-reduce) can silently deadlock when one
+   pod in a gang disables a check that other pods expect to run collectively.
+3. There is no mechanism to protect operator-controlled env vars (e.g.
+   `PLATFORM_CONNECTOR_SOCKET`) from being overridden by workload owners.
+
+## Solution: PreflightProfile CRD
+
+Introduce a `PreflightProfile` namespaced CRD
+(`nvsentinel.nvidia.com/v1alpha1`) that lets workload owners customise which
+init containers are enabled and override their env vars.
+
+### CRD schema
+
+```yaml
+apiVersion: nvsentinel.nvidia.com/v1alpha1
+kind: PreflightProfile
+metadata:
+  name: fast-check
+  namespace: training
+spec:
+  initContainers:
+    - name: preflight-dcgm-diag
+      enabled: true
+      env:
+        - name: DCGM_DIAG_LEVEL
+          value: "1"
+    - name: preflight-nccl-allreduce
+      enabled: false
+```
+
+### Example profiles
+
+**fast-check** -- quick DCGM level 1, no NCCL:
+
+```yaml
+apiVersion: nvsentinel.nvidia.com/v1alpha1
+kind: PreflightProfile
+metadata:
+  name: fast-check
+spec:
+  initContainers:
+    - name: preflight-dcgm-diag
+      enabled: true
+      env:
+        - name: DCGM_DIAG_LEVEL
+          value: "1"
+    - name: preflight-nccl-loopback
+      enabled: false
+    - name: preflight-nccl-allreduce
+      enabled: false
+```
+
+**full-diagnostics** -- DCGM level 3 + NCCL all-reduce:
+
+```yaml
+apiVersion: nvsentinel.nvidia.com/v1alpha1
+kind: PreflightProfile
+metadata:
+  name: full-diagnostics
+spec:
+  initContainers:
+    - name: preflight-dcgm-diag
+      env:
+        - name: DCGM_DIAG_LEVEL
+          value: "3"
+    - name: preflight-nccl-allreduce
+      enabled: true
+      env:
+        - name: BW_THRESHOLD_GBPS
+          value: "200"
+```
+
+**nccl-only** -- skip DCGM, run NCCL all-reduce with custom sizes:
+
+```yaml
+apiVersion: nvsentinel.nvidia.com/v1alpha1
+kind: PreflightProfile
+metadata:
+  name: nccl-only
+spec:
+  initContainers:
+    - name: preflight-dcgm-diag
+      enabled: false
+    - name: preflight-nccl-allreduce
+      enabled: true
+      env:
+        - name: MESSAGE_SIZES
+          value: "1G,4G,8G"
+```
+
+### Referencing a profile from a pod
+
+Pods reference a profile via annotation:
+
+```yaml
+metadata:
+  annotations:
+    nvsentinel.nvidia.com/preflight-profile: "fast-check"
+```
+
+The webhook reads the annotation, fetches the named `PreflightProfile` from
+the pod's namespace, and merges it with the chart-level defaults.
+
+## Precedence
+
+Configuration is resolved in layers, highest priority last:
+
+| Layer | Source | Who controls | Example |
+|-------|--------|-------------|---------|
+| 1 (base) | Helm `values.yaml` | Platform team | Init container images, default env |
+| 2 (profile) | `PreflightProfile` CRD | Workload owner | `DCGM_DIAG_LEVEL=1`, disable NCCL |
+| 3 (protected) | Webhook hardcoded | NVSentinel | `NODE_NAME`, `PLATFORM_CONNECTOR_SOCKET` |
+
+Layer 3 (protected env vars) always wins. The webhook overwrites these
+regardless of what the profile or Helm values specify.
+
+### Protected env vars
+
+The following env vars are injected by the webhook and cannot be overridden
+by profiles:
+
+| Env var | Source |
+|---------|--------|
+| `NODE_NAME` | Downward API (`spec.nodeName`) |
+| `PLATFORM_CONNECTOR_SOCKET` | Chart `dcgm.connectorSocket` |
+| `PROCESSING_STRATEGY` | Chart `dcgm.processingStrategy` |
+| `POD_NAME` | Downward API (`metadata.name`) |
+| `GANG_ID` | Gang coordinator |
+| `GANG_CONFIG_DIR` | Gang coordinator |
+| `GANG_TIMEOUT_SECONDS` | Gang coordinator |
+
+## Fail-closed behavior
+
+If the webhook cannot fetch the referenced `PreflightProfile` (not found,
+API error, RBAC denied), it falls back to the chart-level defaults and logs
+a warning. This is fail-closed: all checks run with default settings rather
+than silently skipping checks.
+
+## Gang fail-fast validation
+
+When pods in a gang have different profiles, one pod may disable a
+collective-op check that other pods expect to run. Without detection this
+causes a distributed deadlock (the remaining pods wait indefinitely for the
+missing peer to join the NCCL communicator).
+
+### Data flow
+
+1. **Webhook** writes each pod's enabled-checks list and a hash of its
+   allreduce configuration into the gang ConfigMap peer line:
+
+   ```
+   pod-0;10.0.0.1;0;preflight-nccl-allreduce,preflight-dcgm;abc123
+   pod-1;10.0.0.2;1;preflight-nccl-allreduce,preflight-dcgm;abc123
+   ```
+
+   Fields 4 and 5 are optional for backward compatibility.
+
+2. **Init container** calls `gang_config.validate_peers("preflight-nccl-allreduce")`
+   before launching torchrun.
+
+3. **Validation** checks:
+   - Every peer has the check in its checks list (old-format peers without
+     the field are skipped with a warning).
+   - All peers share the same `allreduce_config` hash.
+
+4. **On mismatch**: the init container logs the error, reports
+   `GANG_CONFIG_ERROR` to the platform connector, and exits immediately
+   (no deadlock).
+
+### Collective-op checks
+
+The following checks are collective operations that require all gang members
+to participate:
+
+| Check name | Type | Gang required |
+|------------|------|---------------|
+| `preflight-nccl-allreduce` | Multi-node all-reduce | Yes |
+| `preflight-dcgm-diag` | Per-node DCGM | No |
+| `preflight-nccl-loopback` | Per-node loopback | No |
+
+### Timeout safety net
+
+Even with fail-fast validation, a timeout remains as a safety net.
+`GANG_TIMEOUT_SECONDS` (default 600) bounds the maximum wait for gang
+formation. If validation passes but torchrun itself hangs, the container's
+`activeDeadlineSeconds` or Kubernetes liveness probe terminates it.
+
+## Key files
+
+| File | Purpose |
+|------|---------|
+| `preflight-checks/nccl-allreduce/nccl_allreduce/gang.py` | `PeerInfo` dataclass, `GangConfig.validate_peers()` |
+| `preflight-checks/nccl-allreduce/scripts/entrypoint.py` | Pre-torchrun validation call |
+| `preflight-checks/nccl-allreduce/nccl_allreduce/tests/test_gang.py` | Unit tests for peer parsing and validation |
+| `distros/kubernetes/nvsentinel/charts/preflight/crds/nvsentinel.nvidia.com_preflightprofiles.yaml` | CRD definition |
+| `distros/kubernetes/nvsentinel/charts/preflight/templates/clusterrole.yaml` | RBAC for CRD access |
+| `docs/configuration/preflight.md` | User-facing configuration guide |

--- a/preflight-checks/nccl-allreduce/nccl_allreduce/gang.py
+++ b/preflight-checks/nccl-allreduce/nccl_allreduce/gang.py
@@ -129,15 +129,10 @@ class GangConfig:
         errors: list[str] = []
 
         if missing:
-            errors.append(
-                f"Peers missing check '{check_name}': {', '.join(missing)}"
-            )
+            errors.append(f"Peers missing check '{check_name}': {', '.join(missing)}")
 
         if len(hashes) > 1:
-            parts = [
-                f"{config!r}: [{', '.join(pods)}]"
-                for config, pods in hashes.items()
-            ]
+            parts = [f"{config!r}: [{', '.join(pods)}]" for config, pods in hashes.items()]
             errors.append(f"Config mismatch across gang: {'; '.join(parts)}")
 
         if errors:
@@ -297,13 +292,15 @@ class GangConfigReader:
             if len(parts) >= 5:
                 allreduce_config = parts[4].strip()
 
-            peers.append(PeerInfo(
-                pod_name=pod_name,
-                pod_ip=pod_ip,
-                rank=rank,
-                checks=checks,
-                allreduce_config=allreduce_config,
-            ))
+            peers.append(
+                PeerInfo(
+                    pod_name=pod_name,
+                    pod_ip=pod_ip,
+                    rank=rank,
+                    checks=checks,
+                    allreduce_config=allreduce_config,
+                )
+            )
 
         return peers
 

--- a/preflight-checks/nccl-allreduce/nccl_allreduce/gang.py
+++ b/preflight-checks/nccl-allreduce/nccl_allreduce/gang.py
@@ -57,15 +57,13 @@ class PeerInfo:
         pod_name: Kubernetes pod name.
         pod_ip: Pod IP address.
         rank: Distributed rank (0-indexed).
-        checks: Comma-separated list of checks this peer is configured to run.
-        allreduce_config: Hash or identifier for the peer's allreduce configuration.
+        profile_name: PreflightProfile CRD name referenced by the pod.
     """
 
     pod_name: str
     pod_ip: str
     rank: int
-    checks: str = ""
-    allreduce_config: str = ""
+    profile_name: str = ""
 
 
 @dataclass
@@ -90,55 +88,25 @@ class GangConfig:
     my_rank: int
     my_pod_name: str
 
-    def validate_peers(self, check_name: str) -> str | None:
-        """Validate that all peers are configured for the given check.
+    def validate_peers(self) -> str | None:
+        """Validate that all peers reference the same PreflightProfile.
 
-        For each peer:
-        - If the peer has an empty ``checks`` field (old format), log a
-          warning and skip validation for that peer.
-        - Otherwise, verify that ``check_name`` appears in the peer's
-          comma-separated checks list.
-        - Record each peer's ``allreduce_config`` in a dict (even when
-          empty) and detect mismatches across the gang.
-
-        Args:
-            check_name: The check name to look for (e.g.
-                ``"preflight-nccl-allreduce"``).
+        If all peers share the same ``profile_name`` (including all empty,
+        meaning helm defaults), the gang is consistent. A mismatch means
+        different pods would run different check configurations.
 
         Returns:
-            ``None`` if all peers are valid, or a descriptive error string.
+            ``None`` if all peers are consistent, or a descriptive error string.
         """
-        missing: list[str] = []
-        hashes: dict[str, list[str]] = {}
-
+        profiles: dict[str, list[str]] = {}
         for peer in self.peers:
-            # Always record allreduce_config (even empty string).
-            hashes.setdefault(peer.allreduce_config, []).append(peer.pod_name)
+            profiles.setdefault(peer.profile_name or "(default)", []).append(peer.pod_name)
 
-            if not peer.checks:
-                log.warning(
-                    "Peer uses old format without checks field, skipping validation",
-                    extra={"pod_name": peer.pod_name},
-                )
-                continue
+        if len(profiles) <= 1:
+            return None
 
-            peer_checks = [c.strip() for c in peer.checks.split(",")]
-            if check_name not in peer_checks:
-                missing.append(peer.pod_name)
-
-        errors: list[str] = []
-
-        if missing:
-            errors.append(f"Peers missing check '{check_name}': {', '.join(missing)}")
-
-        if len(hashes) > 1:
-            parts = [f"{config!r}: [{', '.join(pods)}]" for config, pods in hashes.items()]
-            errors.append(f"Config mismatch across gang: {'; '.join(parts)}")
-
-        if errors:
-            return "; ".join(errors)
-
-        return None
+        parts = [f"{profile!r}: [{', '.join(pods)}]" for profile, pods in profiles.items()]
+        return f"Profile mismatch across gang: {'; '.join(parts)}"
 
     def get_torchrun_args(self, nprocs_per_node: int, script: str) -> list[str]:
         """Build torchrun command arguments.
@@ -247,7 +215,7 @@ class GangConfigReader:
     def _read_peers(self) -> list[PeerInfo]:
         """Read and parse the peers list from the ConfigMap.
 
-        Format: "pod_name;pod_ip;rank" per line.
+        Format: "pod_name;pod_ip;rank[;profile_name]" per line.
 
         Returns:
             List of PeerInfo objects.
@@ -284,21 +252,16 @@ class GangConfigReader:
                         extra={"line": line, "bad_rank": parts[2].strip()},
                     )
 
-            checks = ""
+            profile_name = ""
             if len(parts) >= 4:
-                checks = parts[3].strip()
-
-            allreduce_config = ""
-            if len(parts) >= 5:
-                allreduce_config = parts[4].strip()
+                profile_name = parts[3].strip()
 
             peers.append(
                 PeerInfo(
                     pod_name=pod_name,
                     pod_ip=pod_ip,
                     rank=rank,
-                    checks=checks,
-                    allreduce_config=allreduce_config,
+                    profile_name=profile_name,
                 )
             )
 

--- a/preflight-checks/nccl-allreduce/nccl_allreduce/gang.py
+++ b/preflight-checks/nccl-allreduce/nccl_allreduce/gang.py
@@ -57,11 +57,15 @@ class PeerInfo:
         pod_name: Kubernetes pod name.
         pod_ip: Pod IP address.
         rank: Distributed rank (0-indexed).
+        checks: Comma-separated list of checks this peer is configured to run.
+        allreduce_config: Hash or identifier for the peer's allreduce configuration.
     """
 
     pod_name: str
     pod_ip: str
     rank: int
+    checks: str = ""
+    allreduce_config: str = ""
 
 
 @dataclass
@@ -85,6 +89,61 @@ class GangConfig:
     peers: list[PeerInfo]
     my_rank: int
     my_pod_name: str
+
+    def validate_peers(self, check_name: str) -> str | None:
+        """Validate that all peers are configured for the given check.
+
+        For each peer:
+        - If the peer has an empty ``checks`` field (old format), log a
+          warning and skip validation for that peer.
+        - Otherwise, verify that ``check_name`` appears in the peer's
+          comma-separated checks list.
+        - Record each peer's ``allreduce_config`` in a dict (even when
+          empty) and detect mismatches across the gang.
+
+        Args:
+            check_name: The check name to look for (e.g.
+                ``"preflight-nccl-allreduce"``).
+
+        Returns:
+            ``None`` if all peers are valid, or a descriptive error string.
+        """
+        missing: list[str] = []
+        hashes: dict[str, list[str]] = {}
+
+        for peer in self.peers:
+            # Always record allreduce_config (even empty string).
+            hashes.setdefault(peer.allreduce_config, []).append(peer.pod_name)
+
+            if not peer.checks:
+                log.warning(
+                    "Peer uses old format without checks field, skipping validation",
+                    extra={"pod_name": peer.pod_name},
+                )
+                continue
+
+            peer_checks = [c.strip() for c in peer.checks.split(",")]
+            if check_name not in peer_checks:
+                missing.append(peer.pod_name)
+
+        errors: list[str] = []
+
+        if missing:
+            errors.append(
+                f"Peers missing check '{check_name}': {', '.join(missing)}"
+            )
+
+        if len(hashes) > 1:
+            parts = [
+                f"{config!r}: [{', '.join(pods)}]"
+                for config, pods in hashes.items()
+            ]
+            errors.append(f"Config mismatch across gang: {'; '.join(parts)}")
+
+        if errors:
+            return "; ".join(errors)
+
+        return None
 
     def get_torchrun_args(self, nprocs_per_node: int, script: str) -> list[str]:
         """Build torchrun command arguments.
@@ -230,7 +289,21 @@ class GangConfigReader:
                         extra={"line": line, "bad_rank": parts[2].strip()},
                     )
 
-            peers.append(PeerInfo(pod_name=pod_name, pod_ip=pod_ip, rank=rank))
+            checks = ""
+            if len(parts) >= 4:
+                checks = parts[3].strip()
+
+            allreduce_config = ""
+            if len(parts) >= 5:
+                allreduce_config = parts[4].strip()
+
+            peers.append(PeerInfo(
+                pod_name=pod_name,
+                pod_ip=pod_ip,
+                rank=rank,
+                checks=checks,
+                allreduce_config=allreduce_config,
+            ))
 
         return peers
 

--- a/preflight-checks/nccl-allreduce/nccl_allreduce/tests/test_gang.py
+++ b/preflight-checks/nccl-allreduce/nccl_allreduce/tests/test_gang.py
@@ -108,19 +108,16 @@ class TestGangConfigReader:
         assert cfg.my_rank == -1
 
 
-class TestExtendedPeerFormat:
-    """Tests for parsing extended peer format with checks and allreduce_config."""
+class TestPeerFormat:
+    """Tests for parsing peer format with profile name."""
 
-    def test_parse_five_field_format(self, tmp_path: Path) -> None:
+    def test_parse_four_field_format(self, tmp_path: Path) -> None:
         config_dir = str(tmp_path)
         write_configmap(
             config_dir,
             {
                 "expected_count": "2",
-                "peers": (
-                    "pod-0;10.0.0.1;0;preflight-nccl-allreduce,preflight-dcgm;abc123\n"
-                    "pod-1;10.0.0.2;1;preflight-nccl-allreduce,preflight-dcgm;abc123"
-                ),
+                "peers": ("pod-0;10.0.0.1;0;full-diagnostics\n" "pod-1;10.0.0.2;1;full-diagnostics"),
             },
         )
 
@@ -128,10 +125,8 @@ class TestExtendedPeerFormat:
         cfg = reader.read("pod-0")
 
         assert len(cfg.peers) == 2
-        assert cfg.peers[0].checks == "preflight-nccl-allreduce,preflight-dcgm"
-        assert cfg.peers[0].allreduce_config == "abc123"
-        assert cfg.peers[1].checks == "preflight-nccl-allreduce,preflight-dcgm"
-        assert cfg.peers[1].allreduce_config == "abc123"
+        assert cfg.peers[0].profile_name == "full-diagnostics"
+        assert cfg.peers[1].profile_name == "full-diagnostics"
 
     def test_backward_compatible_three_field_format(self, tmp_path: Path) -> None:
         config_dir = str(tmp_path)
@@ -147,10 +142,8 @@ class TestExtendedPeerFormat:
         cfg = reader.read("pod-0")
 
         assert len(cfg.peers) == 2
-        assert cfg.peers[0].checks == ""
-        assert cfg.peers[0].allreduce_config == ""
-        assert cfg.peers[1].checks == ""
-        assert cfg.peers[1].allreduce_config == ""
+        assert cfg.peers[0].profile_name == ""
+        assert cfg.peers[1].profile_name == ""
 
     def test_mixed_old_new_format(self, tmp_path: Path) -> None:
         config_dir = str(tmp_path)
@@ -158,7 +151,7 @@ class TestExtendedPeerFormat:
             config_dir,
             {
                 "expected_count": "2",
-                "peers": ("pod-0;10.0.0.1;0\n" "pod-1;10.0.0.2;1;preflight-nccl-allreduce;def456"),
+                "peers": "pod-0;10.0.0.1;0\npod-1;10.0.0.2;1;full-diagnostics",
             },
         )
 
@@ -166,14 +159,12 @@ class TestExtendedPeerFormat:
         cfg = reader.read("pod-0")
 
         assert len(cfg.peers) == 2
-        assert cfg.peers[0].checks == ""
-        assert cfg.peers[0].allreduce_config == ""
-        assert cfg.peers[1].checks == "preflight-nccl-allreduce"
-        assert cfg.peers[1].allreduce_config == "def456"
+        assert cfg.peers[0].profile_name == ""
+        assert cfg.peers[1].profile_name == "full-diagnostics"
 
 
 class TestValidatePeers:
-    """Tests for GangConfig.validate_peers() fail-fast validation."""
+    """Tests for GangConfig.validate_peers() profile consistency validation."""
 
     @staticmethod
     def _make_config(peers: list[PeerInfo]) -> GangConfig:
@@ -187,104 +178,61 @@ class TestValidatePeers:
             my_pod_name="pod-0",
         )
 
-    def test_all_valid(self) -> None:
+    def test_same_profile(self) -> None:
         peers = [
-            PeerInfo("pod-0", "10.0.0.1", 0, "preflight-nccl-allreduce", "abc"),
-            PeerInfo("pod-1", "10.0.0.2", 1, "preflight-nccl-allreduce", "abc"),
+            PeerInfo("pod-0", "10.0.0.1", 0, "full-diagnostics"),
+            PeerInfo("pod-1", "10.0.0.2", 1, "full-diagnostics"),
         ]
         cfg = self._make_config(peers)
-        assert cfg.validate_peers("preflight-nccl-allreduce") is None
+        assert cfg.validate_peers() is None
 
-    def test_peer_missing_check(self) -> None:
+    def test_profile_mismatch(self) -> None:
         peers = [
-            PeerInfo("pod-0", "10.0.0.1", 0, "preflight-nccl-allreduce", "abc"),
-            PeerInfo("pod-1", "10.0.0.2", 1, "preflight-dcgm", "abc"),
+            PeerInfo("pod-0", "10.0.0.1", 0, "full-diagnostics"),
+            PeerInfo("pod-1", "10.0.0.2", 1, "dcgm-only"),
         ]
         cfg = self._make_config(peers)
-        result = cfg.validate_peers("preflight-nccl-allreduce")
-        assert result is not None
-        assert "pod-1" in result
-        assert "missing check" in result.lower()
-
-    def test_config_mismatch(self) -> None:
-        peers = [
-            PeerInfo("pod-0", "10.0.0.1", 0, "preflight-nccl-allreduce", "abc"),
-            PeerInfo("pod-1", "10.0.0.2", 1, "preflight-nccl-allreduce", "def"),
-        ]
-        cfg = self._make_config(peers)
-        result = cfg.validate_peers("preflight-nccl-allreduce")
+        result = cfg.validate_peers()
         assert result is not None
         assert "mismatch" in result.lower()
 
-    def test_old_format_peers_skipped(self) -> None:
+    def test_all_default_no_profile(self) -> None:
         peers = [
-            PeerInfo("pod-0", "10.0.0.1", 0, "", ""),
-            PeerInfo("pod-1", "10.0.0.2", 1, "preflight-nccl-allreduce", "abc"),
+            PeerInfo("pod-0", "10.0.0.1", 0),
+            PeerInfo("pod-1", "10.0.0.2", 1),
         ]
         cfg = self._make_config(peers)
-        # Old-format peer is skipped; only pod-1 is validated — it has the check.
-        # But config mismatch: "" vs "abc".
-        result = cfg.validate_peers("preflight-nccl-allreduce")
+        assert cfg.validate_peers() is None
+
+    def test_mixed_default_and_profile_mismatch(self) -> None:
+        peers = [
+            PeerInfo("pod-0", "10.0.0.1", 0),
+            PeerInfo("pod-1", "10.0.0.2", 1, "full-diagnostics"),
+        ]
+        cfg = self._make_config(peers)
+        result = cfg.validate_peers()
         assert result is not None
         assert "mismatch" in result.lower()
 
-    def test_all_old_format(self) -> None:
+    def test_three_peers_same_profile(self) -> None:
         peers = [
-            PeerInfo("pod-0", "10.0.0.1", 0, "", ""),
-            PeerInfo("pod-1", "10.0.0.2", 1, "", ""),
+            PeerInfo("pod-0", "10.0.0.1", 0, "full-diagnostics"),
+            PeerInfo("pod-1", "10.0.0.2", 1, "full-diagnostics"),
+            PeerInfo("pod-2", "10.0.0.3", 2, "full-diagnostics"),
         ]
         cfg = self._make_config(peers)
-        # All old format — no check validation, configs all empty (match).
-        assert cfg.validate_peers("preflight-nccl-allreduce") is None
+        assert cfg.validate_peers() is None
 
-    def test_multiple_peers_missing(self) -> None:
+    def test_three_peers_one_different(self) -> None:
         peers = [
-            PeerInfo("pod-0", "10.0.0.1", 0, "preflight-nccl-allreduce", "abc"),
-            PeerInfo("pod-1", "10.0.0.2", 1, "preflight-dcgm", "abc"),
-            PeerInfo("pod-2", "10.0.0.3", 2, "preflight-dcgm", "abc"),
+            PeerInfo("pod-0", "10.0.0.1", 0, "full-diagnostics"),
+            PeerInfo("pod-1", "10.0.0.2", 1, "full-diagnostics"),
+            PeerInfo("pod-2", "10.0.0.3", 2, "dcgm-only"),
         ]
         cfg = self._make_config(peers)
-        result = cfg.validate_peers("preflight-nccl-allreduce")
+        result = cfg.validate_peers()
         assert result is not None
-        assert "pod-1" in result
         assert "pod-2" in result
-
-    def test_matching_hashes(self) -> None:
-        peers = [
-            PeerInfo("pod-0", "10.0.0.1", 0, "preflight-nccl-allreduce", "same"),
-            PeerInfo("pod-1", "10.0.0.2", 1, "preflight-nccl-allreduce", "same"),
-            PeerInfo("pod-2", "10.0.0.3", 2, "preflight-nccl-allreduce", "same"),
-        ]
-        cfg = self._make_config(peers)
-        assert cfg.validate_peers("preflight-nccl-allreduce") is None
-
-    def test_empty_config_no_mismatch(self) -> None:
-        peers = [
-            PeerInfo("pod-0", "10.0.0.1", 0, "preflight-nccl-allreduce", ""),
-            PeerInfo("pod-1", "10.0.0.2", 1, "preflight-nccl-allreduce", ""),
-        ]
-        cfg = self._make_config(peers)
-        assert cfg.validate_peers("preflight-nccl-allreduce") is None
-
-    def test_mixed_empty_explicit_config_mismatch(self) -> None:
-        peers = [
-            PeerInfo("pod-0", "10.0.0.1", 0, "preflight-nccl-allreduce", ""),
-            PeerInfo("pod-1", "10.0.0.2", 1, "preflight-nccl-allreduce", "abc"),
-        ]
-        cfg = self._make_config(peers)
-        result = cfg.validate_peers("preflight-nccl-allreduce")
-        assert result is not None
-        assert "mismatch" in result.lower()
-
-    def test_peer_with_none_checks_detected(self) -> None:
-        peers = [
-            PeerInfo("pod-0", "10.0.0.1", 0, "preflight-nccl-allreduce", "abc"),
-            PeerInfo("pod-1", "10.0.0.2", 1, "none", "abc"),
-        ]
-        cfg = self._make_config(peers)
-        result = cfg.validate_peers("preflight-nccl-allreduce")
-        assert result is not None
-        assert "pod-1" in result
 
 
 class TestGangConfig:

--- a/preflight-checks/nccl-allreduce/nccl_allreduce/tests/test_gang.py
+++ b/preflight-checks/nccl-allreduce/nccl_allreduce/tests/test_gang.py
@@ -158,10 +158,7 @@ class TestExtendedPeerFormat:
             config_dir,
             {
                 "expected_count": "2",
-                "peers": (
-                    "pod-0;10.0.0.1;0\n"
-                    "pod-1;10.0.0.2;1;preflight-nccl-allreduce;def456"
-                ),
+                "peers": ("pod-0;10.0.0.1;0\n" "pod-1;10.0.0.2;1;preflight-nccl-allreduce;def456"),
             },
         )
 

--- a/preflight-checks/nccl-allreduce/nccl_allreduce/tests/test_gang.py
+++ b/preflight-checks/nccl-allreduce/nccl_allreduce/tests/test_gang.py
@@ -108,6 +108,188 @@ class TestGangConfigReader:
         assert cfg.my_rank == -1
 
 
+class TestExtendedPeerFormat:
+    """Tests for parsing extended peer format with checks and allreduce_config."""
+
+    def test_parse_five_field_format(self, tmp_path: Path) -> None:
+        config_dir = str(tmp_path)
+        write_configmap(
+            config_dir,
+            {
+                "expected_count": "2",
+                "peers": (
+                    "pod-0;10.0.0.1;0;preflight-nccl-allreduce,preflight-dcgm;abc123\n"
+                    "pod-1;10.0.0.2;1;preflight-nccl-allreduce,preflight-dcgm;abc123"
+                ),
+            },
+        )
+
+        reader = GangConfigReader(config_dir)
+        cfg = reader.read("pod-0")
+
+        assert len(cfg.peers) == 2
+        assert cfg.peers[0].checks == "preflight-nccl-allreduce,preflight-dcgm"
+        assert cfg.peers[0].allreduce_config == "abc123"
+        assert cfg.peers[1].checks == "preflight-nccl-allreduce,preflight-dcgm"
+        assert cfg.peers[1].allreduce_config == "abc123"
+
+    def test_backward_compatible_three_field_format(self, tmp_path: Path) -> None:
+        config_dir = str(tmp_path)
+        write_configmap(
+            config_dir,
+            {
+                "expected_count": "2",
+                "peers": "pod-0;10.0.0.1;0\npod-1;10.0.0.2;1",
+            },
+        )
+
+        reader = GangConfigReader(config_dir)
+        cfg = reader.read("pod-0")
+
+        assert len(cfg.peers) == 2
+        assert cfg.peers[0].checks == ""
+        assert cfg.peers[0].allreduce_config == ""
+        assert cfg.peers[1].checks == ""
+        assert cfg.peers[1].allreduce_config == ""
+
+    def test_mixed_old_new_format(self, tmp_path: Path) -> None:
+        config_dir = str(tmp_path)
+        write_configmap(
+            config_dir,
+            {
+                "expected_count": "2",
+                "peers": (
+                    "pod-0;10.0.0.1;0\n"
+                    "pod-1;10.0.0.2;1;preflight-nccl-allreduce;def456"
+                ),
+            },
+        )
+
+        reader = GangConfigReader(config_dir)
+        cfg = reader.read("pod-0")
+
+        assert len(cfg.peers) == 2
+        assert cfg.peers[0].checks == ""
+        assert cfg.peers[0].allreduce_config == ""
+        assert cfg.peers[1].checks == "preflight-nccl-allreduce"
+        assert cfg.peers[1].allreduce_config == "def456"
+
+
+class TestValidatePeers:
+    """Tests for GangConfig.validate_peers() fail-fast validation."""
+
+    @staticmethod
+    def _make_config(peers: list[PeerInfo]) -> GangConfig:
+        return GangConfig(
+            expected_count=len(peers),
+            gang_id="test-gang",
+            master_addr="10.0.0.1",
+            master_port="29500",
+            peers=peers,
+            my_rank=0,
+            my_pod_name="pod-0",
+        )
+
+    def test_all_valid(self) -> None:
+        peers = [
+            PeerInfo("pod-0", "10.0.0.1", 0, "preflight-nccl-allreduce", "abc"),
+            PeerInfo("pod-1", "10.0.0.2", 1, "preflight-nccl-allreduce", "abc"),
+        ]
+        cfg = self._make_config(peers)
+        assert cfg.validate_peers("preflight-nccl-allreduce") is None
+
+    def test_peer_missing_check(self) -> None:
+        peers = [
+            PeerInfo("pod-0", "10.0.0.1", 0, "preflight-nccl-allreduce", "abc"),
+            PeerInfo("pod-1", "10.0.0.2", 1, "preflight-dcgm", "abc"),
+        ]
+        cfg = self._make_config(peers)
+        result = cfg.validate_peers("preflight-nccl-allreduce")
+        assert result is not None
+        assert "pod-1" in result
+        assert "missing check" in result.lower()
+
+    def test_config_mismatch(self) -> None:
+        peers = [
+            PeerInfo("pod-0", "10.0.0.1", 0, "preflight-nccl-allreduce", "abc"),
+            PeerInfo("pod-1", "10.0.0.2", 1, "preflight-nccl-allreduce", "def"),
+        ]
+        cfg = self._make_config(peers)
+        result = cfg.validate_peers("preflight-nccl-allreduce")
+        assert result is not None
+        assert "mismatch" in result.lower()
+
+    def test_old_format_peers_skipped(self) -> None:
+        peers = [
+            PeerInfo("pod-0", "10.0.0.1", 0, "", ""),
+            PeerInfo("pod-1", "10.0.0.2", 1, "preflight-nccl-allreduce", "abc"),
+        ]
+        cfg = self._make_config(peers)
+        # Old-format peer is skipped; only pod-1 is validated — it has the check.
+        # But config mismatch: "" vs "abc".
+        result = cfg.validate_peers("preflight-nccl-allreduce")
+        assert result is not None
+        assert "mismatch" in result.lower()
+
+    def test_all_old_format(self) -> None:
+        peers = [
+            PeerInfo("pod-0", "10.0.0.1", 0, "", ""),
+            PeerInfo("pod-1", "10.0.0.2", 1, "", ""),
+        ]
+        cfg = self._make_config(peers)
+        # All old format — no check validation, configs all empty (match).
+        assert cfg.validate_peers("preflight-nccl-allreduce") is None
+
+    def test_multiple_peers_missing(self) -> None:
+        peers = [
+            PeerInfo("pod-0", "10.0.0.1", 0, "preflight-nccl-allreduce", "abc"),
+            PeerInfo("pod-1", "10.0.0.2", 1, "preflight-dcgm", "abc"),
+            PeerInfo("pod-2", "10.0.0.3", 2, "preflight-dcgm", "abc"),
+        ]
+        cfg = self._make_config(peers)
+        result = cfg.validate_peers("preflight-nccl-allreduce")
+        assert result is not None
+        assert "pod-1" in result
+        assert "pod-2" in result
+
+    def test_matching_hashes(self) -> None:
+        peers = [
+            PeerInfo("pod-0", "10.0.0.1", 0, "preflight-nccl-allreduce", "same"),
+            PeerInfo("pod-1", "10.0.0.2", 1, "preflight-nccl-allreduce", "same"),
+            PeerInfo("pod-2", "10.0.0.3", 2, "preflight-nccl-allreduce", "same"),
+        ]
+        cfg = self._make_config(peers)
+        assert cfg.validate_peers("preflight-nccl-allreduce") is None
+
+    def test_empty_config_no_mismatch(self) -> None:
+        peers = [
+            PeerInfo("pod-0", "10.0.0.1", 0, "preflight-nccl-allreduce", ""),
+            PeerInfo("pod-1", "10.0.0.2", 1, "preflight-nccl-allreduce", ""),
+        ]
+        cfg = self._make_config(peers)
+        assert cfg.validate_peers("preflight-nccl-allreduce") is None
+
+    def test_mixed_empty_explicit_config_mismatch(self) -> None:
+        peers = [
+            PeerInfo("pod-0", "10.0.0.1", 0, "preflight-nccl-allreduce", ""),
+            PeerInfo("pod-1", "10.0.0.2", 1, "preflight-nccl-allreduce", "abc"),
+        ]
+        cfg = self._make_config(peers)
+        result = cfg.validate_peers("preflight-nccl-allreduce")
+        assert result is not None
+        assert "mismatch" in result.lower()
+
+    def test_peer_with_none_checks_detected(self) -> None:
+        peers = [
+            PeerInfo("pod-0", "10.0.0.1", 0, "preflight-nccl-allreduce", "abc"),
+            PeerInfo("pod-1", "10.0.0.2", 1, "none", "abc"),
+        ]
+        cfg = self._make_config(peers)
+        result = cfg.validate_peers("preflight-nccl-allreduce")
+        assert result is not None
+        assert "pod-1" in result
+
+
 class TestGangConfig:
     """Tests for building torchrun CLI arguments from gang coordination info."""
 

--- a/preflight-checks/nccl-allreduce/scripts/entrypoint.py
+++ b/preflight-checks/nccl-allreduce/scripts/entrypoint.py
@@ -95,7 +95,7 @@ def main() -> int:
         return gang_config
 
     # 3. Validate peers before launching torchrun
-    validation_error = gang_config.validate_peers("preflight-nccl-allreduce")
+    validation_error = gang_config.validate_peers()
     if validation_error is not None:
         log.error(
             "Gang peer validation failed",

--- a/preflight-checks/nccl-allreduce/scripts/entrypoint.py
+++ b/preflight-checks/nccl-allreduce/scripts/entrypoint.py
@@ -18,7 +18,8 @@
 This script:
 1. Waits for gang formation (all peers registered in ConfigMap)
 2. Extracts coordination info (rank, master address, etc.)
-3. Execs torchrun with the appropriate arguments
+3. Validates peers (checks and config consistency)
+4. Execs torchrun with the appropriate arguments
 
 The ConfigMap is mounted at GANG_CONFIG_DIR (default: /etc/preflight) and
 contains:
@@ -93,7 +94,17 @@ def main() -> int:
     if isinstance(gang_config, int):
         return gang_config
 
-    # 3. Launch torchrun (replaces this process)
+    # 3. Validate peers before launching torchrun
+    validation_error = gang_config.validate_peers("preflight-nccl-allreduce")
+    if validation_error is not None:
+        log.error(
+            "Gang peer validation failed",
+            extra={"error": validation_error},
+        )
+        _report_error(NCCLError.GANG_CONFIG_ERROR, validation_error)
+        return NCCLError.GANG_CONFIG_ERROR.value.exit_code
+
+    # 4. Launch torchrun (replaces this process)
     _launch_torchrun(gang_config, cfg.nprocs_per_node)
 
     # Should never reach here (os.execvp replaces the process)

--- a/preflight/main.go
+++ b/preflight/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/nvidia/nvsentinel/preflight/pkg/controller"
 	"github.com/nvidia/nvsentinel/preflight/pkg/gang"
 	"github.com/nvidia/nvsentinel/preflight/pkg/webhook"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
@@ -45,6 +46,7 @@ var (
 	date    = "unknown"
 
 	discoverer     gang.GangDiscoverer
+	profileReader  webhook.ProfileReader
 	onGangRegister webhook.GangRegistrationFunc
 )
 
@@ -89,13 +91,26 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
+	// Create a dynamic client for PreflightProfile CRD lookups.
+	restConfig, err := rest.InClusterConfig()
+	if err != nil {
+		slog.Warn("Failed to get in-cluster config, PreflightProfile CRD lookups disabled", "error", err)
+	} else {
+		dynClient, err := dynamic.NewForConfig(restConfig)
+		if err != nil {
+			return fmt.Errorf("failed to create dynamic client: %w", err)
+		}
+
+		profileReader = webhook.NewK8sProfileReader(dynClient)
+	}
+
 	if cfg.GangCoordination.Enabled {
 		if err := setupGangCoordination(ctx, cfg, stop); err != nil {
 			return err
 		}
 	}
 
-	handler := webhook.NewHandler(cfg, discoverer, onGangRegister)
+	handler := webhook.NewHandler(cfg, discoverer, profileReader, onGangRegister)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/mutate", handler.HandleMutate)

--- a/preflight/pkg/config/config.go
+++ b/preflight/pkg/config/config.go
@@ -46,8 +46,16 @@ const (
 	PlacementPrepend InitContainerPlacement = "prepend"
 )
 
+// InitContainer wraps corev1.Container with a DefaultEnabled field that
+// controls whether the check runs when no per-pod PreflightProfile is present.
+// Defaults to true if omitted.
+type InitContainer struct {
+	corev1.Container `yaml:",inline"`
+	DefaultEnabled   *bool `yaml:"defaultEnabled,omitempty"`
+}
+
 type FileConfig struct {
-	InitContainers       []corev1.Container     `yaml:"initContainers"`
+	InitContainers       []InitContainer        `yaml:"initContainers"`
 	GPUResourceNames     []string               `yaml:"gpuResourceNames"`
 	NetworkResourceNames []string               `yaml:"networkResourceNames"`
 	DCGM                 DCGMConfig             `yaml:"dcgm"`

--- a/preflight/pkg/controller/gang_controller.go
+++ b/preflight/pkg/controller/gang_controller.go
@@ -19,8 +19,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"sort"
-	"strings"
 
 	"github.com/nvidia/nvsentinel/preflight/pkg/config"
 	"github.com/nvidia/nvsentinel/preflight/pkg/gang"
@@ -35,12 +33,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-// collectiveOpEnvVars are the environment variable names extracted from allreduce
-// init containers to record in the peer's AllReduceConfig field.
-var collectiveOpEnvVars = []string{"MESSAGE_SIZES", "BENCHMARK_ITERS", "WARMUP_ITERS", "NCCL_REDUCE_OP"}
-
-// allreduceContainerName is the init container name for the NCCL allreduce check.
-const allreduceContainerName = "preflight-nccl-allreduce"
+// profileAnnotation is the pod annotation key for the PreflightProfile CRD reference.
+const profileAnnotation = "nvsentinel.nvidia.com/preflight-profile"
 
 // GangController reconciles pods to update gang ConfigMaps with peer information.
 type GangController struct {
@@ -162,15 +156,12 @@ func (c *GangController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, nil
 	}
 
-	injectedChecks, allReduceConfig := c.extractPreflightMetadata(&pod)
-
 	peer := gang.PeerInfo{
-		PodName:         pod.Name,
-		PodIP:           pod.Status.PodIP,
-		NodeName:        pod.Spec.NodeName,
-		Namespace:       pod.Namespace,
-		Checks:          injectedChecks,
-		AllReduceConfig: allReduceConfig,
+		PodName:     pod.Name,
+		PodIP:       pod.Status.PodIP,
+		NodeName:    pod.Spec.NodeName,
+		Namespace:   pod.Namespace,
+		ProfileName: pod.Annotations[profileAnnotation],
 	}
 
 	if err := c.coordinator.RegisterPeer(ctx, pod.Namespace, gangInfo, peer); err != nil {
@@ -271,57 +262,3 @@ func (c *GangController) ensureNCCLTopoConfigMap(ctx context.Context, namespace 
 		"configMap", gcfg.NCCLTopoConfigMap)
 }
 
-// extractPreflightMetadata inspects the pod's init containers and returns:
-//   - injectedChecks: comma-separated list of preflight init container names
-//     that match the controller's configured check names, or "none" if no
-//     matches are found.
-//   - allReduceConfig: collective-op env var config from the allreduce init
-//     container (empty string if the container is not present).
-func (c *GangController) extractPreflightMetadata(pod *corev1.Pod) (injectedChecks, allReduceConfig string) {
-	configuredNames := make(map[string]struct{}, len(c.cfg.InitContainers))
-	for _, ic := range c.cfg.InitContainers {
-		configuredNames[ic.Name] = struct{}{}
-	}
-
-	var matched []string
-
-	for _, container := range pod.Spec.InitContainers {
-		if _, ok := configuredNames[container.Name]; !ok {
-			continue
-		}
-
-		matched = append(matched, container.Name)
-
-		if container.Name == allreduceContainerName {
-			allReduceConfig = collectiveOpConfig(container)
-		}
-	}
-
-	if len(matched) == 0 {
-		return "none", allReduceConfig
-	}
-
-	return strings.Join(matched, ","), allReduceConfig
-}
-
-// collectiveOpConfig extracts collective-op environment variables from the
-// given container and returns them as a sorted, comma-separated "KEY=VAL"
-// string. Only variables listed in collectiveOpEnvVars are included.
-func collectiveOpConfig(container corev1.Container) string {
-	wanted := make(map[string]struct{}, len(collectiveOpEnvVars))
-	for _, name := range collectiveOpEnvVars {
-		wanted[name] = struct{}{}
-	}
-
-	var pairs []string
-
-	for _, env := range container.Env {
-		if _, ok := wanted[env.Name]; ok {
-			pairs = append(pairs, env.Name+"="+env.Value)
-		}
-	}
-
-	sort.Strings(pairs)
-
-	return strings.Join(pairs, ",")
-}

--- a/preflight/pkg/controller/gang_controller.go
+++ b/preflight/pkg/controller/gang_controller.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
+	"strings"
 
 	"github.com/nvidia/nvsentinel/preflight/pkg/config"
 	"github.com/nvidia/nvsentinel/preflight/pkg/gang"
@@ -32,6 +34,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
+
+// collectiveOpEnvVars are the environment variable names extracted from allreduce
+// init containers to record in the peer's AllReduceConfig field.
+var collectiveOpEnvVars = []string{"MESSAGE_SIZES", "BENCHMARK_ITERS", "WARMUP_ITERS", "NCCL_REDUCE_OP"}
+
+// allreduceContainerName is the init container name for the NCCL allreduce check.
+const allreduceContainerName = "preflight-nccl-allreduce"
 
 // GangController reconciles pods to update gang ConfigMaps with peer information.
 type GangController struct {
@@ -153,11 +162,15 @@ func (c *GangController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, nil
 	}
 
+	injectedChecks, allReduceConfig := c.extractPreflightMetadata(&pod)
+
 	peer := gang.PeerInfo{
-		PodName:   pod.Name,
-		PodIP:     pod.Status.PodIP,
-		NodeName:  pod.Spec.NodeName,
-		Namespace: pod.Namespace,
+		PodName:         pod.Name,
+		PodIP:           pod.Status.PodIP,
+		NodeName:        pod.Spec.NodeName,
+		Namespace:       pod.Namespace,
+		Checks:          injectedChecks,
+		AllReduceConfig: allReduceConfig,
 	}
 
 	if err := c.coordinator.RegisterPeer(ctx, pod.Namespace, gangInfo, peer); err != nil {
@@ -256,4 +269,59 @@ func (c *GangController) ensureNCCLTopoConfigMap(ctx context.Context, namespace 
 	slog.Info("Created NCCL topo ConfigMap",
 		"namespace", namespace,
 		"configMap", gcfg.NCCLTopoConfigMap)
+}
+
+// extractPreflightMetadata inspects the pod's init containers and returns:
+//   - injectedChecks: comma-separated list of preflight init container names
+//     that match the controller's configured check names, or "none" if no
+//     matches are found.
+//   - allReduceConfig: collective-op env var config from the allreduce init
+//     container (empty string if the container is not present).
+func (c *GangController) extractPreflightMetadata(pod *corev1.Pod) (injectedChecks, allReduceConfig string) {
+	configuredNames := make(map[string]struct{}, len(c.cfg.InitContainers))
+	for _, ic := range c.cfg.InitContainers {
+		configuredNames[ic.Name] = struct{}{}
+	}
+
+	var matched []string
+
+	for _, container := range pod.Spec.InitContainers {
+		if _, ok := configuredNames[container.Name]; !ok {
+			continue
+		}
+
+		matched = append(matched, container.Name)
+
+		if container.Name == allreduceContainerName {
+			allReduceConfig = collectiveOpConfig(container)
+		}
+	}
+
+	if len(matched) == 0 {
+		return "none", allReduceConfig
+	}
+
+	return strings.Join(matched, ","), allReduceConfig
+}
+
+// collectiveOpConfig extracts collective-op environment variables from the
+// given container and returns them as a sorted, comma-separated "KEY=VAL"
+// string. Only variables listed in collectiveOpEnvVars are included.
+func collectiveOpConfig(container corev1.Container) string {
+	wanted := make(map[string]struct{}, len(collectiveOpEnvVars))
+	for _, name := range collectiveOpEnvVars {
+		wanted[name] = struct{}{}
+	}
+
+	var pairs []string
+
+	for _, env := range container.Env {
+		if _, ok := wanted[env.Name]; ok {
+			pairs = append(pairs, env.Name+"="+env.Value)
+		}
+	}
+
+	sort.Strings(pairs)
+
+	return strings.Join(pairs, ",")
 }

--- a/preflight/pkg/gang/coordinator/coordinator.go
+++ b/preflight/pkg/gang/coordinator/coordinator.go
@@ -271,7 +271,9 @@ func (c *Coordinator) GetGangConfigMap(ctx context.Context, namespace, gangID st
 }
 
 // ParsePeers parses the peers string from a ConfigMap into a slice of PeerInfo.
-// Format: "podName;podIP;rank" per line (rank is optional for backwards compatibility).
+// Format: "podName;podIP;rank[;checks;allReduceConfig]" per line.
+// The checks and allReduceConfig fields are optional for backward compatibility
+// with the older 3-field format.
 func ParsePeers(peersData string) []types.PeerInfo {
 	var peers []types.PeerInfo
 
@@ -281,15 +283,25 @@ func ParsePeers(peersData string) []types.PeerInfo {
 			continue
 		}
 
-		parts := strings.SplitN(line, ";", 3)
+		parts := strings.SplitN(line, ";", 5)
 		if len(parts) < 2 {
 			continue
 		}
 
-		peers = append(peers, types.PeerInfo{
+		peer := types.PeerInfo{
 			PodName: strings.TrimSpace(parts[0]),
 			PodIP:   strings.TrimSpace(parts[1]),
-		})
+		}
+
+		if len(parts) >= 4 {
+			peer.Checks = strings.TrimSpace(parts[3])
+		}
+
+		if len(parts) >= 5 {
+			peer.AllReduceConfig = strings.TrimSpace(parts[4])
+		}
+
+		peers = append(peers, peer)
 	}
 
 	return peers
@@ -350,6 +362,8 @@ func (c *Coordinator) addPeerToConfigMap(cm *corev1.ConfigMap, peer types.PeerIn
 	for i, p := range existingPeers {
 		if p.PodName == peer.PodName {
 			existingPeers[i].PodIP = peer.PodIP
+			existingPeers[i].Checks = peer.Checks
+			existingPeers[i].AllReduceConfig = peer.AllReduceConfig
 			found = true
 
 			break
@@ -368,7 +382,7 @@ func (c *Coordinator) addPeerToConfigMap(cm *corev1.ConfigMap, peer types.PeerIn
 	// Serialize peers with rank (index after sorting)
 	var lines []string
 	for rank, p := range existingPeers {
-		lines = append(lines, fmt.Sprintf("%s;%s;%d", p.PodName, p.PodIP, rank))
+		lines = append(lines, fmt.Sprintf("%s;%s;%d;%s;%s", p.PodName, p.PodIP, rank, p.Checks, p.AllReduceConfig))
 	}
 
 	cm.Data[DataKeyPeers] = strings.Join(lines, "\n")

--- a/preflight/pkg/gang/coordinator/coordinator.go
+++ b/preflight/pkg/gang/coordinator/coordinator.go
@@ -271,9 +271,9 @@ func (c *Coordinator) GetGangConfigMap(ctx context.Context, namespace, gangID st
 }
 
 // ParsePeers parses the peers string from a ConfigMap into a slice of PeerInfo.
-// Format: "podName;podIP;rank[;checks;allReduceConfig]" per line.
-// The checks and allReduceConfig fields are optional for backward compatibility
-// with the older 3-field format.
+// Format: "podName;podIP;rank[;profileName]" per line.
+// The profileName field is optional for backward compatibility with the older
+// 3-field format.
 func ParsePeers(peersData string) []types.PeerInfo {
 	var peers []types.PeerInfo
 
@@ -283,7 +283,7 @@ func ParsePeers(peersData string) []types.PeerInfo {
 			continue
 		}
 
-		parts := strings.SplitN(line, ";", 5)
+		parts := strings.SplitN(line, ";", 4)
 		if len(parts) < 2 {
 			continue
 		}
@@ -294,11 +294,7 @@ func ParsePeers(peersData string) []types.PeerInfo {
 		}
 
 		if len(parts) >= 4 {
-			peer.Checks = strings.TrimSpace(parts[3])
-		}
-
-		if len(parts) >= 5 {
-			peer.AllReduceConfig = strings.TrimSpace(parts[4])
+			peer.ProfileName = strings.TrimSpace(parts[3])
 		}
 
 		peers = append(peers, peer)
@@ -362,8 +358,7 @@ func (c *Coordinator) addPeerToConfigMap(cm *corev1.ConfigMap, peer types.PeerIn
 	for i, p := range existingPeers {
 		if p.PodName == peer.PodName {
 			existingPeers[i].PodIP = peer.PodIP
-			existingPeers[i].Checks = peer.Checks
-			existingPeers[i].AllReduceConfig = peer.AllReduceConfig
+			existingPeers[i].ProfileName = peer.ProfileName
 			found = true
 
 			break
@@ -382,7 +377,7 @@ func (c *Coordinator) addPeerToConfigMap(cm *corev1.ConfigMap, peer types.PeerIn
 	// Serialize peers with rank (index after sorting)
 	var lines []string
 	for rank, p := range existingPeers {
-		lines = append(lines, fmt.Sprintf("%s;%s;%d;%s;%s", p.PodName, p.PodIP, rank, p.Checks, p.AllReduceConfig))
+		lines = append(lines, fmt.Sprintf("%s;%s;%d;%s", p.PodName, p.PodIP, rank, p.ProfileName))
 	}
 
 	cm.Data[DataKeyPeers] = strings.Join(lines, "\n")

--- a/preflight/pkg/gang/coordinator/coordinator_test.go
+++ b/preflight/pkg/gang/coordinator/coordinator_test.go
@@ -206,6 +206,29 @@ func TestParsePeers(t *testing.T) {
 			wantCount: 2,
 			wantFirst: types.PeerInfo{PodName: "pod-0", PodIP: "2001:db8::1"},
 		},
+		{
+			name:      "extended 5-field format",
+			peersData: "pod-0;10.0.0.1;0;preflight-dcgm,preflight-nccl-allreduce;BENCHMARK_ITERS=20,MESSAGE_SIZES=8G",
+			wantCount: 1,
+			wantFirst: types.PeerInfo{
+				PodName:         "pod-0",
+				PodIP:           "10.0.0.1",
+				Checks:          "preflight-dcgm,preflight-nccl-allreduce",
+				AllReduceConfig: "BENCHMARK_ITERS=20,MESSAGE_SIZES=8G",
+			},
+		},
+		{
+			name:      "backward-compatible 3-field format",
+			peersData: "pod-0;10.0.0.1;0\npod-1;10.0.0.2;1",
+			wantCount: 2,
+			wantFirst: types.PeerInfo{PodName: "pod-0", PodIP: "10.0.0.1", Checks: "", AllReduceConfig: ""},
+		},
+		{
+			name:      "mixed old and new format peers",
+			peersData: "pod-0;10.0.0.1;0\npod-1;10.0.0.2;1;preflight-nccl-allreduce;MESSAGE_SIZES=8G",
+			wantCount: 2,
+			wantFirst: types.PeerInfo{PodName: "pod-0", PodIP: "10.0.0.1", Checks: "", AllReduceConfig: ""},
+		},
 	}
 
 	for _, tt := range tests {
@@ -216,11 +239,27 @@ func TestParsePeers(t *testing.T) {
 				t.Errorf("ParsePeers() count = %d, want %d", len(got), tt.wantCount)
 			}
 
-			if tt.wantCount > 0 && (got[0].PodName != tt.wantFirst.PodName || got[0].PodIP != tt.wantFirst.PodIP) {
+			if tt.wantCount > 0 && got[0] != tt.wantFirst {
 				t.Errorf("ParsePeers()[0] = %+v, want %+v", got[0], tt.wantFirst)
 			}
 		})
 	}
+}
+
+func TestParsePeersMixedFormatSecondPeer(t *testing.T) {
+	peersData := "pod-0;10.0.0.1;0\npod-1;10.0.0.2;1;preflight-nccl-allreduce;MESSAGE_SIZES=8G"
+	got := ParsePeers(peersData)
+	require.Len(t, got, 2)
+
+	assert.Equal(t, types.PeerInfo{PodName: "pod-0", PodIP: "10.0.0.1"}, got[0],
+		"first peer (old format) should have empty Checks and AllReduceConfig")
+
+	assert.Equal(t, types.PeerInfo{
+		PodName:         "pod-1",
+		PodIP:           "10.0.0.2",
+		Checks:          "preflight-nccl-allreduce",
+		AllReduceConfig: "MESSAGE_SIZES=8G",
+	}, got[1], "second peer (new format) should have Checks and AllReduceConfig populated")
 }
 
 func TestGetRank(t *testing.T) {

--- a/preflight/pkg/gang/coordinator/coordinator_test.go
+++ b/preflight/pkg/gang/coordinator/coordinator_test.go
@@ -207,27 +207,26 @@ func TestParsePeers(t *testing.T) {
 			wantFirst: types.PeerInfo{PodName: "pod-0", PodIP: "2001:db8::1"},
 		},
 		{
-			name:      "extended 5-field format",
-			peersData: "pod-0;10.0.0.1;0;preflight-dcgm,preflight-nccl-allreduce;BENCHMARK_ITERS=20,MESSAGE_SIZES=8G",
+			name:      "4-field format with profile",
+			peersData: "pod-0;10.0.0.1;0;full-diagnostics",
 			wantCount: 1,
 			wantFirst: types.PeerInfo{
-				PodName:         "pod-0",
-				PodIP:           "10.0.0.1",
-				Checks:          "preflight-dcgm,preflight-nccl-allreduce",
-				AllReduceConfig: "BENCHMARK_ITERS=20,MESSAGE_SIZES=8G",
+				PodName:     "pod-0",
+				PodIP:       "10.0.0.1",
+				ProfileName: "full-diagnostics",
 			},
 		},
 		{
 			name:      "backward-compatible 3-field format",
 			peersData: "pod-0;10.0.0.1;0\npod-1;10.0.0.2;1",
 			wantCount: 2,
-			wantFirst: types.PeerInfo{PodName: "pod-0", PodIP: "10.0.0.1", Checks: "", AllReduceConfig: ""},
+			wantFirst: types.PeerInfo{PodName: "pod-0", PodIP: "10.0.0.1"},
 		},
 		{
 			name:      "mixed old and new format peers",
-			peersData: "pod-0;10.0.0.1;0\npod-1;10.0.0.2;1;preflight-nccl-allreduce;MESSAGE_SIZES=8G",
+			peersData: "pod-0;10.0.0.1;0\npod-1;10.0.0.2;1;full-diagnostics",
 			wantCount: 2,
-			wantFirst: types.PeerInfo{PodName: "pod-0", PodIP: "10.0.0.1", Checks: "", AllReduceConfig: ""},
+			wantFirst: types.PeerInfo{PodName: "pod-0", PodIP: "10.0.0.1"},
 		},
 	}
 
@@ -247,19 +246,18 @@ func TestParsePeers(t *testing.T) {
 }
 
 func TestParsePeersMixedFormatSecondPeer(t *testing.T) {
-	peersData := "pod-0;10.0.0.1;0\npod-1;10.0.0.2;1;preflight-nccl-allreduce;MESSAGE_SIZES=8G"
+	peersData := "pod-0;10.0.0.1;0\npod-1;10.0.0.2;1;full-diagnostics"
 	got := ParsePeers(peersData)
 	require.Len(t, got, 2)
 
 	assert.Equal(t, types.PeerInfo{PodName: "pod-0", PodIP: "10.0.0.1"}, got[0],
-		"first peer (old format) should have empty Checks and AllReduceConfig")
+		"first peer (old format) should have empty ProfileName")
 
 	assert.Equal(t, types.PeerInfo{
-		PodName:         "pod-1",
-		PodIP:           "10.0.0.2",
-		Checks:          "preflight-nccl-allreduce",
-		AllReduceConfig: "MESSAGE_SIZES=8G",
-	}, got[1], "second peer (new format) should have Checks and AllReduceConfig populated")
+		PodName:     "pod-1",
+		PodIP:       "10.0.0.2",
+		ProfileName: "full-diagnostics",
+	}, got[1], "second peer (new format) should have ProfileName populated")
 }
 
 func TestGetRank(t *testing.T) {

--- a/preflight/pkg/gang/types/types.go
+++ b/preflight/pkg/gang/types/types.go
@@ -31,17 +31,10 @@ type PeerInfo struct {
 	NodeName  string
 	Namespace string
 
-	// Checks is a comma-separated list of preflight init container names
-	// injected into the pod (e.g. "preflight-dcgm,preflight-nccl-allreduce").
-	// Empty string means the information was not yet available; "none" means
-	// the pod had no matching preflight init containers.
-	Checks string
-
-	// AllReduceConfig is the collective-op configuration for the peer,
-	// encoded as a sorted, comma-separated list of KEY=VAL environment
-	// variable pairs (e.g. "BENCHMARK_ITERS=20,MESSAGE_SIZES=8G").
-	// Only populated when the pod has an allreduce init container.
-	AllReduceConfig string
+	// ProfileName is the PreflightProfile CRD name referenced by the pod
+	// via the nvsentinel.nvidia.com/preflight-profile annotation.
+	// Empty string means no profile was referenced (using helm defaults).
+	ProfileName string
 }
 
 type GangInfo struct {

--- a/preflight/pkg/gang/types/types.go
+++ b/preflight/pkg/gang/types/types.go
@@ -30,6 +30,18 @@ type PeerInfo struct {
 	PodIP     string
 	NodeName  string
 	Namespace string
+
+	// Checks is a comma-separated list of preflight init container names
+	// injected into the pod (e.g. "preflight-dcgm,preflight-nccl-allreduce").
+	// Empty string means the information was not yet available; "none" means
+	// the pod had no matching preflight init containers.
+	Checks string
+
+	// AllReduceConfig is the collective-op configuration for the peer,
+	// encoded as a sorted, comma-separated list of KEY=VAL environment
+	// variable pairs (e.g. "BENCHMARK_ITERS=20,MESSAGE_SIZES=8G").
+	// Only populated when the pod has an allreduce init container.
+	AllReduceConfig string
 }
 
 type GangInfo struct {

--- a/preflight/pkg/webhook/handler.go
+++ b/preflight/pkg/webhook/handler.go
@@ -45,9 +45,9 @@ type Handler struct {
 	onGangRegister GangRegistrationFunc
 }
 
-func NewHandler(cfg *config.Config, discoverer gang.GangDiscoverer, onGangRegister GangRegistrationFunc) *Handler {
+func NewHandler(cfg *config.Config, discoverer gang.GangDiscoverer, profiles ProfileReader, onGangRegister GangRegistrationFunc) *Handler {
 	return &Handler{
-		injector:       NewInjector(cfg, discoverer),
+		injector:       NewInjector(cfg, discoverer, profiles),
 		onGangRegister: onGangRegister,
 	}
 }
@@ -120,7 +120,7 @@ func (h *Handler) mutate(ctx context.Context, req *admissionv1.AdmissionRequest)
 		pod.Namespace = req.Namespace
 	}
 
-	patch, gangCtx, err := h.injector.InjectInitContainers(&pod)
+	patch, gangCtx, err := h.injector.InjectInitContainers(ctx, &pod)
 	if err != nil {
 		slog.Error("Failed to inject init containers", "error", err)
 
@@ -132,15 +132,9 @@ func (h *Handler) mutate(ctx context.Context, req *admissionv1.AdmissionRequest)
 		}
 	}
 
-	if patch == nil {
-		slog.Debug("No mutation needed", "pod", pod.Name, "namespace", req.Namespace)
-
-		return &admissionv1.AdmissionResponse{
-			Allowed: true,
-		}
-	}
-
-	// Register pod with gang controller if it's part of a gang
+	// Register pod with gang controller before checking patches.
+	// Gang registration must happen even when no init containers are injected,
+	// so that pods with disabled checks are still tracked as peers.
 	if gangCtx != nil && h.onGangRegister != nil {
 		podName := pod.Name
 		if podName == "" {
@@ -161,6 +155,14 @@ func (h *Handler) mutate(ctx context.Context, req *admissionv1.AdmissionRequest)
 			GangID:        gangCtx.GangID,
 			ConfigMapName: gangCtx.ConfigMapName,
 		})
+	}
+
+	if patch == nil {
+		slog.Debug("No mutation needed", "pod", pod.Name, "namespace", req.Namespace)
+
+		return &admissionv1.AdmissionResponse{
+			Allowed: true,
+		}
 	}
 
 	patchBytes, err := json.Marshal(patch)

--- a/preflight/pkg/webhook/handler_test.go
+++ b/preflight/pkg/webhook/handler_test.go
@@ -55,8 +55,8 @@ func buildAdmissionReview(pod *corev1.Pod, uid types.UID, namespace string) []by
 func handlerConfig() *config.Config {
 	return &config.Config{
 		FileConfig: config.FileConfig{
-			InitContainers: []corev1.Container{
-				{Name: "preflight-dcgm-diag", Image: "dcgm:latest"},
+			InitContainers: []config.InitContainer{
+				{Container: corev1.Container{Name: "preflight-dcgm-diag", Image: "dcgm:latest"}},
 			},
 			GPUResourceNames: []string{"nvidia.com/gpu"},
 			DCGM: config.DCGMConfig{
@@ -86,7 +86,7 @@ func handlerGangConfig() *config.Config {
 // gang registration callback, and error responses for invalid input.
 func TestHandleMutate(t *testing.T) {
 	t.Run("valid GPU pod returns patch", func(t *testing.T) {
-		handler := NewHandler(handlerConfig(), nil, nil)
+		handler := NewHandler(handlerConfig(), nil, nil, nil)
 
 		pod := &corev1.Pod{
 			Spec: corev1.PodSpec{
@@ -118,7 +118,7 @@ func TestHandleMutate(t *testing.T) {
 	})
 
 	t.Run("valid non-GPU pod returns allowed without patch", func(t *testing.T) {
-		handler := NewHandler(handlerConfig(), nil, nil)
+		handler := NewHandler(handlerConfig(), nil, nil, nil)
 
 		pod := &corev1.Pod{
 			Spec: corev1.PodSpec{
@@ -142,7 +142,7 @@ func TestHandleMutate(t *testing.T) {
 	})
 
 	t.Run("invalid body returns 400", func(t *testing.T) {
-		handler := NewHandler(handlerConfig(), nil, nil)
+		handler := NewHandler(handlerConfig(), nil, nil, nil)
 
 		req := httptest.NewRequest(http.MethodPost, "/mutate", bytes.NewReader([]byte("not-json")))
 		rec := httptest.NewRecorder()
@@ -153,7 +153,7 @@ func TestHandleMutate(t *testing.T) {
 	})
 
 	t.Run("invalid pod JSON returns not allowed", func(t *testing.T) {
-		handler := NewHandler(handlerConfig(), nil, nil)
+		handler := NewHandler(handlerConfig(), nil, nil, nil)
 
 		// Build the outer JSON manually so that object.raw contains invalid JSON
 		// without json.Marshal rejecting it.
@@ -187,7 +187,7 @@ func TestHandleMutate(t *testing.T) {
 	})
 
 	t.Run("nil request returns allowed", func(t *testing.T) {
-		handler := NewHandler(handlerConfig(), nil, nil)
+		handler := NewHandler(handlerConfig(), nil, nil, nil)
 
 		review := admissionv1.AdmissionReview{
 			TypeMeta: metav1.TypeMeta{APIVersion: "admission.k8s.io/v1", Kind: "AdmissionReview"},
@@ -208,7 +208,7 @@ func TestHandleMutate(t *testing.T) {
 	})
 
 	t.Run("response UID matches request", func(t *testing.T) {
-		handler := NewHandler(handlerConfig(), nil, nil)
+		handler := NewHandler(handlerConfig(), nil, nil, nil)
 
 		pod := &corev1.Pod{
 			Spec: corev1.PodSpec{
@@ -238,7 +238,7 @@ func TestHandleMutate(t *testing.T) {
 
 		disc := &mockDiscoverer{name: "test", canHandle: true, gangID: "test-gang"}
 		cfg := handlerGangConfig()
-		handler := NewHandler(cfg, disc, func(_ context.Context, reg GangRegistration) {
+		handler := NewHandler(cfg, disc, nil, func(_ context.Context, reg GangRegistration) {
 			mu.Lock()
 			defer mu.Unlock()
 			captured = reg
@@ -275,7 +275,7 @@ func TestHandleMutate(t *testing.T) {
 
 		disc := &mockDiscoverer{name: "volcano", canHandle: true, gangID: "volcano-default-pg1"}
 		cfg := handlerGangConfig()
-		handler := NewHandler(cfg, disc, func(_ context.Context, reg GangRegistration) {
+		handler := NewHandler(cfg, disc, nil, func(_ context.Context, reg GangRegistration) {
 			mu.Lock()
 			defer mu.Unlock()
 			called = true
@@ -315,7 +315,7 @@ func TestHandleMutate(t *testing.T) {
 
 		disc := &mockDiscoverer{name: "test", canHandle: true, gangID: "test-gang"}
 		cfg := handlerGangConfig()
-		handler := NewHandler(cfg, disc, func(_ context.Context, reg GangRegistration) {
+		handler := NewHandler(cfg, disc, nil, func(_ context.Context, reg GangRegistration) {
 			mu.Lock()
 			defer mu.Unlock()
 			captured = reg
@@ -346,7 +346,7 @@ func TestHandleMutate(t *testing.T) {
 
 	t.Run("gang registration not called without gang", func(t *testing.T) {
 		called := false
-		handler := NewHandler(handlerConfig(), nil, func(_ context.Context, _ GangRegistration) {
+		handler := NewHandler(handlerConfig(), nil, nil, func(_ context.Context, _ GangRegistration) {
 			called = true
 		})
 

--- a/preflight/pkg/webhook/injector.go
+++ b/preflight/pkg/webhook/injector.go
@@ -15,6 +15,7 @@
 package webhook
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -43,7 +44,26 @@ const (
 	dshmVolumeName = "dshm"
 	// ncclTopoVolumeName is the name for the NCCL topology ConfigMap volume
 	ncclTopoVolumeName = "nccl-topo"
+
+	// preflightProfileAnnotation is the pod annotation that references a
+	// PreflightProfile CRD by name. The CRD must exist in the same namespace
+	// as the pod.
+	preflightProfileAnnotation = "nvsentinel.nvidia.com/preflight-profile"
 )
+
+// protectedEnvVars are control-plane env vars injected by the webhook that
+// cannot be overridden by PreflightProfile env overrides.
+var protectedEnvVars = map[string]bool{
+	"POD_NAME":                  true,
+	"POD_IP":                    true,
+	"NODE_NAME":                 true,
+	"GANG_ID":                   true,
+	"GANG_CONFIG_DIR":           true,
+	"GANG_TIMEOUT_SECONDS":      true,
+	"MASTER_PORT":               true,
+	"PLATFORM_CONNECTOR_SOCKET": true,
+	"PROCESSING_STRATEGY":       true,
+}
 
 type PatchOperation struct {
 	Op    string `json:"op"`
@@ -54,12 +74,14 @@ type PatchOperation struct {
 type Injector struct {
 	cfg        *config.Config
 	discoverer gang.GangDiscoverer
+	profiles   ProfileReader
 }
 
-func NewInjector(cfg *config.Config, discoverer gang.GangDiscoverer) *Injector {
+func NewInjector(cfg *config.Config, discoverer gang.GangDiscoverer, profiles ProfileReader) *Injector {
 	return &Injector{
 		cfg:        cfg,
 		discoverer: discoverer,
+		profiles:   profiles,
 	}
 }
 
@@ -70,7 +92,7 @@ type GangContext struct {
 	ConfigMapName string
 }
 
-func (i *Injector) InjectInitContainers(pod *corev1.Pod) ([]PatchOperation, *GangContext, error) {
+func (i *Injector) InjectInitContainers(ctx context.Context, pod *corev1.Pod) ([]PatchOperation, *GangContext, error) {
 	maxResources := i.findMaxResources(pod)
 	if len(maxResources) == 0 {
 		slog.Debug("Pod does not request GPU/network resources, skipping injection")
@@ -104,14 +126,31 @@ func (i *Injector) InjectInitContainers(pod *corev1.Pod) ([]PatchOperation, *Gan
 	}
 
 	initContainers := i.buildInitContainers(pod, maxResources, gangCtx)
-	if len(initContainers) == 0 {
-		// No init containers to inject, but still return gangCtx
-		// so the controller can track gang membership
-		return nil, gangCtx, nil
+
+	// Look up the PreflightProfile CRD if the pod has a profile annotation.
+	// Fail closed: if the annotation exists but the profile can't be read,
+	// reject admission rather than falling back to defaults.
+	profileSpec, err := i.lookupProfile(ctx, pod)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	patches := i.patchInitContainers(pod, initContainers)
-	patches = append(patches, i.injectVolumes(pod, gangCtx)...)
+	initContainers = applyPreflightConfig(profileSpec, i.cfg.InitContainers, initContainers)
+
+	var patches []PatchOperation
+
+	if len(initContainers) > 0 {
+		patches = i.patchInitContainers(pod, initContainers)
+		patches = append(patches, i.injectVolumes(pod, gangCtx)...)
+	} else if gangCtx != nil {
+		// No init containers but pod belongs to a gang. Inject only the gang
+		// ConfigMap volume so the controller can track pod membership.
+		patches = i.injectGangOnlyVolumes(pod, gangCtx)
+	}
+
+	if len(patches) == 0 {
+		return nil, gangCtx, nil
+	}
 
 	return patches, gangCtx, nil
 }
@@ -210,7 +249,7 @@ func (i *Injector) buildInitContainers(
 	userVolumeMounts := i.collectMatchingVolumeMounts(pod.Spec.Containers)
 
 	for _, tmpl := range i.cfg.InitContainers {
-		container := tmpl.DeepCopy()
+		container := tmpl.Container.DeepCopy()
 
 		if container.Resources.Requests == nil {
 			container.Resources.Requests = make(corev1.ResourceList)
@@ -360,6 +399,148 @@ func (i *Injector) injectCommonEnv(container *corev1.Container) {
 	}
 
 	i.mergeEnvVars(container, envVars)
+}
+
+// lookupProfile reads the PreflightProfile CRD referenced by the pod's
+// preflight-profile annotation. Returns nil if no annotation is present.
+// Returns an error if the annotation exists but the profile cannot be read
+// (fail closed — reject admission rather than silently falling back).
+func (i *Injector) lookupProfile(ctx context.Context, pod *corev1.Pod) (*PreflightProfileSpec, error) {
+	profileName, ok := pod.Annotations[preflightProfileAnnotation]
+	if !ok || profileName == "" {
+		return nil, nil
+	}
+
+	if i.profiles == nil {
+		return nil, fmt.Errorf(
+			"pod references PreflightProfile %q but no profile reader is configured",
+			profileName)
+	}
+
+	spec, err := i.profiles.GetProfile(ctx, pod.Namespace, profileName)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"pod references PreflightProfile %q but it could not be read: %w",
+			profileName, err)
+	}
+
+	slog.Info("Loaded PreflightProfile",
+		"profile", profileName,
+		"namespace", pod.Namespace,
+		"overrides", len(spec.InitContainers))
+
+	return spec, nil
+}
+
+// applyPreflightConfig filters and overrides init containers based on
+// Helm defaults (defaultEnabled) and per-pod profile overrides.
+func applyPreflightConfig(
+	profileSpec *PreflightProfileSpec,
+	helmContainers []config.InitContainer,
+	initContainers []corev1.Container,
+) []corev1.Container {
+	var overridesByName map[string]*PreflightContainerOverride
+	if profileSpec != nil {
+		overridesByName = make(map[string]*PreflightContainerOverride, len(profileSpec.InitContainers))
+		for i := range profileSpec.InitContainers {
+			overridesByName[profileSpec.InitContainers[i].Name] = &profileSpec.InitContainers[i]
+		}
+	}
+
+	defaultEnabled := make(map[string]*bool, len(helmContainers))
+	for i := range helmContainers {
+		defaultEnabled[helmContainers[i].Name] = helmContainers[i].DefaultEnabled
+	}
+
+	matched := make(map[string]bool, len(overridesByName))
+	var result []corev1.Container
+
+	for _, c := range initContainers {
+		override := overridesByName[c.Name]
+
+		if override != nil {
+			matched[c.Name] = true
+
+			if override.Enabled != nil && !*override.Enabled {
+				slog.Info("Preflight check disabled via profile", "container", c.Name)
+				continue
+			}
+
+			applyEnvOverrides(&c, override.Env)
+			result = append(result, c)
+			continue
+		}
+
+		if de := defaultEnabled[c.Name]; de != nil && !*de {
+			continue
+		}
+
+		result = append(result, c)
+	}
+
+	for name := range overridesByName {
+		if !matched[name] {
+			slog.Warn("PreflightProfile references unknown container, ignoring",
+				"container", name)
+		}
+	}
+
+	return result
+}
+
+// applyEnvOverrides applies env var overrides to a container.
+// Protected control-plane env vars are silently skipped.
+func applyEnvOverrides(container *corev1.Container, overrides []corev1.EnvVar) {
+	for _, override := range overrides {
+		if protectedEnvVars[override.Name] {
+			slog.Warn("PreflightProfile tried to override protected env var, skipping",
+				"container", container.Name, "envVar", override.Name)
+			continue
+		}
+
+		found := false
+		for j := range container.Env {
+			if container.Env[j].Name == override.Name {
+				container.Env[j] = override
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			container.Env = append(container.Env, override)
+		}
+	}
+}
+
+// injectGangOnlyVolumes injects only the gang ConfigMap volume when a gang
+// pod has all preflight checks disabled.
+func (i *Injector) injectGangOnlyVolumes(pod *corev1.Pod, gangCtx *GangContext) []PatchOperation {
+	existingVolumes := make(map[string]bool)
+	for _, vol := range pod.Spec.Volumes {
+		existingVolumes[vol.Name] = true
+	}
+
+	if existingVolumes[types.GangConfigVolumeName] {
+		return nil
+	}
+
+	optional := true
+	gangVolume := corev1.Volume{
+		Name: types.GangConfigVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: gangCtx.ConfigMapName},
+				Optional:             &optional,
+			},
+		},
+	}
+
+	if len(pod.Spec.Volumes) == 0 {
+		return []PatchOperation{{Op: "add", Path: "/spec/volumes", Value: []corev1.Volume{gangVolume}}}
+	}
+
+	return []PatchOperation{{Op: "add", Path: "/spec/volumes/-", Value: gangVolume}}
 }
 
 func (i *Injector) injectVolumes(pod *corev1.Pod, gangCtx *GangContext) []PatchOperation {

--- a/preflight/pkg/webhook/injector_test.go
+++ b/preflight/pkg/webhook/injector_test.go
@@ -286,9 +286,9 @@ func TestInjectInitContainers(t *testing.T) {
 			cfg: func() *config.Config {
 				c := testConfig()
 				c.InitContainerPlacement = config.PlacementPrepend
-				c.InitContainers = []corev1.Container{
-					{Name: "preflight-dcgm-diag", Image: "dcgm:latest"},
-					{Name: "preflight-nccl-loopback", Image: "nccl:latest"},
+				c.InitContainers = []config.InitContainer{
+					{Container: corev1.Container{Name: "preflight-dcgm-diag", Image: "dcgm:latest"}},
+					{Container: corev1.Container{Name: "preflight-nccl-loopback", Image: "nccl:latest"}},
 				}
 				return c
 			}(),
@@ -395,9 +395,9 @@ func TestInjectInitContainers(t *testing.T) {
 			if tt.discoverer != nil {
 				disc = tt.discoverer
 			}
-			injector := NewInjector(tt.cfg, disc)
+			injector := NewInjector(tt.cfg, disc, nil)
 
-			patches, gangCtx, err := injector.InjectInitContainers(tt.pod)
+			patches, gangCtx, err := injector.InjectInitContainers(context.Background(), tt.pod)
 			require.NoError(t, err)
 
 			if tt.expectPatches {
@@ -429,7 +429,7 @@ func TestInjectInitContainers(t *testing.T) {
 func TestBuildInitContainers(t *testing.T) {
 	t.Run("resources mirrored to init containers", func(t *testing.T) {
 		cfg := testConfig()
-		injector := NewInjector(cfg, nil)
+		injector := NewInjector(cfg, nil, nil)
 		pod := gpuEFAPod()
 
 		maxResources := corev1.ResourceList{
@@ -449,7 +449,7 @@ func TestBuildInitContainers(t *testing.T) {
 
 	t.Run("CPU and memory floor applied when not set", func(t *testing.T) {
 		cfg := testConfig()
-		injector := NewInjector(cfg, nil)
+		injector := NewInjector(cfg, nil, nil)
 		pod := gpuPod()
 
 		containers := injector.buildInitContainers(pod, corev1.ResourceList{
@@ -463,8 +463,8 @@ func TestBuildInitContainers(t *testing.T) {
 
 	t.Run("CPU and memory floor not applied when already set", func(t *testing.T) {
 		cfg := testConfig()
-		cfg.InitContainers = []corev1.Container{
-			{
+		cfg.InitContainers = []config.InitContainer{
+			{Container: corev1.Container{
 				Name:  "preflight-dcgm-diag",
 				Image: "dcgm:latest",
 				Resources: corev1.ResourceRequirements{
@@ -473,9 +473,9 @@ func TestBuildInitContainers(t *testing.T) {
 						corev1.ResourceMemory: resource.MustParse("1Gi"),
 					},
 				},
-			},
+			}},
 		}
-		injector := NewInjector(cfg, nil)
+		injector := NewInjector(cfg, nil, nil)
 
 		containers := injector.buildInitContainers(gpuPod(), corev1.ResourceList{
 			"nvidia.com/gpu": resource.MustParse("8"),
@@ -488,11 +488,11 @@ func TestBuildInitContainers(t *testing.T) {
 
 	t.Run("DCGM env only for dcgm-diag container", func(t *testing.T) {
 		cfg := testConfig()
-		cfg.InitContainers = []corev1.Container{
-			{Name: "preflight-dcgm-diag", Image: "dcgm:latest"},
-			{Name: "preflight-nccl-allreduce", Image: "nccl:latest"},
+		cfg.InitContainers = []config.InitContainer{
+			{Container: corev1.Container{Name: "preflight-dcgm-diag", Image: "dcgm:latest"}},
+			{Container: corev1.Container{Name: "preflight-nccl-allreduce", Image: "nccl:latest"}},
 		}
-		injector := NewInjector(cfg, nil)
+		injector := NewInjector(cfg, nil, nil)
 
 		containers := injector.buildInitContainers(gpuPod(), corev1.ResourceList{
 			"nvidia.com/gpu": resource.MustParse("8"),
@@ -507,7 +507,7 @@ func TestBuildInitContainers(t *testing.T) {
 
 	t.Run("common env injected", func(t *testing.T) {
 		cfg := testConfig()
-		injector := NewInjector(cfg, nil)
+		injector := NewInjector(cfg, nil, nil)
 
 		containers := injector.buildInitContainers(gpuPod(), corev1.ResourceList{
 			"nvidia.com/gpu": resource.MustParse("8"),
@@ -521,7 +521,7 @@ func TestBuildInitContainers(t *testing.T) {
 
 	t.Run("gang env not injected without context", func(t *testing.T) {
 		cfg := testGangConfig()
-		injector := NewInjector(cfg, nil)
+		injector := NewInjector(cfg, nil, nil)
 
 		containers := injector.buildInitContainers(gpuPod(), corev1.ResourceList{
 			"nvidia.com/gpu": resource.MustParse("8"),
@@ -536,7 +536,7 @@ func TestBuildInitContainers(t *testing.T) {
 
 	t.Run("gang env injected with context", func(t *testing.T) {
 		cfg := testGangConfig()
-		injector := NewInjector(cfg, nil)
+		injector := NewInjector(cfg, nil, nil)
 
 		gangCtx := &GangContext{GangID: "test-gang", ConfigMapName: "preflight-test-gang"}
 		containers := injector.buildInitContainers(gpuPod(), corev1.ResourceList{
@@ -556,7 +556,7 @@ func TestBuildInitContainers(t *testing.T) {
 	t.Run("user NCCL env inherited", func(t *testing.T) {
 		cfg := testConfig()
 		cfg.NCCLEnvPatterns = []string{"NCCL_*"}
-		injector := NewInjector(cfg, nil)
+		injector := NewInjector(cfg, nil, nil)
 
 		pod := gpuPod()
 		pod.Spec.Containers[0].Env = []corev1.EnvVar{
@@ -573,14 +573,14 @@ func TestBuildInitContainers(t *testing.T) {
 	t.Run("user env lower precedence than template", func(t *testing.T) {
 		cfg := testConfig()
 		cfg.NCCLEnvPatterns = []string{"NCCL_*"}
-		cfg.InitContainers = []corev1.Container{
-			{
+		cfg.InitContainers = []config.InitContainer{
+			{Container: corev1.Container{
 				Name:  "preflight-dcgm-diag",
 				Image: "dcgm:latest",
 				Env:   []corev1.EnvVar{{Name: "NCCL_DEBUG", Value: "WARN"}},
-			},
+			}},
 		}
-		injector := NewInjector(cfg, nil)
+		injector := NewInjector(cfg, nil, nil)
 
 		pod := gpuPod()
 		pod.Spec.Containers[0].Env = []corev1.EnvVar{
@@ -597,7 +597,7 @@ func TestBuildInitContainers(t *testing.T) {
 	t.Run("user volume mounts inherited", func(t *testing.T) {
 		cfg := testConfig()
 		cfg.VolumeMountPatterns = []string{"nvtcpxo-*"}
-		injector := NewInjector(cfg, nil)
+		injector := NewInjector(cfg, nil, nil)
 
 		pod := gpuPod()
 		pod.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
@@ -613,7 +613,7 @@ func TestBuildInitContainers(t *testing.T) {
 
 	t.Run("DRA claims mirrored when enabled", func(t *testing.T) {
 		cfg := testGangConfig()
-		injector := NewInjector(cfg, nil)
+		injector := NewInjector(cfg, nil, nil)
 
 		pod := gpuPod()
 		pod.Spec.ResourceClaims = []corev1.PodResourceClaim{
@@ -634,7 +634,7 @@ func TestBuildInitContainers(t *testing.T) {
 	t.Run("DRA claims not mirrored when disabled", func(t *testing.T) {
 		cfg := testGangConfig()
 		cfg.GangCoordination.MirrorResourceClaims = boolPtr(false)
-		injector := NewInjector(cfg, nil)
+		injector := NewInjector(cfg, nil, nil)
 
 		pod := gpuPod()
 		pod.Spec.ResourceClaims = []corev1.PodResourceClaim{
@@ -651,7 +651,7 @@ func TestBuildInitContainers(t *testing.T) {
 
 	t.Run("DRA claims not mirrored without gang context", func(t *testing.T) {
 		cfg := testGangConfig()
-		injector := NewInjector(cfg, nil)
+		injector := NewInjector(cfg, nil, nil)
 
 		pod := gpuPod()
 		pod.Spec.ResourceClaims = []corev1.PodResourceClaim{
@@ -864,8 +864,8 @@ func boolPtr(b bool) *bool { return &b }
 func testConfig() *config.Config {
 	return &config.Config{
 		FileConfig: config.FileConfig{
-			InitContainers: []corev1.Container{
-				{Name: "preflight-dcgm-diag", Image: "nvcr.io/nvidia/dcgm:latest"},
+			InitContainers: []config.InitContainer{
+				{Container: corev1.Container{Name: "preflight-dcgm-diag", Image: "nvcr.io/nvidia/dcgm:latest"}},
 			},
 			GPUResourceNames:       []string{"nvidia.com/gpu"},
 			NetworkResourceNames:   []string{"vpc.amazonaws.com/efa"},

--- a/preflight/pkg/webhook/profile.go
+++ b/preflight/pkg/webhook/profile.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+var profileGVR = schema.GroupVersionResource{
+	Group:    "nvsentinel.nvidia.com",
+	Version:  "v1alpha1",
+	Resource: "preflightprofiles",
+}
+
+// PreflightProfileSpec defines the desired preflight check configuration.
+type PreflightProfileSpec struct {
+	InitContainers []PreflightContainerOverride `json:"initContainers,omitempty"`
+}
+
+// PreflightContainerOverride defines per-pod overrides for a single preflight
+// init container. Matches by name against the configured init containers.
+type PreflightContainerOverride struct {
+	Name    string          `json:"name"`
+	Enabled *bool           `json:"enabled,omitempty"`
+	Env     []corev1.EnvVar `json:"env,omitempty"`
+}
+
+// ProfileReader reads PreflightProfile CRDs from the Kubernetes API.
+type ProfileReader interface {
+	GetProfile(ctx context.Context, namespace, name string) (*PreflightProfileSpec, error)
+}
+
+// K8sProfileReader reads PreflightProfile CRDs using the dynamic client.
+type K8sProfileReader struct {
+	client dynamic.Interface
+}
+
+// NewK8sProfileReader creates a ProfileReader backed by the Kubernetes API.
+func NewK8sProfileReader(client dynamic.Interface) ProfileReader {
+	return &K8sProfileReader{client: client}
+}
+
+// GetProfile fetches a PreflightProfile CRD by namespace and name.
+func (r *K8sProfileReader) GetProfile(ctx context.Context, namespace, name string) (*PreflightProfileSpec, error) {
+	obj, err := r.client.Resource(profileGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get PreflightProfile %s/%s: %w", namespace, name, err)
+	}
+
+	specRaw, found := obj.Object["spec"]
+	if !found {
+		return &PreflightProfileSpec{}, nil
+	}
+
+	specBytes, err := json.Marshal(specRaw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal profile spec: %w", err)
+	}
+
+	var spec PreflightProfileSpec
+	if err := json.Unmarshal(specBytes, &spec); err != nil {
+		return nil, fmt.Errorf("failed to parse profile spec: %w", err)
+	}
+
+	return &spec, nil
+}


### PR DESCRIPTION
## Summary
- Add `PreflightProfile` CRD (`nvsentinel.nvidia.com/v1alpha1`) as reusable templates for preflight check configuration — pods reference a profile by name via annotation instead of embedding YAML inline
- Add `defaultEnabled` Helm field so operators can disable expensive checks by default while letting pods opt in via profiles
- Gang members validate check consistency and collective-op config before launching torchrun — mismatches fail fast with actionable errors instead of hanging for 30 minutes

## Design

Pods reference a `PreflightProfile` CRD by name:

```yaml
# Create reusable profiles
apiVersion: nvsentinel.nvidia.com/v1alpha1
kind: PreflightProfile
metadata:
  name: full-diagnostics
spec:
  initContainers:
    - name: preflight-dcgm-diag
      enabled: true
      env:
        - name: DCGM_DIAG_LEVEL
          value: "3"
    - name: preflight-nccl-allreduce
      enabled: true
```

```yaml
# Reference from pod
metadata:
  annotations:
    nvsentinel.nvidia.com/preflight-profile: full-diagnostics
```

Key design decisions:
- **CRD over inline annotations** — reusable, validated at creation time, auditable via RBAC
- **Fail closed** — if the referenced profile doesn't exist, admission is rejected
- **Protected env vars** — profiles cannot override control-plane vars (POD_NAME, GANG_ID, etc.)
- **Gang config validation** — always compares allreduce config hashes including empty values to detect skew

See `docs/designs/034-preflight-pod-config.md` for full ADR.

## Changes from v1
- Replaced inline annotation YAML (`preflight-config`) with CRD reference (`preflight-profile`)
- Added protected env var guard (addresses CodeRabbit review)
- Fail closed on missing/invalid profile (addresses CodeRabbit review)
- Fixed allreduce config hash comparison for empty configs (addresses CodeRabbit review)
- Added GANG_TIMEOUT_SECONDS error handling (addresses CodeRabbit review)
- Removed unrelated objectSelector documentation changes
- Rebased on main, squashed into single commit with DCO sign-off

## Test plan
- [x] Unit tests for profile lookup and fail-closed behavior (`injector_test.go`)
- [x] Unit tests for precedence logic with PreflightProfileSpec (`injector_test.go`)
- [x] Unit tests for protected env var guard (`injector_test.go`)
- [x] Unit tests for peer line serialization/parsing (`coordinator_test.go`)
- [x] Unit tests for `validate_peers()` including mixed empty/explicit config (`test_gang.py`)
- [ ] Manual test: deploy with `defaultEnabled: false`, verify checks skipped
- [ ] Manual test: create PreflightProfile CRD, reference from pod, verify correct injection
- [ ] Manual test: reference nonexistent profile, verify admission rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-pod PreflightProfile support via pod annotation to customize init-container enablement and env overrides
  * Gang-level validation that detects profile mismatches and fails fast to avoid distributed deadlock
  * Fail-closed behavior with fallback to chart defaults and timeout safety to bound gang formation

* **Documentation**
  * Added docs and examples for PreflightProfile usage, protected env vars, and behavior on missing/unreadable profiles
<!-- end of auto-generated comment: release notes by coderabbit.ai -->