### PR TITLE
feat: annotation-based preflight check selection with gang validation

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
@@ -108,7 +108,16 @@ dcgm:
 #   checks before any other init containers.
 initContainerPlacement: "append"
 
+# Per-pod check selection: annotate pods with a comma-separated list of
+# init container names to override which checks run:
+#
+#   nvsentinel.nvidia.com/preflight-checks: "preflight-dcgm-diag,preflight-nccl-loopback"
+#
+# When the annotation is absent, all containers with defaultEnabled: true
+# (or omitted, which defaults to true) are injected.
+
 initContainers:
+  # defaultEnabled: true  # (default when omitted)
   - name: preflight-dcgm-diag
     image:
       repository: ghcr.io/nvidia/nvsentinel/preflight-dcgm-diag

--- a/docs/configuration/preflight.md
+++ b/docs/configuration/preflight.md
@@ -55,7 +55,7 @@ metadata:
     nvsentinel.nvidia.com/preflight-checks: "preflight-dcgm-diag,preflight-nccl-loopback"
 ```
 
-Only the named containers are injected, in the order they appear in the annotation. Unknown container names reject admission with an error listing the invalid names and the available checks.
+Only the named containers are injected, in the order they appear in the annotation. Duplicate or unknown container names reject admission with an error.
 
 An empty value disables all checks:
 

--- a/docs/configuration/preflight.md
+++ b/docs/configuration/preflight.md
@@ -55,7 +55,7 @@ metadata:
     nvsentinel.nvidia.com/preflight-checks: "preflight-dcgm-diag,preflight-nccl-loopback"
 ```
 
-Only the named containers are injected, in the order they appear in the chart (not the annotation). Unknown container names reject admission with an error listing the invalid names and the available checks.
+Only the named containers are injected, in the order they appear in the annotation. Unknown container names reject admission with an error listing the invalid names and the available checks.
 
 An empty value disables all checks:
 

--- a/docs/configuration/preflight.md
+++ b/docs/configuration/preflight.md
@@ -45,6 +45,26 @@ initContainerPlacement: "prepend"
 
 Use `prepend` when preflight checks must run before other init containers — for example, to gate workload setup on GPU health validation.
 
+## Per-pod check selection
+
+By default, all init containers with `defaultEnabled: true` (or omitted, which defaults to true) are injected into every GPU pod. To select a subset of checks for a specific pod, annotate it:
+
+```yaml
+metadata:
+  annotations:
+    nvsentinel.nvidia.com/preflight-checks: "preflight-dcgm-diag,preflight-nccl-loopback"
+```
+
+Only the named containers are injected. An empty value disables all checks:
+
+```yaml
+nvsentinel.nvidia.com/preflight-checks: ""
+```
+
+When the annotation is absent, `defaultEnabled` on each init container controls whether it runs. For gang-aware checks (`nccl-allreduce`), all pods in the gang must have the same annotation value — mismatches are detected and fail fast before torchrun launches.
+
+See [ADR-034](../designs/034-preflight-check-selection.md) for design details.
+
 ## Init containers (check configuration)
 
 The `initContainers` list in the preflight chart defines which checks the webhook injects. Each entry is a standard `corev1.Container` — you control images, env vars, resource limits, security contexts, and volume mounts.

--- a/docs/configuration/preflight.md
+++ b/docs/configuration/preflight.md
@@ -55,7 +55,9 @@ metadata:
     nvsentinel.nvidia.com/preflight-checks: "preflight-dcgm-diag,preflight-nccl-loopback"
 ```
 
-Only the named containers are injected. An empty value disables all checks:
+Only the named containers are injected, in the order they appear in the chart (not the annotation). Unknown container names reject admission with an error listing the invalid names and the available checks.
+
+An empty value disables all checks:
 
 ```yaml
 nvsentinel.nvidia.com/preflight-checks: ""

--- a/docs/designs/034-preflight-check-selection.md
+++ b/docs/designs/034-preflight-check-selection.md
@@ -28,7 +28,11 @@ metadata:
     nvsentinel.nvidia.com/preflight-checks: "preflight-dcgm-diag,preflight-nccl-loopback"
 ```
 
-Only named containers are injected. Unknown names are logged and skipped.
+Only named containers are injected. Unknown names are logged and skipped. An empty value disables all checks:
+
+```yaml
+nvsentinel.nvidia.com/preflight-checks: ""
+```
 
 ### Default behavior (no annotation)
 
@@ -91,6 +95,7 @@ Before launching torchrun, the NCCL all-reduce init container calls `validate_pe
 
 - Annotation cannot override env vars (e.g., DCGM diag level) — that stays in `values.yaml` or on the init container spec
 - Annotation is free-form text; typos in container names are silently skipped (logged as warnings)
+- An empty annotation disables all checks, which may be surprising if set accidentally
 
 ### Mitigations
 

--- a/docs/designs/034-preflight-check-selection.md
+++ b/docs/designs/034-preflight-check-selection.md
@@ -28,7 +28,7 @@ metadata:
     nvsentinel.nvidia.com/preflight-checks: "preflight-dcgm-diag,preflight-nccl-loopback"
 ```
 
-Only named containers are injected, in the order they appear in the chart (not the annotation order). Unknown names reject admission with an error listing the invalid names and the available checks. An empty value disables all checks:
+Only named containers are injected, in the order they appear in the annotation. When no annotation is present, chart order is used. Unknown names reject admission with an error listing the invalid names and the available checks. An empty value disables all checks:
 
 ```yaml
 nvsentinel.nvidia.com/preflight-checks: ""
@@ -128,12 +128,12 @@ All three use the same DCGM image with different env vars. The platform team def
 
 The peer line format in gang ConfigMaps is extended from 3 to 4 fields:
 
-```
+```text
 pod-0;10.0.0.1;0;preflight-dcgm-diag,preflight-nccl-allreduce
 pod-1;10.0.0.2;1;preflight-dcgm-diag,preflight-nccl-allreduce
 ```
 
-The 4th field (`checkNames`) is a comma-separated list of injected check names in chart order. Old 3-field lines parse with an empty check names field for backward compatibility.
+The 4th field (`checkNames`) is a comma-separated list of injected check names. Old 3-field lines parse with an empty check names field for backward compatibility.
 
 Before launching torchrun, the NCCL all-reduce init container calls `validate_peers()`. If any peer has a different check list, it logs the mismatch, reports `GANG_CONFIG_ERROR`, and exits immediately instead of hanging.
 

--- a/docs/designs/034-preflight-check-selection.md
+++ b/docs/designs/034-preflight-check-selection.md
@@ -28,7 +28,7 @@ metadata:
     nvsentinel.nvidia.com/preflight-checks: "preflight-dcgm-diag,preflight-nccl-loopback"
 ```
 
-Only named containers are injected. Unknown names reject admission with an error listing the invalid names and the available checks. An empty value disables all checks:
+Only named containers are injected, in the order they appear in the chart (not the annotation order). Unknown names reject admission with an error listing the invalid names and the available checks. An empty value disables all checks:
 
 ```yaml
 nvsentinel.nvidia.com/preflight-checks: ""
@@ -174,7 +174,7 @@ Before launching torchrun, the NCCL all-reduce init container calls `validate_pe
 ### Mitigations
 
 - Env var overrides can be addressed separately if needed; the annotation mechanism is orthogonal
-- Unknown container name warnings are logged, making typos discoverable via pod admission logs
+- Unknown container names reject admission with an error listing the invalid names and configured checks
 
 ## Alternatives Considered
 

--- a/docs/designs/034-preflight-check-selection.md
+++ b/docs/designs/034-preflight-check-selection.md
@@ -133,7 +133,7 @@ pod-0;10.0.0.1;0;preflight-dcgm-diag,preflight-nccl-allreduce
 pod-1;10.0.0.2;1;preflight-dcgm-diag,preflight-nccl-allreduce
 ```
 
-The 4th field (`checkNames`) is a sorted, comma-separated list of injected check names. Old 3-field lines parse with an empty check names field for backward compatibility.
+The 4th field (`checkNames`) is a comma-separated list of injected check names, sorted for deterministic comparison across peers. Old 3-field lines parse with an empty check names field for backward compatibility.
 
 Before launching torchrun, the NCCL all-reduce init container calls `validate_peers()`. If any peer has a different check list, it logs the mismatch, reports `GANG_CONFIG_ERROR`, and exits immediately instead of hanging.
 

--- a/docs/designs/034-preflight-check-selection.md
+++ b/docs/designs/034-preflight-check-selection.md
@@ -28,7 +28,7 @@ metadata:
     nvsentinel.nvidia.com/preflight-checks: "preflight-dcgm-diag,preflight-nccl-loopback"
 ```
 
-Only named containers are injected, in the order they appear in the annotation. When no annotation is present, chart order is used. Unknown names reject admission with an error listing the invalid names and the available checks. An empty value disables all checks:
+Only named containers are injected, in the order they appear in the annotation. When no annotation is present, chart order is used. Duplicate or unknown names reject admission with an error. An empty value disables all checks:
 
 ```yaml
 nvsentinel.nvidia.com/preflight-checks: ""

--- a/docs/designs/034-preflight-check-selection.md
+++ b/docs/designs/034-preflight-check-selection.md
@@ -133,7 +133,7 @@ pod-0;10.0.0.1;0;preflight-dcgm-diag,preflight-nccl-allreduce
 pod-1;10.0.0.2;1;preflight-dcgm-diag,preflight-nccl-allreduce
 ```
 
-The 4th field (`checkNames`) is a comma-separated list of injected check names, sorted for deterministic comparison across peers. Old 3-field lines parse with an empty check names field for backward compatibility.
+The 4th field (`checkNames`) is a comma-separated list of injected check names in chart order. Old 3-field lines parse with an empty check names field for backward compatibility.
 
 Before launching torchrun, the NCCL all-reduce init container calls `validate_peers()`. If any peer has a different check list, it logs the mismatch, reports `GANG_CONFIG_ERROR`, and exits immediately instead of hanging.
 

--- a/docs/designs/034-preflight-check-selection.md
+++ b/docs/designs/034-preflight-check-selection.md
@@ -1,0 +1,110 @@
+# ADR-034: Feature — Per-Pod Preflight Check Selection
+
+## Context
+
+Preflight injects all configured init containers into every GPU pod in a labeled namespace. There is no way for workload owners to control which checks run on their pods without the platform team creating separate namespaces or Helm releases.
+
+Real clusters need this flexibility:
+
+- Interactive jobs want a fast DCGM-only check (~30s), not the full suite
+- Batch training jobs need NCCL all-reduce validation that interactive jobs can skip
+- Some teams handle DCGM diagnostics externally and only want NCCL checks
+
+A secondary problem: if pods in a gang run different checks, collective-op checks like `nccl-allreduce` deadlock. One pod waits for peers that never join the NCCL communicator.
+
+## Decision
+
+Pods select which preflight checks to run via a simple annotation listing init container names. Gang members are validated for consistency before torchrun launches.
+
+## Implementation
+
+### Pod annotation
+
+Pods annotate with a comma-separated list of check names:
+
+```yaml
+metadata:
+  annotations:
+    nvsentinel.nvidia.com/preflight-checks: "preflight-dcgm-diag,preflight-nccl-loopback"
+```
+
+Only named containers are injected. Unknown names are logged and skipped.
+
+### Default behavior (no annotation)
+
+Each init container in `values.yaml` can set `defaultEnabled`:
+
+```yaml
+initContainers:
+  - name: preflight-dcgm-diag
+    # defaultEnabled: true  (default when omitted)
+    image: ...
+  - name: preflight-nccl-allreduce
+    defaultEnabled: false
+    image: ...
+```
+
+When the annotation is absent, containers with `defaultEnabled: true` (or omitted, which defaults to true) are injected. When the annotation is present, it overrides `defaultEnabled` entirely.
+
+### Gang validation
+
+The peer line format in gang ConfigMaps is extended from 3 to 4 fields:
+
+```
+pod-0;10.0.0.1;0;preflight-dcgm-diag,preflight-nccl-allreduce
+pod-1;10.0.0.2;1;preflight-dcgm-diag,preflight-nccl-allreduce
+```
+
+The 4th field (`checkNames`) is a sorted, comma-separated list of injected check names. Old 3-field lines parse with an empty check names field for backward compatibility.
+
+Before launching torchrun, the NCCL all-reduce init container calls `validate_peers()`. If any peer has a different check list, it logs the mismatch, reports `GANG_CONFIG_ERROR`, and exits immediately instead of hanging.
+
+### Key files
+
+| File | Change |
+|------|--------|
+| `preflight/pkg/config/config.go` | `InitContainerSpec` wrapper with `DefaultEnabled *bool` |
+| `preflight/pkg/webhook/injector.go` | `selectInitContainers()`, `ParseCheckNames()`, `GangContext.CheckNames` |
+| `preflight/pkg/gang/coordinator/coordinator.go` | 4-field peer line serialization and parsing |
+| `preflight/pkg/gang/types/types.go` | `CheckNames` field on `PeerInfo` |
+| `preflight/pkg/controller/gang_controller.go` | Reads annotation, normalizes into `peer.CheckNames` |
+| `preflight-checks/nccl-allreduce/nccl_allreduce/gang.py` | `PeerInfo.check_names`, `GangConfig.validate_peers()` |
+| `preflight-checks/nccl-allreduce/scripts/entrypoint.py` | Calls `validate_peers()` before torchrun |
+
+## Rationale
+
+- **Simple**: a pod annotation is the lightest-weight per-pod override. No CRD, no dynamic client, no extra RBAC.
+- **Consistent with K8s patterns**: annotations for admission webhook hints are standard (e.g., Istio sidecar injection uses `sidecar.istio.io/inject`).
+- **Safe**: gang validation catches mismatches at startup instead of 10+ minutes into a deadlocked torchrun.
+- **Backward compatible**: no annotation means all `defaultEnabled` checks run, same as today. Old peer lines parse without errors.
+
+## Consequences
+
+### Positive
+
+- Workload owners can select checks without platform team involvement
+- No new CRD to deploy, version, or grant RBAC for
+- Gang deadlocks from inconsistent check config are caught in seconds
+- Zero overhead when annotation is absent — existing behavior unchanged
+
+### Negative
+
+- Annotation cannot override env vars (e.g., DCGM diag level) — that stays in `values.yaml` or on the init container spec
+- Annotation is free-form text; typos in container names are silently skipped (logged as warnings)
+
+### Mitigations
+
+- Env var overrides can be addressed separately if needed; the annotation mechanism is orthogonal
+- Unknown container name warnings are logged, making typos discoverable via pod admission logs
+
+## Alternatives Considered
+
+### PreflightProfile CRD
+
+A namespaced CRD that pods reference by name, supporting both check selection and env var overrides.
+
+**Not chosen** because: the added complexity (CRD definition, dynamic client, RBAC for CRD access, profile.go reader) is not justified when the primary need is check selection. Env var overrides can be handled by defining them inline on the init container in `values.yaml`.
+
+## References
+
+- [ADR-026: Preflight checks](./026-preflight-checks.md) — base preflight architecture

--- a/docs/designs/034-preflight-check-selection.md
+++ b/docs/designs/034-preflight-check-selection.md
@@ -28,7 +28,7 @@ metadata:
     nvsentinel.nvidia.com/preflight-checks: "preflight-dcgm-diag,preflight-nccl-loopback"
 ```
 
-Only named containers are injected. Unknown names are logged and skipped. An empty value disables all checks:
+Only named containers are injected. Unknown names reject admission with an error listing the invalid names and the available checks. An empty value disables all checks:
 
 ```yaml
 nvsentinel.nvidia.com/preflight-checks: ""
@@ -94,7 +94,7 @@ Before launching torchrun, the NCCL all-reduce init container calls `validate_pe
 ### Negative
 
 - Annotation cannot override env vars (e.g., DCGM diag level) — that stays in `values.yaml` or on the init container spec
-- Annotation is free-form text; typos in container names are silently skipped (logged as warnings)
+- Annotation is free-form text, though typos in container names are caught — admission is rejected with an error listing the unknown names and the available checks
 - An empty annotation disables all checks, which may be surprising if set accidentally
 
 ### Mitigations

--- a/docs/designs/034-preflight-check-selection.md
+++ b/docs/designs/034-preflight-check-selection.md
@@ -50,6 +50,80 @@ initContainers:
 
 When the annotation is absent, containers with `defaultEnabled: true` (or omitted, which defaults to true) are injected. When the annotation is present, it overrides `defaultEnabled` entirely.
 
+### Example: multiple DCGM diag levels for different workloads
+
+Define three DCGM containers in `values.yaml`, each with a different diagnostic level. Only the fast check is enabled by default — jobs opt into deeper diagnostics via annotation:
+
+```yaml
+initContainers:
+  # Quick hardware check (~30s) — runs on every GPU pod by default
+  - name: preflight-dcgm-fast
+    image:
+      repository: ghcr.io/nvidia/nvsentinel/preflight-dcgm-diag
+      tag: ""
+    env:
+      - name: DCGM_DIAG_LEVEL
+        value: "1"
+
+  # Medium diagnostics (~2 min) — opt-in via annotation
+  - name: preflight-dcgm-medium
+    defaultEnabled: false
+    image:
+      repository: ghcr.io/nvidia/nvsentinel/preflight-dcgm-diag
+      tag: ""
+    env:
+      - name: DCGM_DIAG_LEVEL
+        value: "2"
+
+  # Full stress test (~15 min) — opt-in via annotation
+  - name: preflight-dcgm-full
+    defaultEnabled: false
+    image:
+      repository: ghcr.io/nvidia/nvsentinel/preflight-dcgm-diag
+      tag: ""
+    env:
+      - name: DCGM_DIAG_LEVEL
+        value: "3"
+
+  - name: preflight-nccl-loopback
+    image: ...
+```
+
+Jobs select the level they need:
+
+```yaml
+# Interactive notebook — fast check only (default, no annotation needed)
+apiVersion: v1
+kind: Pod
+metadata:
+  name: notebook
+spec: ...
+```
+
+```yaml
+# Batch training — medium DCGM + NCCL loopback
+apiVersion: v1
+kind: Pod
+metadata:
+  name: training-job
+  annotations:
+    nvsentinel.nvidia.com/preflight-checks: "preflight-dcgm-medium,preflight-nccl-loopback"
+spec: ...
+```
+
+```yaml
+# Post-maintenance validation — full stress test, no NCCL
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-validation
+  annotations:
+    nvsentinel.nvidia.com/preflight-checks: "preflight-dcgm-full"
+spec: ...
+```
+
+All three use the same DCGM image with different env vars. The platform team defines the levels once in the chart; workload owners pick by name.
+
 ### Gang validation
 
 The peer line format in gang ConfigMaps is extended from 3 to 4 fields:

--- a/preflight-checks/nccl-allreduce/nccl_allreduce/gang.py
+++ b/preflight-checks/nccl-allreduce/nccl_allreduce/gang.py
@@ -57,7 +57,7 @@ class PeerInfo:
         pod_name: Kubernetes pod name.
         pod_ip: Pod IP address.
         rank: Distributed rank (0-indexed).
-        check_names: Sorted, comma-separated preflight check names.
+        check_names: Comma-separated preflight check names (sorted for comparison).
     """
 
     pod_name: str

--- a/preflight-checks/nccl-allreduce/nccl_allreduce/gang.py
+++ b/preflight-checks/nccl-allreduce/nccl_allreduce/gang.py
@@ -57,11 +57,13 @@ class PeerInfo:
         pod_name: Kubernetes pod name.
         pod_ip: Pod IP address.
         rank: Distributed rank (0-indexed).
+        check_names: Sorted, comma-separated preflight check names.
     """
 
     pod_name: str
     pod_ip: str
     rank: int
+    check_names: str = ""
 
 
 @dataclass
@@ -85,6 +87,25 @@ class GangConfig:
     peers: list[PeerInfo]
     my_rank: int
     my_pod_name: str
+
+    def validate_peers(self) -> str | None:
+        """Validate that all peers have the same preflight check names.
+
+        Returns:
+            ``None`` if all peers are consistent, or a descriptive error string.
+        """
+        if not self.peers:
+            return None
+
+        first = self.peers[0].check_names
+        for peer in self.peers[1:]:
+            if peer.check_names != first:
+                parts = []
+                for p in self.peers:
+                    parts.append(f"{p.pod_name}=[{p.check_names}]")
+                return f"Check name mismatch across gang: {'; '.join(parts)}"
+
+        return None
 
     def get_torchrun_args(self, nprocs_per_node: int, script: str) -> list[str]:
         """Build torchrun command arguments.
@@ -193,7 +214,8 @@ class GangConfigReader:
     def _read_peers(self) -> list[PeerInfo]:
         """Read and parse the peers list from the ConfigMap.
 
-        Format: "pod_name;pod_ip;rank" per line.
+        Format: "pod_name;pod_ip;rank[;check_names]" per line.
+        The check_names field is optional for backward compatibility.
 
         Returns:
             List of PeerInfo objects.
@@ -230,7 +252,11 @@ class GangConfigReader:
                         extra={"line": line, "bad_rank": parts[2].strip()},
                     )
 
-            peers.append(PeerInfo(pod_name=pod_name, pod_ip=pod_ip, rank=rank))
+            check_names = ""
+            if len(parts) >= 4:
+                check_names = parts[3].strip()
+
+            peers.append(PeerInfo(pod_name=pod_name, pod_ip=pod_ip, rank=rank, check_names=check_names))
 
         return peers
 

--- a/preflight-checks/nccl-allreduce/nccl_allreduce/gang.py
+++ b/preflight-checks/nccl-allreduce/nccl_allreduce/gang.py
@@ -57,7 +57,7 @@ class PeerInfo:
         pod_name: Kubernetes pod name.
         pod_ip: Pod IP address.
         rank: Distributed rank (0-indexed).
-        check_names: Comma-separated preflight check names in chart order.
+        check_names: Comma-separated preflight check names.
     """
 
     pod_name: str

--- a/preflight-checks/nccl-allreduce/nccl_allreduce/gang.py
+++ b/preflight-checks/nccl-allreduce/nccl_allreduce/gang.py
@@ -57,7 +57,7 @@ class PeerInfo:
         pod_name: Kubernetes pod name.
         pod_ip: Pod IP address.
         rank: Distributed rank (0-indexed).
-        check_names: Comma-separated preflight check names (sorted for comparison).
+        check_names: Comma-separated preflight check names in chart order.
     """
 
     pod_name: str

--- a/preflight-checks/nccl-allreduce/nccl_allreduce/tests/test_gang.py
+++ b/preflight-checks/nccl-allreduce/nccl_allreduce/tests/test_gang.py
@@ -216,6 +216,20 @@ class TestValidatePeers:
         cfg = self._make_config([])
         assert cfg.validate_peers() is None
 
+    def test_mismatch_error_includes_pod_details(self) -> None:
+        peers = [
+            PeerInfo("pod-0", "10.0.0.1", 0, "a,b"),
+            PeerInfo("pod-1", "10.0.0.2", 1, "a,b"),
+            PeerInfo("pod-2", "10.0.0.3", 2, "a"),
+        ]
+        cfg = self._make_config(peers)
+        result = cfg.validate_peers()
+        assert result is not None
+        assert "pod-0" in result
+        assert "pod-2" in result
+        assert "[a,b]" in result
+        assert "[a]" in result
+
     def test_mixed_default_and_explicit_mismatch(self) -> None:
         peers = [
             PeerInfo("pod-0", "10.0.0.1", 0),

--- a/preflight-checks/nccl-allreduce/nccl_allreduce/tests/test_gang.py
+++ b/preflight-checks/nccl-allreduce/nccl_allreduce/tests/test_gang.py
@@ -108,6 +108,125 @@ class TestGangConfigReader:
         assert cfg.my_rank == -1
 
 
+class TestPeerFormat:
+    """Tests for parsing peer format with check_names field."""
+
+    def test_parse_four_field_format(self, tmp_path: Path) -> None:
+        config_dir = str(tmp_path)
+        write_configmap(
+            config_dir,
+            {
+                "expected_count": "2",
+                "peers": (
+                    "pod-0;10.0.0.1;0;preflight-dcgm-diag,preflight-nccl-allreduce\n"
+                    "pod-1;10.0.0.2;1;preflight-dcgm-diag,preflight-nccl-allreduce"
+                ),
+            },
+        )
+
+        reader = GangConfigReader(config_dir)
+        cfg = reader.read("pod-0")
+
+        assert len(cfg.peers) == 2
+        assert cfg.peers[0].check_names == "preflight-dcgm-diag,preflight-nccl-allreduce"
+        assert cfg.peers[1].check_names == "preflight-dcgm-diag,preflight-nccl-allreduce"
+
+    def test_backward_compatible_three_field_format(self, tmp_path: Path) -> None:
+        config_dir = str(tmp_path)
+        write_configmap(
+            config_dir,
+            {
+                "expected_count": "2",
+                "peers": "pod-0;10.0.0.1;0\npod-1;10.0.0.2;1",
+            },
+        )
+
+        reader = GangConfigReader(config_dir)
+        cfg = reader.read("pod-0")
+
+        assert len(cfg.peers) == 2
+        assert cfg.peers[0].check_names == ""
+        assert cfg.peers[1].check_names == ""
+
+    def test_mixed_old_new_format(self, tmp_path: Path) -> None:
+        config_dir = str(tmp_path)
+        write_configmap(
+            config_dir,
+            {
+                "expected_count": "2",
+                "peers": "pod-0;10.0.0.1;0\npod-1;10.0.0.2;1;preflight-dcgm-diag",
+            },
+        )
+
+        reader = GangConfigReader(config_dir)
+        cfg = reader.read("pod-0")
+
+        assert len(cfg.peers) == 2
+        assert cfg.peers[0].check_names == ""
+        assert cfg.peers[1].check_names == "preflight-dcgm-diag"
+
+
+class TestValidatePeers:
+    """Tests for GangConfig.validate_peers() check consistency validation."""
+
+    @staticmethod
+    def _make_config(peers: list[PeerInfo]) -> GangConfig:
+        return GangConfig(
+            expected_count=len(peers),
+            gang_id="test-gang",
+            master_addr="10.0.0.1",
+            master_port="29500",
+            peers=peers,
+            my_rank=0,
+            my_pod_name="pod-0",
+        )
+
+    def test_same_checks(self) -> None:
+        peers = [
+            PeerInfo("pod-0", "10.0.0.1", 0, "preflight-dcgm-diag,preflight-nccl-allreduce"),
+            PeerInfo("pod-1", "10.0.0.2", 1, "preflight-dcgm-diag,preflight-nccl-allreduce"),
+        ]
+        cfg = self._make_config(peers)
+        assert cfg.validate_peers() is None
+
+    def test_check_mismatch(self) -> None:
+        peers = [
+            PeerInfo("pod-0", "10.0.0.1", 0, "preflight-dcgm-diag,preflight-nccl-allreduce"),
+            PeerInfo("pod-1", "10.0.0.2", 1, "preflight-nccl-allreduce"),
+        ]
+        cfg = self._make_config(peers)
+        result = cfg.validate_peers()
+        assert result is not None
+        assert "mismatch" in result.lower()
+
+    def test_all_default_no_checks(self) -> None:
+        peers = [
+            PeerInfo("pod-0", "10.0.0.1", 0),
+            PeerInfo("pod-1", "10.0.0.2", 1),
+        ]
+        cfg = self._make_config(peers)
+        assert cfg.validate_peers() is None
+
+    def test_single_peer(self) -> None:
+        peers = [PeerInfo("pod-0", "10.0.0.1", 0, "preflight-dcgm-diag")]
+        cfg = self._make_config(peers)
+        assert cfg.validate_peers() is None
+
+    def test_empty_peers(self) -> None:
+        cfg = self._make_config([])
+        assert cfg.validate_peers() is None
+
+    def test_mixed_default_and_explicit_mismatch(self) -> None:
+        peers = [
+            PeerInfo("pod-0", "10.0.0.1", 0),
+            PeerInfo("pod-1", "10.0.0.2", 1, "preflight-dcgm-diag"),
+        ]
+        cfg = self._make_config(peers)
+        result = cfg.validate_peers()
+        assert result is not None
+        assert "mismatch" in result.lower()
+
+
 class TestGangConfig:
     """Tests for building torchrun CLI arguments from gang coordination info."""
 

--- a/preflight-checks/nccl-allreduce/scripts/entrypoint.py
+++ b/preflight-checks/nccl-allreduce/scripts/entrypoint.py
@@ -93,7 +93,17 @@ def main() -> int:
     if isinstance(gang_config, int):
         return gang_config
 
-    # 3. Launch torchrun (replaces this process)
+    # 3. Validate peers have consistent check configuration
+    validation_error = gang_config.validate_peers()
+    if validation_error is not None:
+        log.error(
+            "Gang peer validation failed",
+            extra={"error": validation_error},
+        )
+        _report_error(NCCLError.GANG_CONFIG_ERROR, validation_error)
+        return NCCLError.GANG_CONFIG_ERROR.value.exit_code
+
+    # 4. Launch torchrun (replaces this process)
     _launch_torchrun(gang_config, cfg.nprocs_per_node)
 
     # Should never reach here (os.execvp replaces the process)

--- a/preflight/pkg/config/config.go
+++ b/preflight/pkg/config/config.go
@@ -294,6 +294,17 @@ func (c *GangCoordinationConfig) setDefaults() {
 }
 
 func (c *FileConfig) validate() error {
+	seen := make(map[string]struct{}, len(c.InitContainers))
+	for i, spec := range c.InitContainers {
+		if spec.Name == "" {
+			return fmt.Errorf("initContainers[%d].name must be set", i)
+		}
+		if _, exists := seen[spec.Name]; exists {
+			return fmt.Errorf("duplicate init container name %q", spec.Name)
+		}
+		seen[spec.Name] = struct{}{}
+	}
+
 	switch c.InitContainerPlacement {
 	case PlacementPrepend, PlacementAppend:
 	default:

--- a/preflight/pkg/config/config.go
+++ b/preflight/pkg/config/config.go
@@ -46,8 +46,21 @@ const (
 	PlacementPrepend InitContainerPlacement = "prepend"
 )
 
+// InitContainerSpec wraps corev1.Container with a DefaultEnabled field
+// that controls whether the check runs when no per-pod annotation overrides
+// the check selection. Defaults to true when omitted (nil).
+type InitContainerSpec struct {
+	corev1.Container `yaml:",inline"`
+	DefaultEnabled   *bool `yaml:"defaultEnabled,omitempty"`
+}
+
+// IsDefaultEnabled returns true when DefaultEnabled is nil or explicitly true.
+func (s *InitContainerSpec) IsDefaultEnabled() bool {
+	return s.DefaultEnabled == nil || *s.DefaultEnabled
+}
+
 type FileConfig struct {
-	InitContainers       []corev1.Container     `yaml:"initContainers"`
+	InitContainers       []InitContainerSpec    `yaml:"initContainers"`
 	GPUResourceNames     []string               `yaml:"gpuResourceNames"`
 	NetworkResourceNames []string               `yaml:"networkResourceNames"`
 	DCGM                 DCGMConfig             `yaml:"dcgm"`

--- a/preflight/pkg/config/config.go
+++ b/preflight/pkg/config/config.go
@@ -299,9 +299,11 @@ func (c *FileConfig) validate() error {
 		if spec.Name == "" {
 			return fmt.Errorf("initContainers[%d].name must be set", i)
 		}
+
 		if _, exists := seen[spec.Name]; exists {
 			return fmt.Errorf("duplicate init container name %q", spec.Name)
 		}
+
 		seen[spec.Name] = struct{}{}
 	}
 

--- a/preflight/pkg/config/config_test.go
+++ b/preflight/pkg/config/config_test.go
@@ -174,6 +174,48 @@ initContainerPlacement: "middle"
 		assert.Contains(t, err.Error(), "initContainerPlacement")
 	})
 
+	t.Run("empty init container name rejected", func(t *testing.T) {
+		path := writeYAML(t, `
+initContainers:
+  - name: ""
+    image: dcgm:latest
+`)
+		_, err := Load(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "name must be set")
+	})
+
+	t.Run("duplicate init container names rejected", func(t *testing.T) {
+		path := writeYAML(t, `
+initContainers:
+  - name: preflight-dcgm-diag
+    image: dcgm:latest
+  - name: preflight-dcgm-diag
+    image: dcgm:v2
+`)
+		_, err := Load(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate")
+		assert.Contains(t, err.Error(), "preflight-dcgm-diag")
+	})
+
+	t.Run("defaultEnabled parsed from YAML", func(t *testing.T) {
+		path := writeYAML(t, `
+initContainers:
+  - name: preflight-dcgm-diag
+    image: dcgm:latest
+  - name: preflight-nccl-allreduce
+    image: nccl:latest
+    defaultEnabled: false
+`)
+		cfg, err := Load(path)
+		require.NoError(t, err)
+		require.Len(t, cfg.InitContainers, 2)
+
+		assert.True(t, cfg.InitContainers[0].IsDefaultEnabled(), "nil DefaultEnabled should be true")
+		assert.False(t, cfg.InitContainers[1].IsDefaultEnabled(), "explicit false should be false")
+	})
+
 	t.Run("extra hostPath readOnly explicit false", func(t *testing.T) {
 		path := writeYAML(t, `
 initContainers:

--- a/preflight/pkg/controller/gang_controller.go
+++ b/preflight/pkg/controller/gang_controller.go
@@ -156,9 +156,17 @@ func (c *GangController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	// Normalize the preflight-checks annotation so all peers serialize the
 	// same sorted value, enabling gang-level consistency validation.
+	// Errors are not expected here — the webhook already validated the
+	// annotation at admission time. Log and continue with empty if it fails.
 	checkNames := ""
 	if ann, ok := pod.Annotations[webhook.PreflightChecksAnnotation]; ok {
-		checkNames = strings.Join(webhook.ParseCheckNames(ann), ",")
+		parsed, err := webhook.ParseCheckNames(ann)
+		if err != nil {
+			slog.Warn("Failed to parse preflight-checks annotation, using empty",
+				"pod", pod.Name, "error", err)
+		} else {
+			checkNames = strings.Join(parsed, ",")
+		}
 	}
 
 	peer := gang.PeerInfo{

--- a/preflight/pkg/controller/gang_controller.go
+++ b/preflight/pkg/controller/gang_controller.go
@@ -264,9 +264,9 @@ func (c *GangController) ensureNCCLTopoConfigMap(ctx context.Context, namespace 
 		"configMap", gcfg.NCCLTopoConfigMap)
 }
 
-// checkNamesFromPod computes the check names string for a pod using chart
-// order, matching the injector's selectInitContainers logic. This ensures
-// the gang peer line is identical regardless of annotation order.
+// checkNamesFromPod computes the check names string for a pod, matching
+// the injector's selectInitContainers logic. Annotation order is preserved
+// so the string matches what the injector produces.
 func checkNamesFromPod(pod *corev1.Pod, cfg *config.Config) string {
 	ann, ok := pod.Annotations[webhook.PreflightChecksAnnotation]
 	if !ok {
@@ -281,7 +281,7 @@ func checkNamesFromPod(pod *corev1.Pod, cfg *config.Config) string {
 		return strings.Join(names, ",")
 	}
 
-	// Annotation present — parse names, then walk chart order.
+	// Annotation present — use annotation order, skip unknown names.
 	parsed, err := webhook.ParseCheckNames(ann)
 	if err != nil {
 		slog.Warn("Failed to parse preflight-checks annotation",
@@ -290,19 +290,15 @@ func checkNamesFromPod(pod *corev1.Pod, cfg *config.Config) string {
 		return ""
 	}
 
-	if len(parsed) == 0 {
-		return ""
-	}
-
-	requestedSet := make(map[string]bool, len(parsed))
-	for _, name := range parsed {
-		requestedSet[name] = true
+	configuredSet := make(map[string]bool, len(cfg.InitContainers))
+	for _, spec := range cfg.InitContainers {
+		configuredSet[spec.Name] = true
 	}
 
 	var names []string
-	for _, spec := range cfg.InitContainers {
-		if requestedSet[spec.Name] {
-			names = append(names, spec.Name)
+	for _, name := range parsed {
+		if configuredSet[name] {
+			names = append(names, name)
 		}
 	}
 

--- a/preflight/pkg/controller/gang_controller.go
+++ b/preflight/pkg/controller/gang_controller.go
@@ -154,20 +154,9 @@ func (c *GangController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, nil
 	}
 
-	// Normalize the preflight-checks annotation so all peers serialize the
-	// same sorted value, enabling gang-level consistency validation.
-	// Errors are not expected here — the webhook already validated the
-	// annotation at admission time. Log and continue with empty if it fails.
-	checkNames := ""
-	if ann, ok := pod.Annotations[webhook.PreflightChecksAnnotation]; ok {
-		parsed, err := webhook.ParseCheckNames(ann)
-		if err != nil {
-			slog.Warn("Failed to parse preflight-checks annotation, using empty",
-				"pod", pod.Name, "error", err)
-		} else {
-			checkNames = strings.Join(parsed, ",")
-		}
-	}
+	// Build check names in chart order — same logic as the injector's
+	// selectInitContainers so both paths produce identical strings.
+	checkNames := checkNamesFromPod(&pod, c.cfg)
 
 	peer := gang.PeerInfo{
 		PodName:    pod.Name,
@@ -273,4 +262,49 @@ func (c *GangController) ensureNCCLTopoConfigMap(ctx context.Context, namespace 
 	slog.Info("Created NCCL topo ConfigMap",
 		"namespace", namespace,
 		"configMap", gcfg.NCCLTopoConfigMap)
+}
+
+// checkNamesFromPod computes the check names string for a pod using chart
+// order, matching the injector's selectInitContainers logic. This ensures
+// the gang peer line is identical regardless of annotation order.
+func checkNamesFromPod(pod *corev1.Pod, cfg *config.Config) string {
+	ann, ok := pod.Annotations[webhook.PreflightChecksAnnotation]
+	if !ok {
+		// No annotation — use defaultEnabled in chart order.
+		var names []string
+		for _, spec := range cfg.InitContainers {
+			if spec.IsDefaultEnabled() {
+				names = append(names, spec.Name)
+			}
+		}
+
+		return strings.Join(names, ",")
+	}
+
+	// Annotation present — parse names, then walk chart order.
+	parsed, err := webhook.ParseCheckNames(ann)
+	if err != nil {
+		slog.Warn("Failed to parse preflight-checks annotation",
+			"pod", pod.Name, "error", err)
+
+		return ""
+	}
+
+	if len(parsed) == 0 {
+		return ""
+	}
+
+	requestedSet := make(map[string]bool, len(parsed))
+	for _, name := range parsed {
+		requestedSet[name] = true
+	}
+
+	var names []string
+	for _, spec := range cfg.InitContainers {
+		if requestedSet[spec.Name] {
+			names = append(names, spec.Name)
+		}
+	}
+
+	return strings.Join(names, ",")
 }

--- a/preflight/pkg/controller/gang_controller.go
+++ b/preflight/pkg/controller/gang_controller.go
@@ -272,6 +272,7 @@ func checkNamesFromPod(pod *corev1.Pod, cfg *config.Config) string {
 	if !ok {
 		// No annotation — use defaultEnabled in chart order.
 		var names []string
+
 		for _, spec := range cfg.InitContainers {
 			if spec.IsDefaultEnabled() {
 				names = append(names, spec.Name)
@@ -296,6 +297,7 @@ func checkNamesFromPod(pod *corev1.Pod, cfg *config.Config) string {
 	}
 
 	var names []string
+
 	for _, name := range parsed {
 		if configuredSet[name] {
 			names = append(names, name)

--- a/preflight/pkg/controller/gang_controller.go
+++ b/preflight/pkg/controller/gang_controller.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/nvidia/nvsentinel/preflight/pkg/config"
 	"github.com/nvidia/nvsentinel/preflight/pkg/gang"
@@ -153,11 +154,19 @@ func (c *GangController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, nil
 	}
 
+	// Normalize the preflight-checks annotation so all peers serialize the
+	// same sorted value, enabling gang-level consistency validation.
+	checkNames := ""
+	if ann, ok := pod.Annotations[webhook.PreflightChecksAnnotation]; ok {
+		checkNames = strings.Join(webhook.ParseCheckNames(ann), ",")
+	}
+
 	peer := gang.PeerInfo{
-		PodName:   pod.Name,
-		PodIP:     pod.Status.PodIP,
-		NodeName:  pod.Spec.NodeName,
-		Namespace: pod.Namespace,
+		PodName:    pod.Name,
+		PodIP:      pod.Status.PodIP,
+		NodeName:   pod.Spec.NodeName,
+		Namespace:  pod.Namespace,
+		CheckNames: checkNames,
 	}
 
 	if err := c.coordinator.RegisterPeer(ctx, pod.Namespace, gangInfo, peer); err != nil {

--- a/preflight/pkg/controller/gang_controller_test.go
+++ b/preflight/pkg/controller/gang_controller_test.go
@@ -184,13 +184,12 @@ func TestGangController_WebhookRegistration(t *testing.T) {
 	})
 }
 
-
 // Verifies that topology configmap are created upon pod registration and is idempotent upon subsequent registrations.
 func TestGangController_EnsureNCCLTopoConfigMap(t *testing.T) {
 	const (
-		gangID       = "topo-gang"
-		topoName     = "nccl-topo"
-		topoData     = "<topology>test</topology>"
+		gangID   = "topo-gang"
+		topoName = "nccl-topo"
+		topoData = "<topology>test</topology>"
 	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -269,7 +268,6 @@ func TestGangController_MultipleGangsIndependent(t *testing.T) {
 		assert.NotEqual(t, "worker-b", p.PodName, "gang-a ConfigMap should not contain worker-b")
 	}
 }
-
 
 type mockDiscoverer struct {
 	canHandle bool

--- a/preflight/pkg/gang/coordinator/coordinator.go
+++ b/preflight/pkg/gang/coordinator/coordinator.go
@@ -271,7 +271,8 @@ func (c *Coordinator) GetGangConfigMap(ctx context.Context, namespace, gangID st
 }
 
 // ParsePeers parses the peers string from a ConfigMap into a slice of PeerInfo.
-// Format: "podName;podIP;rank" per line (rank is optional for backwards compatibility).
+// Format: "podName;podIP;rank[;checkNames]" per line.
+// The checkNames field is optional for backward compatibility with older 3-field lines.
 func ParsePeers(peersData string) []types.PeerInfo {
 	var peers []types.PeerInfo
 
@@ -281,15 +282,21 @@ func ParsePeers(peersData string) []types.PeerInfo {
 			continue
 		}
 
-		parts := strings.SplitN(line, ";", 3)
+		parts := strings.SplitN(line, ";", 4)
 		if len(parts) < 2 {
 			continue
 		}
 
-		peers = append(peers, types.PeerInfo{
+		peer := types.PeerInfo{
 			PodName: strings.TrimSpace(parts[0]),
 			PodIP:   strings.TrimSpace(parts[1]),
-		})
+		}
+
+		if len(parts) >= 4 {
+			peer.CheckNames = strings.TrimSpace(parts[3])
+		}
+
+		peers = append(peers, peer)
 	}
 
 	return peers
@@ -350,6 +357,7 @@ func (c *Coordinator) addPeerToConfigMap(cm *corev1.ConfigMap, peer types.PeerIn
 	for i, p := range existingPeers {
 		if p.PodName == peer.PodName {
 			existingPeers[i].PodIP = peer.PodIP
+			existingPeers[i].CheckNames = peer.CheckNames
 			found = true
 
 			break
@@ -368,7 +376,7 @@ func (c *Coordinator) addPeerToConfigMap(cm *corev1.ConfigMap, peer types.PeerIn
 	// Serialize peers with rank (index after sorting)
 	var lines []string
 	for rank, p := range existingPeers {
-		lines = append(lines, fmt.Sprintf("%s;%s;%d", p.PodName, p.PodIP, rank))
+		lines = append(lines, fmt.Sprintf("%s;%s;%d;%s", p.PodName, p.PodIP, rank, p.CheckNames))
 	}
 
 	cm.Data[DataKeyPeers] = strings.Join(lines, "\n")

--- a/preflight/pkg/gang/coordinator/coordinator_test.go
+++ b/preflight/pkg/gang/coordinator/coordinator_test.go
@@ -245,6 +245,59 @@ func TestParsePeers(t *testing.T) {
 	}
 }
 
+func TestAddPeerToConfigMapCheckNames(t *testing.T) {
+	c := &Coordinator{config: CoordinatorConfig{MasterPort: 29500}}
+
+	t.Run("serializes and round-trips CheckNames", func(t *testing.T) {
+		cm := &corev1.ConfigMap{Data: map[string]string{}}
+		c.addPeerToConfigMap(cm, types.PeerInfo{
+			PodName: "pod-0", PodIP: "10.0.0.1",
+			CheckNames: "preflight-dcgm-diag,preflight-nccl-allreduce",
+		})
+		c.addPeerToConfigMap(cm, types.PeerInfo{
+			PodName: "pod-1", PodIP: "10.0.0.2",
+			CheckNames: "preflight-dcgm-diag,preflight-nccl-allreduce",
+		})
+
+		parsed := ParsePeers(cm.Data[DataKeyPeers])
+		require.Len(t, parsed, 2)
+		assert.Equal(t, "preflight-dcgm-diag,preflight-nccl-allreduce", parsed[0].CheckNames)
+		assert.Equal(t, "preflight-dcgm-diag,preflight-nccl-allreduce", parsed[1].CheckNames)
+	})
+
+	t.Run("update preserves CheckNames", func(t *testing.T) {
+		cm := &corev1.ConfigMap{Data: map[string]string{}}
+		c.addPeerToConfigMap(cm, types.PeerInfo{
+			PodName: "pod-0", PodIP: "10.0.0.1",
+			CheckNames: "preflight-dcgm-diag",
+		})
+		// Re-register with new IP, same CheckNames
+		c.addPeerToConfigMap(cm, types.PeerInfo{
+			PodName: "pod-0", PodIP: "10.0.0.99",
+			CheckNames: "preflight-dcgm-diag",
+		})
+
+		parsed := ParsePeers(cm.Data[DataKeyPeers])
+		require.Len(t, parsed, 1)
+		assert.Equal(t, "10.0.0.99", parsed[0].PodIP)
+		assert.Equal(t, "preflight-dcgm-diag", parsed[0].CheckNames)
+	})
+
+	t.Run("empty CheckNames produces valid 4-field line", func(t *testing.T) {
+		cm := &corev1.ConfigMap{Data: map[string]string{}}
+		c.addPeerToConfigMap(cm, types.PeerInfo{
+			PodName: "pod-0", PodIP: "10.0.0.1",
+		})
+
+		// Raw format should be "pod-0;10.0.0.1;0;" (trailing semicolon)
+		assert.Contains(t, cm.Data[DataKeyPeers], "pod-0;10.0.0.1;0;")
+
+		parsed := ParsePeers(cm.Data[DataKeyPeers])
+		require.Len(t, parsed, 1)
+		assert.Equal(t, "", parsed[0].CheckNames)
+	})
+}
+
 func TestGetRank(t *testing.T) {
 	peers := []types.PeerInfo{
 		{PodName: "worker-2", PodIP: "10.0.0.3"},

--- a/preflight/pkg/gang/coordinator/coordinator_test.go
+++ b/preflight/pkg/gang/coordinator/coordinator_test.go
@@ -206,6 +206,28 @@ func TestParsePeers(t *testing.T) {
 			wantCount: 2,
 			wantFirst: types.PeerInfo{PodName: "pod-0", PodIP: "2001:db8::1"},
 		},
+		{
+			name:      "4-field format with check names",
+			peersData: "pod-0;10.0.0.1;0;preflight-dcgm-diag,preflight-nccl-allreduce",
+			wantCount: 1,
+			wantFirst: types.PeerInfo{
+				PodName:    "pod-0",
+				PodIP:      "10.0.0.1",
+				CheckNames: "preflight-dcgm-diag,preflight-nccl-allreduce",
+			},
+		},
+		{
+			name:      "backward compatible 3-field format",
+			peersData: "pod-0;10.0.0.1;0\npod-1;10.0.0.2;1",
+			wantCount: 2,
+			wantFirst: types.PeerInfo{PodName: "pod-0", PodIP: "10.0.0.1"},
+		},
+		{
+			name:      "mixed old and new format",
+			peersData: "pod-0;10.0.0.1;0\npod-1;10.0.0.2;1;preflight-dcgm-diag",
+			wantCount: 2,
+			wantFirst: types.PeerInfo{PodName: "pod-0", PodIP: "10.0.0.1"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -216,7 +238,7 @@ func TestParsePeers(t *testing.T) {
 				t.Errorf("ParsePeers() count = %d, want %d", len(got), tt.wantCount)
 			}
 
-			if tt.wantCount > 0 && (got[0].PodName != tt.wantFirst.PodName || got[0].PodIP != tt.wantFirst.PodIP) {
+			if tt.wantCount > 0 && got[0] != tt.wantFirst {
 				t.Errorf("ParsePeers()[0] = %+v, want %+v", got[0], tt.wantFirst)
 			}
 		})

--- a/preflight/pkg/gang/types/types.go
+++ b/preflight/pkg/gang/types/types.go
@@ -32,8 +32,8 @@ type PeerInfo struct {
 	Namespace string
 
 	// CheckNames is a comma-separated list of preflight check container
-	// names this pod is configured to run. Gang validation compares
-	// these as sets — all peers must run the same checks.
+	// names this pod is configured to run. All peers in a gang must
+	// have the same value.
 	CheckNames string
 }
 

--- a/preflight/pkg/gang/types/types.go
+++ b/preflight/pkg/gang/types/types.go
@@ -30,6 +30,11 @@ type PeerInfo struct {
 	PodIP     string
 	NodeName  string
 	Namespace string
+
+	// CheckNames is a sorted, comma-separated list of preflight check
+	// container names this pod is configured to run. Used for gang
+	// validation — all peers must have the same value.
+	CheckNames string
 }
 
 type GangInfo struct {

--- a/preflight/pkg/gang/types/types.go
+++ b/preflight/pkg/gang/types/types.go
@@ -31,9 +31,10 @@ type PeerInfo struct {
 	NodeName  string
 	Namespace string
 
-	// CheckNames is a sorted, comma-separated list of preflight check
-	// container names this pod is configured to run. Used for gang
-	// validation — all peers must have the same value.
+	// CheckNames is a comma-separated list of preflight check container
+	// names this pod is configured to run, sorted for deterministic
+	// comparison. Used for gang validation — all peers must have the
+	// same value.
 	CheckNames string
 }
 

--- a/preflight/pkg/gang/types/types.go
+++ b/preflight/pkg/gang/types/types.go
@@ -32,9 +32,8 @@ type PeerInfo struct {
 	Namespace string
 
 	// CheckNames is a comma-separated list of preflight check container
-	// names this pod is configured to run, sorted for deterministic
-	// comparison. Used for gang validation — all peers must have the
-	// same value.
+	// names this pod is configured to run. Gang validation compares
+	// these as sets — all peers must run the same checks.
 	CheckNames string
 }
 

--- a/preflight/pkg/webhook/handler.go
+++ b/preflight/pkg/webhook/handler.go
@@ -35,6 +35,9 @@ type GangRegistration struct {
 	PodName       string
 	GangID        string
 	ConfigMapName string
+	// CheckNames is a sorted, comma-separated list of preflight checks
+	// this pod will run. Written into the gang peer line for validation.
+	CheckNames string
 }
 
 // GangRegistrationFunc is called after a pod is admitted to register it with a gang.
@@ -160,6 +163,7 @@ func (h *Handler) mutate(ctx context.Context, req *admissionv1.AdmissionRequest)
 			PodName:       podName,
 			GangID:        gangCtx.GangID,
 			ConfigMapName: gangCtx.ConfigMapName,
+			CheckNames:    gangCtx.CheckNames,
 		})
 	}
 

--- a/preflight/pkg/webhook/handler.go
+++ b/preflight/pkg/webhook/handler.go
@@ -35,8 +35,8 @@ type GangRegistration struct {
 	PodName       string
 	GangID        string
 	ConfigMapName string
-	// CheckNames is a sorted, comma-separated list of preflight checks
-	// this pod will run. Written into the gang peer line for validation.
+	// CheckNames is a comma-separated list of preflight checks this pod
+	// will run, sorted for deterministic gang validation.
 	CheckNames string
 }
 

--- a/preflight/pkg/webhook/handler.go
+++ b/preflight/pkg/webhook/handler.go
@@ -36,7 +36,7 @@ type GangRegistration struct {
 	GangID        string
 	ConfigMapName string
 	// CheckNames is a comma-separated list of preflight checks this pod
-	// will run, sorted for deterministic gang validation.
+	// will run. Gang validation compares these as sets.
 	CheckNames string
 }
 

--- a/preflight/pkg/webhook/handler.go
+++ b/preflight/pkg/webhook/handler.go
@@ -36,7 +36,7 @@ type GangRegistration struct {
 	GangID        string
 	ConfigMapName string
 	// CheckNames is a comma-separated list of preflight checks this pod
-	// will run. Gang validation compares these as sets.
+	// will run. Annotation order when present, chart order for defaults.
 	CheckNames string
 }
 

--- a/preflight/pkg/webhook/handler_test.go
+++ b/preflight/pkg/webhook/handler_test.go
@@ -55,8 +55,8 @@ func buildAdmissionReview(pod *corev1.Pod, uid types.UID, namespace string) []by
 func handlerConfig() *config.Config {
 	return &config.Config{
 		FileConfig: config.FileConfig{
-			InitContainers: []corev1.Container{
-				{Name: "preflight-dcgm-diag", Image: "dcgm:latest"},
+			InitContainers: []config.InitContainerSpec{
+				{Container: corev1.Container{Name: "preflight-dcgm-diag", Image: "dcgm:latest"}},
 			},
 			GPUResourceNames: []string{"nvidia.com/gpu"},
 			DCGM: config.DCGMConfig{

--- a/preflight/pkg/webhook/injector.go
+++ b/preflight/pkg/webhook/injector.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -76,16 +75,13 @@ type GangContext struct {
 	GangID        string
 	ConfigMapName string
 	// CheckNames is a comma-separated list of injected check container
-	// names, sorted for deterministic comparison across peers.
-	// Containers are injected in chart order; this string is sorted
-	// independently for gang validation.
+	// names in chart order. Gang validation compares these as sets.
 	CheckNames string
 }
 
-// ParseCheckNames splits a comma-separated annotation value into a sorted
-// list of container names. Returns an error if any name appears more than
-// once. Sorted for deterministic comparison across peers in gang validation.
-// Exported so the gang controller can use the same normalization.
+// ParseCheckNames splits a comma-separated annotation value into a list of
+// container names. Returns an error if any name appears more than once.
+// Exported so the gang controller can use the same parsing.
 func ParseCheckNames(csv string) ([]string, error) {
 	seen := make(map[string]bool)
 	var names []string
@@ -102,8 +98,6 @@ func ParseCheckNames(csv string) ([]string, error) {
 		seen[name] = true
 		names = append(names, name)
 	}
-
-	sort.Strings(names)
 
 	return names, nil
 }
@@ -157,13 +151,12 @@ func (i *Injector) InjectInitContainers(pod *corev1.Pod) ([]PatchOperation, *Gan
 
 	initContainers := i.buildInitContainers(pod, maxResources, gangCtx, selected)
 
-	// Compute check names for gang validation (sorted for deterministic comparison).
+	// Compute check names for gang validation.
 	if gangCtx != nil {
 		names := make([]string, len(initContainers))
 		for idx, c := range initContainers {
 			names[idx] = c.Name
 		}
-		sort.Strings(names)
 		gangCtx.CheckNames = strings.Join(names, ",")
 	}
 

--- a/preflight/pkg/webhook/injector.go
+++ b/preflight/pkg/webhook/injector.go
@@ -75,14 +75,17 @@ func NewInjector(cfg *config.Config, discoverer gang.GangDiscoverer) *Injector {
 type GangContext struct {
 	GangID        string
 	ConfigMapName string
-	// CheckNames is a sorted, comma-separated list of injected check
-	// container names. Written into the gang peer line for validation.
+	// CheckNames is a comma-separated list of injected check container
+	// names, sorted for deterministic comparison across peers.
+	// Containers are injected in chart order; this string is sorted
+	// independently for gang validation.
 	CheckNames string
 }
 
 // ParseCheckNames splits a comma-separated annotation value into a sorted,
-// deduplicated list of container names. Exported so the gang controller can
-// use the same normalization.
+// deduplicated list of container names. Sorted for deterministic comparison
+// across peers in gang validation. Exported so the gang controller can use
+// the same normalization.
 func ParseCheckNames(csv string) []string {
 	seen := make(map[string]bool)
 	var names []string
@@ -149,7 +152,7 @@ func (i *Injector) InjectInitContainers(pod *corev1.Pod) ([]PatchOperation, *Gan
 
 	initContainers := i.buildInitContainers(pod, maxResources, gangCtx, selected)
 
-	// Compute sorted check names for gang validation.
+	// Compute check names for gang validation (sorted for deterministic comparison).
 	if gangCtx != nil {
 		names := make([]string, len(initContainers))
 		for idx, c := range initContainers {

--- a/preflight/pkg/webhook/injector.go
+++ b/preflight/pkg/webhook/injector.go
@@ -85,6 +85,7 @@ type GangContext struct {
 // Exported so the gang controller can use the same parsing.
 func ParseCheckNames(csv string) ([]string, error) {
 	seen := make(map[string]bool)
+
 	var names []string
 
 	for _, part := range strings.Split(csv, ",") {
@@ -92,10 +93,12 @@ func ParseCheckNames(csv string) ([]string, error) {
 		if name == "" {
 			continue
 		}
+
 		if seen[name] {
 			return nil, fmt.Errorf("duplicate check name %q in annotation %s",
 				name, PreflightChecksAnnotation)
 		}
+
 		seen[name] = true
 		names = append(names, name)
 	}
@@ -158,6 +161,7 @@ func (i *Injector) InjectInitContainers(pod *corev1.Pod) ([]PatchOperation, *Gan
 		for idx, c := range initContainers {
 			names[idx] = c.Name
 		}
+
 		gangCtx.CheckNames = strings.Join(names, ",")
 	}
 
@@ -256,6 +260,7 @@ func (i *Injector) selectInitContainers(pod *corev1.Pod) ([]config.InitContainer
 	if !ok {
 		// No annotation — use defaultEnabled.
 		var result []config.InitContainerSpec
+
 		for _, spec := range i.cfg.InitContainers {
 			if spec.IsDefaultEnabled() {
 				result = append(result, spec)
@@ -275,11 +280,13 @@ func (i *Injector) selectInitContainers(pod *corev1.Pod) ([]config.InitContainer
 	if err != nil {
 		return nil, err
 	}
+
 	if len(requested) == 0 {
 		return nil, nil
 	}
 
 	configuredByName := make(map[string]config.InitContainerSpec, len(i.cfg.InitContainers))
+
 	for _, spec := range i.cfg.InitContainers {
 		configuredByName[spec.Name] = spec
 	}
@@ -287,14 +294,17 @@ func (i *Injector) selectInitContainers(pod *corev1.Pod) ([]config.InitContainer
 	// Walk annotation order so init container execution order matches
 	// what the user specified.
 	var result []config.InitContainerSpec
+
 	var unknown []string
 
 	for _, name := range requested {
 		spec, exists := configuredByName[name]
 		if !exists {
 			unknown = append(unknown, name)
+
 			continue
 		}
+
 		result = append(result, spec)
 	}
 
@@ -328,7 +338,7 @@ func (i *Injector) buildInitContainers(
 	userVolumeMounts := i.collectMatchingVolumeMounts(pod.Spec.Containers)
 
 	for _, tmpl := range selected {
-		container := tmpl.Container.DeepCopy()
+		container := tmpl.DeepCopy()
 
 		if container.Resources.Requests == nil {
 			container.Resources.Requests = make(corev1.ResourceList)

--- a/preflight/pkg/webhook/injector.go
+++ b/preflight/pkg/webhook/injector.go
@@ -273,7 +273,7 @@ func (i *Injector) selectInitContainers(pod *corev1.Pod) ([]config.InitContainer
 	}
 
 	// Annotation present — only inject named containers.
-	// ParseCheckNames normalizes: split, trim, sort; rejects duplicates.
+	// ParseCheckNames normalizes: split, trim; rejects duplicates.
 	// An empty or whitespace/comma-only annotation yields an empty list,
 	// which disables all checks.
 	requested, err := ParseCheckNames(ann)

--- a/preflight/pkg/webhook/injector.go
+++ b/preflight/pkg/webhook/injector.go
@@ -266,24 +266,41 @@ func (i *Injector) selectInitContainers(pod *corev1.Pod) ([]config.InitContainer
 	}
 
 	// Annotation present — only inject named containers.
+	// ParseCheckNames normalizes: split, trim, sort, dedup.
+	// An empty or whitespace/comma-only annotation yields an empty list,
+	// which disables all checks.
 	requested := ParseCheckNames(ann)
-	configuredByName := make(map[string]config.InitContainerSpec, len(i.cfg.InitContainers))
-
-	for _, spec := range i.cfg.InitContainers {
-		configuredByName[spec.Name] = spec
+	if len(requested) == 0 {
+		return nil, nil
 	}
 
+	requestedSet := make(map[string]bool, len(requested))
+	for _, name := range requested {
+		requestedSet[name] = true
+	}
+
+	// Walk configured containers in their defined order so init container
+	// execution order matches the chart, regardless of annotation order.
 	var result []config.InitContainerSpec
 	var unknown []string
 
-	for _, name := range requested {
-		spec, exists := configuredByName[name]
-		if !exists {
-			unknown = append(unknown, name)
-			continue
+	for _, spec := range i.cfg.InitContainers {
+		if requestedSet[spec.Name] {
+			result = append(result, spec)
 		}
+	}
 
-		result = append(result, spec)
+	for _, name := range requested {
+		found := false
+		for _, spec := range i.cfg.InitContainers {
+			if spec.Name == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			unknown = append(unknown, name)
+		}
 	}
 
 	if len(unknown) > 0 {

--- a/preflight/pkg/webhook/injector.go
+++ b/preflight/pkg/webhook/injector.go
@@ -82,25 +82,30 @@ type GangContext struct {
 	CheckNames string
 }
 
-// ParseCheckNames splits a comma-separated annotation value into a sorted,
-// deduplicated list of container names. Sorted for deterministic comparison
-// across peers in gang validation. Exported so the gang controller can use
-// the same normalization.
-func ParseCheckNames(csv string) []string {
+// ParseCheckNames splits a comma-separated annotation value into a sorted
+// list of container names. Returns an error if any name appears more than
+// once. Sorted for deterministic comparison across peers in gang validation.
+// Exported so the gang controller can use the same normalization.
+func ParseCheckNames(csv string) ([]string, error) {
 	seen := make(map[string]bool)
 	var names []string
 
 	for _, part := range strings.Split(csv, ",") {
 		name := strings.TrimSpace(part)
-		if name != "" && !seen[name] {
-			seen[name] = true
-			names = append(names, name)
+		if name == "" {
+			continue
 		}
+		if seen[name] {
+			return nil, fmt.Errorf("duplicate check name %q in annotation %s",
+				name, PreflightChecksAnnotation)
+		}
+		seen[name] = true
+		names = append(names, name)
 	}
 
 	sort.Strings(names)
 
-	return names
+	return names, nil
 }
 
 func configuredNames(specs []config.InitContainerSpec) []string {
@@ -269,10 +274,13 @@ func (i *Injector) selectInitContainers(pod *corev1.Pod) ([]config.InitContainer
 	}
 
 	// Annotation present — only inject named containers.
-	// ParseCheckNames normalizes: split, trim, sort, dedup.
+	// ParseCheckNames normalizes: split, trim, sort; rejects duplicates.
 	// An empty or whitespace/comma-only annotation yields an empty list,
 	// which disables all checks.
-	requested := ParseCheckNames(ann)
+	requested, err := ParseCheckNames(ann)
+	if err != nil {
+		return nil, err
+	}
 	if len(requested) == 0 {
 		return nil, nil
 	}

--- a/preflight/pkg/webhook/injector.go
+++ b/preflight/pkg/webhook/injector.go
@@ -238,7 +238,7 @@ func (i *Injector) updateMax(resources corev1.ResourceList, name corev1.Resource
 // inject based on the pod's preflight-checks annotation or defaultEnabled.
 func (i *Injector) selectInitContainers(pod *corev1.Pod) []config.InitContainerSpec {
 	ann, ok := pod.Annotations[PreflightChecksAnnotation]
-	if !ok || strings.TrimSpace(ann) == "" {
+	if !ok {
 		// No annotation — use defaultEnabled.
 		var result []config.InitContainerSpec
 		for _, spec := range i.cfg.InitContainers {

--- a/preflight/pkg/webhook/injector.go
+++ b/preflight/pkg/webhook/injector.go
@@ -18,7 +18,9 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/nvidia/nvsentinel/preflight/pkg/config"
 	"github.com/nvidia/nvsentinel/preflight/pkg/gang"
@@ -43,6 +45,11 @@ const (
 	dshmVolumeName = "dshm"
 	// ncclTopoVolumeName is the name for the NCCL topology ConfigMap volume
 	ncclTopoVolumeName = "nccl-topo"
+
+	// PreflightChecksAnnotation is the pod annotation listing which preflight
+	// checks to run. Value is a comma-separated list of init container names.
+	// When absent, all containers with defaultEnabled (or omitted) are injected.
+	PreflightChecksAnnotation = "nvsentinel.nvidia.com/preflight-checks"
 )
 
 type PatchOperation struct {
@@ -68,6 +75,29 @@ func NewInjector(cfg *config.Config, discoverer gang.GangDiscoverer) *Injector {
 type GangContext struct {
 	GangID        string
 	ConfigMapName string
+	// CheckNames is a sorted, comma-separated list of injected check
+	// container names. Written into the gang peer line for validation.
+	CheckNames string
+}
+
+// ParseCheckNames splits a comma-separated annotation value into a sorted,
+// deduplicated list of container names. Exported so the gang controller can
+// use the same normalization.
+func ParseCheckNames(csv string) []string {
+	seen := make(map[string]bool)
+	var names []string
+
+	for _, part := range strings.Split(csv, ",") {
+		name := strings.TrimSpace(part)
+		if name != "" && !seen[name] {
+			seen[name] = true
+			names = append(names, name)
+		}
+	}
+
+	sort.Strings(names)
+
+	return names
 }
 
 func (i *Injector) InjectInitContainers(pod *corev1.Pod) ([]PatchOperation, *GangContext, error) {
@@ -103,7 +133,19 @@ func (i *Injector) InjectInitContainers(pod *corev1.Pod) ([]PatchOperation, *Gan
 		}
 	}
 
-	initContainers := i.buildInitContainers(pod, maxResources, gangCtx)
+	selected := i.selectInitContainers(pod)
+	initContainers := i.buildInitContainers(pod, maxResources, gangCtx, selected)
+
+	// Compute sorted check names for gang validation.
+	if gangCtx != nil {
+		names := make([]string, len(initContainers))
+		for idx, c := range initContainers {
+			names[idx] = c.Name
+		}
+		sort.Strings(names)
+		gangCtx.CheckNames = strings.Join(names, ",")
+	}
+
 	if len(initContainers) == 0 {
 		// No init containers to inject, but still return gangCtx
 		// so the controller can track gang membership
@@ -192,10 +234,54 @@ func (i *Injector) updateMax(resources corev1.ResourceList, name corev1.Resource
 	}
 }
 
+// selectInitContainers returns the subset of configured init containers to
+// inject based on the pod's preflight-checks annotation or defaultEnabled.
+func (i *Injector) selectInitContainers(pod *corev1.Pod) []config.InitContainerSpec {
+	ann, ok := pod.Annotations[PreflightChecksAnnotation]
+	if !ok || strings.TrimSpace(ann) == "" {
+		// No annotation — use defaultEnabled.
+		var result []config.InitContainerSpec
+		for _, spec := range i.cfg.InitContainers {
+			if spec.IsDefaultEnabled() {
+				result = append(result, spec)
+			} else {
+				slog.Debug("Init container disabled by default", "container", spec.Name)
+			}
+		}
+
+		return result
+	}
+
+	// Annotation present — only inject named containers.
+	requested := ParseCheckNames(ann)
+	configuredByName := make(map[string]config.InitContainerSpec, len(i.cfg.InitContainers))
+
+	for _, spec := range i.cfg.InitContainers {
+		configuredByName[spec.Name] = spec
+	}
+
+	var result []config.InitContainerSpec
+
+	for _, name := range requested {
+		spec, exists := configuredByName[name]
+		if !exists {
+			slog.Warn("Annotation requests unknown preflight check, skipping",
+				"check", name, "pod", pod.Name, "namespace", pod.Namespace)
+
+			continue
+		}
+
+		result = append(result, spec)
+	}
+
+	return result
+}
+
 func (i *Injector) buildInitContainers(
 	pod *corev1.Pod,
 	maxResources corev1.ResourceList,
 	gangCtx *GangContext,
+	selected []config.InitContainerSpec,
 ) []corev1.Container {
 	var initContainers []corev1.Container
 
@@ -209,8 +295,8 @@ func (i *Injector) buildInitContainers(
 	userEnvVars := i.collectMatchingEnvVars(pod.Spec.Containers)
 	userVolumeMounts := i.collectMatchingVolumeMounts(pod.Spec.Containers)
 
-	for _, tmpl := range i.cfg.InitContainers {
-		container := tmpl.DeepCopy()
+	for _, tmpl := range selected {
+		container := tmpl.Container.DeepCopy()
 
 		if container.Resources.Requests == nil {
 			container.Resources.Requests = make(corev1.ResourceList)

--- a/preflight/pkg/webhook/injector.go
+++ b/preflight/pkg/webhook/injector.go
@@ -75,7 +75,8 @@ type GangContext struct {
 	GangID        string
 	ConfigMapName string
 	// CheckNames is a comma-separated list of injected check container
-	// names in chart order. Gang validation compares these as sets.
+	// names. Annotation order when annotation is present, chart order
+	// when using defaults.
 	CheckNames string
 }
 
@@ -278,33 +279,23 @@ func (i *Injector) selectInitContainers(pod *corev1.Pod) ([]config.InitContainer
 		return nil, nil
 	}
 
-	requestedSet := make(map[string]bool, len(requested))
-	for _, name := range requested {
-		requestedSet[name] = true
+	configuredByName := make(map[string]config.InitContainerSpec, len(i.cfg.InitContainers))
+	for _, spec := range i.cfg.InitContainers {
+		configuredByName[spec.Name] = spec
 	}
 
-	// Walk configured containers in their defined order so init container
-	// execution order matches the chart, regardless of annotation order.
+	// Walk annotation order so init container execution order matches
+	// what the user specified.
 	var result []config.InitContainerSpec
 	var unknown []string
 
-	for _, spec := range i.cfg.InitContainers {
-		if requestedSet[spec.Name] {
-			result = append(result, spec)
-		}
-	}
-
 	for _, name := range requested {
-		found := false
-		for _, spec := range i.cfg.InitContainers {
-			if spec.Name == name {
-				found = true
-				break
-			}
-		}
-		if !found {
+		spec, exists := configuredByName[name]
+		if !exists {
 			unknown = append(unknown, name)
+			continue
 		}
+		result = append(result, spec)
 	}
 
 	if len(unknown) > 0 {

--- a/preflight/pkg/webhook/injector.go
+++ b/preflight/pkg/webhook/injector.go
@@ -100,6 +100,15 @@ func ParseCheckNames(csv string) []string {
 	return names
 }
 
+func configuredNames(specs []config.InitContainerSpec) []string {
+	names := make([]string, len(specs))
+	for i, s := range specs {
+		names[i] = s.Name
+	}
+
+	return names
+}
+
 func (i *Injector) InjectInitContainers(pod *corev1.Pod) ([]PatchOperation, *GangContext, error) {
 	maxResources := i.findMaxResources(pod)
 	if len(maxResources) == 0 {
@@ -133,7 +142,11 @@ func (i *Injector) InjectInitContainers(pod *corev1.Pod) ([]PatchOperation, *Gan
 		}
 	}
 
-	selected := i.selectInitContainers(pod)
+	selected, err := i.selectInitContainers(pod)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	initContainers := i.buildInitContainers(pod, maxResources, gangCtx, selected)
 
 	// Compute sorted check names for gang validation.
@@ -236,7 +249,7 @@ func (i *Injector) updateMax(resources corev1.ResourceList, name corev1.Resource
 
 // selectInitContainers returns the subset of configured init containers to
 // inject based on the pod's preflight-checks annotation or defaultEnabled.
-func (i *Injector) selectInitContainers(pod *corev1.Pod) []config.InitContainerSpec {
+func (i *Injector) selectInitContainers(pod *corev1.Pod) ([]config.InitContainerSpec, error) {
 	ann, ok := pod.Annotations[PreflightChecksAnnotation]
 	if !ok {
 		// No annotation — use defaultEnabled.
@@ -249,7 +262,7 @@ func (i *Injector) selectInitContainers(pod *corev1.Pod) []config.InitContainerS
 			}
 		}
 
-		return result
+		return result, nil
 	}
 
 	// Annotation present — only inject named containers.
@@ -261,20 +274,27 @@ func (i *Injector) selectInitContainers(pod *corev1.Pod) []config.InitContainerS
 	}
 
 	var result []config.InitContainerSpec
+	var unknown []string
 
 	for _, name := range requested {
 		spec, exists := configuredByName[name]
 		if !exists {
-			slog.Warn("Annotation requests unknown preflight check, skipping",
-				"check", name, "pod", pod.Name, "namespace", pod.Namespace)
-
+			unknown = append(unknown, name)
 			continue
 		}
 
 		result = append(result, spec)
 	}
 
-	return result
+	if len(unknown) > 0 {
+		return nil, fmt.Errorf(
+			"annotation %s references unknown checks: %s (configured: %s)",
+			PreflightChecksAnnotation,
+			strings.Join(unknown, ", "),
+			strings.Join(configuredNames(i.cfg.InitContainers), ", "))
+	}
+
+	return result, nil
 }
 
 func (i *Injector) buildInitContainers(

--- a/preflight/pkg/webhook/injector_test.go
+++ b/preflight/pkg/webhook/injector_test.go
@@ -923,10 +923,10 @@ func TestSelectInitContainers(t *testing.T) {
 }
 
 func TestParseCheckNames(t *testing.T) {
-	t.Run("sorts names", func(t *testing.T) {
+	t.Run("preserves order", func(t *testing.T) {
 		names, err := ParseCheckNames("b, a, c")
 		require.NoError(t, err)
-		assert.Equal(t, []string{"a", "b", "c"}, names)
+		assert.Equal(t, []string{"b", "a", "c"}, names)
 	})
 
 	t.Run("empty string returns empty", func(t *testing.T) {

--- a/preflight/pkg/webhook/injector_test.go
+++ b/preflight/pkg/webhook/injector_test.go
@@ -892,18 +892,18 @@ func TestSelectInitContainers(t *testing.T) {
 		assert.Len(t, selected, 2)
 	})
 
-	t.Run("annotation with duplicates selects each once", func(t *testing.T) {
+	t.Run("annotation with duplicates returns error", func(t *testing.T) {
 		cfg := multiConfig()
 		injector := NewInjector(cfg, nil)
 		pod := gpuPod()
 		pod.Annotations = map[string]string{
-			PreflightChecksAnnotation: "preflight-dcgm-diag,preflight-dcgm-diag,preflight-dcgm-diag",
+			PreflightChecksAnnotation: "preflight-dcgm-diag,preflight-dcgm-diag",
 		}
 
-		selected, err := injector.selectInitContainers(pod)
-		require.NoError(t, err)
-		require.Len(t, selected, 1)
-		assert.Equal(t, "preflight-dcgm-diag", selected[0].Name)
+		_, err := injector.selectInitContainers(pod)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate")
+		assert.Contains(t, err.Error(), "preflight-dcgm-diag")
 	})
 
 	t.Run("unknown check name lists configured checks in error", func(t *testing.T) {
@@ -923,19 +923,29 @@ func TestSelectInitContainers(t *testing.T) {
 }
 
 func TestParseCheckNames(t *testing.T) {
-	t.Run("sorts and deduplicates", func(t *testing.T) {
-		names := ParseCheckNames("b, a, b, c")
+	t.Run("sorts names", func(t *testing.T) {
+		names, err := ParseCheckNames("b, a, c")
+		require.NoError(t, err)
 		assert.Equal(t, []string{"a", "b", "c"}, names)
 	})
 
 	t.Run("empty string returns empty", func(t *testing.T) {
-		names := ParseCheckNames("")
+		names, err := ParseCheckNames("")
+		require.NoError(t, err)
 		assert.Empty(t, names)
 	})
 
 	t.Run("whitespace only returns empty", func(t *testing.T) {
-		names := ParseCheckNames("  ,  , ")
+		names, err := ParseCheckNames("  ,  , ")
+		require.NoError(t, err)
 		assert.Empty(t, names)
+	})
+
+	t.Run("duplicate name returns error", func(t *testing.T) {
+		_, err := ParseCheckNames("a, b, a")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate")
+		assert.Contains(t, err.Error(), "a")
 	})
 }
 

--- a/preflight/pkg/webhook/injector_test.go
+++ b/preflight/pkg/webhook/injector_test.go
@@ -851,6 +851,34 @@ func TestSelectInitContainers(t *testing.T) {
 		assert.Contains(t, err.Error(), "unknown checks")
 	})
 
+	t.Run("annotation preserves configured order not annotation order", func(t *testing.T) {
+		cfg := multiConfig()
+		injector := NewInjector(cfg, nil)
+		pod := gpuPod()
+		pod.Annotations = map[string]string{
+			PreflightChecksAnnotation: "preflight-nccl-loopback,preflight-dcgm-diag",
+		}
+
+		selected, err := injector.selectInitContainers(pod)
+		require.NoError(t, err)
+		require.Len(t, selected, 2)
+		assert.Equal(t, "preflight-dcgm-diag", selected[0].Name)
+		assert.Equal(t, "preflight-nccl-loopback", selected[1].Name)
+	})
+
+	t.Run("comma-only annotation disables all checks", func(t *testing.T) {
+		cfg := multiConfig()
+		injector := NewInjector(cfg, nil)
+		pod := gpuPod()
+		pod.Annotations = map[string]string{
+			PreflightChecksAnnotation: " , , ",
+		}
+
+		selected, err := injector.selectInitContainers(pod)
+		require.NoError(t, err)
+		assert.Empty(t, selected)
+	})
+
 	t.Run("annotation with spaces and trailing commas", func(t *testing.T) {
 		cfg := multiConfig()
 		injector := NewInjector(cfg, nil)

--- a/preflight/pkg/webhook/injector_test.go
+++ b/preflight/pkg/webhook/injector_test.go
@@ -286,9 +286,9 @@ func TestInjectInitContainers(t *testing.T) {
 			cfg: func() *config.Config {
 				c := testConfig()
 				c.InitContainerPlacement = config.PlacementPrepend
-				c.InitContainers = []corev1.Container{
-					{Name: "preflight-dcgm-diag", Image: "dcgm:latest"},
-					{Name: "preflight-nccl-loopback", Image: "nccl:latest"},
+				c.InitContainers = []config.InitContainerSpec{
+					{Container: corev1.Container{Name: "preflight-dcgm-diag", Image: "dcgm:latest"}},
+					{Container: corev1.Container{Name: "preflight-nccl-loopback", Image: "nccl:latest"}},
 				}
 				return c
 			}(),
@@ -437,7 +437,7 @@ func TestBuildInitContainers(t *testing.T) {
 			"vpc.amazonaws.com/efa": resource.MustParse("4"),
 		}
 
-		containers := injector.buildInitContainers(pod, maxResources, nil)
+		containers := injector.buildInitContainers(pod, maxResources, nil, cfg.InitContainers)
 		require.Len(t, containers, 1)
 
 		c := containers[0]
@@ -454,7 +454,7 @@ func TestBuildInitContainers(t *testing.T) {
 
 		containers := injector.buildInitContainers(pod, corev1.ResourceList{
 			"nvidia.com/gpu": resource.MustParse("8"),
-		}, nil)
+		}, nil, cfg.InitContainers)
 		require.Len(t, containers, 1)
 
 		assert.Equal(t, resource.MustParse("100m"), containers[0].Resources.Requests[corev1.ResourceCPU])
@@ -463,8 +463,8 @@ func TestBuildInitContainers(t *testing.T) {
 
 	t.Run("CPU and memory floor not applied when already set", func(t *testing.T) {
 		cfg := testConfig()
-		cfg.InitContainers = []corev1.Container{
-			{
+		cfg.InitContainers = []config.InitContainerSpec{
+			{Container: corev1.Container{
 				Name:  "preflight-dcgm-diag",
 				Image: "dcgm:latest",
 				Resources: corev1.ResourceRequirements{
@@ -473,13 +473,13 @@ func TestBuildInitContainers(t *testing.T) {
 						corev1.ResourceMemory: resource.MustParse("1Gi"),
 					},
 				},
-			},
+			}},
 		}
 		injector := NewInjector(cfg, nil)
 
 		containers := injector.buildInitContainers(gpuPod(), corev1.ResourceList{
 			"nvidia.com/gpu": resource.MustParse("8"),
-		}, nil)
+		}, nil, cfg.InitContainers)
 		require.Len(t, containers, 1)
 
 		assert.Equal(t, resource.MustParse("200m"), containers[0].Resources.Requests[corev1.ResourceCPU])
@@ -488,15 +488,15 @@ func TestBuildInitContainers(t *testing.T) {
 
 	t.Run("DCGM env only for dcgm-diag container", func(t *testing.T) {
 		cfg := testConfig()
-		cfg.InitContainers = []corev1.Container{
-			{Name: "preflight-dcgm-diag", Image: "dcgm:latest"},
-			{Name: "preflight-nccl-allreduce", Image: "nccl:latest"},
+		cfg.InitContainers = []config.InitContainerSpec{
+			{Container: corev1.Container{Name: "preflight-dcgm-diag", Image: "dcgm:latest"}},
+			{Container: corev1.Container{Name: "preflight-nccl-allreduce", Image: "nccl:latest"}},
 		}
 		injector := NewInjector(cfg, nil)
 
 		containers := injector.buildInitContainers(gpuPod(), corev1.ResourceList{
 			"nvidia.com/gpu": resource.MustParse("8"),
-		}, nil)
+		}, nil, cfg.InitContainers)
 		require.Len(t, containers, 2)
 
 		assert.True(t, hasEnvVar(containers[0], "DCGM_DIAG_LEVEL"), "dcgm-diag should have DCGM_DIAG_LEVEL")
@@ -511,7 +511,7 @@ func TestBuildInitContainers(t *testing.T) {
 
 		containers := injector.buildInitContainers(gpuPod(), corev1.ResourceList{
 			"nvidia.com/gpu": resource.MustParse("8"),
-		}, nil)
+		}, nil, cfg.InitContainers)
 		require.Len(t, containers, 1)
 
 		assert.True(t, hasEnvVar(containers[0], "NODE_NAME"))
@@ -525,7 +525,7 @@ func TestBuildInitContainers(t *testing.T) {
 
 		containers := injector.buildInitContainers(gpuPod(), corev1.ResourceList{
 			"nvidia.com/gpu": resource.MustParse("8"),
-		}, nil)
+		}, nil, cfg.InitContainers)
 		require.Len(t, containers, 1)
 
 		assert.False(t, hasEnvVar(containers[0], "GANG_ID"))
@@ -541,7 +541,7 @@ func TestBuildInitContainers(t *testing.T) {
 		gangCtx := &GangContext{GangID: "test-gang", ConfigMapName: "preflight-test-gang"}
 		containers := injector.buildInitContainers(gpuPod(), corev1.ResourceList{
 			"nvidia.com/gpu": resource.MustParse("8"),
-		}, gangCtx)
+		}, gangCtx, cfg.InitContainers)
 		require.Len(t, containers, 1)
 
 		c := containers[0]
@@ -565,7 +565,7 @@ func TestBuildInitContainers(t *testing.T) {
 
 		containers := injector.buildInitContainers(pod, corev1.ResourceList{
 			"nvidia.com/gpu": resource.MustParse("8"),
-		}, nil)
+		}, nil, cfg.InitContainers)
 		require.Len(t, containers, 1)
 		assert.Equal(t, "INFO", findEnv(containers[0].Env, "NCCL_DEBUG"))
 	})
@@ -573,12 +573,12 @@ func TestBuildInitContainers(t *testing.T) {
 	t.Run("user env lower precedence than template", func(t *testing.T) {
 		cfg := testConfig()
 		cfg.NCCLEnvPatterns = []string{"NCCL_*"}
-		cfg.InitContainers = []corev1.Container{
-			{
+		cfg.InitContainers = []config.InitContainerSpec{
+			{Container: corev1.Container{
 				Name:  "preflight-dcgm-diag",
 				Image: "dcgm:latest",
 				Env:   []corev1.EnvVar{{Name: "NCCL_DEBUG", Value: "WARN"}},
-			},
+			}},
 		}
 		injector := NewInjector(cfg, nil)
 
@@ -589,7 +589,7 @@ func TestBuildInitContainers(t *testing.T) {
 
 		containers := injector.buildInitContainers(pod, corev1.ResourceList{
 			"nvidia.com/gpu": resource.MustParse("8"),
-		}, nil)
+		}, nil, cfg.InitContainers)
 		require.Len(t, containers, 1)
 		assert.Equal(t, "WARN", findEnv(containers[0].Env, "NCCL_DEBUG"))
 	})
@@ -606,7 +606,7 @@ func TestBuildInitContainers(t *testing.T) {
 
 		containers := injector.buildInitContainers(pod, corev1.ResourceList{
 			"nvidia.com/gpu": resource.MustParse("8"),
-		}, nil)
+		}, nil, cfg.InitContainers)
 		require.Len(t, containers, 1)
 		assert.True(t, hasVolumeMount(containers[0], "nvtcpxo-libraries"))
 	})
@@ -624,7 +624,7 @@ func TestBuildInitContainers(t *testing.T) {
 
 		containers := injector.buildInitContainers(pod, corev1.ResourceList{
 			"nvidia.com/gpu": resource.MustParse("8"),
-		}, gangCtx)
+		}, gangCtx, cfg.InitContainers)
 		require.Len(t, containers, 1)
 		require.Len(t, containers[0].Resources.Claims, 2)
 		assert.Equal(t, "gpu-claim", containers[0].Resources.Claims[0].Name)
@@ -644,7 +644,7 @@ func TestBuildInitContainers(t *testing.T) {
 
 		containers := injector.buildInitContainers(pod, corev1.ResourceList{
 			"nvidia.com/gpu": resource.MustParse("8"),
-		}, gangCtx)
+		}, gangCtx, cfg.InitContainers)
 		require.Len(t, containers, 1)
 		assert.Empty(t, containers[0].Resources.Claims)
 	})
@@ -660,7 +660,7 @@ func TestBuildInitContainers(t *testing.T) {
 
 		containers := injector.buildInitContainers(pod, corev1.ResourceList{
 			"nvidia.com/gpu": resource.MustParse("8"),
-		}, nil)
+		}, nil, cfg.InitContainers)
 		require.Len(t, containers, 1)
 		assert.Empty(t, containers[0].Resources.Claims)
 	})
@@ -864,8 +864,8 @@ func boolPtr(b bool) *bool { return &b }
 func testConfig() *config.Config {
 	return &config.Config{
 		FileConfig: config.FileConfig{
-			InitContainers: []corev1.Container{
-				{Name: "preflight-dcgm-diag", Image: "nvcr.io/nvidia/dcgm:latest"},
+			InitContainers: []config.InitContainerSpec{
+				{Container: corev1.Container{Name: "preflight-dcgm-diag", Image: "nvcr.io/nvidia/dcgm:latest"}},
 			},
 			GPUResourceNames:       []string{"nvidia.com/gpu"},
 			NetworkResourceNames:   []string{"vpc.amazonaws.com/efa"},

--- a/preflight/pkg/webhook/injector_test.go
+++ b/preflight/pkg/webhook/injector_test.go
@@ -208,13 +208,14 @@ func TestInjectInitContainers(t *testing.T) {
 			expectGangCtx: false,
 		},
 		{
-			name:          "GPU pod with gang enabled and is gang member",
-			cfg:           testGangConfig(),
-			discoverer:    &mockDiscoverer{name: "volcano", canHandle: true, gangID: "volcano-default-pg1"},
-			pod:           gpuEFAPod(),
-			expectPatches: true,
-			expectGangCtx: true,
-			expectGangID:  "volcano-default-pg1",
+			name:             "GPU pod with gang enabled and is gang member",
+			cfg:              testGangConfig(),
+			discoverer:       &mockDiscoverer{name: "volcano", canHandle: true, gangID: "volcano-default-pg1"},
+			pod:              gpuEFAPod(),
+			expectPatches:    true,
+			expectGangCtx:    true,
+			expectGangID:     "volcano-default-pg1",
+			expectCheckNames: "preflight-dcgm-diag",
 			validatePatches: func(t *testing.T, patches []PatchOperation) {
 				t.Helper()
 				initPatch := findPatchByPath(patches, "/spec/initContainers")
@@ -335,9 +336,10 @@ func TestInjectInitContainers(t *testing.T) {
 			},
 		},
 		{
-			name:       "existing volumes are not duplicated",
-			cfg:        testGangConfig(),
-			discoverer: &mockDiscoverer{name: "test", canHandle: true, gangID: "test-gang"},
+			name:             "existing volumes are not duplicated",
+			cfg:              testGangConfig(),
+			discoverer:       &mockDiscoverer{name: "test", canHandle: true, gangID: "test-gang"},
+			expectCheckNames: "preflight-dcgm-diag",
 			pod: func() *corev1.Pod {
 				p := gpuPod()
 				p.Spec.Volumes = []corev1.Volume{
@@ -486,9 +488,7 @@ func TestInjectInitContainers(t *testing.T) {
 					assert.Equal(t, tt.expectGangID, gangCtx.GangID)
 					assert.NotEmpty(t, gangCtx.ConfigMapName)
 				}
-				if tt.expectCheckNames != "" {
-					assert.Equal(t, tt.expectCheckNames, gangCtx.CheckNames)
-				}
+				assert.Equal(t, tt.expectCheckNames, gangCtx.CheckNames)
 			} else {
 				assert.Nil(t, gangCtx)
 			}

--- a/preflight/pkg/webhook/injector_test.go
+++ b/preflight/pkg/webhook/injector_test.go
@@ -695,6 +695,118 @@ func requireVolume(t *testing.T, volumes []corev1.Volume, name string) *corev1.V
 	return vol
 }
 
+func TestSelectInitContainers(t *testing.T) {
+	multiConfig := func() *config.Config {
+		cfg := testConfig()
+		f := false
+		cfg.InitContainers = []config.InitContainerSpec{
+			{Container: corev1.Container{Name: "preflight-dcgm-diag", Image: "dcgm:latest"}},
+			{Container: corev1.Container{Name: "preflight-nccl-loopback", Image: "nccl:latest"}},
+			{Container: corev1.Container{Name: "preflight-nccl-allreduce", Image: "nccl:latest"}, DefaultEnabled: &f},
+		}
+		return cfg
+	}
+
+	t.Run("no annotation uses defaultEnabled", func(t *testing.T) {
+		cfg := multiConfig()
+		injector := NewInjector(cfg, nil)
+		pod := gpuPod()
+
+		selected, err := injector.selectInitContainers(pod)
+		require.NoError(t, err)
+		assert.Len(t, selected, 2)
+		assert.Equal(t, "preflight-dcgm-diag", selected[0].Name)
+		assert.Equal(t, "preflight-nccl-loopback", selected[1].Name)
+	})
+
+	t.Run("annotation selects subset", func(t *testing.T) {
+		cfg := multiConfig()
+		injector := NewInjector(cfg, nil)
+		pod := gpuPod()
+		pod.Annotations = map[string]string{
+			PreflightChecksAnnotation: "preflight-dcgm-diag",
+		}
+
+		selected, err := injector.selectInitContainers(pod)
+		require.NoError(t, err)
+		require.Len(t, selected, 1)
+		assert.Equal(t, "preflight-dcgm-diag", selected[0].Name)
+	})
+
+	t.Run("annotation overrides defaultEnabled false", func(t *testing.T) {
+		cfg := multiConfig()
+		injector := NewInjector(cfg, nil)
+		pod := gpuPod()
+		pod.Annotations = map[string]string{
+			PreflightChecksAnnotation: "preflight-nccl-allreduce",
+		}
+
+		selected, err := injector.selectInitContainers(pod)
+		require.NoError(t, err)
+		require.Len(t, selected, 1)
+		assert.Equal(t, "preflight-nccl-allreduce", selected[0].Name)
+	})
+
+	t.Run("empty annotation disables all checks", func(t *testing.T) {
+		cfg := multiConfig()
+		injector := NewInjector(cfg, nil)
+		pod := gpuPod()
+		pod.Annotations = map[string]string{
+			PreflightChecksAnnotation: "",
+		}
+
+		selected, err := injector.selectInitContainers(pod)
+		require.NoError(t, err)
+		assert.Empty(t, selected)
+	})
+
+	t.Run("unknown check name rejects admission", func(t *testing.T) {
+		cfg := multiConfig()
+		injector := NewInjector(cfg, nil)
+		pod := gpuPod()
+		pod.Annotations = map[string]string{
+			PreflightChecksAnnotation: "preflight-dcgm-diag,bogus-check",
+		}
+
+		_, err := injector.selectInitContainers(pod)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bogus-check")
+		assert.Contains(t, err.Error(), "unknown checks")
+	})
+
+	t.Run("unknown check name lists configured checks in error", func(t *testing.T) {
+		cfg := multiConfig()
+		injector := NewInjector(cfg, nil)
+		pod := gpuPod()
+		pod.Annotations = map[string]string{
+			PreflightChecksAnnotation: "typo-check",
+		}
+
+		_, err := injector.selectInitContainers(pod)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "preflight-dcgm-diag")
+		assert.Contains(t, err.Error(), "preflight-nccl-loopback")
+		assert.Contains(t, err.Error(), "preflight-nccl-allreduce")
+	})
+}
+
+func TestParseCheckNames(t *testing.T) {
+	t.Run("sorts and deduplicates", func(t *testing.T) {
+		names := ParseCheckNames("b, a, b, c")
+		assert.Equal(t, []string{"a", "b", "c"}, names)
+	})
+
+	t.Run("empty string returns empty", func(t *testing.T) {
+		names := ParseCheckNames("")
+		assert.Empty(t, names)
+	})
+
+	t.Run("whitespace only returns empty", func(t *testing.T) {
+		names := ParseCheckNames("  ,  , ")
+		assert.Empty(t, names)
+	})
+}
+
 // TestInjectVolumes covers volume patch generation: nvsentinel socket,
 // gang ConfigMap (optional), /dev/shm, NCCL topology, extra hostPaths,
 // and dedup against existing pod volumes.

--- a/preflight/pkg/webhook/injector_test.go
+++ b/preflight/pkg/webhook/injector_test.go
@@ -142,8 +142,6 @@ func TestFindMaxResources_NoGPU_ReturnsNil(t *testing.T) {
 	assert.Nil(t, injector.findMaxResources(pod))
 }
 
-
-
 // TestInjectInitContainers covers the main entry point: GPU detection,
 // gang context extraction, init container / volume patch generation,
 // and append-vs-create behavior for existing init containers and volumes.
@@ -156,6 +154,8 @@ func TestInjectInitContainers(t *testing.T) {
 		expectPatches    bool
 		expectGangCtx    bool
 		expectGangID     string
+		expectCheckNames string
+		expectError      bool
 		validatePatches  func(t *testing.T, patches []PatchOperation)
 	}{
 		{
@@ -183,20 +183,20 @@ func TestInjectInitContainers(t *testing.T) {
 				assert.Len(t, containers, 1)
 				assert.Equal(t, "preflight-dcgm-diag", containers[0].Name)
 
-			// No gang volumes should be present (check both single-volume
-			// appends and the initial slice-valued /spec/volumes patch).
-			for _, p := range patches {
-				switch v := p.Value.(type) {
-				case corev1.Volume:
-					assert.NotEqual(t, types.GangConfigVolumeName, v.Name)
-					assert.NotEqual(t, dshmVolumeName, v.Name)
-				case []corev1.Volume:
-					for _, vol := range v {
-						assert.NotEqual(t, types.GangConfigVolumeName, vol.Name)
-						assert.NotEqual(t, dshmVolumeName, vol.Name)
+				// No gang volumes should be present (check both single-volume
+				// appends and the initial slice-valued /spec/volumes patch).
+				for _, p := range patches {
+					switch v := p.Value.(type) {
+					case corev1.Volume:
+						assert.NotEqual(t, types.GangConfigVolumeName, v.Name)
+						assert.NotEqual(t, dshmVolumeName, v.Name)
+					case []corev1.Volume:
+						for _, vol := range v {
+							assert.NotEqual(t, types.GangConfigVolumeName, vol.Name)
+							assert.NotEqual(t, dshmVolumeName, vol.Name)
+						}
 					}
 				}
-			}
 			},
 		},
 		{
@@ -208,10 +208,10 @@ func TestInjectInitContainers(t *testing.T) {
 			expectGangCtx: false,
 		},
 		{
-			name:       "GPU pod with gang enabled and is gang member",
-			cfg:        testGangConfig(),
-			discoverer: &mockDiscoverer{name: "volcano", canHandle: true, gangID: "volcano-default-pg1"},
-			pod:        gpuEFAPod(),
+			name:          "GPU pod with gang enabled and is gang member",
+			cfg:           testGangConfig(),
+			discoverer:    &mockDiscoverer{name: "volcano", canHandle: true, gangID: "volcano-default-pg1"},
+			pod:           gpuEFAPod(),
 			expectPatches: true,
 			expectGangCtx: true,
 			expectGangID:  "volcano-default-pg1",
@@ -235,10 +235,10 @@ func TestInjectInitContainers(t *testing.T) {
 			},
 		},
 		{
-			name: "GPU pod with gang enabled but nil discoverer",
-			cfg:  testGangConfig(),
-			discoverer: nil,
-			pod:        gpuPod(),
+			name:          "GPU pod with gang enabled but nil discoverer",
+			cfg:           testGangConfig(),
+			discoverer:    nil,
+			pod:           gpuPod(),
 			expectPatches: true,
 			expectGangCtx: false,
 		},
@@ -335,8 +335,8 @@ func TestInjectInitContainers(t *testing.T) {
 			},
 		},
 		{
-			name: "existing volumes are not duplicated",
-			cfg:  testGangConfig(),
+			name:       "existing volumes are not duplicated",
+			cfg:        testGangConfig(),
 			discoverer: &mockDiscoverer{name: "test", canHandle: true, gangID: "test-gang"},
 			pod: func() *corev1.Pod {
 				p := gpuPod()
@@ -387,6 +387,76 @@ func TestInjectInitContainers(t *testing.T) {
 				assert.Equal(t, "add", p.Op)
 			},
 		},
+		{
+			name: "annotation selects subset and populates GangContext.CheckNames",
+			cfg: func() *config.Config {
+				cfg := testGangConfig()
+				cfg.InitContainers = []config.InitContainerSpec{
+					{Container: corev1.Container{Name: "preflight-dcgm-diag", Image: "dcgm:latest"}},
+					{Container: corev1.Container{Name: "preflight-nccl-loopback", Image: "nccl:latest"}},
+					{Container: corev1.Container{Name: "preflight-nccl-allreduce", Image: "nccl:latest"}},
+				}
+				return cfg
+			}(),
+			discoverer: &mockDiscoverer{name: "test", canHandle: true, gangID: "test-gang"},
+			pod: func() *corev1.Pod {
+				p := gpuPod()
+				p.Annotations = map[string]string{
+					PreflightChecksAnnotation: "preflight-nccl-allreduce,preflight-dcgm-diag",
+				}
+				return p
+			}(),
+			expectPatches:    true,
+			expectGangCtx:    true,
+			expectGangID:     "test-gang",
+			expectCheckNames: "preflight-dcgm-diag,preflight-nccl-allreduce",
+		},
+		{
+			name:       "empty annotation with gang returns empty CheckNames",
+			cfg:        testGangConfig(),
+			discoverer: &mockDiscoverer{name: "test", canHandle: true, gangID: "test-gang"},
+			pod: func() *corev1.Pod {
+				p := gpuPod()
+				p.Annotations = map[string]string{
+					PreflightChecksAnnotation: "",
+				}
+				return p
+			}(),
+			expectPatches: false,
+			expectGangCtx: true,
+			expectGangID:  "test-gang",
+		},
+		{
+			name: "no annotation populates CheckNames from defaultEnabled",
+			cfg: func() *config.Config {
+				cfg := testGangConfig()
+				f := false
+				cfg.InitContainers = []config.InitContainerSpec{
+					{Container: corev1.Container{Name: "preflight-dcgm-diag", Image: "dcgm:latest"}},
+					{Container: corev1.Container{Name: "preflight-nccl-allreduce", Image: "nccl:latest"}, DefaultEnabled: &f},
+				}
+				return cfg
+			}(),
+			discoverer:       &mockDiscoverer{name: "test", canHandle: true, gangID: "test-gang"},
+			pod:              gpuPod(),
+			expectPatches:    true,
+			expectGangCtx:    true,
+			expectGangID:     "test-gang",
+			expectCheckNames: "preflight-dcgm-diag",
+		},
+		{
+			name: "unknown check name returns error",
+			cfg:  testConfig(),
+			pod: func() *corev1.Pod {
+				p := gpuPod()
+				p.Annotations = map[string]string{
+					PreflightChecksAnnotation: "preflight-dcgm-diag,nonexistent",
+				}
+				return p
+			}(),
+			expectPatches: false,
+			expectError:   true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -398,6 +468,10 @@ func TestInjectInitContainers(t *testing.T) {
 			injector := NewInjector(tt.cfg, disc)
 
 			patches, gangCtx, err := injector.InjectInitContainers(tt.pod)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 
 			if tt.expectPatches {
@@ -411,6 +485,9 @@ func TestInjectInitContainers(t *testing.T) {
 				if tt.expectGangID != "" {
 					assert.Equal(t, tt.expectGangID, gangCtx.GangID)
 					assert.NotEmpty(t, gangCtx.ConfigMapName)
+				}
+				if tt.expectCheckNames != "" {
+					assert.Equal(t, tt.expectCheckNames, gangCtx.CheckNames)
 				}
 			} else {
 				assert.Nil(t, gangCtx)
@@ -774,6 +851,33 @@ func TestSelectInitContainers(t *testing.T) {
 		assert.Contains(t, err.Error(), "unknown checks")
 	})
 
+	t.Run("annotation with spaces and trailing commas", func(t *testing.T) {
+		cfg := multiConfig()
+		injector := NewInjector(cfg, nil)
+		pod := gpuPod()
+		pod.Annotations = map[string]string{
+			PreflightChecksAnnotation: " , preflight-dcgm-diag , preflight-nccl-loopback , ",
+		}
+
+		selected, err := injector.selectInitContainers(pod)
+		require.NoError(t, err)
+		assert.Len(t, selected, 2)
+	})
+
+	t.Run("annotation with duplicates selects each once", func(t *testing.T) {
+		cfg := multiConfig()
+		injector := NewInjector(cfg, nil)
+		pod := gpuPod()
+		pod.Annotations = map[string]string{
+			PreflightChecksAnnotation: "preflight-dcgm-diag,preflight-dcgm-diag,preflight-dcgm-diag",
+		}
+
+		selected, err := injector.selectInitContainers(pod)
+		require.NoError(t, err)
+		require.Len(t, selected, 1)
+		assert.Equal(t, "preflight-dcgm-diag", selected[0].Name)
+	})
+
 	t.Run("unknown check name lists configured checks in error", func(t *testing.T) {
 		cfg := multiConfig()
 		injector := NewInjector(cfg, nil)
@@ -957,7 +1061,6 @@ func findEnv(envs []corev1.EnvVar, name string) string {
 	return ""
 }
 
-
 type mockDiscoverer struct {
 	name      string
 	canHandle bool
@@ -995,11 +1098,11 @@ func testConfig() *config.Config {
 func testGangConfig() *config.Config {
 	cfg := testConfig()
 	cfg.GangCoordination = config.GangCoordinationConfig{
-		Enabled:            true,
-		Timeout:            "10m",
-		TimeoutDuration:    10 * time.Minute,
-		MasterPort:         29500,
-		ConfigMapMountPath: "/etc/preflight",
+		Enabled:              true,
+		Timeout:              "10m",
+		TimeoutDuration:      10 * time.Minute,
+		MasterPort:           29500,
+		ConfigMapMountPath:   "/etc/preflight",
 		MirrorResourceClaims: boolPtr(true),
 	}
 	return cfg

--- a/preflight/pkg/webhook/injector_test.go
+++ b/preflight/pkg/webhook/injector_test.go
@@ -409,7 +409,7 @@ func TestInjectInitContainers(t *testing.T) {
 			expectPatches:    true,
 			expectGangCtx:    true,
 			expectGangID:     "test-gang",
-			expectCheckNames: "preflight-dcgm-diag,preflight-nccl-allreduce",
+			expectCheckNames: "preflight-nccl-allreduce,preflight-dcgm-diag",
 		},
 		{
 			name:       "empty annotation with gang returns empty CheckNames",
@@ -851,10 +851,11 @@ func TestSelectInitContainers(t *testing.T) {
 		assert.Contains(t, err.Error(), "unknown checks")
 	})
 
-	t.Run("annotation preserves configured order not annotation order", func(t *testing.T) {
+	t.Run("annotation order controls injection order", func(t *testing.T) {
 		cfg := multiConfig()
 		injector := NewInjector(cfg, nil)
 		pod := gpuPod()
+		// Reverse of chart order — should inject in annotation order.
 		pod.Annotations = map[string]string{
 			PreflightChecksAnnotation: "preflight-nccl-loopback,preflight-dcgm-diag",
 		}
@@ -862,8 +863,8 @@ func TestSelectInitContainers(t *testing.T) {
 		selected, err := injector.selectInitContainers(pod)
 		require.NoError(t, err)
 		require.Len(t, selected, 2)
-		assert.Equal(t, "preflight-dcgm-diag", selected[0].Name)
-		assert.Equal(t, "preflight-nccl-loopback", selected[1].Name)
+		assert.Equal(t, "preflight-nccl-loopback", selected[0].Name)
+		assert.Equal(t, "preflight-dcgm-diag", selected[1].Name)
 	})
 
 	t.Run("comma-only annotation disables all checks", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Per-pod preflight check selection via annotation, with gang-level consistency validation.

Pods select which checks to run by annotating with a comma-separated list of init container names:

```yaml
metadata:
  annotations:
    nvsentinel.nvidia.com/preflight-checks: "preflight-dcgm-diag,preflight-nccl-loopback"
```

- **Annotation present** — only named checks are injected. Empty value disables all checks.
- **Annotation absent** — all checks with `defaultEnabled: true` (default when omitted) are injected. Same as current behavior.
- **Gang validation** — all pods in a gang must have the same check list. Mismatches fail fast before torchrun, preventing distributed deadlocks.

## Changes

- **`config.go`**: `InitContainerSpec` wrapping `corev1.Container` with `DefaultEnabled *bool`
- **`injector.go`**: `selectInitContainers()` reads annotation or uses `defaultEnabled`; `ParseCheckNames()` normalizes (sort, dedup); `GangContext.CheckNames` for peer line
- **`coordinator.go`**: 4-field peer line `"podName;podIP;rank;checkNames"` with backward compat
- **`gang_controller.go`**: reads annotation, normalizes, sets `peer.CheckNames`
- **`gang.py`**: `PeerInfo.check_names`, `GangConfig.validate_peers()` fails fast on mismatch
- **`entrypoint.py`**: calls `validate_peers()` before torchrun
- **`docs/designs/034-preflight-check-selection.md`**: ADR for this feature
- **`docs/configuration/preflight.md`**: user-facing docs for per-pod check selection

## Test plan

- [x] Go build passes (`go build ./...`)
- [x] Go unit tests pass — config, coordinator, webhook, gang packages
- [x] Python unit tests pass — 18/18 including 9 new tests for peer format parsing and validation
- [x] Manual: deploy with annotation, verify only named checks injected
- [x] Manual: empty annotation, verify no checks injected
- [x] Manual: gang with mismatched annotations, verify fail-fast error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-pod annotation nvsentinel.nvidia.com/preflight-checks to pick which preflight init containers are injected (annotation order preserved; empty value disables all checks). Annotation overrides per-container default-enabled (default true).
  * Gang-level propagation of selected checks and pre-launch validation that all peers share identical check lists; mismatches fail early.

* **Documentation**
  * Added docs and ADR describing annotation semantics and default-enabled behavior.

* **Tests**
  * Expanded coverage for parsing, selection, injection, validation, and config validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->