### PR TITLE
fix(ci): update fern CI workflows

### DIFF
--- a/.github/workflows/fern-docs-ci.yml
+++ b/.github/workflows/fern-docs-ci.yml
@@ -73,5 +73,5 @@ jobs:
       - name: Check for broken links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --offline --no-progress --exclude-path 'docs/designs' 'docs/**/*.md'
+          args: --offline --no-progress --exclude-path '^docs/designs(/|$)' 'docs/**/*.md'
           fail: true

--- a/.github/workflows/fern-docs-ci.yml
+++ b/.github/workflows/fern-docs-ci.yml
@@ -70,22 +70,8 @@ jobs:
             fi
           done
 
-  fern-broken-links:
-    name: Fern Broken Links Check
-    needs: changed-files
-    if: needs.changed-files.outputs.docs == 'true'
-    runs-on: linux-amd64-cpu32
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Install Fern CLI
-        run: npm install -g fern-api@4.42.1
-
       - name: Check for broken links
-        run: fern docs broken-links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --offline --no-progress --exclude-path 'docs/designs' 'docs/**/*.md'
+          fail: true

--- a/.github/workflows/fern-docs-ci.yml
+++ b/.github/workflows/fern-docs-ci.yml
@@ -73,5 +73,5 @@ jobs:
       - name: Check for broken links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --offline --no-progress --exclude-path '^docs/designs(/|$)' 'docs/**/*.md'
+          args: --offline --no-progress 'docs/**/*.md'
           fail: true

--- a/.github/workflows/fern-docs-preview-build.yml
+++ b/.github/workflows/fern-docs-preview-build.yml
@@ -58,7 +58,7 @@ jobs:
           mkdir -p .preview-metadata
           echo "$PR_NUMBER" > .preview-metadata/pr_number
           echo "$HEAD_REF" > .preview-metadata/head_ref
-          git diff --name-only "origin/main...HEAD" -- '*.mdx' > .preview-metadata/changed_mdx_files 2>/dev/null || true
+          git diff --name-only "origin/main...HEAD" -- '*.md' > .preview-metadata/changed_mdx_files 2>/dev/null || true
 
       - name: Upload fern sources and metadata
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -1,27 +1,25 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Publishes the Fern documentation site when a docs tag is pushed or manually triggered.
-#
-# To publish:  git tag docs/v1.0.0 && git push origin docs/v1.0.0
-# Or use the "Run workflow" button in the Actions tab.
+# Publishes the Fern docs site on a docs/v* tag push or manual dispatch.
 #
 # Required configuration:
-# - Organization secret: DOCS_FERN_TOKEN (from `fern token` for the nvidia Fern org)
+# - Repository secret: DOCS_FERN_TOKEN (provisioned by the docs infrastructure team)
 
 name: Publish Fern Docs
 
 on:
   push:
     tags:
-      - 'docs/v*'
-  workflow_dispatch:
+      - "docs/v*"
+  workflow_dispatch: {}
 
 permissions:
   contents: read
 
 jobs:
   publish:
+    name: Publish Fern Docs
     runs-on: linux-amd64-cpu32
     steps:
       - name: Checkout repository
@@ -35,8 +33,7 @@ jobs:
       - name: Install Fern CLI
         run: npm install -g fern-api@4.42.1
 
-      - name: Publish Docs
+      - name: Publish docs
         env:
           FERN_TOKEN: ${{ secrets.DOCS_FERN_TOKEN }}
-        working-directory: ./fern
         run: fern generate --docs

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,10 @@
+# Lychee link checker configuration.
+# exclude_path patterns are matched against full file paths (including absolute paths in CI).
+# Use (^|/) prefix to match directory names anywhere in the path.
+#
+# Excluded directories mirror those intentionally omitted from docs/index.yml.
+
+[params]
+exclude_path = [
+    "(^|/)designs(/|$)",
+]

--- a/docs/csp-health-monitor-iam.md
+++ b/docs/csp-health-monitor-iam.md
@@ -159,4 +159,4 @@ csp-health-monitor:
 ## Additional Resources
 
 - **Configuration Guide**: See [docs/configuration/csp-health-monitor.md](./configuration/csp-health-monitor.md) for detailed Helm configuration options
-- **Troubleshooting**: See [docs/runbooks/csp-health-monitor.md](./runbooks/csp-health-monitor.md) for common issues and solutions
+- **Troubleshooting**: See [docs/runbooks/csp-health-monitor-iam.md](./runbooks/csp-health-monitor-iam.md) for common issues and solutions

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -19,7 +19,7 @@ This directory contains troubleshooting runbooks for NVSentinel operations.
 ### Health Monitor Issues
 - [Health Monitor UDS Communication Failures](health-monitor-uds-failures.md) - Troubleshoot health monitor to platform-connector communication
 - [GPU Monitor DCGM Connectivity Failures](gpu-monitor-dcgm-failures.md) - Resolve DCGM connectivity issues
-- [CSP Health Monitor Issues](csp-health-monitor.md) - Troubleshoot cloud provider API access and permissions
+- [CSP Health Monitor Issues](csp-health-monitor-iam.md) - Troubleshoot cloud provider API access and permissions
 
 ### Operational Issues
 - [Log Collection Job Failures](log-collection-job-failures.md) - Troubleshoot failed log collection jobs


### PR DESCRIPTION
  ## Summary

  Updates the Fern CI workflows:

  - Replace `fern docs broken-links` job with lychee offline link check inside `fern-check`, excluding unpublished `docs/designs/`
  - Fix `fern-docs-preview-build.yml` to diff `*.md` files instead of `*.mdx`
  - Remove stale `working-directory: ./fern` from `publish-fern-docs.yml` and align style with other workflows

  ## Type of Change
  - [ ] 🐛 Bug fix
  - [ ] ✨ New feature
  - [ ] 💥 Breaking change
  - [ ] 📚 Documentation
  - [x] 🔨 Build/CI

  ## Component(s) Affected
  - [ ] Core Services
  - [x] Documentation/CI
  - [ ] Fault Management
  - [ ] Health Monitors
  - [ ] Janitor
  - [ ] Other: ____________

  ## Testing
  - [ ] Tests pass locally
  - [ ] Manual testing completed
  - [x] No breaking changes (or documented)

  ## Checklist
  - [x] Self-review completed
  - [ ] Documentation updated (if needed)
  - [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced the standalone broken-link job with a new link-check step integrated into the existing checks and added a link-check configuration that excludes design assets.
  * Adjusted the documentation preview flow to detect changed Markdown files.
  * Made minor publish workflow configuration tweaks (explicit manual trigger, step label and tag pattern formatting, removed an explicit working directory).
* **Documentation**
  * Updated troubleshooting links to point to the IAM-specific health monitor runbook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->