### PR TITLE
feat: Add configuration for prepend|append init container in preflight framework

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/configmap.yaml
@@ -73,6 +73,9 @@ data:
       {{- if not (kindIs "invalid" .Values.gangCoordination.mirrorResourceClaims) }}
       mirrorResourceClaims: {{ .Values.gangCoordination.mirrorResourceClaims }}
       {{- end }}
+    {{- if .Values.initContainerPlacement }}
+    initContainerPlacement: {{ .Values.initContainerPlacement | quote }}
+    {{- end }}
     initContainers:
       {{- $extraEnv := .Values.ncclAllreduceExtraEnv | default list }}
       {{- $globalTag := ((.Values.global).image).tag | default "" }}

--- a/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
@@ -100,6 +100,14 @@ dcgm:
   # Event processing strategy: EXECUTE_REMEDIATION or STORE_ONLY
   processingStrategy: "EXECUTE_REMEDIATION"
 
+# Controls where preflight init containers are placed relative to existing
+# init containers in the pod spec.
+# "append" (default): add after existing init containers — ensures
+#   provider-injected setup (e.g., GCP TCPXO daemon) completes first.
+# "prepend": add before existing init containers — runs GPU health
+#   checks before any other init containers.
+initContainerPlacement: "append"
+
 initContainers:
   - name: preflight-dcgm-diag
     image:

--- a/docs/configuration/preflight.md
+++ b/docs/configuration/preflight.md
@@ -31,6 +31,20 @@ kubectl label namespace <namespace> nvsentinel.nvidia.com/preflight=enabled
 
 The chart default `namespaceSelector` matches that label.
 
+## Init container placement
+
+By default the webhook **appends** preflight init containers after any existing init containers in the pod spec. This ensures provider-injected setup containers (e.g., GCP TCPXO daemon) complete before preflight checks run.
+
+Set `initContainerPlacement` to change this behavior:
+
+```yaml
+# "append" (default): add after existing init containers
+# "prepend": add before existing init containers
+initContainerPlacement: "prepend"
+```
+
+Use `prepend` when preflight checks must run before other init containers — for example, to gate workload setup on GPU health validation.
+
 ## Init containers (check configuration)
 
 The `initContainers` list in the preflight chart defines which checks the webhook injects. Each entry is a standard `corev1.Container` — you control images, env vars, resource limits, security contexts, and volume mounts.
@@ -259,6 +273,7 @@ For DRA / device claims mirrored into init containers, see [ADR-026 §DRA Integr
 | Area | Location |
 |------|-----------|
 | Webhook TLS, failure policy, cert provider | `preflight.webhook` |
+| Init container placement (append/prepend) | `preflight.initContainerPlacement` |
 | Injected init container images and env | `preflight.initContainers` |
 | GPU / network resource names | `preflight.gpuResourceNames`, `preflight.networkResourceNames` |
 | Copy NCCL / fabric env and mounts from user containers | `preflight.ncclEnvPatterns`, `preflight.volumeMountPatterns` |

--- a/docs/designs/026-preflight-checks.md
+++ b/docs/designs/026-preflight-checks.md
@@ -178,7 +178,7 @@ webhooks:
 
 ### Injected init containers (sketch)
 
-One init container per enabled check with be prepended to the pod's init containers:
+One init container per enabled check is injected into the pod's init containers (appended by default; configurable via `initContainerPlacement`):
 
 ```yaml
 initContainers:

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -23,7 +23,7 @@ Preflight runs as a Deployment with a mutating admission webhook:
 
 1. **Namespace opt-in**: Label namespaces with `nvsentinel.nvidia.com/preflight=enabled`
 2. **Pod admission**: When a GPU pod is created in a labeled namespace, the webhook intercepts the request. Optionally, an `objectSelector` can further restrict which pods are intercepted based on pod labels
-3. **Init container injection**: The webhook prepends diagnostic init containers to the pod spec
+3. **Init container injection**: The webhook injects diagnostic init containers into the pod spec (appended after existing init containers by default; set `initContainerPlacement: prepend` to insert before)
 4. **Checks run**: Init containers execute sequentially before the main workload starts
 5. **Health reporting**: Each check reports results as health events via the Platform Connector (gRPC over Unix domain socket)
 6. **Pass/fail**: If all checks pass (exit code 0), the main containers start normally. If any check fails, the pod stays in `Init:Error` and a health event triggers quarantine

--- a/preflight/pkg/config/config.go
+++ b/preflight/pkg/config/config.go
@@ -30,6 +30,22 @@ type Config struct {
 	FileConfig
 }
 
+// InitContainerPlacement controls where preflight init containers are
+// inserted relative to existing init containers in the pod spec.
+type InitContainerPlacement string
+
+const (
+	// PlacementAppend appends preflight init containers after existing ones.
+	// This is the default and ensures provider-injected setup containers
+	// (e.g., GCP TCPXO daemon) complete before preflight checks run.
+	PlacementAppend InitContainerPlacement = "append"
+
+	// PlacementPrepend prepends preflight init containers before existing ones.
+	// Use this when preflight checks must run before other init containers,
+	// for example to gate workload setup on GPU health validation.
+	PlacementPrepend InitContainerPlacement = "prepend"
+)
+
 type FileConfig struct {
 	InitContainers       []corev1.Container     `yaml:"initContainers"`
 	GPUResourceNames     []string               `yaml:"gpuResourceNames"`
@@ -37,6 +53,11 @@ type FileConfig struct {
 	DCGM                 DCGMConfig             `yaml:"dcgm"`
 	GangDiscovery        GangDiscoveryConfig    `yaml:"gangDiscovery"`
 	GangCoordination     GangCoordinationConfig `yaml:"gangCoordination"`
+
+	// InitContainerPlacement controls where preflight init containers are
+	// placed relative to existing init containers in the pod spec.
+	// Valid values: "prepend", "append". Default: "append".
+	InitContainerPlacement InitContainerPlacement `yaml:"initContainerPlacement,omitempty"`
 
 	// NCCLEnvPatterns are glob patterns for environment variable names to copy
 	// from the pod's main containers to preflight init containers.
@@ -201,6 +222,10 @@ func (c *FileConfig) setDefaults() {
 		c.GPUResourceNames = []string{"nvidia.com/gpu"}
 	}
 
+	if c.InitContainerPlacement == "" {
+		c.InitContainerPlacement = PlacementAppend
+	}
+
 	c.DCGM.setDefaults()
 	c.GangCoordination.setDefaults()
 }
@@ -256,6 +281,13 @@ func (c *GangCoordinationConfig) setDefaults() {
 }
 
 func (c *FileConfig) validate() error {
+	switch c.InitContainerPlacement {
+	case PlacementPrepend, PlacementAppend:
+	default:
+		return fmt.Errorf("invalid initContainerPlacement %q: must be %q or %q",
+			c.InitContainerPlacement, PlacementPrepend, PlacementAppend)
+	}
+
 	if c.GangCoordination.Enabled {
 		timeout, err := time.ParseDuration(c.GangCoordination.Timeout)
 		if err != nil {

--- a/preflight/pkg/config/config_test.go
+++ b/preflight/pkg/config/config_test.go
@@ -137,6 +137,43 @@ gangCoordination:
 		assert.True(t, *cfg.GangCoordination.ExtraHostPathMounts[0].ReadOnly)
 	})
 
+	t.Run("initContainerPlacement defaults to append", func(t *testing.T) {
+		path := writeYAML(t, `
+initContainers:
+  - name: preflight-dcgm-diag
+    image: dcgm:latest
+`)
+		cfg, err := Load(path)
+		require.NoError(t, err)
+
+		assert.Equal(t, PlacementAppend, cfg.InitContainerPlacement)
+	})
+
+	t.Run("initContainerPlacement prepend", func(t *testing.T) {
+		path := writeYAML(t, `
+initContainers:
+  - name: preflight-dcgm-diag
+    image: dcgm:latest
+initContainerPlacement: "prepend"
+`)
+		cfg, err := Load(path)
+		require.NoError(t, err)
+
+		assert.Equal(t, PlacementPrepend, cfg.InitContainerPlacement)
+	})
+
+	t.Run("initContainerPlacement invalid value", func(t *testing.T) {
+		path := writeYAML(t, `
+initContainers:
+  - name: preflight-dcgm-diag
+    image: dcgm:latest
+initContainerPlacement: "middle"
+`)
+		_, err := Load(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "initContainerPlacement")
+	})
+
 	t.Run("extra hostPath readOnly explicit false", func(t *testing.T) {
 		path := writeYAML(t, `
 initContainers:

--- a/preflight/pkg/webhook/injector.go
+++ b/preflight/pkg/webhook/injector.go
@@ -110,42 +110,48 @@ func (i *Injector) InjectInitContainers(pod *corev1.Pod) ([]PatchOperation, *Gan
 		return nil, gangCtx, nil
 	}
 
-	var patches []PatchOperation
+	patches := i.patchInitContainers(pod, initContainers)
+	patches = append(patches, i.injectVolumes(pod, gangCtx)...)
 
+	return patches, gangCtx, nil
+}
+
+// patchInitContainers builds JSON Patch operations to add preflight init
+// containers to the pod. When no existing init containers are present,
+// the array is created. Otherwise placement is controlled by config.
+func (i *Injector) patchInitContainers(pod *corev1.Pod, initContainers []corev1.Container) []PatchOperation {
 	if len(pod.Spec.InitContainers) == 0 {
-		patches = append(patches, PatchOperation{
+		return []PatchOperation{{
 			Op:    "add",
 			Path:  "/spec/initContainers",
 			Value: initContainers,
-		})
-	} else if i.cfg.InitContainerPlacement == config.PlacementPrepend {
-		// Insert preflight init containers before existing ones so that
-		// GPU health checks gate subsequent init containers.
-		for idx, c := range initContainers {
-			patches = append(patches, PatchOperation{
-				Op:    "add",
-				Path:  fmt.Sprintf("/spec/initContainers/%d", idx),
-				Value: c,
-			})
-		}
-	} else {
-		// Append preflight init containers after existing init containers.
-		// This preserves platform/user init ordering and ensures any
-		// provider-injected setup init containers (e.g., GCP TCPXO daemon)
-		// complete before running preflight checks.
-		for _, c := range initContainers {
-			patches = append(patches, PatchOperation{
-				Op:    "add",
-				Path:  "/spec/initContainers/-",
-				Value: c,
-			})
-		}
+		}}
 	}
 
-	volumePatches := i.injectVolumes(pod, gangCtx)
-	patches = append(patches, volumePatches...)
+	placement := i.cfg.InitContainerPlacement
+	if placement != config.PlacementPrepend && placement != config.PlacementAppend {
+		slog.Warn("Unknown initContainerPlacement, defaulting to append",
+			"placement", placement)
 
-	return patches, gangCtx, nil
+		placement = config.PlacementAppend
+	}
+
+	patches := make([]PatchOperation, 0, len(initContainers))
+
+	for idx, c := range initContainers {
+		path := "/spec/initContainers/-"
+		if placement == config.PlacementPrepend {
+			path = fmt.Sprintf("/spec/initContainers/%d", idx)
+		}
+
+		patches = append(patches, PatchOperation{
+			Op:    "add",
+			Path:  path,
+			Value: c,
+		})
+	}
+
+	return patches
 }
 
 // findMaxResources scans all containers and returns the maximum quantity

--- a/preflight/pkg/webhook/injector.go
+++ b/preflight/pkg/webhook/injector.go
@@ -128,19 +128,11 @@ func (i *Injector) patchInitContainers(pod *corev1.Pod, initContainers []corev1.
 		}}
 	}
 
-	placement := i.cfg.InitContainerPlacement
-	if placement != config.PlacementPrepend && placement != config.PlacementAppend {
-		slog.Warn("Unknown initContainerPlacement, defaulting to append",
-			"placement", placement)
-
-		placement = config.PlacementAppend
-	}
-
 	patches := make([]PatchOperation, 0, len(initContainers))
 
 	for idx, c := range initContainers {
 		path := "/spec/initContainers/-"
-		if placement == config.PlacementPrepend {
+		if i.cfg.InitContainerPlacement == config.PlacementPrepend {
 			path = fmt.Sprintf("/spec/initContainers/%d", idx)
 		}
 

--- a/preflight/pkg/webhook/injector.go
+++ b/preflight/pkg/webhook/injector.go
@@ -118,6 +118,16 @@ func (i *Injector) InjectInitContainers(pod *corev1.Pod) ([]PatchOperation, *Gan
 			Path:  "/spec/initContainers",
 			Value: initContainers,
 		})
+	} else if i.cfg.InitContainerPlacement == config.PlacementPrepend {
+		// Insert preflight init containers before existing ones so that
+		// GPU health checks gate subsequent init containers.
+		for idx, c := range initContainers {
+			patches = append(patches, PatchOperation{
+				Op:    "add",
+				Path:  fmt.Sprintf("/spec/initContainers/%d", idx),
+				Value: c,
+			})
+		}
 	} else {
 		// Append preflight init containers after existing init containers.
 		// This preserves platform/user init ordering and ensures any

--- a/preflight/pkg/webhook/injector_test.go
+++ b/preflight/pkg/webhook/injector_test.go
@@ -259,6 +259,70 @@ func TestInjectInitContainers(t *testing.T) {
 			},
 		},
 		{
+			name: "placement prepend inserts init containers before existing",
+			cfg: func() *config.Config {
+				c := testConfig()
+				c.InitContainerPlacement = config.PlacementPrepend
+				return c
+			}(),
+			pod: func() *corev1.Pod {
+				p := gpuPod()
+				p.Spec.InitContainers = []corev1.Container{{Name: "user-init", Image: "busybox"}}
+				return p
+			}(),
+			expectPatches: true,
+			validatePatches: func(t *testing.T, patches []PatchOperation) {
+				t.Helper()
+				assert.Nil(t, findPatchByPath(patches, "/spec/initContainers"), "should not replace init containers array")
+				assert.Zero(t, countPatchesByPath(patches, "/spec/initContainers/-"), "should not use append path")
+
+				p := findPatchByPath(patches, "/spec/initContainers/0")
+				require.NotNil(t, p, "should insert at index 0")
+				assert.Equal(t, "add", p.Op)
+			},
+		},
+		{
+			name: "placement prepend with multiple init containers uses sequential indices",
+			cfg: func() *config.Config {
+				c := testConfig()
+				c.InitContainerPlacement = config.PlacementPrepend
+				c.InitContainers = []corev1.Container{
+					{Name: "preflight-dcgm-diag", Image: "dcgm:latest"},
+					{Name: "preflight-nccl-loopback", Image: "nccl:latest"},
+				}
+				return c
+			}(),
+			pod: func() *corev1.Pod {
+				p := gpuPod()
+				p.Spec.InitContainers = []corev1.Container{{Name: "user-init", Image: "busybox"}}
+				return p
+			}(),
+			expectPatches: true,
+			validatePatches: func(t *testing.T, patches []PatchOperation) {
+				t.Helper()
+				p0 := findPatchByPath(patches, "/spec/initContainers/0")
+				require.NotNil(t, p0, "should insert first container at index 0")
+				p1 := findPatchByPath(patches, "/spec/initContainers/1")
+				require.NotNil(t, p1, "should insert second container at index 1")
+			},
+		},
+		{
+			name: "placement prepend with no existing init containers creates array",
+			cfg: func() *config.Config {
+				c := testConfig()
+				c.InitContainerPlacement = config.PlacementPrepend
+				return c
+			}(),
+			pod:           gpuPod(),
+			expectPatches: true,
+			validatePatches: func(t *testing.T, patches []PatchOperation) {
+				t.Helper()
+				p := findPatchByPath(patches, "/spec/initContainers")
+				require.NotNil(t, p, "should create init containers array")
+				assert.Equal(t, "add", p.Op)
+			},
+		},
+		{
 			name:          "no existing init containers creates array",
 			cfg:           testConfig(),
 			pod:           gpuPod(),

--- a/preflight/pkg/webhook/injector_test.go
+++ b/preflight/pkg/webhook/injector_test.go
@@ -867,8 +867,9 @@ func testConfig() *config.Config {
 			InitContainers: []corev1.Container{
 				{Name: "preflight-dcgm-diag", Image: "nvcr.io/nvidia/dcgm:latest"},
 			},
-			GPUResourceNames:     []string{"nvidia.com/gpu"},
-			NetworkResourceNames: []string{"vpc.amazonaws.com/efa"},
+			GPUResourceNames:       []string{"nvidia.com/gpu"},
+			NetworkResourceNames:   []string{"vpc.amazonaws.com/efa"},
+			InitContainerPlacement: config.PlacementAppend,
 			DCGM: config.DCGMConfig{
 				HostengineAddr:     "localhost:5555",
 				DiagLevel:          1,


### PR DESCRIPTION

## Summary

Prior to this change, the init container were hardcoded to be appended to existing init container in the pod, this change makes that hard-coded behaviour configuration driven i.e. we can choose whether prepend | append the preflight tests' init container with respect to the existing init container in the workload pod. For validation of this feature, unit tests and integration test has been added.

## Manual Testing

Setup: Preflight webhook deployed in `nvsentinel` namespace. Test namespace placement-test labeled with `nvsentinel.nvidia.com/preflight=enabled`. Each test pod has a pre-existing user-setup init container and requests `nvidia.com/gpu: 1`.

### Test 1 : `initContainerPlacement: "append"`

```bash
$ kubectl get pod test-append -n placement-test \
  -o jsonpath='{range .spec.initContainers[*]}{.name}{"\n"}{end}'
user-setup
preflight-dcgm-diag
```
Preflight init container appended after the existing user-setup init container.

### Test 2 : `initContainerPlacement: "prepend"`

ConfigMap patched to `"prepend"`, `preflight` deployment restarted, new pod created:

```bash
$ kubectl get pod test-prepend -n placement-test \
    -o jsonpath='{range .spec.initContainers[*]}{.name}{"\n"}{end}'
preflight-dcgm-diag
user-setup
```
Preflight init container prepended before the existing `user-setup` init container.

### Test 3 : No existing init containers (prepend mode)

```bash
$ kubectl get pod test-prepend-no-init -n placement-test \
    -o jsonpath='{range .spec.initContainers[*]}{.name}{"\n"}{end}'
preflight-dcgm-diag
```
Init container array created correctly when pod has no pre-existing init containers.

### Test 4 : Non-GPU pod (no injection)

```bash
$ kubectl get pod test-no-gpu -n placement-test \
    -o jsonpath='{range .spec.initContainers[*]}{.name}{"\n"}{end}'
user-setup
```
## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [x] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to control whether preflight init containers are appended (default) or prepended to existing pod initContainers; exposed in chart values.

* **Documentation**
  * Updated configuration, design, and preflight docs to describe the new placement setting and default behavior.

* **Tests**
  * Added tests for defaulting, prepend behavior, and invalid-value validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->