### PR TITLE
feat: OTEL setup for health-events-analzer

### DIFF
--- a/commons/pkg/tracing/tracing.go
+++ b/commons/pkg/tracing/tracing.go
@@ -37,6 +37,11 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+const (
+	ServicePlatformConnector    = "platform-connector"
+	ServiceHealthEventsAnalyzer = "health-events-analyzer"
+)
+
 var (
 	tracerProvider          *sdktrace.TracerProvider
 	childOnlyTracerProvider *sdktrace.TracerProvider

--- a/commons/pkg/tracing/tracing.go
+++ b/commons/pkg/tracing/tracing.go
@@ -37,11 +37,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-const (
-	ServicePlatformConnector    = "platform-connector"
-	ServiceHealthEventsAnalyzer = "health-events-analyzer"
-)
-
 var (
 	tracerProvider          *sdktrace.TracerProvider
 	childOnlyTracerProvider *sdktrace.TracerProvider
@@ -53,9 +48,10 @@ var (
 // event-exporter, and health-events-analyzer to establish parent-child
 // trace relationships.
 const (
-	ServicePlatformConnector = "platform-connector"
-	ServiceFaultQuarantine   = "fault-quarantine"
-	ServiceEventExporter     = "event-exporter"
+	ServicePlatformConnector    = "platform-connector"
+	ServiceFaultQuarantine      = "fault-quarantine"
+	ServiceEventExporter        = "event-exporter"
+	ServiceHealthEventsAnalyzer = "health-events-analyzer"
 )
 
 // MetadataKeyTraceID is the key used to store the trace ID in the health event's

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
@@ -144,11 +144,16 @@ spec:
               value: {{ $certMountPath }}
             {{- end }}
             {{- end }}
+            {{- if .Values.global.tracing.enabled }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.global.tracing.endpoint | quote }}
+            - name: OTEL_EXPORTER_OTLP_INSECURE
+              value: {{ .Values.global.tracing.insecure | quote }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ if .Values.global.datastore }}{{ .Release.Name }}-datastore-config{{ else }}mongodb-config{{ end }}
                 optional: true
-            {{- include "nvsentinel.datastore.secretEnvFrom" . | nindent 12 }}
       volumes:
       - name: config-volume
         configMap:

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
@@ -154,6 +154,7 @@ spec:
             - configMapRef:
                 name: {{ if .Values.global.datastore }}{{ .Release.Name }}-datastore-config{{ else }}mongodb-config{{ end }}
                 optional: true
+            {{- include "nvsentinel.datastore.secretEnvFrom" . | nindent 12 }}
       volumes:
       - name: config-volume
         configMap:

--- a/health-events-analyzer/go.mod
+++ b/health-events-analyzer/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/sync v0.20.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
@@ -81,7 +82,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.49.0 // indirect

--- a/health-events-analyzer/go.mod
+++ b/health-events-analyzer/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/nvidia/nvsentinel/store-client v0.0.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
+	go.opentelemetry.io/otel v1.43.0
 	golang.org/x/sync v0.20.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
@@ -76,7 +77,6 @@ require (
 	go.mongodb.org/mongo-driver v1.17.9 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo v0.67.0 // indirect
-	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect

--- a/health-events-analyzer/main.go
+++ b/health-events-analyzer/main.go
@@ -60,11 +60,12 @@ func main() {
 	err := run()
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 
 	if shutdownErr := tracing.ShutdownTracing(shutdownCtx); shutdownErr != nil {
 		slog.Warn("Failed to shutdown tracing", "error", shutdownErr)
 	}
+
+	cancel()
 
 	if err != nil {
 		slog.Error("Fatal error", "error", err)

--- a/health-events-analyzer/main.go
+++ b/health-events-analyzer/main.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -58,12 +60,11 @@ func main() {
 	err := run()
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 
 	if shutdownErr := tracing.ShutdownTracing(shutdownCtx); shutdownErr != nil {
 		slog.Warn("Failed to shutdown tracing", "error", shutdownErr)
 	}
-
-	cancel()
 
 	if err != nil {
 		slog.Error("Fatal error", "error", err)
@@ -111,7 +112,8 @@ func connectToPlatform(socket string, processingStrategy protos.ProcessingStrate
 }
 
 func run() error {
-	ctx := context.Background()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
 	metricsPort := flag.String("metrics-port", "2112", "port to expose Prometheus metrics on")
 	socket := flag.String("socket", "unix:///var/run/nvsentinel.sock", "unix domain socket")

--- a/health-events-analyzer/main.go
+++ b/health-events-analyzer/main.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"os"
 	"strconv"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
@@ -29,6 +30,7 @@ import (
 	"github.com/nvidia/nvsentinel/commons/pkg/flags"
 	"github.com/nvidia/nvsentinel/commons/pkg/logger"
 	"github.com/nvidia/nvsentinel/commons/pkg/server"
+	"github.com/nvidia/nvsentinel/commons/pkg/tracing"
 	protos "github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	config "github.com/nvidia/nvsentinel/health-events-analyzer/pkg/config"
 	"github.com/nvidia/nvsentinel/health-events-analyzer/pkg/publisher"
@@ -46,10 +48,24 @@ var (
 )
 
 func main() {
-	logger.SetDefaultStructuredLogger("health-events-analyzer", version)
+	logger.SetDefaultStructuredLoggerWithTraceCorrelation("health-events-analyzer", version)
 	slog.Info("Starting health-events-analyzer", "version", version, "commit", commit, "date", date)
 
-	if err := run(); err != nil {
+	if err := tracing.InitTracing(tracing.ServiceHealthEventsAnalyzer); err != nil {
+		slog.Warn("Failed to initialize tracing", "error", err)
+	}
+
+	err := run()
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+
+	if shutdownErr := tracing.ShutdownTracing(shutdownCtx); shutdownErr != nil {
+		slog.Warn("Failed to shutdown tracing", "error", shutdownErr)
+	}
+
+	cancel()
+
+	if err != nil {
 		slog.Error("Fatal error", "error", err)
 		os.Exit(1)
 	}

--- a/health-events-analyzer/pkg/publisher/publisher.go
+++ b/health-events-analyzer/pkg/publisher/publisher.go
@@ -20,11 +20,13 @@ import (
 	"log/slog"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	"github.com/nvidia/nvsentinel/commons/pkg/tracing"
 	protos "github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	"github.com/nvidia/nvsentinel/health-events-analyzer/pkg/config"
 )
@@ -54,6 +56,9 @@ func isRetryableError(err error) bool {
 }
 
 func (p *PublisherConfig) sendHealthEventWithRetry(ctx context.Context, healthEvents *protos.HealthEvents) error {
+	ctx, span := tracing.StartSpan(ctx, "health_events_analyzer.grpc.publish")
+	defer span.End()
+
 	backoff := wait.Backoff{
 		Steps:    maxRetries,
 		Duration: delay,
@@ -64,26 +69,32 @@ func (p *PublisherConfig) sendHealthEventWithRetry(ctx context.Context, healthEv
 	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
 		_, err := p.platformConnectorClient.HealthEventOccurredV1(ctx, healthEvents)
 		if err == nil {
-			slog.Debug("Successfully sent health events", "events", healthEvents)
+			slog.DebugContext(ctx, "Successfully sent health events", "events", healthEvents)
 
 			return true, nil
 		}
 
 		if isRetryableError(err) {
-			slog.Error("Retryable error occurred", "error", err)
+			slog.ErrorContext(ctx, "Retryable error occurred", "error", err)
 			fatalEventPublishingError.WithLabelValues("retryable_error").Inc()
 
 			return false, nil
 		}
 
-		slog.Error("Non-retryable error occurred", "error", err)
+		slog.ErrorContext(ctx, "Non-retryable error occurred", "error", err)
 		fatalEventPublishingError.WithLabelValues("non_retryable_error").Inc()
 
 		return false, fmt.Errorf("non retryable error occurred while sending health event: %w", err)
 	})
 	if err != nil {
-		slog.Error("All retry attempts to send health event failed", "error", err)
+		slog.ErrorContext(ctx, "All retry attempts to send health event failed", "error", err)
 		fatalEventPublishingError.WithLabelValues("event_publishing_to_UDS_error").Inc()
+
+		span.SetAttributes(
+			attribute.String("health_events_analyzer.error.type", "grpc_publish_error"),
+			attribute.String("health_events_analyzer.error.message", err.Error()),
+		)
+		tracing.RecordError(span, err)
 
 		return fmt.Errorf("all retry attempts to send health event failed: %w", err)
 	}
@@ -102,6 +113,14 @@ func NewPublisher(platformConnectorClient protos.PlatformConnectorClient,
 func (p *PublisherConfig) Publish(ctx context.Context, event *protos.HealthEvent,
 	recommendedAction protos.RecommendedAction, ruleName string, message string,
 	rule *config.HealthEventsAnalyzerRule) error {
+	ctx, span := tracing.StartSpan(ctx, "health_events_analyzer.publish")
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.String("health_events_analyzer.publish.rule_name", ruleName),
+		attribute.String("health_events_analyzer.publish.recommended_action", recommendedAction.String()),
+	)
+
 	newEvent := proto.Clone(event).(*protos.HealthEvent)
 
 	newEvent.Agent = "health-events-analyzer"
@@ -116,6 +135,13 @@ func (p *PublisherConfig) Publish(ctx context.Context, event *protos.HealthEvent
 	if rule != nil && rule.ProcessingStrategy != "" {
 		value, ok := protos.ProcessingStrategy_value[rule.ProcessingStrategy]
 		if !ok {
+			span.SetAttributes(
+				attribute.String("health_events_analyzer.error.type", "invalid_processing_strategy"),
+				attribute.String("health_events_analyzer.error.message",
+					fmt.Sprintf("unexpected processingStrategy: %q", rule.ProcessingStrategy)),
+			)
+			tracing.RecordError(span, fmt.Errorf("unexpected processingStrategy value: %q", rule.ProcessingStrategy))
+
 			return fmt.Errorf("unexpected processingStrategy value: %q", rule.ProcessingStrategy)
 		}
 

--- a/health-events-analyzer/pkg/publisher/publisher.go
+++ b/health-events-analyzer/pkg/publisher/publisher.go
@@ -102,6 +102,8 @@ func (p *PublisherConfig) sendHealthEventWithRetry(ctx context.Context, healthEv
 	return nil
 }
 
+// NewPublisher creates a PublisherConfig that sends health events to the
+// platform-connector via gRPC.
 func NewPublisher(platformConnectorClient protos.PlatformConnectorClient,
 	processingStrategy protos.ProcessingStrategy) *PublisherConfig {
 	return &PublisherConfig{
@@ -110,6 +112,9 @@ func NewPublisher(platformConnectorClient protos.PlatformConnectorClient,
 	}
 }
 
+// Publish clones the incoming health event, updates the fields defined by the
+// rule (agent, check name, recommended action, isFatal, and processing strategy),
+// and sends the resulting event to the platform-connector with retries.
 func (p *PublisherConfig) Publish(ctx context.Context, event *protos.HealthEvent,
 	recommendedAction protos.RecommendedAction, ruleName string, message string,
 	rule *config.HealthEventsAnalyzerRule) error {

--- a/health-events-analyzer/pkg/reconciler/reconciler.go
+++ b/health-events-analyzer/pkg/reconciler/reconciler.go
@@ -21,7 +21,10 @@ import (
 	"time"
 
 	multierror "github.com/hashicorp/go-multierror"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
+	"github.com/nvidia/nvsentinel/commons/pkg/tracing"
 	datamodels "github.com/nvidia/nvsentinel/data-models/pkg/model"
 	protos "github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	"github.com/nvidia/nvsentinel/health-events-analyzer/pkg/analyzer"
@@ -70,14 +73,14 @@ func (r *Reconciler) Start(ctx context.Context) error {
 
 	// Check if using PostgreSQL and enable XID burst detector
 	if ds.Provider() == datastore.ProviderPostgreSQL {
-		slog.Debug("PostgreSQL detected - enabling Go-based XID burst detection")
+		slog.DebugContext(ctx, "PostgreSQL detected - enabling Go-based XID burst detection")
 
 		// Extract XID burst detector config from the RepeatedXidError rule's pipeline
 		xidConfig := r.extractXidDetectorConfig()
 		r.xidDetector = analyzer.NewXidBurstDetectorWithConfig(xidConfig)
 		r.useXidDetector = true
 	} else {
-		slog.Debug("MongoDB detected - using pipeline-based XID detection")
+		slog.DebugContext(ctx, "MongoDB detected - using pipeline-based XID detection")
 
 		r.useXidDetector = false
 	}
@@ -127,7 +130,7 @@ func (r *Reconciler) Start(ctx context.Context) error {
 	// Set the event handler for processing health events
 	r.eventProcessor.SetEventHandler(client.EventHandlerFunc(r.processHealthEvent))
 
-	slog.Info("Starting health events analyzer with unified event processor...")
+	slog.InfoContext(ctx, "Starting health events analyzer with unified event processor...")
 
 	// Start the event processor
 	return r.eventProcessor.Start(ctx)
@@ -136,6 +139,13 @@ func (r *Reconciler) Start(ctx context.Context) error {
 // processHealthEvent handles individual health events and implements the EventHandler interface
 func (r *Reconciler) processHealthEvent(ctx context.Context, event *datamodels.HealthEventWithStatus) error {
 	startTime := time.Now()
+
+	traceID := tracing.TraceIDFromMetadata(event.HealthEvent.GetMetadata())
+	parentSpanID := tracing.ParentSpanID(event.HealthEventStatus.SpanIds, tracing.ServicePlatformConnector)
+
+	ctx, span := tracing.StartSpanWithLinkFromTraceContext(
+		ctx, traceID, parentSpanID, "health_events_analyzer.process_health_event")
+	defer span.End()
 
 	// Track event reception metrics
 	// Use nodeName as label value, fall back to first entity if available
@@ -157,7 +167,13 @@ func (r *Reconciler) processHealthEvent(ctx context.Context, event *datamodels.H
 		// Return error - EventProcessor will NOT mark as processed
 		// Event will be retried on next pod restart
 		totalEventProcessingError.WithLabelValues("handle_event_error").Inc()
-		slog.Error("Failed to process health event", "error", err, "nodeName", labelValue)
+		slog.ErrorContext(ctx, "Failed to process health event", "error", err, "nodeName", labelValue)
+
+		span.SetAttributes(
+			attribute.String("health_events_analyzer.error.type", "handle_event_error"),
+			attribute.String("health_events_analyzer.error.message", err.Error()),
+		)
+		tracing.RecordError(span, err)
 
 		return fmt.Errorf("failed to handle event: %w", err)
 	}
@@ -165,17 +181,21 @@ func (r *Reconciler) processHealthEvent(ctx context.Context, event *datamodels.H
 	// Track success metrics
 	totalEventsSuccessfullyProcessed.Inc()
 
+	span.SetAttributes(
+		attribute.Bool("health_events_analyzer.event.published", publishedNewEvent),
+	)
+
 	if publishedNewEvent {
-		slog.Info("New fatal event published.")
+		slog.InfoContext(ctx, "New fatal event published.")
 		// Only track entity-specific metrics if EntitiesImpacted is not empty
 		if len(event.HealthEvent.EntitiesImpacted) > 0 {
 			fatalEventsPublishedTotal.WithLabelValues(event.HealthEvent.EntitiesImpacted[0].EntityValue).Inc()
 		} else {
-			slog.Warn("Fatal event published but EntitiesImpacted is empty, using 'unknown' for metrics")
+			slog.WarnContext(ctx, "Fatal event published but EntitiesImpacted is empty, using 'unknown' for metrics")
 			fatalEventsPublishedTotal.WithLabelValues("unknown").Inc()
 		}
 	} else {
-		slog.Info("Fatal event is not published, rule set criteria didn't match.")
+		slog.InfoContext(ctx, "Fatal event is not published, rule set criteria didn't match.")
 	}
 
 	// Track processing duration
@@ -186,6 +206,9 @@ func (r *Reconciler) processHealthEvent(ctx context.Context, event *datamodels.H
 }
 
 func (r *Reconciler) handleEvent(ctx context.Context, event *datamodels.HealthEventWithStatus) (bool, error) {
+	ctx, span := tracing.StartSpan(ctx, "health_events_analyzer.handle_event")
+	defer span.End()
+
 	var multiErr *multierror.Error
 
 	publishedNewEvent := false
@@ -203,13 +226,18 @@ func (r *Reconciler) handleEvent(ctx context.Context, event *datamodels.HealthEv
 	// Process regular rules
 	for _, rule := range r.config.HealthEventsAnalyzerRules.Rules {
 		if !rule.EvaluateRule {
-			slog.Info("Skipping rule evaluation", "rule_name", rule.Name)
+			slog.InfoContext(ctx, "Skipping rule evaluation", "rule_name", rule.Name)
 			continue
 		}
 
 		published, err := r.processRule(ctx, rule, event)
 		if err != nil {
 			multiErr = multierror.Append(multiErr, err)
+			span.AddEvent("rule_evaluation_error", trace.WithAttributes(
+				attribute.String("health_events_analyzer.error.type", "rule_evaluation_error"),
+				attribute.String("health_events_analyzer.error.message", err.Error()),
+			))
+
 			continue
 		}
 
@@ -219,7 +247,13 @@ func (r *Reconciler) handleEvent(ctx context.Context, event *datamodels.HealthEv
 	}
 
 	if multiErr.ErrorOrNil() != nil {
-		slog.Error("Error in handling the event", "error", multiErr)
+		slog.ErrorContext(ctx, "Error in handling the event", "error", multiErr)
+		span.SetAttributes(
+			attribute.String("health_events_analyzer.error.type", "handle_event_error"),
+			attribute.String("health_events_analyzer.error.message", multiErr.Error()),
+		)
+		tracing.RecordError(span, multiErr.ErrorOrNil())
+
 		return publishedNewEvent, fmt.Errorf("error in handling the event: %w", multiErr)
 	}
 
@@ -232,11 +266,14 @@ func (r *Reconciler) handleXidDetector(ctx context.Context, event *datamodels.He
 		return false, nil
 	}
 
+	ctx, span := tracing.StartSpan(ctx, "health_events_analyzer.handle_xid_detector")
+	defer span.End()
+
 	// Clear XID burst history when a healthy GPU event is received
-	// This prevents stale XID history from triggering RepeatedXidError after recovery
 	if r.shouldClearXidHistory(event.HealthEvent) {
 		r.xidDetector.ClearNodeHistory(event.HealthEvent.NodeName)
-		slog.Info("Cleared XID burst history for node due to healthy GPU event",
+		span.SetAttributes(attribute.Bool("health_events_analyzer.xid.history_cleared", true))
+		slog.InfoContext(ctx, "Cleared XID burst history for node due to healthy GPU event",
 			"node", event.HealthEvent.NodeName)
 	}
 
@@ -244,9 +281,17 @@ func (r *Reconciler) handleXidDetector(ctx context.Context, event *datamodels.He
 	if r.shouldProcessXidEvent(event.HealthEvent) {
 		published, err := r.processXidBurstDetection(ctx, event.HealthEvent)
 		if err != nil {
-			slog.Error("Error processing XID burst detection", "error", err)
+			slog.ErrorContext(ctx, "Error processing XID burst detection", "error", err)
+			span.SetAttributes(
+				attribute.String("health_events_analyzer.error.type", "xid_burst_detection_error"),
+				attribute.String("health_events_analyzer.error.message", err.Error()),
+			)
+			tracing.RecordError(span, err)
+
 			return false, err
 		}
+
+		span.SetAttributes(attribute.Bool("health_events_analyzer.published_event", published))
 
 		return published, nil
 	}
@@ -258,17 +303,35 @@ func (r *Reconciler) handleXidDetector(ctx context.Context, event *datamodels.He
 func (r *Reconciler) processRule(ctx context.Context,
 	rule config.HealthEventsAnalyzerRule,
 	event *datamodels.HealthEventWithStatus) (bool, error) {
+	ctx, span := tracing.StartSpan(ctx, "health_events_analyzer.evaluate_rule")
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.String("health_events_analyzer.rule.name", rule.Name),
+		attribute.String("health_events_analyzer.rule.recommended_action", rule.RecommendedAction),
+	)
+
 	startTime := time.Now()
 
 	// Validate all sequences from DB docs
 	matchedSequences, err := r.validateAllSequenceCriteria(ctx, rule, *event)
 	if err != nil {
-		slog.Error("Error in validating all sequence criteria", "error", err)
+		slog.ErrorContext(ctx, "Error in validating all sequence criteria", "error", err)
+		span.SetAttributes(
+			attribute.String("health_events_analyzer.error.type", "validate_sequence_error"),
+			attribute.String("health_events_analyzer.error.message", err.Error()),
+		)
+		tracing.RecordError(span, err)
+
 		return false, fmt.Errorf("error in validating all sequence criteria: %w", err)
 	}
 
 	duration := time.Since(startTime).Seconds()
 	mongoQueryExecutionDuration.WithLabelValues(rule.Name).Observe(duration)
+
+	span.AddEvent("rule_evaluation_duration_seconds", trace.WithAttributes(
+		attribute.Float64("rule_evaluation_duration_seconds", duration),
+	))
 
 	if !matchedSequences {
 		return false, nil
@@ -276,7 +339,13 @@ func (r *Reconciler) processRule(ctx context.Context,
 
 	err = r.publishMatchedEvent(ctx, rule, event)
 	if err != nil {
-		slog.Error("Error in publishing the matched event", "error", err)
+		slog.ErrorContext(ctx, "Error in publishing the matched event", "error", err)
+		span.SetAttributes(
+			attribute.String("health_events_analyzer.error.type", "publish_matched_event_error"),
+			attribute.String("health_events_analyzer.error.message", err.Error()),
+		)
+		tracing.RecordError(span, err)
+
 		return false, fmt.Errorf("error in publishing the matched event: %w", err)
 	}
 
@@ -287,21 +356,29 @@ func (r *Reconciler) processRule(ctx context.Context,
 func (r *Reconciler) publishMatchedEvent(ctx context.Context,
 	rule config.HealthEventsAnalyzerRule,
 	event *datamodels.HealthEventWithStatus) error {
-	slog.Info("Rule matched for event", "rule_name", rule.Name, "event", event)
+	ctx, span := tracing.StartSpan(ctx, "health_events_analyzer.publish_matched_event")
+	defer span.End()
+
+	slog.InfoContext(ctx, "Rule matched for event", "rule_name", rule.Name, "event", event)
 	ruleMatchedTotal.WithLabelValues(rule.Name, event.HealthEvent.NodeName).Inc()
 
 	actionVal := r.getRecommendedActionValue(rule.RecommendedAction, rule.Name)
 
-	// No need to clone here - Publisher.Publish already clones the event
-	// The EventProcessor creates a fresh stack variable for each event, so no mutation risk
 	err := r.config.Publisher.Publish(ctx, event.HealthEvent, protos.RecommendedAction(actionVal),
 		rule.Name, rule.Message, &rule)
 	if err != nil {
-		slog.Error("Error in publishing the new fatal event", "error", err)
+		slog.ErrorContext(ctx, "Error in publishing the new fatal event", "error", err)
+		span.SetAttributes(
+			attribute.Bool("health_events_analyzer.event.published", false),
+			attribute.String("health_events_analyzer.error.type", "publish_event_error"),
+			attribute.String("health_events_analyzer.error.message", err.Error()),
+		)
+		tracing.RecordError(span, err)
+
 		return fmt.Errorf("error in publishing the new fatal event: %w", err)
 	}
 
-	slog.Info("New event successfully published for matching rule", "rule_name", rule.Name)
+	slog.InfoContext(ctx, "New event successfully published for matching rule", "rule_name", rule.Name)
 
 	return nil
 }
@@ -324,7 +401,11 @@ func (r *Reconciler) getRecommendedActionValue(recommendedAction, ruleName strin
 
 func (r *Reconciler) validateAllSequenceCriteria(ctx context.Context, rule config.HealthEventsAnalyzerRule,
 	healthEventWithStatus datamodels.HealthEventWithStatus) (bool, error) {
-	slog.Info("→ Evaluating rule for event",
+	// Execute aggregation with tracing
+	ctx, span := tracing.StartSpan(ctx, "health_events_analyzer.mongo.aggregate")
+	defer span.End()
+
+	slog.InfoContext(ctx, "→ Evaluating rule for event",
 		"rule_name", rule.Name,
 		"node", healthEventWithStatus.HealthEvent.NodeName,
 		"error_code", healthEventWithStatus.HealthEvent.ErrorCode,
@@ -333,21 +414,31 @@ func (r *Reconciler) validateAllSequenceCriteria(ctx context.Context, rule confi
 	// Build aggregation pipeline from stages
 	pipelineStages, err := r.getPipelineStages(rule, healthEventWithStatus)
 	if err != nil {
-		slog.Error("Failed to build pipeline stages", "error", err)
-		totalEventProcessingError.WithLabelValues("build_pipeline_error").Inc()
+		slog.ErrorContext(ctx, "Failed to build pipeline stages", "error", err)
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("health_events_analyzer.error.type", "build_pipeline_error"),
+			attribute.String("health_events_analyzer.error.message", err.Error()),
+		)
 
 		return false, fmt.Errorf("failed to build pipeline stages: %w", err)
 	}
 
 	var result []map[string]interface{}
 
-	// Execute aggregation using store-client abstraction
-	slog.Debug("Executing aggregation pipeline", "rule_name", rule.Name, "pipeline_stages_count", len(pipelineStages))
+	slog.DebugContext(ctx, "Executing aggregation pipeline",
+		"rule_name", rule.Name, "pipeline_stages_count", len(pipelineStages))
 
 	cursor, err := r.databaseClient.Aggregate(ctx, pipelineStages)
 	if err != nil {
-		slog.Error("Failed to execute aggregation pipeline", "error", err, "rule_name", rule.Name)
+		slog.ErrorContext(ctx, "Failed to execute aggregation pipeline", "error", err, "rule_name", rule.Name)
 		totalEventProcessingError.WithLabelValues("execute_pipeline_error").Inc()
+
+		span.SetAttributes(
+			attribute.String("health_events_analyzer.error.type", "execute_pipeline_error"),
+			attribute.String("health_events_analyzer.error.message", err.Error()),
+		)
+		tracing.RecordError(span, err)
 
 		return false, fmt.Errorf("failed to execute aggregation pipeline: %w", err)
 	}
@@ -355,27 +446,33 @@ func (r *Reconciler) validateAllSequenceCriteria(ctx context.Context, rule confi
 	defer cursor.Close(ctx)
 
 	if err = cursor.All(ctx, &result); err != nil {
-		slog.Error("Failed to decode cursor", "error", err, "rule_name", rule.Name)
+		slog.ErrorContext(ctx, "Failed to decode cursor", "error", err, "rule_name", rule.Name)
 		totalEventProcessingError.WithLabelValues("decode_cursor_error").Inc()
+
+		span.SetAttributes(
+			attribute.String("health_events_analyzer.error.type", "decode_cursor_error"),
+			attribute.String("health_events_analyzer.error.message", err.Error()),
+		)
+		tracing.RecordError(span, err)
 
 		return false, fmt.Errorf("failed to decode cursor: %w", err)
 	}
 
-	slog.Debug("Aggregation pipeline completed", "rule_name", rule.Name, "result_count", len(result))
+	slog.DebugContext(ctx, "Aggregation pipeline completed", "rule_name", rule.Name, "result_count", len(result))
 
 	// Check if we have results (rule matched)
 	if len(result) > 0 {
 		// Check for explicit ruleMatched field (used in tests and by SequenceFacet pipelines)
 		if matched, ok := result[0]["ruleMatched"].(bool); ok {
 			if matched {
-				slog.Info("Rule matched via ruleMatched field",
+				slog.InfoContext(ctx, "Rule matched via ruleMatched field",
 					"rule_name", rule.Name,
 					"node", healthEventWithStatus.HealthEvent.NodeName)
 
 				return true, nil
 			}
 
-			slog.Info("Rule did not match (ruleMatched=false)",
+			slog.InfoContext(ctx, "Rule did not match (ruleMatched=false)",
 				"rule_name", rule.Name,
 				"node", healthEventWithStatus.HealthEvent.NodeName,
 				"result", result[0])
@@ -386,7 +483,7 @@ func (r *Reconciler) validateAllSequenceCriteria(ctx context.Context, rule confi
 		return true, nil
 	}
 
-	slog.Info("Rule did not match (no results)",
+	slog.InfoContext(ctx, "Rule did not match (no results)",
 		"rule_name", rule.Name,
 		"node", healthEventWithStatus.HealthEvent.NodeName)
 
@@ -453,10 +550,18 @@ func (r *Reconciler) shouldClearXidHistory(event *protos.HealthEvent) bool {
 // processXidBurstDetection processes GPU XID events through the burst detector
 // and publishes RepeatedXidError events when burst patterns are detected
 func (r *Reconciler) processXidBurstDetection(ctx context.Context, event *protos.HealthEvent) (bool, error) {
+	ctx, span := tracing.StartSpan(ctx, "health_events_analyzer.xid.burst_detection")
+	defer span.End()
+
 	shouldTrigger, burstCount := r.xidDetector.ProcessEvent(event)
 
+	span.SetAttributes(
+		attribute.Bool("health_events_analyzer.xid.burst_detected", shouldTrigger),
+		attribute.Int("health_events_analyzer.xid.burst_count", burstCount),
+	)
+
 	if !shouldTrigger {
-		slog.Debug("XID event processed but no burst pattern detected",
+		slog.DebugContext(ctx, "XID event processed but no burst pattern detected",
 			"node", event.NodeName,
 			"xid", event.ErrorCode[0],
 			"burstCount", burstCount)
@@ -466,7 +571,7 @@ func (r *Reconciler) processXidBurstDetection(ctx context.Context, event *protos
 
 	// Burst pattern detected - publish RepeatedXidError event
 	xidCode := event.ErrorCode[0]
-	slog.Info("RepeatedXidError detected - publishing alert",
+	slog.InfoContext(ctx, "RepeatedXidError detected - publishing alert",
 		"node", event.NodeName,
 		"xid", xidCode,
 		"burstCount", burstCount)
@@ -476,15 +581,26 @@ func (r *Reconciler) processXidBurstDetection(ctx context.Context, event *protos
 	err := r.config.Publisher.Publish(ctx, event, protos.RecommendedAction_CONTACT_SUPPORT, "RepeatedXidError",
 		event.Message, nil)
 	if err != nil {
-		slog.Error("Failed to publish RepeatedXidError event",
+		slog.ErrorContext(ctx, "Failed to publish RepeatedXidError event",
 			"error", err,
 			"node", event.NodeName,
 			"xid", xidCode)
 
+		span.SetAttributes(
+			attribute.String("health_events_analyzer.error.type", "xid_publish_error"),
+			attribute.String("health_events_analyzer.error.message", err.Error()),
+		)
+		tracing.RecordError(span, err)
+
 		return false, fmt.Errorf("failed to publish RepeatedXidError event: %w", err)
 	}
 
-	slog.Info("Successfully published RepeatedXidError event",
+	span.SetAttributes(
+		attribute.Bool("health_events_analyzer.event.published", true),
+		attribute.String("health_events_analyzer.event.published_rule", "RepeatedXidError"),
+	)
+
+	slog.InfoContext(ctx, "Successfully published RepeatedXidError event",
 		"node", event.NodeName,
 		"xid", xidCode,
 		"burstCount", burstCount)

--- a/health-events-analyzer/pkg/reconciler/reconciler.go
+++ b/health-events-analyzer/pkg/reconciler/reconciler.go
@@ -359,7 +359,6 @@ func (r *Reconciler) publishMatchedEvent(ctx context.Context,
 	ctx, span := tracing.StartSpan(ctx, "health_events_analyzer.publish_matched_event")
 	defer span.End()
 
-	slog.InfoContext(ctx, "Rule matched for event", "rule_name", rule.Name, "event", event)
 	ruleMatchedTotal.WithLabelValues(rule.Name, event.HealthEvent.NodeName).Inc()
 
 	actionVal := r.getRecommendedActionValue(rule.RecommendedAction, rule.Name)

--- a/health-events-analyzer/pkg/reconciler/reconciler.go
+++ b/health-events-analyzer/pkg/reconciler/reconciler.go
@@ -372,6 +372,7 @@ func (r *Reconciler) publishMatchedEvent(ctx context.Context,
 			attribute.String("health_events_analyzer.error.type", "publish_event_error"),
 			attribute.String("health_events_analyzer.error.message", err.Error()),
 		)
+
 		tracing.RecordError(span, err)
 
 		return fmt.Errorf("error in publishing the new fatal event: %w", err)

--- a/health-events-analyzer/pkg/reconciler/reconciler_test.go
+++ b/health-events-analyzer/pkg/reconciler/reconciler_test.go
@@ -244,7 +244,7 @@ func TestCheckRule(t *testing.T) {
 		cursor, _ := createMockCursor([]map[string]interface{}{
 			{"ruleMatched": true},
 		})
-		mockClient.On("Aggregate", ctx, mock.Anything).Return(cursor, nil).Once()
+		mockClient.On("Aggregate", mock.Anything, mock.Anything).Return(cursor, nil).Once()
 		result, err := reconciler.validateAllSequenceCriteria(ctx, rules[0], healthEvent_13)
 		assert.NoError(t, err)
 		assert.True(t, result)
@@ -256,7 +256,7 @@ func TestCheckRule(t *testing.T) {
 		cursor, _ := createMockCursor([]map[string]interface{}{
 			{"ruleMatched": false},
 		})
-		mockClient.On("Aggregate", ctx, mock.Anything).Return(cursor, nil).Once()
+		mockClient.On("Aggregate", mock.Anything, mock.Anything).Return(cursor, nil).Once()
 		result, err := reconciler.validateAllSequenceCriteria(ctx, rules[1], healthEvent_13)
 		assert.NoError(t, err)
 		assert.False(t, result)
@@ -264,7 +264,7 @@ func TestCheckRule(t *testing.T) {
 	})
 
 	t.Run("aggregate fails", func(t *testing.T) {
-		mockClient.On("Aggregate", ctx, mock.Anything).Return((*mockCursor)(nil), fmt.Errorf("aggregate failed")).Once()
+		mockClient.On("Aggregate", mock.Anything, mock.Anything).Return((*mockCursor)(nil), fmt.Errorf("aggregate failed")).Once()
 		result, err := reconciler.validateAllSequenceCriteria(ctx, rules[0], healthEvent_13)
 		assert.Error(t, err)
 		assert.False(t, result)
@@ -317,13 +317,13 @@ func TestHandleEvent(t *testing.T) {
 			Events:  []*protos.HealthEvent{expectedTransformedEvent},
 		}
 
-		mockPublisher.On("HealthEventOccurredV1", ctx, expectedHealthEvents).Return(&emptypb.Empty{}, nil)
+		mockPublisher.On("HealthEventOccurredV1", mock.Anything, expectedHealthEvents).Return(&emptypb.Empty{}, nil)
 
 		// Rule2 requires 3 occurrences, so return ruleMatched: true
 		cursor, _ := createMockCursor([]map[string]interface{}{
 			{"ruleMatched": true},
 		})
-		mockClient.On("Aggregate", ctx, mock.Anything).Return(cursor, nil)
+		mockClient.On("Aggregate", mock.Anything, mock.Anything).Return(cursor, nil)
 
 		published, _ := reconciler.handleEvent(ctx, &healthEvent_13)
 		assert.True(t, published)
@@ -367,7 +367,7 @@ func TestHandleEvent(t *testing.T) {
 		cursor, _ := createMockCursor([]map[string]interface{}{
 			{"ruleMatched": false},
 		})
-		mockClient.On("Aggregate", ctx, mock.Anything).Return(cursor, nil).Maybe()
+		mockClient.On("Aggregate", mock.Anything, mock.Anything).Return(cursor, nil).Maybe()
 
 		published, err := reconciler.handleEvent(ctx, &testEventCopy)
 		assert.NoError(t, err)
@@ -393,7 +393,7 @@ func TestHandleEvent(t *testing.T) {
 		cursor, _ := createMockCursor([]map[string]interface{}{
 			{"ruleMatched": false},
 		})
-		mockClient.On("Aggregate", ctx, mock.Anything).Return(cursor, nil).Maybe() // Rule1 and other calls
+		mockClient.On("Aggregate", mock.Anything, mock.Anything).Return(cursor, nil).Maybe() // Rule1 and other calls
 
 		published, _ := reconciler.handleEvent(ctx, &healthEvent_13)
 		assert.False(t, published)


### PR DESCRIPTION
## Summary

<!-- Brief description of your changes -->

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [x] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review

## Testing
Tested these changes in tilt and dev cluster and following are the traces generated for different cases

1. Event published for the matched rulset:
<img width="581" height="250" alt="Screenshot 2026-04-08 at 10 36 13 AM" src="https://github.com/user-attachments/assets/e2bd62ca-07f7-4cba-89bc-36df9cbc7176" />

<img width="1361" height="634" alt="Screenshot 2026-04-08 at 10 35 33 AM" src="https://github.com/user-attachments/assets/d6d6fe9e-15ca-49fb-8f9f-e1427daca7b0" />


2. Each span showed the duration in evaluating single rule

<img width="1360" height="1182" alt="Screenshot 2026-04-08 at 10 35 56 AM" src="https://github.com/user-attachments/assets/334f4102-59ce-41e1-a323-eb0965dd3d92" />


3. Event publishing failed because of invalid pipeline query, rule aggregation failed

<img width="1354" height="648" alt="Screenshot 2026-04-08 at 10 46 27 AM" src="https://github.com/user-attachments/assets/363d89b1-0fa8-41aa-a5ae-7a4601034435" />

<img width="1298" height="367" alt="Screenshot 2026-04-08 at 10 45 58 AM" src="https://github.com/user-attachments/assets/23cf6784-8203-4934-b5da-ef229d07594c" />

<img width="633" height="293" alt="Screenshot 2026-04-08 at 10 45 48 AM" src="https://github.com/user-attachments/assets/fb3a6b21-3ee4-49c9-9ece-b5a3fd4e0203" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broad OpenTelemetry tracing added across health-event processing and platform connector flows; logs now include trace correlation and context-aware logging.

* **Infrastructure**
  * Kubernetes chart can inject OTEL exporter endpoint and insecure flag via configuration.
  * OpenTelemetry libraries promoted to direct dependencies.

* **Behavior**
  * Tracing initialized at startup and shut down gracefully; service shutdown now respects OS signals.

* **Tests**
  * Unit tests adjusted for tracing and relaxed context matching.

* **Chore**
  * Minor tracing export/API cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->