### PR TITLE
feat: imagePullSecrets injection + fix gang ConfigMap mismatch

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/configmap.yaml
@@ -73,6 +73,10 @@ data:
     {{- if .Values.initContainerPlacement }}
     initContainerPlacement: {{ .Values.initContainerPlacement | quote }}
     {{- end }}
+    {{- if .Values.injectedImagePullSecrets }}
+    imagePullSecrets:
+      {{- toYaml .Values.injectedImagePullSecrets | nindent 6 }}
+    {{- end }}
     initContainers:
       {{- $extraEnv := .Values.ncclAllreduceExtraEnv | default list }}
       {{- $globalTag := ((.Values.global).image).tag | default "" }}

--- a/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
@@ -96,6 +96,14 @@ processingStrategy: "EXECUTE_REMEDIATION"
 #   checks before any other init containers.
 initContainerPlacement: "append"
 
+# ImagePullSecrets injected into target pods when init containers are added.
+# Use this when init container images are in a private registry.
+# These are added to the pod's spec.imagePullSecrets (not the webhook deployment).
+# Example:
+#   injectedImagePullSecrets:
+#     - name: gcr-image-pull
+injectedImagePullSecrets: []
+
 # Per-pod check selection: annotate pods with a comma-separated list of
 # init container names to override which checks run:
 #

--- a/preflight/pkg/config/config.go
+++ b/preflight/pkg/config/config.go
@@ -74,6 +74,11 @@ type FileConfig struct {
 	// Valid values: "prepend", "append". Default: "append".
 	InitContainerPlacement InitContainerPlacement `yaml:"initContainerPlacement,omitempty"`
 
+	// ImagePullSecrets are added to the target pod's spec.imagePullSecrets
+	// when init containers are injected. This is needed when the init
+	// container images are stored in a private registry.
+	ImagePullSecrets []corev1.LocalObjectReference `yaml:"imagePullSecrets,omitempty"`
+
 	// NCCLEnvPatterns are glob patterns for environment variable names to copy
 	// from the pod's main containers to preflight init containers.
 	// This allows the init container to inherit fabric-specific NCCL config

--- a/preflight/pkg/controller/gang_controller.go
+++ b/preflight/pkg/controller/gang_controller.go
@@ -194,10 +194,7 @@ func (c *GangController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	// a different ConfigMap than the one the webhook mounted. This happens
 	// when the webhook used a label fallback before the scheduler annotation
 	// arrived, producing a different gang ID.
-	derivedCM := gang.ConfigMapName(gangID)
-	if webhookCM != "" && derivedCM != webhookCM {
-		c.deleteOrphanedConfigMap(ctx, pod.Namespace, derivedCM)
-	}
+	c.cleanupOrphanedConfigMap(ctx, pod.Namespace, webhookCM, gangID)
 
 	return ctrl.Result{}, nil
 }
@@ -292,6 +289,18 @@ func webhookConfigMapName(pod *corev1.Pod) string {
 	}
 
 	return ""
+}
+
+// cleanupOrphanedConfigMap deletes the annotation-derived ConfigMap when it
+// differs from the one the webhook actually mounted. No-op when the names
+// match or the webhook name is empty (no volume found).
+func (c *GangController) cleanupOrphanedConfigMap(ctx context.Context, namespace, webhookCM, gangID string) {
+	derivedCM := gang.ConfigMapName(gangID)
+	if webhookCM == "" || derivedCM == webhookCM {
+		return
+	}
+
+	c.deleteOrphanedConfigMap(ctx, namespace, derivedCM)
 }
 
 // deleteOrphanedConfigMap deletes a gang ConfigMap that was created for an

--- a/preflight/pkg/controller/gang_controller.go
+++ b/preflight/pkg/controller/gang_controller.go
@@ -195,7 +195,7 @@ func (c *GangController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	// when the webhook used a label fallback before the scheduler annotation
 	// arrived, producing a different gang ID.
 	derivedCM := gang.ConfigMapName(gangID)
-	if derivedCM != webhookCM {
+	if webhookCM != "" && derivedCM != webhookCM {
 		c.deleteOrphanedConfigMap(ctx, pod.Namespace, derivedCM)
 	}
 

--- a/preflight/pkg/controller/gang_controller.go
+++ b/preflight/pkg/controller/gang_controller.go
@@ -154,6 +154,12 @@ func (c *GangController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, nil
 	}
 
+	// The webhook may have used a different gang ID (e.g., from a label
+	// fallback) than the one the controller discovers from the scheduler
+	// annotation. We must update the ConfigMap the webhook mounted, not
+	// create a new one derived from the controller's gang ID.
+	webhookCM := webhookConfigMapName(&pod)
+
 	// Build check names in chart order — same logic as the injector's
 	// selectInitContainers so both paths produce identical strings.
 	checkNames := checkNamesFromPod(&pod, c.cfg)
@@ -166,11 +172,12 @@ func (c *GangController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		CheckNames: checkNames,
 	}
 
-	if err := c.coordinator.RegisterPeer(ctx, pod.Namespace, gangInfo, peer); err != nil {
+	if err := c.coordinator.RegisterPeerInConfigMap(ctx, pod.Namespace, webhookCM, gangInfo, peer); err != nil {
 		slog.Error("Failed to register peer",
 			"pod", pod.Name,
 			"namespace", pod.Namespace,
 			"gangID", gangID,
+			"configMap", webhookCM,
 			"error", err)
 
 		return ctrl.Result{}, fmt.Errorf("failed to register peer: %w", err)
@@ -180,7 +187,17 @@ func (c *GangController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		"pod", pod.Name,
 		"namespace", pod.Namespace,
 		"gangID", gangID,
+		"configMap", webhookCM,
 		"podIP", pod.Status.PodIP)
+
+	// Clean up orphaned ConfigMap if the annotation-based gang ID maps to
+	// a different ConfigMap than the one the webhook mounted. This happens
+	// when the webhook used a label fallback before the scheduler annotation
+	// arrived, producing a different gang ID.
+	derivedCM := gang.ConfigMapName(gangID)
+	if derivedCM != webhookCM {
+		c.deleteOrphanedConfigMap(ctx, pod.Namespace, derivedCM)
+	}
 
 	return ctrl.Result{}, nil
 }
@@ -262,6 +279,49 @@ func (c *GangController) ensureNCCLTopoConfigMap(ctx context.Context, namespace 
 	slog.Info("Created NCCL topo ConfigMap",
 		"namespace", namespace,
 		"configMap", gcfg.NCCLTopoConfigMap)
+}
+
+// webhookConfigMapName extracts the ConfigMap name from the pod's gang config
+// volume. This is the ConfigMap the webhook created and the init container is
+// actually reading — the controller must update this one, not derive a new name.
+func webhookConfigMapName(pod *corev1.Pod) string {
+	for _, vol := range pod.Spec.Volumes {
+		if vol.Name == types.GangConfigVolumeName && vol.ConfigMap != nil {
+			return vol.ConfigMap.Name
+		}
+	}
+
+	return ""
+}
+
+// deleteOrphanedConfigMap deletes a gang ConfigMap that was created for an
+// annotation-based gang ID that differs from the webhook's label-based one.
+// This is best-effort — if it doesn't exist, that's fine.
+func (c *GangController) deleteOrphanedConfigMap(ctx context.Context, namespace, name string) {
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, cm); err != nil {
+		if !errors.IsNotFound(err) {
+			slog.Debug("Failed to get orphaned gang ConfigMap",
+				"configMap", name,
+				"namespace", namespace,
+				"error", err)
+		}
+
+		return
+	}
+
+	if err := c.Delete(ctx, cm); err != nil && !errors.IsNotFound(err) {
+		slog.Warn("Failed to delete orphaned gang ConfigMap",
+			"configMap", name,
+			"namespace", namespace,
+			"error", err)
+
+		return
+	}
+
+	slog.Info("Deleted orphaned gang ConfigMap",
+		"configMap", name,
+		"namespace", namespace)
 }
 
 // checkNamesFromPod computes the check names string for a pod, matching

--- a/preflight/pkg/controller/gang_controller.go
+++ b/preflight/pkg/controller/gang_controller.go
@@ -190,10 +190,6 @@ func (c *GangController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		"configMap", webhookCM,
 		"podIP", pod.Status.PodIP)
 
-	// Clean up orphaned ConfigMap if the annotation-based gang ID maps to
-	// a different ConfigMap than the one the webhook mounted. This happens
-	// when the webhook used a label fallback before the scheduler annotation
-	// arrived, producing a different gang ID.
 	c.cleanupOrphanedConfigMap(ctx, pod.Namespace, webhookCM, gangID)
 
 	return ctrl.Result{}, nil
@@ -291,9 +287,9 @@ func webhookConfigMapName(pod *corev1.Pod) string {
 	return ""
 }
 
-// cleanupOrphanedConfigMap deletes the annotation-derived ConfigMap when it
-// differs from the one the webhook actually mounted. No-op when the names
-// match or the webhook name is empty (no volume found).
+// cleanupOrphanedConfigMap deletes the annotation-derived ConfigMap when the
+// webhook mounted a different one (label-fallback). This happens when the
+// webhook used a provisional gang ID before the scheduler annotation arrived.
 func (c *GangController) cleanupOrphanedConfigMap(ctx context.Context, namespace, webhookCM, gangID string) {
 	derivedCM := gang.ConfigMapName(gangID)
 	if webhookCM == "" || derivedCM == webhookCM {

--- a/preflight/pkg/controller/gang_controller_test.go
+++ b/preflight/pkg/controller/gang_controller_test.go
@@ -27,10 +27,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -426,6 +429,7 @@ func (te *testEnv) assertNoConfigMaps(t *testing.T, ctx context.Context, namespa
 	assert.Empty(t, cms.Items, "expected no ConfigMaps")
 }
 
+
 func newTestPod(name, namespace, ip string) *corev1.Pod {
 	return newTestPodWithGangVolume(name, namespace, ip, false)
 }
@@ -481,4 +485,177 @@ func newGangDiscoverer(gangID string, minCount int) *mockDiscoverer {
 
 func newNonGangDiscoverer() *mockDiscoverer {
 	return &mockDiscoverer{canHandle: false}
+}
+
+func TestWebhookConfigMapName(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want string
+	}{
+		{
+			name: "pod with gang config volume returns ConfigMap name",
+			pod:  newGangPod("p", "ns", "10.0.0.1"),
+			want: "preflight-test-gang",
+		},
+		{
+			name: "pod without gang config volume returns empty",
+			pod:  newTestPod("p", "ns", "10.0.0.1"),
+			want: "",
+		},
+		{
+			name: "gang volume name present but no ConfigMap source returns empty",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c", Image: "img"}},
+					Volumes: []corev1.Volume{
+						{
+							Name: types.GangConfigVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "pod with unrelated volumes returns empty",
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c", Image: "img"}},
+					Volumes: []corev1.Volume{
+						{
+							Name: "other-volume",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "other-cm"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, webhookConfigMapName(tt.pod))
+		})
+	}
+}
+
+func TestCheckNamesFromPod(t *testing.T) {
+	boolPtr := func(b bool) *bool { return &b }
+
+	baseCfg := &config.Config{
+		FileConfig: config.FileConfig{
+			InitContainers: []config.InitContainerSpec{
+				{Container: corev1.Container{Name: "preflight-dcgm-diag"}, DefaultEnabled: nil},
+				{Container: corev1.Container{Name: "preflight-nccl-allreduce"}, DefaultEnabled: nil},
+				{Container: corev1.Container{Name: "preflight-nccl-loopback"}, DefaultEnabled: boolPtr(false)},
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		cfg  *config.Config
+		want string
+	}{
+		{
+			name: "no annotation uses defaultEnabled checks in chart order",
+			pod:  &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p"}},
+			cfg:  baseCfg,
+			want: "preflight-dcgm-diag,preflight-nccl-allreduce",
+		},
+		{
+			name: "annotation overrides with explicit order",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "p",
+					Annotations: map[string]string{webhook.PreflightChecksAnnotation: "preflight-nccl-allreduce,preflight-dcgm-diag"},
+				},
+			},
+			cfg:  baseCfg,
+			want: "preflight-nccl-allreduce,preflight-dcgm-diag",
+		},
+		{
+			name: "annotation with unknown check names filters them out",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "p",
+					Annotations: map[string]string{webhook.PreflightChecksAnnotation: "preflight-dcgm-diag,nonexistent"},
+				},
+			},
+			cfg:  baseCfg,
+			want: "preflight-dcgm-diag",
+		},
+		{
+			name: "annotation can enable a non-default check",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "p",
+					Annotations: map[string]string{webhook.PreflightChecksAnnotation: "preflight-nccl-loopback"},
+				},
+			},
+			cfg:  baseCfg,
+			want: "preflight-nccl-loopback",
+		},
+		{
+			name: "duplicate annotation returns empty",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "p",
+					Annotations: map[string]string{webhook.PreflightChecksAnnotation: "preflight-dcgm-diag,preflight-dcgm-diag"},
+				},
+			},
+			cfg:  baseCfg,
+			want: "",
+		},
+		{
+			name: "empty config returns empty string",
+			pod:  &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p"}},
+			cfg:  &config.Config{},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, checkNamesFromPod(tt.pod, tt.cfg))
+		})
+	}
+}
+
+func TestDeleteOrphanedConfigMap(t *testing.T) {
+	t.Run("deletes existing orphaned ConfigMap", func(t *testing.T) {
+		ctx := context.Background()
+		orphanName := coordinator.ConfigMapName("orphan-gang")
+
+		orphanCM := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: orphanName, Namespace: "default"},
+		}
+		fc := fake.NewClientBuilder().WithObjects(orphanCM).Build()
+
+		gc := &GangController{Client: fc}
+		gc.deleteOrphanedConfigMap(ctx, "default", orphanName)
+
+		err := fc.Get(ctx, client.ObjectKey{Namespace: "default", Name: orphanName}, &corev1.ConfigMap{})
+		assert.True(t, errors.IsNotFound(err), "orphaned ConfigMap should be deleted")
+	})
+
+	t.Run("no-op when ConfigMap does not exist", func(t *testing.T) {
+		ctx := context.Background()
+		fc := fake.NewClientBuilder().Build()
+
+		gc := &GangController{Client: fc}
+
+		// Should not panic or error.
+		gc.deleteOrphanedConfigMap(ctx, "default", "nonexistent-cm")
+	})
 }

--- a/preflight/pkg/controller/gang_controller_test.go
+++ b/preflight/pkg/controller/gang_controller_test.go
@@ -632,6 +632,53 @@ func TestCheckNamesFromPod(t *testing.T) {
 	}
 }
 
+func TestCleanupOrphanedConfigMap(t *testing.T) {
+	t.Run("deletes when webhook and derived names differ", func(t *testing.T) {
+		ctx := context.Background()
+		derivedName := coordinator.ConfigMapName("annotation-gang")
+
+		fc := fake.NewClientBuilder().WithObjects(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: derivedName, Namespace: "default"},
+		}).Build()
+
+		gc := &GangController{Client: fc}
+		gc.cleanupOrphanedConfigMap(ctx, "default", "webhook-label-cm", "annotation-gang")
+
+		err := fc.Get(ctx, client.ObjectKey{Namespace: "default", Name: derivedName}, &corev1.ConfigMap{})
+		assert.True(t, errors.IsNotFound(err), "derived ConfigMap should be deleted")
+	})
+
+	t.Run("no-op when names match", func(t *testing.T) {
+		ctx := context.Background()
+		cmName := coordinator.ConfigMapName("same-gang")
+
+		fc := fake.NewClientBuilder().WithObjects(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: cmName, Namespace: "default"},
+		}).Build()
+
+		gc := &GangController{Client: fc}
+		gc.cleanupOrphanedConfigMap(ctx, "default", cmName, "same-gang")
+
+		err := fc.Get(ctx, client.ObjectKey{Namespace: "default", Name: cmName}, &corev1.ConfigMap{})
+		assert.NoError(t, err, "ConfigMap should still exist when names match")
+	})
+
+	t.Run("no-op when webhookCM is empty", func(t *testing.T) {
+		ctx := context.Background()
+		derivedName := coordinator.ConfigMapName("some-gang")
+
+		fc := fake.NewClientBuilder().WithObjects(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: derivedName, Namespace: "default"},
+		}).Build()
+
+		gc := &GangController{Client: fc}
+		gc.cleanupOrphanedConfigMap(ctx, "default", "", "some-gang")
+
+		err := fc.Get(ctx, client.ObjectKey{Namespace: "default", Name: derivedName}, &corev1.ConfigMap{})
+		assert.NoError(t, err, "ConfigMap should still exist when webhookCM is empty")
+	})
+}
+
 func TestDeleteOrphanedConfigMap(t *testing.T) {
 	t.Run("deletes existing orphaned ConfigMap", func(t *testing.T) {
 		ctx := context.Background()

--- a/preflight/pkg/controller/gang_controller_test.go
+++ b/preflight/pkg/controller/gang_controller_test.go
@@ -45,13 +45,15 @@ import (
 func TestGangController_Reconcile(t *testing.T) {
 	tests := []struct {
 		name            string
+		gangID          string
 		pod             *corev1.Pod
 		discoverer      *mockDiscoverer
 		expectConfigMap bool
 	}{
 		{
 			name:            "pod with IP belonging to gang registers peer",
-			pod:             newGangPod("gang-pod-0", "default", "10.0.0.1"),
+			gangID:          "test-gang",
+			pod:             newGangPod("gang-pod-0", "default", "10.0.0.1", "test-gang"),
 			discoverer:      newGangDiscoverer("test-gang", 2),
 			expectConfigMap: true,
 		},
@@ -78,6 +80,12 @@ func TestGangController_Reconcile(t *testing.T) {
 			defer te.teardown()
 
 			te.createNamespace(t, ctx, tt.pod.Namespace)
+
+			// Pre-create the gang ConfigMap (in prod the webhook does this).
+			if tt.gangID != "" {
+				te.ensureGangConfigMap(t, ctx, tt.pod.Namespace, tt.gangID)
+			}
+
 			te.createPodWithIP(t, ctx, tt.pod)
 
 			if tt.expectConfigMap {
@@ -182,7 +190,7 @@ func TestGangController_WebhookRegistration(t *testing.T) {
 		})
 
 		// Now create a pod with IP — the controller should reconcile and register the peer
-		te.createPodWithIP(t, ctx, newGangPod("worker-0", "default", "10.0.0.1"))
+		te.createPodWithIP(t, ctx, newGangPod("worker-0", "default", "10.0.0.1", "full-gang"))
 		te.assertConfigMapWithPeer(t, ctx, "default", "full-gang", "worker-0", "10.0.0.1")
 	})
 }
@@ -255,9 +263,13 @@ func TestGangController_MultipleGangsIndependent(t *testing.T) {
 
 	te.createNamespace(t, ctx, "default")
 
+	// Pre-create gang ConfigMaps (in prod the webhook does this).
+	te.ensureGangConfigMap(t, ctx, "default", "gang-a")
+	te.ensureGangConfigMap(t, ctx, "default", "gang-b")
+
 	// Create two gang pods — each belongs to a different gang.
-	te.createPodWithIP(t, ctx, newGangPod("worker-a", "default", "10.0.0.1"))
-	te.createPodWithIP(t, ctx, newGangPod("worker-b", "default", "10.0.0.2"))
+	te.createPodWithIP(t, ctx, newGangPod("worker-a", "default", "10.0.0.1", "gang-a"))
+	te.createPodWithIP(t, ctx, newGangPod("worker-b", "default", "10.0.0.2", "gang-b"))
 
 	// Each pod should register into its own gang's ConfigMap.
 	te.assertConfigMapWithPeer(t, ctx, "default", "gang-a", "worker-a", "10.0.0.1")
@@ -378,6 +390,13 @@ func (te *testEnv) createNamespace(t *testing.T, ctx context.Context, name strin
 	}
 }
 
+func (te *testEnv) ensureGangConfigMap(t *testing.T, ctx context.Context, namespace, gangID string) {
+	t.Helper()
+	coord := gang.NewCoordinator(te.mgr.GetClient(), gang.DefaultCoordinatorConfig())
+	err := coord.EnsureConfigMap(ctx, namespace, gangID, 0)
+	require.NoError(t, err, "failed to create gang ConfigMap")
+}
+
 func (te *testEnv) createPodWithIP(t *testing.T, ctx context.Context, pod *corev1.Pod) {
 	t.Helper()
 	createdPod, err := te.kubeClient.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
@@ -431,14 +450,14 @@ func (te *testEnv) assertNoConfigMaps(t *testing.T, ctx context.Context, namespa
 
 
 func newTestPod(name, namespace, ip string) *corev1.Pod {
-	return newTestPodWithGangVolume(name, namespace, ip, false)
+	return newTestPodWithGangVolume(name, namespace, ip, "")
 }
 
-func newGangPod(name, namespace, ip string) *corev1.Pod {
-	return newTestPodWithGangVolume(name, namespace, ip, true)
+func newGangPod(name, namespace, ip, gangID string) *corev1.Pod {
+	return newTestPodWithGangVolume(name, namespace, ip, gangID)
 }
 
-func newTestPodWithGangVolume(name, namespace, ip string, withGangVolume bool) *corev1.Pod {
+func newTestPodWithGangVolume(name, namespace, ip, gangID string) *corev1.Pod {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -454,14 +473,14 @@ func newTestPodWithGangVolume(name, namespace, ip string, withGangVolume bool) *
 		},
 	}
 
-	if withGangVolume {
+	if gangID != "" {
 		pod.Spec.Volumes = []corev1.Volume{
 			{
 				Name: types.GangConfigVolumeName,
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: "preflight-test-gang",
+							Name: coordinator.ConfigMapName(gangID),
 						},
 					},
 				},
@@ -495,8 +514,8 @@ func TestWebhookConfigMapName(t *testing.T) {
 	}{
 		{
 			name: "pod with gang config volume returns ConfigMap name",
-			pod:  newGangPod("p", "ns", "10.0.0.1"),
-			want: "preflight-test-gang",
+			pod:  newGangPod("p", "ns", "10.0.0.1", "test-gang"),
+			want: coordinator.ConfigMapName("test-gang"),
 		},
 		{
 			name: "pod without gang config volume returns empty",

--- a/preflight/pkg/gang/coordinator/coordinator.go
+++ b/preflight/pkg/gang/coordinator/coordinator.go
@@ -229,6 +229,42 @@ func (c *Coordinator) RegisterPeer(
 	return nil
 }
 
+// RegisterPeerInConfigMap registers a pod as a peer in a specific ConfigMap
+// (rather than deriving the name from the gang ID). This is used when the
+// webhook created a ConfigMap under a provisional gang ID (e.g., from a label
+// fallback) that differs from the controller's discovered gang ID.
+func (c *Coordinator) RegisterPeerInConfigMap(
+	ctx context.Context,
+	namespace string,
+	configMapName string,
+	gangInfo *types.GangInfo,
+	peer types.PeerInfo,
+) error {
+	if configMapName == "" {
+		// Fallback: no webhook ConfigMap found, use the standard path.
+		return c.RegisterPeer(ctx, namespace, gangInfo, peer)
+	}
+
+	slog.Debug("Registering peer in webhook ConfigMap",
+		"configMap", configMapName,
+		"namespace", namespace,
+		"gangID", gangInfo.GangID,
+		"peer", peer.PodName,
+		"peerIP", peer.PodIP)
+
+	if err := c.updateConfigMap(ctx, namespace, configMapName, gangInfo.ExpectedMinCount, peer); err != nil {
+		return fmt.Errorf("failed to update ConfigMap: %w", err)
+	}
+
+	slog.Info("Registered peer in gang ConfigMap",
+		"configMap", configMapName,
+		"namespace", namespace,
+		"peer", peer.PodName,
+		"peerIP", peer.PodIP)
+
+	return nil
+}
+
 // updateConfigMap updates an existing ConfigMap, retrying on conflict.
 func (c *Coordinator) updateConfigMap(
 	ctx context.Context,

--- a/preflight/pkg/webhook/injector.go
+++ b/preflight/pkg/webhook/injector.go
@@ -173,6 +173,7 @@ func (i *Injector) InjectInitContainers(pod *corev1.Pod) ([]PatchOperation, *Gan
 
 	patches := i.patchInitContainers(pod, initContainers)
 	patches = append(patches, i.injectVolumes(pod, gangCtx)...)
+	patches = append(patches, i.injectImagePullSecrets(pod)...)
 
 	return patches, gangCtx, nil
 }
@@ -538,6 +539,51 @@ func (i *Injector) injectVolumes(pod *corev1.Pod, gangCtx *GangContext) []PatchO
 				Value: vol,
 			})
 		}
+	}
+
+	return patches
+}
+
+// injectImagePullSecrets builds JSON Patch operations to add configured
+// imagePullSecrets to the pod. Secrets already present on the pod are skipped.
+func (i *Injector) injectImagePullSecrets(pod *corev1.Pod) []PatchOperation {
+	if len(i.cfg.ImagePullSecrets) == 0 {
+		return nil
+	}
+
+	existing := make(map[string]bool, len(pod.Spec.ImagePullSecrets))
+	for _, s := range pod.Spec.ImagePullSecrets {
+		existing[s.Name] = true
+	}
+
+	var toAdd []corev1.LocalObjectReference
+
+	for _, s := range i.cfg.ImagePullSecrets {
+		if !existing[s.Name] {
+			toAdd = append(toAdd, s)
+			existing[s.Name] = true
+		}
+	}
+
+	if len(toAdd) == 0 {
+		return nil
+	}
+
+	if len(pod.Spec.ImagePullSecrets) == 0 {
+		return []PatchOperation{{
+			Op:    "add",
+			Path:  "/spec/imagePullSecrets",
+			Value: toAdd,
+		}}
+	}
+
+	patches := make([]PatchOperation, 0, len(toAdd))
+	for _, s := range toAdd {
+		patches = append(patches, PatchOperation{
+			Op:    "add",
+			Path:  "/spec/imagePullSecrets/-",
+			Value: s,
+		})
 	}
 
 	return patches

--- a/preflight/pkg/webhook/injector_test.go
+++ b/preflight/pkg/webhook/injector_test.go
@@ -447,6 +447,27 @@ func TestInjectInitContainers(t *testing.T) {
 			expectCheckNames: "preflight-dcgm-diag",
 		},
 		{
+			name: "imagePullSecrets injected into target pod",
+			cfg: func() *config.Config {
+				c := testConfig()
+				c.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "gcr-pull"}}
+				return c
+			}(),
+			pod:           gpuPod(),
+			expectPatches: true,
+			validatePatches: func(t *testing.T, patches []PatchOperation) {
+				t.Helper()
+				p := findPatchByPath(patches, "/spec/imagePullSecrets")
+				require.NotNil(t, p, "expected /spec/imagePullSecrets patch")
+				assert.Equal(t, "add", p.Op)
+
+				secrets, ok := p.Value.([]corev1.LocalObjectReference)
+				require.True(t, ok)
+				require.Len(t, secrets, 1)
+				assert.Equal(t, "gcr-pull", secrets[0].Name)
+			},
+		},
+		{
 			name: "unknown check name returns error",
 			cfg:  testConfig(),
 			pod: func() *corev1.Pod {
@@ -1033,6 +1054,84 @@ func TestInjectVolumes(t *testing.T) {
 		volumes := extractVolumes(t, injector.injectVolumes(&corev1.Pod{}, gangCtx))
 		assert.Nil(t, findVolume(volumes, "bad-type"), "bogus hostPathType should be skipped")
 		assert.NotNil(t, findVolume(volumes, "good-type"), "valid hostPath should be included")
+	})
+}
+
+func TestInjectImagePullSecrets(t *testing.T) {
+	t.Run("no config secrets returns nil", func(t *testing.T) {
+		injector := &Injector{cfg: testConfig()}
+		patches := injector.injectImagePullSecrets(&corev1.Pod{})
+		assert.Nil(t, patches)
+	})
+
+	t.Run("creates array when pod has none", func(t *testing.T) {
+		cfg := testConfig()
+		cfg.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "gcr-pull"}}
+		injector := &Injector{cfg: cfg}
+
+		patches := injector.injectImagePullSecrets(&corev1.Pod{})
+		require.Len(t, patches, 1)
+		assert.Equal(t, "add", patches[0].Op)
+		assert.Equal(t, "/spec/imagePullSecrets", patches[0].Path)
+
+		secrets, ok := patches[0].Value.([]corev1.LocalObjectReference)
+		require.True(t, ok)
+		require.Len(t, secrets, 1)
+		assert.Equal(t, "gcr-pull", secrets[0].Name)
+	})
+
+	t.Run("appends when pod already has secrets", func(t *testing.T) {
+		cfg := testConfig()
+		cfg.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "gcr-pull"}}
+		injector := &Injector{cfg: cfg}
+
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "existing"}},
+			},
+		}
+
+		patches := injector.injectImagePullSecrets(pod)
+		require.Len(t, patches, 1)
+		assert.Equal(t, "add", patches[0].Op)
+		assert.Equal(t, "/spec/imagePullSecrets/-", patches[0].Path)
+	})
+
+	t.Run("skips duplicates", func(t *testing.T) {
+		cfg := testConfig()
+		cfg.ImagePullSecrets = []corev1.LocalObjectReference{
+			{Name: "already-there"},
+			{Name: "new-one"},
+		}
+		injector := &Injector{cfg: cfg}
+
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "already-there"}},
+			},
+		}
+
+		patches := injector.injectImagePullSecrets(pod)
+		require.Len(t, patches, 1)
+
+		secret, ok := patches[0].Value.(corev1.LocalObjectReference)
+		require.True(t, ok)
+		assert.Equal(t, "new-one", secret.Name)
+	})
+
+	t.Run("all secrets already present returns nil", func(t *testing.T) {
+		cfg := testConfig()
+		cfg.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "existing"}}
+		injector := &Injector{cfg: cfg}
+
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "existing"}},
+			},
+		}
+
+		patches := injector.injectImagePullSecrets(pod)
+		assert.Nil(t, patches)
 	})
 }
 


### PR DESCRIPTION
## Summary

- **Inject imagePullSecrets into target pods** when init container images are in a private registry. Adds a top-level `imagePullSecrets` field to `FileConfig` and a new `injectedImagePullSecrets` chart value. The webhook patches `spec.imagePullSecrets` on mutated pods, deduplicating against existing secrets.

- **Fix gang controller ConfigMap mismatch.** When the webhook fires before the scheduler annotates pods, it uses a label fallback to derive a provisional gang ID. The controller later discovers a different gang ID from the scheduler annotation. Previously the controller created a second ConfigMap that the init container never read. Now:
  1. Controller reads the ConfigMap name from the pod's mounted volume
  2. Writes peer data to that ConfigMap (the one the init container actually reads)
  3. Cleans up any orphaned ConfigMap from the annotation-based gang ID

## Testing

Tested on sea1-a (5-node H100 cluster) with KAI scheduler.

### imagePullSecrets

Created a test pod with `nvsentinel.nvidia.com/preflight-checks: preflight-dcgm-diag-1` annotation. Verified:
- `spec.imagePullSecrets: [{name: gcr-image-pull}]` injected into the pod
- Init container pulled successfully from private Artifact Registry (`us-central1-docker.pkg.dev/reflectionai-gpu-platform/nvsentinel/...`)
- Previously failed with `ErrImagePull` without this fix

### DCGM diagnostics

- **Level 1** (software deployment): 8/8 GPUs passed, 0 warnings, 0 failures (~2s)
- **Level 2** (software + memory + PCIe): 24/24 tests passed across 8 GPUs (~3 min)
- Note: Level 1 initially showed `/dev/nvidia0` permission warnings because the DCGM hostengine DaemonSet was missing a `/dev` volume mount. Fixed separately in the cluster config.

### NCCL loopback (single-node)

- 8 GPUs, 256 MB test size
- Bus bandwidth: **347.68 GB/s** (NVLink), threshold: 150 GB/s — **PASSED**

### NCCL all-reduce (multi-node, gang-scheduled)

Created a 2-replica JobSet with KAI scheduler (`schedulerName: kai-scheduler`). The full gang coordination pipeline worked end-to-end:
- KAI created PodGroup and scheduled both pods to different nodes (g1011, g1012)
- **Single ConfigMap** created (not two) — controller wrote to the webhook's mounted ConfigMap
- Gang formation: 2 peers registered, master IP set automatically
- NCCL connected across 16 GPUs (2 nodes × 8), all-reduce benchmark ran to completion
- Bus bandwidth: 2.44 GB/s (below 100 GB/s threshold). This is expected — the test cluster uses TCP between nodes (no IB/RoCE). On an IB-equipped cluster this would pass.

### Gang ConfigMap mismatch fix verification

From controller logs:
```
Discovering gang ... podGroup="pg-nccl-ar-ctrlfix-46e55591-..." gangID="kai-jobset-mid-training-pg-nccl-ar-ctrlfix-46e55591-..."
Registered peer in gang ConfigMap configMap="preflight-kai-jobset-mid-training-nccl-ar-ctrlfix" ...
```
- Webhook used label-based gang ID → created `preflight-kai-jobset-mid-training-nccl-ar-ctrlfix`
- Controller discovered annotation-based gang ID → wrote to the **webhook's** ConfigMap (not a new one)
- Init containers read the correct ConfigMap and gang formation completed automatically

## Unit tests

- imagePullSecrets: 6 new test cases (no config, create array, append, dedup, all-present, e2e integration)
- All existing webhook, coordinator, and discoverer tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable imagePullSecrets for injected init-container pods (values, config surface, and template rendering).

* **Improvements**
  * Gang registration now uses the webhook-mounted ConfigMap with clearer logging and best‑effort orphaned ConfigMap cleanup.
  * Coordinator exposes a registration path that accepts an explicit ConfigMap name.

* **Tests**
  * Added unit tests for imagePullSecrets injection, ConfigMap name extraction, orphaned ConfigMap cleanup, and related controller/gang behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->