### PR TITLE
docs: prefer inline env vars over dcgm: block for DCGM config

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
@@ -85,10 +85,20 @@ webhook:
   # certProvider: openshift-service-ca
   certProvider: cert-manager
 
-# Local fallback values - global.dcgm takes precedence when set
+# DCGM config block (legacy — prefer inline env vars on the init container).
+#
+# New deployments should define DCGM_HOSTENGINE_ADDR and DCGM_DIAG_LEVEL as
+# env vars directly on the preflight-dcgm-diag container in initContainers
+# below. This matches how NCCL checks are configured and avoids split-brain
+# config between this block and the container spec. Inline env vars take
+# precedence over values injected from this block.
+#
+# See ADR-035 (docs/designs/035-preflight-inline-dcgm-config.md) for details.
+#
+# connectorSocket and processingStrategy are global preflight config and will
+# move to top-level keys in a future release.
 dcgm:
   service:
-    # DCGM hostengine service endpoint (fallback when global.dcgm.service not set)
     endpoint: "nvidia-dcgm.gpu-operator.svc"
     port: 5555
   # Diagnostic level (maps to dcgmi diag -r <level>):
@@ -113,6 +123,13 @@ initContainers:
     image:
       repository: ghcr.io/nvidia/nvsentinel/preflight-dcgm-diag
       tag: ""
+    # Preferred: define DCGM config as inline env vars here instead of in the
+    # dcgm: block above. These take precedence over webhook-injected values.
+    # env:
+    #   - name: DCGM_HOSTENGINE_ADDR
+    #     value: "nvidia-dcgm.gpu-operator.svc:5555"
+    #   - name: DCGM_DIAG_LEVEL
+    #     value: "2"
     volumeMounts:
       - name: nvsentinel-socket
         mountPath: /var/run

--- a/docs/configuration/preflight.md
+++ b/docs/configuration/preflight.md
@@ -54,8 +54,8 @@ The webhook automatically injects these env vars into every init container (you 
 | Env var | Source | Purpose |
 |---------|--------|---------|
 | `NODE_NAME` | Downward API (`spec.nodeName`) | Kubernetes node name for health events |
-| `PLATFORM_CONNECTOR_SOCKET` | Chart `dcgm.connectorSocket` | Unix socket for the platform-connector gRPC endpoint |
-| `PROCESSING_STRATEGY` | Chart `dcgm.processingStrategy` | `EXECUTE_REMEDIATION` or `STORE_ONLY` — controls downstream action |
+| `PLATFORM_CONNECTOR_SOCKET` | Chart `connectorSocket` (legacy: `dcgm.connectorSocket`) | Unix socket for the platform-connector gRPC endpoint |
+| `PROCESSING_STRATEGY` | Chart `processingStrategy` (legacy: `dcgm.processingStrategy`) | `EXECUTE_REMEDIATION` or `STORE_ONLY` — controls downstream action |
 
 For gang-aware containers the webhook also injects `GANG_ID`, `GANG_CONFIG_DIR`, `GANG_TIMEOUT_SECONDS`, and `POD_NAME`.
 
@@ -63,16 +63,39 @@ For gang-aware containers the webhook also injects `GANG_ID`, `GANG_CONFIG_DIR`,
 
 Runs DCGM diagnostics against every GPU allocated to the pod via the remote hostengine.
 
-The webhook auto-injects `DCGM_DIAG_LEVEL` and `DCGM_HOSTENGINE_ADDR` from the chart-level `dcgm` block. Override per-container if needed.
-
 | Env var | Default | Description |
 |---------|---------|-------------|
-| `DCGM_DIAG_LEVEL` | `2` (from chart `dcgm.diagLevel`) | Diagnostic depth: 1 = short (approx 30 s, software deployment checks), 2 = medium (approx 2 min, adds PCIe and basic GPU stress), 3 = long (approx 15 min, adds Diagnostic plugin stress), 4 = xlong (1-2 hr, extended stress) |
+| `DCGM_DIAG_LEVEL` | `2` | Diagnostic depth: 1 = short (approx 30 s, software deployment checks), 2 = medium (approx 2 min, adds PCIe and basic GPU stress), 3 = long (approx 15 min, adds Diagnostic plugin stress), 4 = xlong (1-2 hr, extended stress) |
 | `DCGM_HOSTENGINE_ADDR` | `nvidia-dcgm.gpu-operator.svc:5555` | DCGM hostengine gRPC endpoint |
 
-Chart-level DCGM settings (apply to dcgm-diag):
+#### Preferred: inline env vars on the init container
+
+Define DCGM settings as env vars directly on the `preflight-dcgm-diag` container in `initContainers`. This is consistent with how NCCL checks are configured and keeps all per-check config in one place:
 
 ```yaml
+initContainers:
+  - name: preflight-dcgm-diag
+    image:
+      repository: ghcr.io/nvidia/nvsentinel/preflight-dcgm-diag
+      tag: ""
+    env:
+      - name: DCGM_HOSTENGINE_ADDR
+        value: "nvidia-dcgm.gpu-operator.svc:5555"
+      - name: DCGM_DIAG_LEVEL
+        value: "2"
+    volumeMounts:
+      - name: nvsentinel-socket
+        mountPath: /var/run
+```
+
+When env vars are defined on the container, they take precedence over values injected from the `dcgm:` block (via `mergeEnvVars`). You can leave the `dcgm:` block empty or at defaults.
+
+#### Legacy: chart-level `dcgm:` block
+
+The `dcgm:` block still works but is not recommended for new deployments. It splits DCGM config across two locations (the `dcgm:` block and the `initContainers` list), and the webhook bridges them by matching the hardcoded container name `"preflight-dcgm-diag"`. See [ADR-035](../designs/035-preflight-inline-dcgm-config.md) for background on why inline config is preferred.
+
+```yaml
+# Legacy approach — prefer inline env vars above
 dcgm:
   service:
     endpoint: "nvidia-dcgm.gpu-operator.svc"
@@ -318,6 +341,7 @@ Tilt development often trims init containers to DCGM-only; see `distros/kubernet
 ## Related documentation
 
 - [ADR-026: Preflight checks](../designs/026-preflight-checks.md)
+- [ADR-035: Inline DCGM config](../designs/035-preflight-inline-dcgm-config.md) — why inline env vars are preferred over the `dcgm:` block
 - [gRPC / TLS authentication](../designs/030-grpc-tls-authentication.md) (mentions preflight among webhooks)
 - [Helm chart README](../../distros/kubernetes/README.md)
 - E2E test entry point: `tests/preflight_test.go` (build tag `amd64_group`)

--- a/docs/designs/026-preflight-checks.md
+++ b/docs/designs/026-preflight-checks.md
@@ -657,12 +657,13 @@ preflight-injector:
     # - name: nccl-allreduce
     #   image: ghcr.io/nvidia/nvsentinel/preflight-nccl-allreduce:v1
   
-  # DCGM configuration
+  # DCGM configuration (legacy — prefer inline env vars on the init container;
+  # see ADR-035 for rationale)
   dcgm:
     hostengineAddr: "dcgm-hostengine.nvsentinel.svc:5555"  # DCGM Service address
     diagLevel: 1       # 1 (quick, ~30s) or 2 (extended, ~2-3min)
   
-  # NCCL test configuration
+  # NCCL test configuration (inlined before shipping — DCGM should follow)
   nccl:
     loopbackThresholdGBps: 10.0   # Min bus bandwidth for loopback pass
     allreduceThresholdGBps: 5.0   # Min bus bandwidth for all-reduce pass

--- a/docs/designs/035-preflight-inline-dcgm-config.md
+++ b/docs/designs/035-preflight-inline-dcgm-config.md
@@ -1,0 +1,115 @@
+# ADR-035: Inline DCGM Config into Init Container
+
+## Context
+
+The preflight webhook injects init containers into GPU pods. Each check's configuration follows one of two patterns:
+
+1. **Inline** (NCCL checks): config lives as env vars on the container in `values.yaml`. The webhook doesn't touch them.
+2. **Split** (DCGM): config lives in a separate `dcgm:` Helm block. The webhook reads it and injects env vars into the container by matching the hardcoded name `"preflight-dcgm-diag"`.
+
+The NCCL checks originally had a separate config block too (ADR-026, lines 666-668):
+
+```yaml
+# ADR-026 original design (not shipped)
+nccl:
+  loopbackThresholdGBps: 10.0
+  allreduceThresholdGBps: 5.0
+```
+
+This was inlined before shipping. DCGM was not.
+
+### Current state
+
+```yaml
+# values.yaml — config here
+dcgm:
+  service:
+    endpoint: "nvidia-dcgm.gpu-operator.svc"
+    port: 5555
+  diagLevel: 2
+  processingStrategy: "EXECUTE_REMEDIATION"
+
+# values.yaml — container here (easy to forget or get out of sync)
+initContainers:
+  - name: preflight-dcgm-diag
+    image: ...
+```
+
+The webhook bridges these with `injectDCGMEnv()` (`injector.go:715-736`), which checks `container.Name != "preflight-dcgm-diag"` to decide which container gets DCGM env vars.
+
+### Problems
+
+1. **Split-brain config**: the `dcgm:` block is meaningless without a container named exactly `preflight-dcgm-diag`, and vice versa. Rename the container and injection silently breaks.
+2. **Overloaded `dcgm:` block**: it also carries `connectorSocket` and `processingStrategy`, which are injected into *all* init containers (`injectCommonEnv`), not just the DCGM one. These are global preflight config, not DCGM-specific.
+3. **Inconsistent with NCCL**: NCCL checks define their config inline (`BW_THRESHOLD_GBPS`, `MESSAGE_SIZES`). DCGM is the only check that relies on webhook-side injection from a separate config block.
+
+### Why it was split originally
+
+The ADR-026 design assumed `dcgm:` config would be shared with the GPU health monitor at the parent chart level. In practice, the preflight chart has its own `dcgm:` block in its configmap (confirmed on sea1-a). The shared-config rationale didn't hold.
+
+## Decision
+
+Inline DCGM-specific config as env vars on the container, matching how NCCL checks work. Move global config out of the `dcgm:` block.
+
+### Proposed values.yaml
+
+```yaml
+# Global preflight config (was incorrectly scoped under dcgm:)
+connectorSocket: "unix:///var/run/nvsentinel.sock"
+processingStrategy: "EXECUTE_REMEDIATION"
+
+initContainers:
+  - name: preflight-dcgm-diag
+    image:
+      repository: ghcr.io/nvidia/nvsentinel/preflight-dcgm-diag
+      tag: ""
+    env:
+      - name: DCGM_HOSTENGINE_ADDR
+        value: "nvidia-dcgm.gpu-operator.svc:5555"
+      - name: DCGM_DIAG_LEVEL
+        value: "2"
+    volumeMounts:
+      - name: nvsentinel-socket
+        mountPath: /var/run
+
+  - name: preflight-nccl-loopback
+    # ... unchanged, already inline
+```
+
+### Code changes
+
+1. **Delete `injectDCGMEnv()`** (`injector.go:715-736`): no longer needed. The env vars are on the container already; `mergeEnvVars()` preserves user-defined values over webhook-injected ones.
+2. **Move `connectorSocket` and `processingStrategy`** out of `DCGMConfig` into a top-level preflight config in `config.go`. `injectCommonEnv()` reads from there instead of `cfg.DCGM`.
+3. **Remove `dcgm:` from `values.yaml`** and `configmap.yaml` template. Update `_helpers.tpl` accordingly.
+4. **Update `global.dcgm` fallback** in `_helpers.tpl`: if the parent chart still exposes a global `dcgm.service` block, the template can render it into the container's env vars directly rather than routing through a config struct.
+
+### What stays the same
+
+- Gang config (`gangDiscovery:`, `gangCoordination:`) is unaffected. These are webhook-level orchestration concerns, not per-container config. `injectGangEnv()` has no name check — it applies to all containers when a gang context exists.
+- NCCL checks are already inline, no changes needed.
+- The `initContainers:` list remains the plugin registry for checks. Third-party checks still just add an entry.
+
+## Consequences
+
+### Positive
+
+- DCGM config follows the same pattern as NCCL — one place to look
+- No more hardcoded container name matching in webhook code
+- `dcgm:` block gone; global config is properly scoped
+- Adding new checks never requires a new config block or webhook injection function
+
+### Negative
+
+- Breaking change for existing Helm values (`dcgm:` block removed, env vars move to container)
+- Users with `global.dcgm` overrides at the parent chart level need migration
+
+### Migration
+
+The `dcgm:` block values map directly to container env vars:
+
+| Old (`dcgm:` block)              | New (container env var)    |
+|-----------------------------------|----------------------------|
+| `dcgm.service.endpoint` + `port` | `DCGM_HOSTENGINE_ADDR`     |
+| `dcgm.diagLevel`                 | `DCGM_DIAG_LEVEL`          |
+| `dcgm.processingStrategy`        | top-level `processingStrategy` |
+| `dcgm.connectorSocket`           | top-level `connectorSocket`    |

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -62,8 +62,8 @@ Key configuration areas:
 
 | Area | Description |
 |------|-------------|
-| `preflight.initContainers` | Which checks to inject, their images, env vars, and resource limits |
-| `preflight.dcgm` | DCGM hostengine endpoint, diagnostic level, processing strategy |
+| `preflight.initContainers` | Which checks to inject, their images, env vars, and resource limits. **Preferred** location for DCGM config — define `DCGM_HOSTENGINE_ADDR` and `DCGM_DIAG_LEVEL` as env vars directly on the `preflight-dcgm-diag` container |
+| `preflight.dcgm` | DCGM hostengine endpoint, diagnostic level, processing strategy. Legacy — prefer inline env vars on the init container instead (see [ADR-035](./designs/035-preflight-inline-dcgm-config.md)) |
 | `preflight.gangDiscovery` | Scheduler-specific gang identification (Volcano, Run:ai, native K8s) |
 | `preflight.gangCoordination` | Multi-node coordination timeouts, NCCL topology, extra mounts |
 | `preflight.webhook` | TLS, failure policy, cert provider |
@@ -76,4 +76,5 @@ For detailed configuration including per-check env vars, fabric-specific NCCL se
 
 - [Preflight configuration guide](./configuration/preflight.md) — full Helm values reference
 - [ADR-026: Preflight checks](./designs/026-preflight-checks.md) — architecture and design rationale
+- [ADR-035: Inline DCGM config](./designs/035-preflight-inline-dcgm-config.md) — why inline env vars are preferred over the `dcgm:` block
 - [GPU Health Monitor](./gpu-health-monitor.md) — continuous runtime GPU monitoring (complementary to preflight)

--- a/preflight/pkg/config/config.go
+++ b/preflight/pkg/config/config.go
@@ -72,6 +72,15 @@ type FileConfig struct {
 	VolumeMountPatterns []string `yaml:"volumeMountPatterns,omitempty"`
 }
 
+// DCGMConfig holds DCGM-specific and (legacy) global preflight config.
+//
+// Prefer defining HostengineAddr and DiagLevel as inline env vars on the
+// preflight-dcgm-diag init container in values.yaml instead of using this
+// config block. Inline env vars take precedence via mergeEnvVars.
+//
+// ConnectorSocket and ProcessingStrategy are global preflight config that
+// apply to all init containers — they are incorrectly scoped here and will
+// move to a top-level struct (see ADR-035).
 type DCGMConfig struct {
 	HostengineAddr     string `yaml:"hostengineAddr"`
 	DiagLevel          int    `yaml:"diagLevel"`

--- a/preflight/pkg/webhook/injector.go
+++ b/preflight/pkg/webhook/injector.go
@@ -345,6 +345,10 @@ func (i *Injector) injectCommonEnv(container *corev1.Container) {
 		},
 	}
 
+	// NOTE: ConnectorSocket and ProcessingStrategy are global preflight config
+	// that is incorrectly scoped under DCGMConfig. These apply to all init
+	// containers, not just dcgm-diag. They will move to a top-level config
+	// struct when the dcgm: block is removed (see ADR-035).
 	if i.cfg.DCGM.ConnectorSocket != "" {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  "PLATFORM_CONNECTOR_SOCKET",
@@ -532,6 +536,12 @@ func parseHostPathType(hostPathType string) (*corev1.HostPathType, bool) {
 }
 
 // injectDCGMEnv injects DCGM-specific environment variables for the dcgm-diag check.
+//
+// Deprecated: prefer defining DCGM_DIAG_LEVEL and DCGM_HOSTENGINE_ADDR as
+// inline env vars on the preflight-dcgm-diag init container in values.yaml.
+// Inline env vars take precedence via mergeEnvVars (user-defined wins over
+// webhook-injected). This function will be removed when the dcgm: config
+// block is dropped (see ADR-035).
 func (i *Injector) injectDCGMEnv(container *corev1.Container) {
 	if container.Name != "preflight-dcgm-diag" {
 		return


### PR DESCRIPTION
## Summary

- Documents that inline env vars on the `preflight-dcgm-diag` init container are the preferred way to configure DCGM settings, matching how NCCL checks already work
- Marks the chart-level `dcgm:` block as legacy across all preflight docs (preflight.md, configuration/preflight.md, ADR-026)
- Adds inline code comments to `injector.go` (`injectDCGMEnv`, `injectCommonEnv`) and `config.go` (`DCGMConfig`) noting the deprecation path with ADR-035 references
- Adds commented-out example env vars to the `preflight-dcgm-diag` container in `values.yaml` so users see the preferred pattern

## Test plan

- [x] Docs render correctly (no broken links to ADR-035)
- [x] Helm template still renders — no functional changes, only comments
- [x] Go builds cleanly — comments only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Marked DCGM config as legacy and updated preflight guidance to prefer defining DCGM settings as inline environment variables on the preflight init container; added examples, clarified precedence, and linked ADR-035.

* **Chores**
  * Added deprecation/migration guidance across charts and docs encouraging migration to inline DCGM config and clarifying that inline env vars override legacy/chart-injected values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->