### PR TITLE
fix(ci): rename .preview-metadata to preview-metadata in Fern preview workflows

### DIFF
--- a/.github/workflows/fern-docs-preview-build.yml
+++ b/.github/workflows/fern-docs-preview-build.yml
@@ -55,10 +55,10 @@ jobs:
         run: |
           PR_NUMBER="${GITHUB_REF#refs/heads/pull-request/}"
           HEAD_REF="${GITHUB_REF#refs/heads/}"
-          mkdir -p .preview-metadata
-          echo "$PR_NUMBER" > .preview-metadata/pr_number
-          echo "$HEAD_REF" > .preview-metadata/head_ref
-          git diff --name-only "origin/main...HEAD" -- '*.md' > .preview-metadata/changed_mdx_files 2>/dev/null || true
+          mkdir -p preview-metadata
+          echo "$PR_NUMBER" > preview-metadata/pr_number
+          echo "$HEAD_REF" > preview-metadata/head_ref
+          git diff --name-only "origin/main...HEAD" -- '*.md' > preview-metadata/changed_mdx_files 2>/dev/null || true
 
       - name: Upload fern sources and metadata
         uses: actions/upload-artifact@v7
@@ -67,5 +67,5 @@ jobs:
           path: |
             fern/
             docs/
-            .preview-metadata/
+            preview-metadata/
           retention-days: 1

--- a/.github/workflows/fern-docs-preview-build.yml
+++ b/.github/workflows/fern-docs-preview-build.yml
@@ -58,7 +58,7 @@ jobs:
           mkdir -p preview-metadata
           echo "$PR_NUMBER" > preview-metadata/pr_number
           echo "$HEAD_REF" > preview-metadata/head_ref
-          git diff --name-only "origin/main...HEAD" -- '*.md' > preview-metadata/changed_mdx_files 2>/dev/null || true
+          git diff --name-only "origin/main...HEAD" -- '*.md' > preview-metadata/changed_md_files 2>/dev/null || true
 
       - name: Upload fern sources and metadata
         uses: actions/upload-artifact@v7

--- a/.github/workflows/fern-docs-preview-comment.yml
+++ b/.github/workflows/fern-docs-preview-comment.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Read PR metadata
         id: metadata
         run: |
-          echo "pr_number=$(cat .preview-metadata/pr_number)" >> "$GITHUB_OUTPUT"
-          echo "head_ref=$(cat .preview-metadata/head_ref)" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$(cat preview-metadata/pr_number)" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$(cat preview-metadata/head_ref)" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Rename `.preview-metadata/` to `preview-metadata/` in the Fern preview build and comment workflows. `upload-artifact@v4`/v7 silently drops hidden directories (leading dot), so the artifact was being uploaded without the PR metadata, breaking the preview comment workflow.

Fixes #1187

## Type of Change
- [x] 🐛 Bug fix
- [x] 🔨 Build/CI

## Component(s) Affected
- [x] Documentation/CI

## Testing
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to use a renamed metadata directory for PR preview storage and retrieval, ensuring preview metadata and changed-file listings are produced and uploaded from the new location. This improves consistency of preview builds and metadata consumption by downstream preview and comment steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->