### PR TITLE
refactor: inline DCGM config into init container (ADR-035)

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/_helpers.tpl
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/_helpers.tpl
@@ -91,46 +91,10 @@ Certificate DNS names
 {{- end }}
 
 {{/*
-DCGM service endpoint - uses global.dcgm.service.endpoint with fallback to local
-*/}}
-{{- define "preflight.dcgmEndpoint" -}}
-{{- if and .Values.global .Values.global.dcgm .Values.global.dcgm.service }}
-{{- .Values.global.dcgm.service.endpoint | default .Values.dcgm.service.endpoint }}
-{{- else }}
-{{- .Values.dcgm.service.endpoint }}
-{{- end }}
-{{- end }}
-
-{{/*
-DCGM service port - uses global.dcgm.service.port with fallback to local
-*/}}
-{{- define "preflight.dcgmPort" -}}
-{{- if and .Values.global .Values.global.dcgm .Values.global.dcgm.service }}
-{{- .Values.global.dcgm.service.port | default .Values.dcgm.service.port }}
-{{- else }}
-{{- .Values.dcgm.service.port }}
-{{- end }}
-{{- end }}
-
-{{/*
-DCGM hostengine address - combines endpoint and port
-*/}}
-{{- define "preflight.dcgmHostengineAddr" -}}
-{{- printf "%s:%v" (include "preflight.dcgmEndpoint" .) (include "preflight.dcgmPort" .) }}
-{{- end }}
-
-{{/*
-DCGM diagnostic level
-*/}}
-{{- define "preflight.dcgmDiagLevel" -}}
-{{- .Values.dcgm.diagLevel | default 1 }}
-{{- end }}
-
-{{/*
 Event processing strategy
 */}}
 {{- define "preflight.processingStrategy" -}}
-{{- .Values.dcgm.processingStrategy | default "EXECUTE_REMEDIATION" }}
+{{- .Values.processingStrategy | default "EXECUTE_REMEDIATION" }}
 {{- end }}
 
 {{/*

--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/configmap.yaml
@@ -33,11 +33,8 @@ data:
     volumeMountPatterns:
       {{- toYaml .Values.volumeMountPatterns | nindent 6 }}
     {{- end }}
-    dcgm:
-      hostengineAddr: {{ include "preflight.dcgmHostengineAddr" . | quote }}
-      diagLevel: {{ include "preflight.dcgmDiagLevel" . }}
-      connectorSocket: {{ include "preflight.connectorSocket" . | quote }}
-      processingStrategy: {{ include "preflight.processingStrategy" . | quote }}
+    connectorSocket: {{ include "preflight.connectorSocket" . | quote }}
+    processingStrategy: {{ include "preflight.processingStrategy" . | quote }}
     gangDiscovery:
       {{- toYaml .Values.gangDiscovery | nindent 6 }}
     gangCoordination:

--- a/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
@@ -85,30 +85,8 @@ webhook:
   # certProvider: openshift-service-ca
   certProvider: cert-manager
 
-# DCGM config block (legacy — prefer inline env vars on the init container).
-#
-# New deployments should define DCGM_HOSTENGINE_ADDR and DCGM_DIAG_LEVEL as
-# env vars directly on the preflight-dcgm-diag container in initContainers
-# below. This matches how NCCL checks are configured and avoids split-brain
-# config between this block and the container spec. Inline env vars take
-# precedence over values injected from this block.
-#
-# See ADR-035 (docs/designs/035-preflight-inline-dcgm-config.md) for details.
-#
-# connectorSocket and processingStrategy are global preflight config and will
-# move to top-level keys in a future release.
-dcgm:
-  service:
-    endpoint: "nvidia-dcgm.gpu-operator.svc"
-    port: 5555
-  # Diagnostic level (maps to dcgmi diag -r <level>):
-  #   1 = Short  (~30 s)   - software deployment checks only (permissions, libraries, etc.)
-  #   2 = Medium (~2 min)  - adds PCIe bandwidth and basic GPU stress tests
-  #   3 = Long   (~15 min) - adds targeted stress (Diagnostic plugin, default 180 s per GPU)
-  #   4 = XLong  (~1-2 hr) - extended stress with longer Diagnostic plugin duration
-  diagLevel: 2
-  # Event processing strategy: EXECUTE_REMEDIATION or STORE_ONLY
-  processingStrategy: "EXECUTE_REMEDIATION"
+# Event processing strategy: EXECUTE_REMEDIATION or STORE_ONLY
+processingStrategy: "EXECUTE_REMEDIATION"
 
 # Controls where preflight init containers are placed relative to existing
 # init containers in the pod spec.
@@ -132,13 +110,16 @@ initContainers:
     image:
       repository: ghcr.io/nvidia/nvsentinel/preflight-dcgm-diag
       tag: ""
-    # Preferred: define DCGM config as inline env vars here instead of in the
-    # dcgm: block above. These take precedence over webhook-injected values.
-    # env:
-    #   - name: DCGM_HOSTENGINE_ADDR
-    #     value: "nvidia-dcgm.gpu-operator.svc:5555"
-    #   - name: DCGM_DIAG_LEVEL
-    #     value: "2"
+    env:
+      - name: DCGM_HOSTENGINE_ADDR
+        value: "nvidia-dcgm.gpu-operator.svc:5555"
+      # Diagnostic level (maps to dcgmi diag -r <level>):
+      #   1 = Short  (~30 s)   - software deployment checks only
+      #   2 = Medium (~2 min)  - adds PCIe bandwidth and basic GPU stress tests
+      #   3 = Long   (~15 min) - adds targeted stress (Diagnostic plugin)
+      #   4 = XLong  (~1-2 hr) - extended stress
+      - name: DCGM_DIAG_LEVEL
+        value: "2"
     volumeMounts:
       - name: nvsentinel-socket
         mountPath: /var/run

--- a/distros/kubernetes/nvsentinel/values-full.yaml
+++ b/distros/kubernetes/nvsentinel/values-full.yaml
@@ -1561,28 +1561,6 @@ preflight:
     certProvider: cert-manager
 
   ##############################################################################
-  # DCGM CONFIGURATION
-  #
-  # Shared by the preflight-dcgm-diag init container.
-  # global.dcgm takes precedence when set.
-  ##############################################################################
-  dcgm:
-    service:
-      # DCGM hostengine gRPC endpoint
-      endpoint: "nvidia-dcgm.gpu-operator.svc"
-      port: 5555
-    # Diagnostic level (maps to dcgmi diag -r <level>):
-    #   1 = Short  (~30 s)   - software deployment checks only (permissions, libraries, etc.)
-    #   2 = Medium (~2 min)  - adds PCIe bandwidth and basic GPU stress tests
-    #   3 = Long   (~15 min) - adds targeted stress (Diagnostic plugin, default 180 s per GPU)
-    #   4 = XLong  (~1-2 hr) - extended stress with longer Diagnostic plugin duration
-    diagLevel: 2
-    # How downstream modules handle the health event:
-    #   EXECUTE_REMEDIATION - trigger quarantine/drain/remediation pipeline
-    #   STORE_ONLY          - persist the event without acting on it
-    processingStrategy: "EXECUTE_REMEDIATION"
-
-  ##############################################################################
   # INIT CONTAINERS (PREFLIGHT CHECKS)
   #
   # Each entry becomes an init container injected into GPU pods.
@@ -1591,15 +1569,14 @@ preflight:
   #
   # The webhook automatically injects these env vars on every init container:
   #   NODE_NAME, PLATFORM_CONNECTOR_SOCKET, PROCESSING_STRATEGY
-  # And for the dcgm-diag container:
-  #   DCGM_DIAG_LEVEL, DCGM_HOSTENGINE_ADDR
   # And for gang-aware containers:
   #   GANG_ID, GANG_CONFIG_DIR, GANG_TIMEOUT_SECONDS, POD_NAME
   ##############################################################################
   initContainers:
     # DCGM diagnostic - runs DCGM diag against allocated GPUs
-    # Env: DCGM_DIAG_LEVEL (1-4, set from dcgm.diagLevel above),
-    #       DCGM_HOSTENGINE_ADDR (set from dcgm.service above)
+    # Env vars:
+    #   DCGM_DIAG_LEVEL       - diagnostic depth 1-4 (default 2)
+    #   DCGM_HOSTENGINE_ADDR  - hostengine gRPC endpoint (default nvidia-dcgm.gpu-operator.svc:5555)
     - name: preflight-dcgm-diag
       image: ghcr.io/nvidia/nvsentinel/preflight-dcgm-diag:latest
       volumeMounts:

--- a/distros/kubernetes/nvsentinel/values-tilt.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt.yaml
@@ -102,8 +102,6 @@ global:
   metricsPort: 2112
 
 # Preflight subchart: use Tilt fake DCGM (nvidia-dcgm.gpu-operator.svc) and quick diag for faster E2E pass.
-# global.dcgm already points to nvidia-dcgm.gpu-operator.svc:5555; override diagLevel so dcgm-diag init runs
-# the quick test and returns Pass (fake DCGM returns Pass for dcgmi diag -r 4).
 # Init containers (name, image, volumeMounts, env) are declared in charts/preflight/values.yaml; here we
 # override to only inject preflight-dcgm-diag for Tilt (NCCL inits need real GPUs and would fail/hang).
 preflight:
@@ -117,8 +115,6 @@ preflight:
       version: "v2alpha2"
       resource: "podgroups"
     minCountExpr: "podGroup.spec.minMember"
-  dcgm:
-    diagLevel: 3
   initContainers:
     - name: preflight-dcgm-diag
       image:

--- a/distros/kubernetes/nvsentinel/values.yaml
+++ b/distros/kubernetes/nvsentinel/values.yaml
@@ -106,7 +106,7 @@ global:
   metadataPath: /var/lib/nvsentinel/gpu_metadata.json
 
   # DCGM (Data Center GPU Manager) configuration
-  # Shared by gpu-health-monitor and preflight dcgm-diag
+  # Used by gpu-health-monitor
   dcgm:
     # Enable DCGM Kubernetes service integration
     enabled: true

--- a/docs/configuration/preflight.md
+++ b/docs/configuration/preflight.md
@@ -90,7 +90,7 @@ Runs DCGM diagnostics against every GPU allocated to the pod via the remote host
 | `DCGM_DIAG_LEVEL` | `2` | Diagnostic depth: 1 = short (approx 30 s, software deployment checks), 2 = medium (approx 2 min, adds PCIe and basic GPU stress), 3 = long (approx 15 min, adds Diagnostic plugin stress), 4 = xlong (1-2 hr, extended stress) |
 | `DCGM_HOSTENGINE_ADDR` | `nvidia-dcgm.gpu-operator.svc:5555` | DCGM hostengine gRPC endpoint |
 
-DCGM settings are defined as env vars directly on the `preflight-dcgm-diag` container in `initContainers`, consistent with how all other checks are configured:
+Example values override:
 
 ```yaml
 initContainers:
@@ -107,8 +107,6 @@ initContainers:
       - name: nvsentinel-socket
         mountPath: /var/run
 ```
-
-> **Migrating from the legacy `dcgm:` block?** The separate `dcgm:` config block was removed in the ADR-035 refactor. Move `dcgm.service.endpoint` and `dcgm.service.port` into `DCGM_HOSTENGINE_ADDR` (as `host:port`), `dcgm.diagLevel` into `DCGM_DIAG_LEVEL`, and `dcgm.processingStrategy` into the top-level `processingStrategy`. See [ADR-035](../designs/035-preflight-inline-dcgm-config.md) for details.
 
 ### preflight-nccl-loopback
 
@@ -347,7 +345,7 @@ Tilt development often trims init containers to DCGM-only; see `distros/kubernet
 ## Related documentation
 
 - [ADR-026: Preflight checks](../designs/026-preflight-checks.md)
-- [ADR-035: Inline DCGM config](../designs/035-preflight-inline-dcgm-config.md) — removal of the legacy `dcgm:` block in favor of inline env vars
+- [ADR-035: Inline DCGM config](../designs/035-preflight-inline-dcgm-config.md) — design rationale for inline env var configuration
 - [gRPC / TLS authentication](../designs/030-grpc-tls-authentication.md) (mentions preflight among webhooks)
 - [Helm chart README](../../distros/kubernetes/README.md)
 - E2E test entry point: `tests/preflight_test.go` (build tag `amd64_group`)

--- a/docs/configuration/preflight.md
+++ b/docs/configuration/preflight.md
@@ -8,7 +8,7 @@ For architecture, tradeoffs, and metrics design, see [ADR-026: Preflight checks]
 
 - Helm subchart is off by default; enable with `global.preflight.enabled` (see below).
 - cert-manager (or OpenShift service CA) for webhook TLS—same expectation as the rest of the NVSentinel chart.
-- DCGM reachable from injected init containers (typically the NVIDIA GPU Operator's DCGM / hostengine service). The chart shares DCGM settings with the GPU health monitor where applicable (`global.dcgm`).
+- DCGM reachable from injected init containers (typically the NVIDIA GPU Operator's DCGM / hostengine service). Configure the endpoint via `DCGM_HOSTENGINE_ADDR` on the `preflight-dcgm-diag` init container.
 - Multi-node / gang checks (e.g. `preflight-nccl-allreduce`): enable gang coordination and configure gang discovery for your scheduler (see below).
 
 ## Enable preflight
@@ -21,7 +21,7 @@ global:
     enabled: true
 ```
 
-2. Configure the preflight subchart under the top-level `preflight:` key (values merge into `distros/kubernetes/nvsentinel/charts/preflight/values.yaml`). At minimum, review `initContainers`, `webhook.failurePolicy`, and DCGM connectivity.
+2. Configure the preflight subchart under the top-level `preflight:` key (values merge into `distros/kubernetes/nvsentinel/charts/preflight/values.yaml`). At minimum, review `initContainers` (including DCGM and NCCL env vars) and `webhook.failurePolicy`.
 
 3. Label namespaces where injection should apply:
 
@@ -76,8 +76,8 @@ The webhook automatically injects these env vars into every init container (you 
 | Env var | Source | Purpose |
 |---------|--------|---------|
 | `NODE_NAME` | Downward API (`spec.nodeName`) | Kubernetes node name for health events |
-| `PLATFORM_CONNECTOR_SOCKET` | Chart `connectorSocket` (legacy: `dcgm.connectorSocket`) | Unix socket for the platform-connector gRPC endpoint |
-| `PROCESSING_STRATEGY` | Chart `processingStrategy` (legacy: `dcgm.processingStrategy`) | `EXECUTE_REMEDIATION` or `STORE_ONLY` — controls downstream action |
+| `PLATFORM_CONNECTOR_SOCKET` | Chart `connectorSocket` | Unix socket for the platform-connector gRPC endpoint |
+| `PROCESSING_STRATEGY` | Chart `processingStrategy` | `EXECUTE_REMEDIATION` or `STORE_ONLY` — controls downstream action |
 
 For gang-aware containers the webhook also injects `GANG_ID`, `GANG_CONFIG_DIR`, `GANG_TIMEOUT_SECONDS`, and `POD_NAME`.
 
@@ -90,9 +90,7 @@ Runs DCGM diagnostics against every GPU allocated to the pod via the remote host
 | `DCGM_DIAG_LEVEL` | `2` | Diagnostic depth: 1 = short (approx 30 s, software deployment checks), 2 = medium (approx 2 min, adds PCIe and basic GPU stress), 3 = long (approx 15 min, adds Diagnostic plugin stress), 4 = xlong (1-2 hr, extended stress) |
 | `DCGM_HOSTENGINE_ADDR` | `nvidia-dcgm.gpu-operator.svc:5555` | DCGM hostengine gRPC endpoint |
 
-#### Preferred: inline env vars on the init container
-
-Define DCGM settings as env vars directly on the `preflight-dcgm-diag` container in `initContainers`. This is consistent with how NCCL checks are configured and keeps all per-check config in one place:
+DCGM settings are defined as env vars directly on the `preflight-dcgm-diag` container in `initContainers`, consistent with how all other checks are configured:
 
 ```yaml
 initContainers:
@@ -110,21 +108,7 @@ initContainers:
         mountPath: /var/run
 ```
 
-When env vars are defined on the container, they take precedence over values injected from the `dcgm:` block (via `mergeEnvVars`). You can leave the `dcgm:` block empty or at defaults.
-
-#### Legacy: chart-level `dcgm:` block
-
-The `dcgm:` block still works but is not recommended for new deployments. It splits DCGM config across two locations (the `dcgm:` block and the `initContainers` list), and the webhook bridges them by matching the hardcoded container name `"preflight-dcgm-diag"`. See [ADR-035](../designs/035-preflight-inline-dcgm-config.md) for background on why inline config is preferred.
-
-```yaml
-# Legacy approach — prefer inline env vars above
-dcgm:
-  service:
-    endpoint: "nvidia-dcgm.gpu-operator.svc"
-    port: 5555
-  diagLevel: 2
-  processingStrategy: "EXECUTE_REMEDIATION"
-```
+> **Migrating from the legacy `dcgm:` block?** The separate `dcgm:` config block was removed in the ADR-035 refactor. Move `dcgm.service.endpoint` and `dcgm.service.port` into `DCGM_HOSTENGINE_ADDR` (as `host:port`), `dcgm.diagLevel` into `DCGM_DIAG_LEVEL`, and `dcgm.processingStrategy` into the top-level `processingStrategy`. See [ADR-035](../designs/035-preflight-inline-dcgm-config.md) for details.
 
 ### preflight-nccl-loopback
 
@@ -363,7 +347,7 @@ Tilt development often trims init containers to DCGM-only; see `distros/kubernet
 ## Related documentation
 
 - [ADR-026: Preflight checks](../designs/026-preflight-checks.md)
-- [ADR-035: Inline DCGM config](../designs/035-preflight-inline-dcgm-config.md) — why inline env vars are preferred over the `dcgm:` block
+- [ADR-035: Inline DCGM config](../designs/035-preflight-inline-dcgm-config.md) — removal of the legacy `dcgm:` block in favor of inline env vars
 - [gRPC / TLS authentication](../designs/030-grpc-tls-authentication.md) (mentions preflight among webhooks)
 - [Helm chart README](../../distros/kubernetes/README.md)
 - E2E test entry point: `tests/preflight_test.go` (build tag `amd64_group`)

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -62,8 +62,7 @@ Key configuration areas:
 
 | Area | Description |
 |------|-------------|
-| `preflight.initContainers` | Which checks to inject, their images, env vars, and resource limits. **Preferred** location for DCGM config — define `DCGM_HOSTENGINE_ADDR` and `DCGM_DIAG_LEVEL` as env vars directly on the `preflight-dcgm-diag` container |
-| `preflight.dcgm` | DCGM hostengine endpoint, diagnostic level, processing strategy. Legacy — prefer inline env vars on the init container instead (see [ADR-035](./designs/035-preflight-inline-dcgm-config.md)) |
+| `preflight.initContainers` | Which checks to inject, their images, env vars, and resource limits. DCGM config (`DCGM_HOSTENGINE_ADDR`, `DCGM_DIAG_LEVEL`) is defined as env vars on the `preflight-dcgm-diag` container |
 | `preflight.gangDiscovery` | Scheduler-specific gang identification (Volcano, Run:ai, native K8s) |
 | `preflight.gangCoordination` | Multi-node coordination timeouts, NCCL topology, extra mounts |
 | `preflight.webhook` | TLS, failure policy, cert provider |
@@ -76,5 +75,5 @@ For detailed configuration including per-check env vars, fabric-specific NCCL se
 
 - [Preflight configuration guide](./configuration/preflight.md) — full Helm values reference
 - [ADR-026: Preflight checks](./designs/026-preflight-checks.md) — architecture and design rationale
-- [ADR-035: Inline DCGM config](./designs/035-preflight-inline-dcgm-config.md) — why inline env vars are preferred over the `dcgm:` block
+- [ADR-035: Inline DCGM config](./designs/035-preflight-inline-dcgm-config.md) — design rationale for inline env var configuration
 - [GPU Health Monitor](./gpu-health-monitor.md) — continuous runtime GPU monitoring (complementary to preflight)

--- a/preflight/pkg/config/config.go
+++ b/preflight/pkg/config/config.go
@@ -60,14 +60,14 @@ func (s *InitContainerSpec) IsDefaultEnabled() bool {
 }
 
 type FileConfig struct {
-	InitContainers       []InitContainerSpec    `yaml:"initContainers"`
-	GPUResourceNames     []string               `yaml:"gpuResourceNames"`
-	NetworkResourceNames []string               `yaml:"networkResourceNames"`
-	ConnectorSocket    string `yaml:"connectorSocket"`
-	ProcessingStrategy string `yaml:"processingStrategy"`
+	InitContainers       []InitContainerSpec `yaml:"initContainers"`
+	GPUResourceNames     []string            `yaml:"gpuResourceNames"`
+	NetworkResourceNames []string            `yaml:"networkResourceNames"`
+	ConnectorSocket      string              `yaml:"connectorSocket"`
+	ProcessingStrategy   string              `yaml:"processingStrategy"`
 
-	GangDiscovery GangDiscoveryConfig `yaml:"gangDiscovery"`
-	GangCoordination     GangCoordinationConfig `yaml:"gangCoordination"`
+	GangDiscovery    GangDiscoveryConfig    `yaml:"gangDiscovery"`
+	GangCoordination GangCoordinationConfig `yaml:"gangCoordination"`
 
 	// InitContainerPlacement controls where preflight init containers are
 	// placed relative to existing init containers in the pod spec.

--- a/preflight/pkg/config/config.go
+++ b/preflight/pkg/config/config.go
@@ -63,8 +63,10 @@ type FileConfig struct {
 	InitContainers       []InitContainerSpec    `yaml:"initContainers"`
 	GPUResourceNames     []string               `yaml:"gpuResourceNames"`
 	NetworkResourceNames []string               `yaml:"networkResourceNames"`
-	DCGM                 DCGMConfig             `yaml:"dcgm"`
-	GangDiscovery        GangDiscoveryConfig    `yaml:"gangDiscovery"`
+	ConnectorSocket    string `yaml:"connectorSocket"`
+	ProcessingStrategy string `yaml:"processingStrategy"`
+
+	GangDiscovery GangDiscoveryConfig `yaml:"gangDiscovery"`
 	GangCoordination     GangCoordinationConfig `yaml:"gangCoordination"`
 
 	// InitContainerPlacement controls where preflight init containers are
@@ -83,22 +85,6 @@ type FileConfig struct {
 	// This allows the init container to inherit fabric-specific mounts
 	// (e.g. host EFA libs, TCPXO plugin volumes) from the user's container.
 	VolumeMountPatterns []string `yaml:"volumeMountPatterns,omitempty"`
-}
-
-// DCGMConfig holds DCGM-specific and (legacy) global preflight config.
-//
-// Prefer defining HostengineAddr and DiagLevel as inline env vars on the
-// preflight-dcgm-diag init container in values.yaml instead of using this
-// config block. Inline env vars take precedence via mergeEnvVars.
-//
-// ConnectorSocket and ProcessingStrategy are global preflight config that
-// apply to all init containers — they are incorrectly scoped here and will
-// move to a top-level struct (see ADR-035).
-type DCGMConfig struct {
-	HostengineAddr     string `yaml:"hostengineAddr"`
-	DiagLevel          int    `yaml:"diagLevel"`
-	ConnectorSocket    string `yaml:"connectorSocket"`
-	ProcessingStrategy string `yaml:"processingStrategy"`
 }
 
 // GangDiscoveryConfig configures gang discovery for PodGroup-based schedulers.
@@ -248,18 +234,11 @@ func (c *FileConfig) setDefaults() {
 		c.InitContainerPlacement = PlacementAppend
 	}
 
-	c.DCGM.setDefaults()
-	c.GangCoordination.setDefaults()
-}
-
-func (c *DCGMConfig) setDefaults() {
-	if c.DiagLevel == 0 {
-		c.DiagLevel = 1
-	}
-
 	if c.ProcessingStrategy == "" {
 		c.ProcessingStrategy = "EXECUTE_REMEDIATION"
 	}
+
+	c.GangCoordination.setDefaults()
 }
 
 func (c *GangCoordinationConfig) setDefaults() {

--- a/preflight/pkg/config/config_test.go
+++ b/preflight/pkg/config/config_test.go
@@ -32,7 +32,7 @@ func writeYAML(t *testing.T, content string) string {
 	return path
 }
 
-// TestLoad covers YAML parsing, default population (GPU resources, DCGM,
+// TestLoad covers YAML parsing, default population (GPU resources,
 // gang coordination), validation errors (bad timeout), file errors,
 // and extraHostPathMounts readOnly defaulting.
 func TestLoad(t *testing.T) {
@@ -46,8 +46,7 @@ initContainers:
 		require.NoError(t, err)
 
 		assert.Equal(t, []string{"nvidia.com/gpu"}, cfg.GPUResourceNames)
-		assert.Equal(t, 1, cfg.DCGM.DiagLevel)
-		assert.Equal(t, "EXECUTE_REMEDIATION", cfg.DCGM.ProcessingStrategy)
+		assert.Equal(t, "EXECUTE_REMEDIATION", cfg.ProcessingStrategy)
 		assert.Len(t, cfg.InitContainers, 1)
 		assert.Equal(t, "preflight-dcgm-diag", cfg.InitContainers[0].Name)
 	})

--- a/preflight/pkg/webhook/handler_test.go
+++ b/preflight/pkg/webhook/handler_test.go
@@ -59,11 +59,8 @@ func handlerConfig() *config.Config {
 				{Container: corev1.Container{Name: "preflight-dcgm-diag", Image: "dcgm:latest"}},
 			},
 			GPUResourceNames: []string{"nvidia.com/gpu"},
-			DCGM: config.DCGMConfig{
-				ConnectorSocket:    "/var/run/nvsentinel/nvsentinel.sock",
-				DiagLevel:          1,
-				ProcessingStrategy: "EXECUTE_REMEDIATION",
-			},
+			ConnectorSocket:    "/var/run/nvsentinel/nvsentinel.sock",
+			ProcessingStrategy: "EXECUTE_REMEDIATION",
 		},
 	}
 }

--- a/preflight/pkg/webhook/injector.go
+++ b/preflight/pkg/webhook/injector.go
@@ -362,7 +362,6 @@ func (i *Injector) buildInitContainers(
 		}
 
 		i.injectCommonEnv(container)
-		i.injectDCGMEnv(container)
 		i.injectGangEnv(container, gangCtx)
 
 		// Copy matching env vars from user containers (lower precedence
@@ -473,21 +472,17 @@ func (i *Injector) injectCommonEnv(container *corev1.Container) {
 		},
 	}
 
-	// NOTE: ConnectorSocket and ProcessingStrategy are global preflight config
-	// that is incorrectly scoped under DCGMConfig. These apply to all init
-	// containers, not just dcgm-diag. They will move to a top-level config
-	// struct when the dcgm: block is removed (see ADR-035).
-	if i.cfg.DCGM.ConnectorSocket != "" {
+	if i.cfg.ConnectorSocket != "" {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  "PLATFORM_CONNECTOR_SOCKET",
-			Value: i.cfg.DCGM.ConnectorSocket,
+			Value: i.cfg.ConnectorSocket,
 		})
 	}
 
-	if i.cfg.DCGM.ProcessingStrategy != "" {
+	if i.cfg.ProcessingStrategy != "" {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  "PROCESSING_STRATEGY",
-			Value: i.cfg.DCGM.ProcessingStrategy,
+			Value: i.cfg.ProcessingStrategy,
 		})
 	}
 
@@ -504,7 +499,7 @@ func (i *Injector) injectVolumes(pod *corev1.Pod, gangCtx *GangContext) []PatchO
 		existingVolumes[vol.Name] = true
 	}
 
-	if i.cfg.DCGM.ConnectorSocket != "" && !existingVolumes[nvsentinelSocketVolumeName] {
+	if i.cfg.ConnectorSocket != "" && !existingVolumes[nvsentinelSocketVolumeName] {
 		// Platform-connector mounts /var/run/nvsentinel (host) -> /var/run (container)
 		// and creates socket at /var/run/nvsentinel.sock inside its container.
 		// This is the same hostPath used by gpu-health-monitor.
@@ -661,35 +656,6 @@ func parseHostPathType(hostPathType string) (*corev1.HostPathType, bool) {
 	}
 
 	return &t, true
-}
-
-// injectDCGMEnv injects DCGM-specific environment variables for the dcgm-diag check.
-//
-// Deprecated: prefer defining DCGM_DIAG_LEVEL and DCGM_HOSTENGINE_ADDR as
-// inline env vars on the preflight-dcgm-diag init container in values.yaml.
-// Inline env vars take precedence via mergeEnvVars (user-defined wins over
-// webhook-injected). This function will be removed when the dcgm: config
-// block is dropped (see ADR-035).
-func (i *Injector) injectDCGMEnv(container *corev1.Container) {
-	if container.Name != "preflight-dcgm-diag" {
-		return
-	}
-
-	envVars := []corev1.EnvVar{
-		{
-			Name:  "DCGM_DIAG_LEVEL",
-			Value: fmt.Sprintf("%d", i.cfg.DCGM.DiagLevel),
-		},
-	}
-
-	if i.cfg.DCGM.HostengineAddr != "" {
-		envVars = append(envVars, corev1.EnvVar{
-			Name:  "DCGM_HOSTENGINE_ADDR",
-			Value: i.cfg.DCGM.HostengineAddr,
-		})
-	}
-
-	i.mergeEnvVars(container, envVars)
 }
 
 // injectGangEnv injects gang-related environment variables for multi-node checks.

--- a/preflight/pkg/webhook/injector_test.go
+++ b/preflight/pkg/webhook/injector_test.go
@@ -563,25 +563,6 @@ func TestBuildInitContainers(t *testing.T) {
 		assert.Equal(t, resource.MustParse("1Gi"), containers[0].Resources.Requests[corev1.ResourceMemory])
 	})
 
-	t.Run("DCGM env only for dcgm-diag container", func(t *testing.T) {
-		cfg := testConfig()
-		cfg.InitContainers = []config.InitContainerSpec{
-			{Container: corev1.Container{Name: "preflight-dcgm-diag", Image: "dcgm:latest"}},
-			{Container: corev1.Container{Name: "preflight-nccl-allreduce", Image: "nccl:latest"}},
-		}
-		injector := NewInjector(cfg, nil)
-
-		containers := injector.buildInitContainers(gpuPod(), corev1.ResourceList{
-			"nvidia.com/gpu": resource.MustParse("8"),
-		}, nil, cfg.InitContainers)
-		require.Len(t, containers, 2)
-
-		assert.True(t, hasEnvVar(containers[0], "DCGM_DIAG_LEVEL"), "dcgm-diag should have DCGM_DIAG_LEVEL")
-		assert.True(t, hasEnvVar(containers[0], "DCGM_HOSTENGINE_ADDR"), "dcgm-diag should have DCGM_HOSTENGINE_ADDR")
-		assert.False(t, hasEnvVar(containers[1], "DCGM_DIAG_LEVEL"), "nccl container should NOT have DCGM_DIAG_LEVEL")
-		assert.False(t, hasEnvVar(containers[1], "DCGM_HOSTENGINE_ADDR"), "nccl container should NOT have DCGM_HOSTENGINE_ADDR")
-	})
-
 	t.Run("common env injected", func(t *testing.T) {
 		cfg := testConfig()
 		injector := NewInjector(cfg, nil)
@@ -1124,12 +1105,8 @@ func testConfig() *config.Config {
 			GPUResourceNames:       []string{"nvidia.com/gpu"},
 			NetworkResourceNames:   []string{"vpc.amazonaws.com/efa"},
 			InitContainerPlacement: config.PlacementAppend,
-			DCGM: config.DCGMConfig{
-				HostengineAddr:     "localhost:5555",
-				DiagLevel:          1,
-				ConnectorSocket:    "/var/run/nvsentinel/nvsentinel.sock",
-				ProcessingStrategy: "EXECUTE_REMEDIATION",
-			},
+			ConnectorSocket:    "/var/run/nvsentinel/nvsentinel.sock",
+			ProcessingStrategy: "EXECUTE_REMEDIATION",
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- Remove the separate `dcgm:` config block and `injectDCGMEnv()` function
- DCGM-specific config (`DCGM_HOSTENGINE_ADDR`, `DCGM_DIAG_LEVEL`) is now defined as inline env vars on the `preflight-dcgm-diag` container, matching how NCCL checks work
- Move `connectorSocket` and `processingStrategy` to top-level preflight config (they apply to all init containers, not just DCGM)

See `docs/designs/035-preflight-inline-dcgm-config.md` for the full ADR.

## Migration

| Old (`dcgm:` block) | New |
|---|---|
| `dcgm.service.endpoint` + `port` | `DCGM_HOSTENGINE_ADDR` env var on container |
| `dcgm.diagLevel` | `DCGM_DIAG_LEVEL` env var on container |
| `dcgm.processingStrategy` | top-level `processingStrategy` |
| `dcgm.connectorSocket` | top-level `connectorSocket` |

## Test plan
- [x] `go test ./pkg/config/ ./pkg/webhook/` passes
- [x] `helm lint` passes
- [ ] CI lint-test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed chart-level DCGM block; connectorSocket and processingStrategy are now top-level. Config no longer emits a dcgm section and DCGM diag env vars are provided inline on the preflight init container.

* **Tests**
  * Adjusted tests to the new top-level config shape and removed assertions for DCGM-specific injection.

* **Documentation**
  * Updated docs and migration guidance to describe inline env-var DCGM configuration and the new top-level settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->