### PR TITLE
docs: add demo video thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,35 @@ kubectl get nodes  # Verify GPU nodes are visible
 
 ## 🎮 Try the Demo
 
-Want to see NVSentinel in action without GPU hardware? Try our **[Local Fault Injection Demo](demos/local-fault-injection-demo/README.md)**:
+### Demo Videos
+
+See NVSentinel in action — click any thumbnail to watch:
+
+<table>
+<tr>
+<td align="center">
+<a href="https://youtu.be/6HHYMF-YfqY"><img src="https://img.youtube.com/vi/6HHYMF-YfqY/mqdefault.jpg" alt="End-to-End" width="240"/><br/><b>End-to-End</b></a>
+</td>
+<td align="center">
+<a href="https://youtu.be/0qmrHUmxNPQ"><img src="https://img.youtube.com/vi/0qmrHUmxNPQ/mqdefault.jpg" alt="Custom Health Monitors" width="240"/><br/><b>Custom Health Monitors</b></a>
+</td>
+<td align="center">
+<a href="https://youtu.be/G1j4NV5IMkY"><img src="https://img.youtube.com/vi/G1j4NV5IMkY/mqdefault.jpg" alt="Custom Drain Plugins" width="240"/><br/><b>Custom Drain Plugins</b></a>
+</td>
+<td align="center">
+<a href="https://youtu.be/VVAtON7ERHQ"><img src="https://img.youtube.com/vi/VVAtON7ERHQ/mqdefault.jpg" alt="Extensible Remediation" width="240"/><br/><b>Extensible Remediation</b></a>
+</td>
+<td align="center">
+<a href="https://youtu.be/kwWnC0SEFEI"><img src="https://img.youtube.com/vi/kwWnC0SEFEI/mqdefault.jpg" alt="Health Events Analyzer" width="240"/><br/><b>Health Events Analyzer</b></a>
+</td>
+</tr>
+</table>
+
+See the [demos directory](demos/) for full descriptions.
+
+### Run It Locally
+
+Want to try NVSentinel without GPU hardware? Run our **[Local Fault Injection Demo](demos/local-fault-injection-demo/README.md)**:
 
 - 🚀 **5-minute setup** - runs entirely in a local KIND cluster
 - 🔍 **Real pipeline** - see fault detection → quarantine → node cordon

--- a/README.md
+++ b/README.md
@@ -107,21 +107,39 @@ See NVSentinel in action — click any thumbnail to watch:
 
 <table>
 <tr>
-<td align="center">
-<a href="https://youtu.be/6HHYMF-YfqY"><img src="https://img.youtube.com/vi/6HHYMF-YfqY/mqdefault.jpg" alt="End-to-End" width="240"/><br/><b>End-to-End</b></a>
+<td align="center" width="33%">
+<a href="https://youtu.be/6HHYMF-YfqY">
+<img src="https://img.youtube.com/vi/6HHYMF-YfqY/hqdefault.jpg" alt="End-to-End" width="300"/>
+<br/><b>End-to-End</b>
+</a>
 </td>
-<td align="center">
-<a href="https://youtu.be/0qmrHUmxNPQ"><img src="https://img.youtube.com/vi/0qmrHUmxNPQ/mqdefault.jpg" alt="Custom Health Monitors" width="240"/><br/><b>Custom Health Monitors</b></a>
+<td align="center" width="33%">
+<a href="https://youtu.be/0qmrHUmxNPQ">
+<img src="https://img.youtube.com/vi/0qmrHUmxNPQ/hqdefault.jpg" alt="Custom Health Monitors" width="300"/>
+<br/><b>Custom Health Monitors</b>
+</a>
 </td>
-<td align="center">
-<a href="https://youtu.be/G1j4NV5IMkY"><img src="https://img.youtube.com/vi/G1j4NV5IMkY/mqdefault.jpg" alt="Custom Drain Plugins" width="240"/><br/><b>Custom Drain Plugins</b></a>
+<td align="center" width="33%">
+<a href="https://youtu.be/G1j4NV5IMkY">
+<img src="https://img.youtube.com/vi/G1j4NV5IMkY/hqdefault.jpg" alt="Custom Drain Plugins" width="300"/>
+<br/><b>Custom Drain Plugins</b>
+</a>
 </td>
-<td align="center">
-<a href="https://youtu.be/VVAtON7ERHQ"><img src="https://img.youtube.com/vi/VVAtON7ERHQ/mqdefault.jpg" alt="Extensible Remediation" width="240"/><br/><b>Extensible Remediation</b></a>
+</tr>
+<tr>
+<td align="center" width="33%">
+<a href="https://youtu.be/VVAtON7ERHQ">
+<img src="https://img.youtube.com/vi/VVAtON7ERHQ/hqdefault.jpg" alt="Extensible Remediation" width="300"/>
+<br/><b>Extensible Remediation</b>
+</a>
 </td>
-<td align="center">
-<a href="https://youtu.be/kwWnC0SEFEI"><img src="https://img.youtube.com/vi/kwWnC0SEFEI/mqdefault.jpg" alt="Health Events Analyzer" width="240"/><br/><b>Health Events Analyzer</b></a>
+<td align="center" width="33%">
+<a href="https://youtu.be/kwWnC0SEFEI">
+<img src="https://img.youtube.com/vi/kwWnC0SEFEI/hqdefault.jpg" alt="Health Events Analyzer" width="300"/>
+<br/><b>Health Events Analyzer</b>
+</a>
 </td>
+<td></td>
 </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -109,19 +109,19 @@ See NVSentinel in action — click any thumbnail to watch:
 <tr>
 <td align="center" width="33%">
 <a href="https://youtu.be/6HHYMF-YfqY">
-<img src="https://img.youtube.com/vi/6HHYMF-YfqY/hqdefault.jpg" alt="End-to-End" width="300"/>
+<img src="https://img.youtube.com/vi/6HHYMF-YfqY/hqdefault.jpg" alt="End-to-End" width="100%"/>
 <br/><b>End-to-End</b>
 </a>
 </td>
 <td align="center" width="33%">
 <a href="https://youtu.be/0qmrHUmxNPQ">
-<img src="https://img.youtube.com/vi/0qmrHUmxNPQ/hqdefault.jpg" alt="Custom Health Monitors" width="300"/>
+<img src="https://img.youtube.com/vi/0qmrHUmxNPQ/hqdefault.jpg" alt="Custom Health Monitors" width="100%"/>
 <br/><b>Custom Health Monitors</b>
 </a>
 </td>
 <td align="center" width="33%">
 <a href="https://youtu.be/G1j4NV5IMkY">
-<img src="https://img.youtube.com/vi/G1j4NV5IMkY/hqdefault.jpg" alt="Custom Drain Plugins" width="300"/>
+<img src="https://img.youtube.com/vi/G1j4NV5IMkY/hqdefault.jpg" alt="Custom Drain Plugins" width="100%"/>
 <br/><b>Custom Drain Plugins</b>
 </a>
 </td>
@@ -129,13 +129,13 @@ See NVSentinel in action — click any thumbnail to watch:
 <tr>
 <td align="center" width="33%">
 <a href="https://youtu.be/VVAtON7ERHQ">
-<img src="https://img.youtube.com/vi/VVAtON7ERHQ/hqdefault.jpg" alt="Extensible Remediation" width="300"/>
+<img src="https://img.youtube.com/vi/VVAtON7ERHQ/hqdefault.jpg" alt="Extensible Remediation" width="100%"/>
 <br/><b>Extensible Remediation</b>
 </a>
 </td>
 <td align="center" width="33%">
 <a href="https://youtu.be/kwWnC0SEFEI">
-<img src="https://img.youtube.com/vi/kwWnC0SEFEI/hqdefault.jpg" alt="Health Events Analyzer" width="300"/>
+<img src="https://img.youtube.com/vi/kwWnC0SEFEI/hqdefault.jpg" alt="Health Events Analyzer" width="100%"/>
 <br/><b>Health Events Analyzer</b>
 </a>
 </td>

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,8 +1,57 @@
 # NVSentinel Demos
 
-Interactive demonstrations of NVSentinel's core capabilities that run locally on your laptop.
+Interactive demonstrations of NVSentinel's core capabilities.
 
-## Available Demos
+## Demo Videos
+
+<table>
+<tr>
+<td align="center" width="50%">
+<a href="https://youtu.be/6HHYMF-YfqY">
+<img src="https://img.youtube.com/vi/6HHYMF-YfqY/hqdefault.jpg" alt="End-to-End Fault Detection & Remediation" width="400"/>
+<br/><b>End-to-End Fault Detection & Remediation</b>
+</a>
+<br/>Full pipeline: health monitoring, fault detection, quarantine, drain, and breakfix
+</td>
+<td align="center" width="50%">
+<a href="https://youtu.be/0qmrHUmxNPQ">
+<img src="https://img.youtube.com/vi/0qmrHUmxNPQ/hqdefault.jpg" alt="Custom Health Monitors" width="400"/>
+<br/><b>Custom Health Monitors</b>
+</a>
+<br/>Building your own GPU health monitor using the gRPC interface
+</td>
+</tr>
+<tr>
+<td align="center" width="50%">
+<a href="https://youtu.be/G1j4NV5IMkY">
+<img src="https://img.youtube.com/vi/G1j4NV5IMkY/hqdefault.jpg" alt="Custom Drain Plugins" width="400"/>
+<br/><b>Custom Drain Plugins</b>
+</a>
+<br/>Slinky integration for coordinated drain of HPC workloads
+</td>
+<td align="center" width="50%">
+<a href="https://youtu.be/VVAtON7ERHQ">
+<img src="https://img.youtube.com/vi/VVAtON7ERHQ/hqdefault.jpg" alt="Extensible Remediation" width="400"/>
+<br/><b>Extensible Remediation</b>
+</a>
+<br/>Bringing your own breakfix system or remediation operator
+</td>
+</tr>
+<tr>
+<td align="center" width="50%">
+<a href="https://youtu.be/kwWnC0SEFEI">
+<img src="https://img.youtube.com/vi/kwWnC0SEFEI/hqdefault.jpg" alt="Health Events Analyzer" width="400"/>
+<br/><b>Health Events Analyzer</b>
+</a>
+<br/>Identifying and removing bad GPU nodes from the cluster
+</td>
+<td></td>
+</tr>
+</table>
+
+## Interactive Demos
+
+Run these locally on your laptop — no GPU hardware needed.
 
 ### [Local Fault Injection Demo](local-fault-injection-demo/)
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -8,14 +8,14 @@ Interactive demonstrations of NVSentinel's core capabilities.
 <tr>
 <td align="center" width="50%">
 <a href="https://youtu.be/6HHYMF-YfqY">
-<img src="https://img.youtube.com/vi/6HHYMF-YfqY/hqdefault.jpg" alt="End-to-End Fault Detection & Remediation" width="400"/>
+<img src="https://img.youtube.com/vi/6HHYMF-YfqY/hqdefault.jpg" alt="End-to-End Fault Detection & Remediation" width="100%"/>
 <br/><b>End-to-End Fault Detection & Remediation</b>
 </a>
 <br/>Full pipeline: health monitoring, fault detection, quarantine, drain, and breakfix
 </td>
 <td align="center" width="50%">
 <a href="https://youtu.be/0qmrHUmxNPQ">
-<img src="https://img.youtube.com/vi/0qmrHUmxNPQ/hqdefault.jpg" alt="Custom Health Monitors" width="400"/>
+<img src="https://img.youtube.com/vi/0qmrHUmxNPQ/hqdefault.jpg" alt="Custom Health Monitors" width="100%"/>
 <br/><b>Custom Health Monitors</b>
 </a>
 <br/>Building your own GPU health monitor using the gRPC interface
@@ -24,14 +24,14 @@ Interactive demonstrations of NVSentinel's core capabilities.
 <tr>
 <td align="center" width="50%">
 <a href="https://youtu.be/G1j4NV5IMkY">
-<img src="https://img.youtube.com/vi/G1j4NV5IMkY/hqdefault.jpg" alt="Custom Drain Plugins" width="400"/>
+<img src="https://img.youtube.com/vi/G1j4NV5IMkY/hqdefault.jpg" alt="Custom Drain Plugins" width="100%"/>
 <br/><b>Custom Drain Plugins</b>
 </a>
 <br/>Slinky integration for coordinated drain of HPC workloads
 </td>
 <td align="center" width="50%">
 <a href="https://youtu.be/VVAtON7ERHQ">
-<img src="https://img.youtube.com/vi/VVAtON7ERHQ/hqdefault.jpg" alt="Extensible Remediation" width="400"/>
+<img src="https://img.youtube.com/vi/VVAtON7ERHQ/hqdefault.jpg" alt="Extensible Remediation" width="100%"/>
 <br/><b>Extensible Remediation</b>
 </a>
 <br/>Bringing your own breakfix system or remediation operator
@@ -40,7 +40,7 @@ Interactive demonstrations of NVSentinel's core capabilities.
 <tr>
 <td align="center" width="50%">
 <a href="https://youtu.be/kwWnC0SEFEI">
-<img src="https://img.youtube.com/vi/kwWnC0SEFEI/hqdefault.jpg" alt="Health Events Analyzer" width="400"/>
+<img src="https://img.youtube.com/vi/kwWnC0SEFEI/hqdefault.jpg" alt="Health Events Analyzer" width="100%"/>
 <br/><b>Health Events Analyzer</b>
 </a>
 <br/>Identifying and removing bad GPU nodes from the cluster


### PR DESCRIPTION
## Summary
- Add 5 NVSentinel demo video thumbnails with clickable YouTube links to the main README (3-2 grid) and demos/README.md (2-column grid)
- Reorganize the "Try the Demo" section into "Demo Videos" and "Run It Locally" subsections
- Thumbnails are served from YouTube's CDN — no images stored in the repo

## Test plan
- [x] Verify thumbnail images render on the GitHub PR preview for both README.md and demos/README.md
- [x] Confirm all 5 YouTube links open the correct video
- [x] Check grid layout looks reasonable on desktop and mobile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a structured "Demo Videos" section with thumbnails linking five YouTube demos (End-to-End, Custom Health Monitors, Custom Drain Plugins, Extensible Remediation, Health Events Analyzer).
  * Renamed and expanded "Run It Locally" guidance with specific notes (simulated DCGM, local KIND/cordon pipeline).
  * Pointed to the demos directory for full descriptions.
  * Clarified interactive demos can run without GPU hardware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->