### PR TITLE
fix: skip metadata collector chassis serial on pre-R560 drivers

### DIFF
--- a/metadata-collector/pkg/collector/collector.go
+++ b/metadata-collector/pkg/collector/collector.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	gonvml "github.com/NVIDIA/go-nvml/pkg/nvml"
@@ -27,16 +29,35 @@ import (
 	"github.com/nvidia/nvsentinel/metadata-collector/pkg/nvml"
 )
 
-type Collector struct {
-	nvml *nvml.NVMLWrapper
+type nvmlClient interface {
+	GetDeviceCount() (int, error)
+	GetDriverVersion() (string, error)
+	BuildDeviceMap() (map[string]gonvml.Device, error)
+	ParseNVLinkTopologyWithContext(context.Context) (map[int]nvml.GPUNVLinkTopology, error)
+	GetGPUInfo(index int) (*model.GPUInfo, error)
+	GetChassisSerial(index int) *string
+	CollectNVLinkTopology(
+		gpuInfo *model.GPUInfo,
+		index int,
+		deviceMap map[string]gonvml.Device,
+		parsedTopology map[int]nvml.GPUNVLinkTopology,
+	) (map[string]struct{}, error)
 }
 
-func NewCollector(nvmlWrapper *nvml.NVMLWrapper) *Collector {
+// Collector gathers GPU metadata from a node using NVML.
+type Collector struct {
+	nvml nvmlClient
+}
+
+// NewCollector creates a Collector backed by the provided NVML client.
+func NewCollector(nvmlWrapper nvmlClient) *Collector {
 	return &Collector{
 		nvml: nvmlWrapper,
 	}
 }
 
+// Collect gathers GPU metadata from the node via NVML, including device info,
+// NVLink topology, NVSwitch PCIs, and (for drivers >= R560) chassis serial.
 func (c *Collector) Collect(ctx context.Context) (*model.GPUMetadata, error) {
 	count, err := c.nvml.GetDeviceCount()
 	if err != nil {
@@ -73,6 +94,7 @@ func (c *Collector) Collect(ctx context.Context) (*model.GPUMetadata, error) {
 	return metadata, nil
 }
 
+// prepareTopologyData builds the device map and parses NVLink topology.
 func (c *Collector) prepareTopologyData(
 	ctx context.Context,
 ) (map[string]gonvml.Device, map[int]nvml.GPUNVLinkTopology, error) {
@@ -95,6 +117,7 @@ func (c *Collector) prepareTopologyData(
 	return deviceMap, parsedTopology, nil
 }
 
+// collectGPUData iterates over GPUs to populate metadata, NVSwitch, and chassis serial fields.
 func (c *Collector) collectGPUData(
 	count int,
 	metadata *model.GPUMetadata,
@@ -105,13 +128,20 @@ func (c *Collector) collectGPUData(
 
 	var chassisSerial *string
 
+	collectChassisSerial := supportsChassisSerial(metadata.DriverVersion)
+
+	if !collectChassisSerial {
+		slog.Info("Skipping chassis serial collection because driver does not support platform info",
+			"driver_version", metadata.DriverVersion)
+	}
+
 	for i := range count {
 		nvmlGPUInfo, err := c.nvml.GetGPUInfo(i)
 		if err != nil {
 			return fmt.Errorf("failed to get GPU info for GPU %d: %w", i, err)
 		}
 
-		if i == 0 {
+		if i == 0 && collectChassisSerial {
 			chassisSerial = c.nvml.GetChassisSerial(i)
 		}
 
@@ -135,4 +165,29 @@ func (c *Collector) collectGPUData(
 	}
 
 	return nil
+}
+
+// supportsChassisSerial reports whether the driver version supports platform info queries (>= R560).
+func supportsChassisSerial(driverVersion string) bool {
+	const minSupportedMajorVersion = 560
+
+	majorVersionString := strings.TrimSpace(strings.SplitN(driverVersion, ".", 2)[0])
+	if majorVersionString == "" {
+		slog.Warn("Failed to parse driver major version for chassis serial support",
+			"driver_version", driverVersion,
+			"error", "missing major version")
+
+		return false
+	}
+
+	majorVersion, err := strconv.Atoi(majorVersionString)
+	if err != nil {
+		slog.Warn("Failed to parse driver major version for chassis serial support",
+			"driver_version", driverVersion,
+			"error", err)
+
+		return false
+	}
+
+	return majorVersion >= minSupportedMajorVersion
 }

--- a/metadata-collector/pkg/collector/collector_test.go
+++ b/metadata-collector/pkg/collector/collector_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"context"
+	"testing"
+
+	gonvml "github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nvidia/nvsentinel/data-models/pkg/model"
+	"github.com/nvidia/nvsentinel/metadata-collector/pkg/nvml"
+)
+
+// fakeNVMLClient is a test double for the nvmlClient interface.
+type fakeNVMLClient struct {
+	deviceCount           int
+	driverVersion         string
+	chassisSerial         *string
+	getChassisSerialCalls int
+}
+
+// GetDeviceCount returns the configured device count.
+func (f *fakeNVMLClient) GetDeviceCount() (int, error) {
+	return f.deviceCount, nil
+}
+
+// GetDriverVersion returns the configured driver version string.
+func (f *fakeNVMLClient) GetDriverVersion() (string, error) {
+	return f.driverVersion, nil
+}
+
+// BuildDeviceMap returns an empty device map.
+func (f *fakeNVMLClient) BuildDeviceMap() (map[string]gonvml.Device, error) {
+	return map[string]gonvml.Device{}, nil
+}
+
+// ParseNVLinkTopologyWithContext returns an empty topology map.
+func (f *fakeNVMLClient) ParseNVLinkTopologyWithContext(context.Context) (map[int]nvml.GPUNVLinkTopology, error) {
+	return map[int]nvml.GPUNVLinkTopology{}, nil
+}
+
+// GetGPUInfo returns a stub GPUInfo for the given index.
+func (f *fakeNVMLClient) GetGPUInfo(index int) (*model.GPUInfo, error) {
+	return &model.GPUInfo{
+		GPUID:      index,
+		UUID:       "GPU-test",
+		PCIAddress: "0000:01:00.0",
+		DeviceName: "NVIDIA Test GPU",
+		NVLinks:    []model.NVLink{},
+	}, nil
+}
+
+// GetChassisSerial records the call and returns the configured serial.
+func (f *fakeNVMLClient) GetChassisSerial(index int) *string {
+	f.getChassisSerialCalls++
+	return f.chassisSerial
+}
+
+// CollectNVLinkTopology returns an empty NVSwitch set.
+func (f *fakeNVMLClient) CollectNVLinkTopology(
+	_ *model.GPUInfo,
+	_ int,
+	_ map[string]gonvml.Device,
+	_ map[int]nvml.GPUNVLinkTopology,
+) (map[string]struct{}, error) {
+	return map[string]struct{}{}, nil
+}
+
+// TestSupportsChassisSerial validates driver version gating for chassis serial collection.
+func TestSupportsChassisSerial(t *testing.T) {
+	tests := []struct {
+		name          string
+		driverVersion string
+		expected      bool
+	}{
+		{name: "older R550 driver", driverVersion: "550.54.15", expected: false},
+		{name: "older R559 driver", driverVersion: "559.99.99", expected: false},
+		{name: "minimum supported R560 driver", driverVersion: "560.0.0", expected: true},
+		{name: "newer driver", driverVersion: "575.51.02", expected: true},
+		{name: "major version only", driverVersion: "560", expected: true},
+		{name: "driver version with whitespace", driverVersion: " 560.35.03 ", expected: true},
+		{name: "empty version", driverVersion: "", expected: false},
+		{name: "invalid version", driverVersion: "invalid", expected: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, supportsChassisSerial(tc.driverVersion))
+		})
+	}
+}
+
+// TestCollectSkipsChassisSerialOnUnsupportedDrivers verifies that pre-R560 drivers do not call GetChassisSerial.
+func TestCollectSkipsChassisSerialOnUnsupportedDrivers(t *testing.T) {
+	serial := "CHASSIS-1234"
+	fake := &fakeNVMLClient{
+		deviceCount:   1,
+		driverVersion: "550.54.15",
+		chassisSerial: &serial,
+	}
+
+	collector := NewCollector(fake)
+
+	metadata, err := collector.Collect(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, metadata.ChassisSerial)
+	assert.Equal(t, 0, fake.getChassisSerialCalls)
+}
+
+// TestCollectCollectsChassisSerialOnSupportedDrivers verifies that R560+ drivers populate chassis serial.
+func TestCollectCollectsChassisSerialOnSupportedDrivers(t *testing.T) {
+	serial := "CHASSIS-1234"
+	fake := &fakeNVMLClient{
+		deviceCount:   1,
+		driverVersion: "560.35.03",
+		chassisSerial: &serial,
+	}
+
+	collector := NewCollector(fake)
+
+	metadata, err := collector.Collect(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, metadata.ChassisSerial)
+	assert.Equal(t, serial, *metadata.ChassisSerial)
+	assert.Equal(t, 1, fake.getChassisSerialCalls)
+}


### PR DESCRIPTION
## Summary
- avoid calling platform info APIs on drivers older than R560 by gating chassis serial collection on the detected driver major version
- skip chassis serial collection when the driver version is missing or unparsable instead of crashing the collector
- add unit coverage for the version gate and collector behavior on R550 and R560 drivers

## Testing
- go test ./...

Closes #810

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPU metadata collection now conditionally gathers chassis serial info only for driver major versions 560+; when supported, only the primary GPU is queried. Informational logs are emitted when chassis-serial collection is skipped for unsupported or unparseable driver versions.

* **Refactor**
  * Collector now depends on an abstract NVML client to improve flexibility and testability.

* **Tests**
  * Added tests for driver-version detection and chassis-serial collection behavior (supported, unsupported, malformed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->