### PR TITLE
fix: preflight STORE_ONLY resilience and stale gang configmap pruning

### DIFF
--- a/preflight-checks/dcgm-diag/dcgm_diag/__main__.py
+++ b/preflight-checks/dcgm-diag/dcgm_diag/__main__.py
@@ -110,12 +110,12 @@ def main() -> None:
             test_name=r.test_name,
         )
 
-    if failures and not store_only:
-        log.error("DCGM diagnostic check failed")
-        sys.exit(1)
-
-    if failures and store_only:
-        log.warning("DCGM diagnostic check failed (STORE_ONLY — not blocking pod)")
+    if failures:
+        if store_only:
+            log.warning("DCGM diagnostic check failed (STORE_ONLY — not blocking pod)")
+        else:
+            log.error("DCGM diagnostic check failed")
+            sys.exit(1)
 
     log.info("DCGM diagnostic check passed")
     sys.exit(0)

--- a/preflight-checks/dcgm-diag/dcgm_diag/__main__.py
+++ b/preflight-checks/dcgm-diag/dcgm_diag/__main__.py
@@ -76,7 +76,18 @@ def _run_diagnostic(cfg: Config, reporter: HealthReporter, diag: DCGMDiagnostic)
         log.error("DCGM diagnostic failed", extra={"error": str(e)})
         # is_fatal=True: sets node condition for visibility, even though this may be
         # an infrastructure issue (DCGM unavailable) rather than a confirmed GPU failure.
-        reporter.send_event(gpu_uuid="", is_healthy=False, is_fatal=True, message=str(e))
+        try:
+            reporter.send_event(gpu_uuid="", is_healthy=False, is_fatal=True, message=str(e))
+        except Exception as send_err:  # noqa: BLE001
+            log.error(
+                "Failed to send health event",
+                extra={
+                    "error": str(send_err),
+                    "gpu_uuid": "",
+                    "is_healthy": False,
+                    "is_fatal": True,
+                },
+            )
         return 1
 
     failures = [r for r in results if r.status == "fail"]
@@ -108,14 +119,26 @@ def _run_diagnostic(cfg: Config, reporter: HealthReporter, diag: DCGMDiagnostic)
             f"Test {r.status}",
             extra={"gpu": r.gpu_uuid, "test": r.test_name, "error_code": r.error_code, "detail": message},
         )
-        reporter.send_event(
-            gpu_uuid=r.gpu_uuid,
-            is_healthy=is_pass,
-            is_fatal=is_fatal,
-            message=message,
-            error_code=r.error_code if not is_pass else 0,
-            test_name=r.test_name,
-        )
+        try:
+            reporter.send_event(
+                gpu_uuid=r.gpu_uuid,
+                is_healthy=is_pass,
+                is_fatal=is_fatal,
+                message=message,
+                error_code=r.error_code if not is_pass else 0,
+                test_name=r.test_name,
+            )
+        except Exception as send_err:  # noqa: BLE001
+            log.error(
+                "Failed to send health event",
+                extra={
+                    "error": str(send_err),
+                    "gpu_uuid": r.gpu_uuid,
+                    "test": r.test_name,
+                    "is_healthy": is_pass,
+                    "is_fatal": is_fatal,
+                },
+            )
 
     if failures:
         log.error("DCGM diagnostic check failed")

--- a/preflight-checks/dcgm-diag/dcgm_diag/__main__.py
+++ b/preflight-checks/dcgm-diag/dcgm_diag/__main__.py
@@ -58,6 +58,8 @@ def main() -> None:
 
     diag = DCGMDiagnostic(hostengine_addr=cfg.hostengine_addr)
 
+    store_only = cfg.processing_strategy == pb.ProcessingStrategy.STORE_ONLY
+
     try:
         results = diag.run(cfg.diag_level)
     except Exception as e:
@@ -65,6 +67,9 @@ def main() -> None:
         # is_fatal=True: sets node condition for visibility, even though this may be
         # an infrastructure issue (DCGM unavailable) rather than a confirmed GPU failure.
         reporter.send_event(gpu_uuid="", is_healthy=False, is_fatal=True, message=str(e))
+        if store_only:
+            log.warning("DCGM unavailable (STORE_ONLY — not blocking pod)")
+            sys.exit(0)
         sys.exit(1)
 
     failures = [r for r in results if r.status == "fail"]
@@ -105,9 +110,12 @@ def main() -> None:
             test_name=r.test_name,
         )
 
-    if failures:
+    if failures and not store_only:
         log.error("DCGM diagnostic check failed")
         sys.exit(1)
+
+    if failures and store_only:
+        log.warning("DCGM diagnostic check failed (STORE_ONLY — not blocking pod)")
 
     log.info("DCGM diagnostic check passed")
     sys.exit(0)

--- a/preflight-checks/dcgm-diag/dcgm_diag/__main__.py
+++ b/preflight-checks/dcgm-diag/dcgm_diag/__main__.py
@@ -57,8 +57,18 @@ def main() -> None:
     )
 
     diag = DCGMDiagnostic(hostengine_addr=cfg.hostengine_addr)
-
     store_only = cfg.processing_strategy == pb.ProcessingStrategy.STORE_ONLY
+
+    exit_code = _run_diagnostic(cfg, reporter, diag)
+
+    if exit_code != 0 and store_only:
+        log.warning("Check failed (STORE_ONLY — not blocking pod)")
+        sys.exit(0)
+    sys.exit(exit_code)
+
+
+def _run_diagnostic(cfg: Config, reporter: HealthReporter, diag: DCGMDiagnostic) -> int:
+    log = logging.getLogger(__name__)
 
     try:
         results = diag.run(cfg.diag_level)
@@ -67,10 +77,7 @@ def main() -> None:
         # is_fatal=True: sets node condition for visibility, even though this may be
         # an infrastructure issue (DCGM unavailable) rather than a confirmed GPU failure.
         reporter.send_event(gpu_uuid="", is_healthy=False, is_fatal=True, message=str(e))
-        if store_only:
-            log.warning("DCGM unavailable (STORE_ONLY — not blocking pod)")
-            sys.exit(0)
-        sys.exit(1)
+        return 1
 
     failures = [r for r in results if r.status == "fail"]
     warnings = [r for r in results if r.status == "warn"]
@@ -111,14 +118,11 @@ def main() -> None:
         )
 
     if failures:
-        if store_only:
-            log.warning("DCGM diagnostic check failed (STORE_ONLY — not blocking pod)")
-        else:
-            log.error("DCGM diagnostic check failed")
-            sys.exit(1)
+        log.error("DCGM diagnostic check failed")
+        return 1
 
     log.info("DCGM diagnostic check passed")
-    sys.exit(0)
+    return 0
 
 
 if __name__ == "__main__":

--- a/preflight-checks/dcgm-diag/dcgm_diag/diag.py
+++ b/preflight-checks/dcgm-diag/dcgm_diag/diag.py
@@ -15,6 +15,7 @@
 import logging
 from dataclasses import dataclass
 
+import dcgm_agent
 import dcgm_structs
 import pydcgm
 
@@ -77,6 +78,13 @@ class DCGMDiagnostic:
             raise RuntimeError("No GPUs allocated to this container")
 
         log.info(f"Running DCGM diagnostic level={level} gpus={gpu_indices}")
+
+        # Stop any zombie diagnostic left by a previous crashed container on this
+        # node.  Without this, RunDiagnostic fails with "already running".
+        try:
+            dcgm_agent.dcgmStopDiagnostic(self._handle.handle)
+        except Exception:
+            pass
 
         group = self._create_gpu_group(gpu_indices)
         try:

--- a/preflight-checks/dcgm-diag/dcgm_diag/diag.py
+++ b/preflight-checks/dcgm-diag/dcgm_diag/diag.py
@@ -83,8 +83,8 @@ class DCGMDiagnostic:
         # node.  Without this, RunDiagnostic fails with "already running".
         try:
             dcgm_agent.dcgmStopDiagnostic(self._handle.handle)
-        except Exception:
-            pass
+        except Exception:  # noqa: BLE001
+            log.debug("Failed to stop previous diagnostic", exc_info=True)
 
         group = self._create_gpu_group(gpu_indices)
         try:

--- a/preflight-checks/dcgm-diag/dcgm_diag/tests/conftest.py
+++ b/preflight-checks/dcgm-diag/dcgm_diag/tests/conftest.py
@@ -114,6 +114,7 @@ class MockPyDCGM:
         def __init__(self, ipAddress: str | None = None, opMode: int | None = None) -> None:
             self.ipAddress = ipAddress
             self.opMode = opMode
+            self.handle = MagicMock()
 
         def Shutdown(self) -> None:
             pass
@@ -135,11 +136,21 @@ class MockPyDCGM:
             pass
 
 
+class MockDCGMAgent:
+    """Mock dcgm_agent module for testing."""
+
+    @staticmethod
+    def dcgmStopDiagnostic(handle: object) -> None:
+        pass
+
+
 # Install mocks in sys.modules before any imports
 dcgm_structs_mock = MockDCGMStructs()
+dcgm_agent_mock = MockDCGMAgent()
 pydcgm_mock = MockPyDCGM()
 pynvml_mock = MockPyNVML()
 
+sys.modules["dcgm_agent"] = dcgm_agent_mock
 sys.modules["dcgm_structs"] = dcgm_structs_mock
 sys.modules["pydcgm"] = pydcgm_mock
 sys.modules["pynvml"] = pynvml_mock

--- a/preflight-checks/nccl-allreduce/nccl_allreduce/__main__.py
+++ b/preflight-checks/nccl-allreduce/nccl_allreduce/__main__.py
@@ -46,6 +46,7 @@ import torch.distributed as dist
 from .benchmark import Benchmark, BenchmarkResult, parse_size
 from .config import Config
 from .errors import NCCLError
+from .protos import health_event_pb2 as pb
 from .health import HealthReporter
 from .logger import set_default_structured_logger
 
@@ -271,6 +272,10 @@ def _handle_failure(cfg: Config, error: NCCLError, message: str) -> int:
             extra={"error": str(err)},
         )
         return NCCLError.HEALTH_REPORT_FAILED.value.exit_code
+
+    if cfg.processing_strategy == pb.ProcessingStrategy.STORE_ONLY:
+        log.warning("Check failed (STORE_ONLY — not blocking pod)", extra={"details": message})
+        return NCCLError.SUCCESS.value.exit_code
 
     return error.value.exit_code
 

--- a/preflight-checks/nccl-allreduce/nccl_allreduce/__main__.py
+++ b/preflight-checks/nccl-allreduce/nccl_allreduce/__main__.py
@@ -106,7 +106,6 @@ def run() -> int:
 
 def _run_benchmark_flow(cfg: Config) -> int:
     """Execute the benchmark and return an exit code."""
-
     # Set NCCL defaults if not already set by the container env.
     if "NCCL_DEBUG" not in os.environ:
         os.environ["NCCL_DEBUG"] = "INFO"

--- a/preflight-checks/nccl-allreduce/nccl_allreduce/__main__.py
+++ b/preflight-checks/nccl-allreduce/nccl_allreduce/__main__.py
@@ -95,6 +95,18 @@ def run() -> int:
         log.error("Configuration error", extra={"error": str(err)})
         return NCCLError.GANG_CONFIG_ERROR.value.exit_code
 
+    store_only = cfg.processing_strategy == pb.ProcessingStrategy.STORE_ONLY
+    exit_code = _run_benchmark_flow(cfg)
+
+    if exit_code != 0 and store_only:
+        log.warning("Check failed (STORE_ONLY — not blocking pod)")
+        return NCCLError.SUCCESS.value.exit_code
+    return exit_code
+
+
+def _run_benchmark_flow(cfg: Config) -> int:
+    """Execute the benchmark and return an exit code."""
+
     # Set NCCL defaults if not already set by the container env.
     if "NCCL_DEBUG" not in os.environ:
         os.environ["NCCL_DEBUG"] = "INFO"
@@ -272,10 +284,6 @@ def _handle_failure(cfg: Config, error: NCCLError, message: str) -> int:
             extra={"error": str(err)},
         )
         return NCCLError.HEALTH_REPORT_FAILED.value.exit_code
-
-    if cfg.processing_strategy == pb.ProcessingStrategy.STORE_ONLY:
-        log.warning("Check failed (STORE_ONLY — not blocking pod)", extra={"details": message})
-        return NCCLError.SUCCESS.value.exit_code
 
     return error.value.exit_code
 

--- a/preflight-checks/nccl-loopback/main.go
+++ b/preflight-checks/nccl-loopback/main.go
@@ -24,6 +24,8 @@ import (
 	"github.com/nvidia/nvsentinel/preflight-checks/nccl-loopback/pkg/benchmark"
 	"github.com/nvidia/nvsentinel/preflight-checks/nccl-loopback/pkg/config"
 	"github.com/nvidia/nvsentinel/preflight-checks/nccl-loopback/pkg/health"
+
+	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
 )
 
 var (
@@ -89,6 +91,11 @@ func run() int {
 			return exitSendEventError
 		}
 
+		if cfg.ProcessingStrategy == pb.ProcessingStrategy_STORE_ONLY {
+			slog.Warn("NCCL benchmark failed (STORE_ONLY — not blocking pod)", "error", err)
+			return exitSuccess
+		}
+
 		return exitTestFailed
 	}
 
@@ -134,6 +141,13 @@ func run() int {
 		); sendErr != nil {
 			slog.Error("Failed to send health event", "error", sendErr)
 			return exitSendEventError
+		}
+
+		if cfg.ProcessingStrategy == pb.ProcessingStrategy_STORE_ONLY {
+			slog.Warn("NCCL loopback test failed (STORE_ONLY — not blocking pod)",
+				"measured_gbps", result.BusBandwidthGbps,
+				"threshold_gbps", cfg.BWThresholdGbps)
+			return exitSuccess
 		}
 
 		return exitTestFailed

--- a/preflight-checks/nccl-loopback/main.go
+++ b/preflight-checks/nccl-loopback/main.go
@@ -67,11 +67,11 @@ func run() int {
 		slog.Warn("Check failed (STORE_ONLY — not blocking pod)")
 		return exitSuccess
 	}
+
 	return exitCode
 }
 
 func execute(ctx context.Context, cfg *config.Config) int {
-
 	slog.Info("Configuration loaded",
 		"bw_threshold_gbps", cfg.BWThresholdGbps,
 		"skip_bandwidth_check", cfg.SkipBandwidthCheck,

--- a/preflight-checks/nccl-loopback/main.go
+++ b/preflight-checks/nccl-loopback/main.go
@@ -61,6 +61,17 @@ func run() int {
 		return exitConfigError
 	}
 
+	exitCode := execute(ctx, cfg)
+
+	if exitCode != exitSuccess && cfg.ProcessingStrategy == pb.ProcessingStrategy_STORE_ONLY {
+		slog.Warn("Check failed (STORE_ONLY — not blocking pod)")
+		return exitSuccess
+	}
+	return exitCode
+}
+
+func execute(ctx context.Context, cfg *config.Config) int {
+
 	slog.Info("Configuration loaded",
 		"bw_threshold_gbps", cfg.BWThresholdGbps,
 		"skip_bandwidth_check", cfg.SkipBandwidthCheck,
@@ -89,11 +100,6 @@ func run() int {
 		); sendErr != nil {
 			slog.Error("Failed to send health event", "error", sendErr)
 			return exitSendEventError
-		}
-
-		if cfg.ProcessingStrategy == pb.ProcessingStrategy_STORE_ONLY {
-			slog.Warn("NCCL benchmark failed (STORE_ONLY — not blocking pod)", "error", err)
-			return exitSuccess
 		}
 
 		return exitTestFailed
@@ -141,13 +147,6 @@ func run() int {
 		); sendErr != nil {
 			slog.Error("Failed to send health event", "error", sendErr)
 			return exitSendEventError
-		}
-
-		if cfg.ProcessingStrategy == pb.ProcessingStrategy_STORE_ONLY {
-			slog.Warn("NCCL loopback test failed (STORE_ONLY — not blocking pod)",
-				"measured_gbps", result.BusBandwidthGbps,
-				"threshold_gbps", cfg.BWThresholdGbps)
-			return exitSuccess
 		}
 
 		return exitTestFailed

--- a/preflight/pkg/gang/coordinator/coordinator.go
+++ b/preflight/pkg/gang/coordinator/coordinator.go
@@ -216,7 +216,9 @@ func (c *Coordinator) RegisterPeer(
 		"peer", peer.PodName,
 		"peerIP", peer.PodIP)
 
-	if err := c.updateConfigMap(ctx, namespace, configMapName, gangInfo.ExpectedMinCount, peer); err != nil {
+	livePodNames := livePodNamesFromPeers(gangInfo.Peers)
+
+	if err := c.updateConfigMap(ctx, namespace, configMapName, gangInfo.ExpectedMinCount, peer, livePodNames); err != nil {
 		return fmt.Errorf("failed to update ConfigMap: %w", err)
 	}
 
@@ -252,7 +254,9 @@ func (c *Coordinator) RegisterPeerInConfigMap(
 		"peer", peer.PodName,
 		"peerIP", peer.PodIP)
 
-	if err := c.updateConfigMap(ctx, namespace, configMapName, gangInfo.ExpectedMinCount, peer); err != nil {
+	livePodNames := livePodNamesFromPeers(gangInfo.Peers)
+
+	if err := c.updateConfigMap(ctx, namespace, configMapName, gangInfo.ExpectedMinCount, peer, livePodNames); err != nil {
 		return fmt.Errorf("failed to update ConfigMap: %w", err)
 	}
 
@@ -272,6 +276,7 @@ func (c *Coordinator) updateConfigMap(
 	configMapName string,
 	expectedCount int,
 	peer types.PeerInfo,
+	livePodNames map[string]bool,
 ) error {
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		cm := &corev1.ConfigMap{}
@@ -287,7 +292,7 @@ func (c *Coordinator) updateConfigMap(
 			}
 		}
 
-		c.addPeerToConfigMap(cm, peer)
+		c.addPeerToConfigMap(cm, peer, livePodNames)
 		c.updateMasterAddr(cm)
 
 		return c.client.Update(ctx, cm)
@@ -378,7 +383,10 @@ func (c *Coordinator) createConfigMap(name, namespace string, gangInfo *types.Ga
 }
 
 // addPeerToConfigMap adds a peer to the ConfigMap's peer list.
-func (c *Coordinator) addPeerToConfigMap(cm *corev1.ConfigMap, peer types.PeerInfo) {
+// When livePodNames is non-nil, entries for pods not in the set are pruned.
+// This prevents stale entries from accumulating when pods are rescheduled
+// (each replacement pod gets a new name, leaving the old entry behind).
+func (c *Coordinator) addPeerToConfigMap(cm *corev1.ConfigMap, peer types.PeerInfo, livePodNames map[string]bool) {
 	if cm.Data == nil {
 		cm.Data = make(map[string]string)
 	}
@@ -388,6 +396,21 @@ func (c *Coordinator) addPeerToConfigMap(cm *corev1.ConfigMap, peer types.PeerIn
 	}
 
 	existingPeers := ParsePeers(cm.Data[DataKeyPeers])
+
+	if len(livePodNames) > 0 {
+		activePeers := existingPeers[:0]
+		for _, p := range existingPeers {
+			if livePodNames[p.PodName] {
+				activePeers = append(activePeers, p)
+			} else {
+				slog.Info("Pruning stale gang peer",
+					"stalePod", p.PodName,
+					"triggerPod", peer.PodName)
+			}
+		}
+		existingPeers = activePeers
+	}
+
 	found := false
 
 	for i, p := range existingPeers {
@@ -416,6 +439,16 @@ func (c *Coordinator) addPeerToConfigMap(cm *corev1.ConfigMap, peer types.PeerIn
 	}
 
 	cm.Data[DataKeyPeers] = strings.Join(lines, "\n")
+}
+
+// livePodNamesFromPeers builds a set of pod names from the discovered peers.
+func livePodNamesFromPeers(peers []types.PeerInfo) map[string]bool {
+	names := make(map[string]bool, len(peers))
+	for _, p := range peers {
+		names[p.PodName] = true
+	}
+
+	return names
 }
 
 // updateMasterAddr updates the master address in the ConfigMap.

--- a/preflight/pkg/gang/coordinator/coordinator.go
+++ b/preflight/pkg/gang/coordinator/coordinator.go
@@ -397,7 +397,7 @@ func (c *Coordinator) addPeerToConfigMap(cm *corev1.ConfigMap, peer types.PeerIn
 
 	existingPeers := ParsePeers(cm.Data[DataKeyPeers])
 
-	if len(livePodNames) > 0 {
+	if livePodNames != nil {
 		activePeers := existingPeers[:0]
 		for _, p := range existingPeers {
 			if livePodNames[p.PodName] {
@@ -408,6 +408,7 @@ func (c *Coordinator) addPeerToConfigMap(cm *corev1.ConfigMap, peer types.PeerIn
 					"triggerPod", peer.PodName)
 			}
 		}
+
 		existingPeers = activePeers
 	}
 
@@ -442,7 +443,14 @@ func (c *Coordinator) addPeerToConfigMap(cm *corev1.ConfigMap, peer types.PeerIn
 }
 
 // livePodNamesFromPeers builds a set of pod names from the discovered peers.
+// Returns nil when peers is empty so callers can distinguish "no live data
+// available" (nil → skip pruning) from "discovered peers but none matched"
+// (non-nil empty map → prune all stale entries).
 func livePodNamesFromPeers(peers []types.PeerInfo) map[string]bool {
+	if len(peers) == 0 {
+		return nil
+	}
+
 	names := make(map[string]bool, len(peers))
 	for _, p := range peers {
 		names[p.PodName] = true

--- a/preflight/pkg/gang/coordinator/coordinator_test.go
+++ b/preflight/pkg/gang/coordinator/coordinator_test.go
@@ -253,11 +253,11 @@ func TestAddPeerToConfigMapCheckNames(t *testing.T) {
 		c.addPeerToConfigMap(cm, types.PeerInfo{
 			PodName: "pod-0", PodIP: "10.0.0.1",
 			CheckNames: "preflight-dcgm-diag,preflight-nccl-allreduce",
-		})
+		}, nil)
 		c.addPeerToConfigMap(cm, types.PeerInfo{
 			PodName: "pod-1", PodIP: "10.0.0.2",
 			CheckNames: "preflight-dcgm-diag,preflight-nccl-allreduce",
-		})
+		}, nil)
 
 		parsed := ParsePeers(cm.Data[DataKeyPeers])
 		require.Len(t, parsed, 2)
@@ -270,12 +270,12 @@ func TestAddPeerToConfigMapCheckNames(t *testing.T) {
 		c.addPeerToConfigMap(cm, types.PeerInfo{
 			PodName: "pod-0", PodIP: "10.0.0.1",
 			CheckNames: "preflight-dcgm-diag",
-		})
+		}, nil)
 		// Re-register with new IP, same CheckNames
 		c.addPeerToConfigMap(cm, types.PeerInfo{
 			PodName: "pod-0", PodIP: "10.0.0.99",
 			CheckNames: "preflight-dcgm-diag",
-		})
+		}, nil)
 
 		parsed := ParsePeers(cm.Data[DataKeyPeers])
 		require.Len(t, parsed, 1)
@@ -287,7 +287,7 @@ func TestAddPeerToConfigMapCheckNames(t *testing.T) {
 		cm := &corev1.ConfigMap{Data: map[string]string{}}
 		c.addPeerToConfigMap(cm, types.PeerInfo{
 			PodName: "pod-0", PodIP: "10.0.0.1",
-		})
+		}, nil)
 
 		// Raw format should be "pod-0;10.0.0.1;0;" (trailing semicolon)
 		assert.Contains(t, cm.Data[DataKeyPeers], "pod-0;10.0.0.1;0;")
@@ -295,6 +295,50 @@ func TestAddPeerToConfigMapCheckNames(t *testing.T) {
 		parsed := ParsePeers(cm.Data[DataKeyPeers])
 		require.Len(t, parsed, 1)
 		assert.Equal(t, "", parsed[0].CheckNames)
+	})
+
+	t.Run("prunes stale peers from rescheduled pods", func(t *testing.T) {
+		cm := &corev1.ConfigMap{Data: map[string]string{}}
+
+		// Gen 1: two pods register with no live-set (nil).
+		c.addPeerToConfigMap(cm, types.PeerInfo{
+			PodName: "job-workers-0-0-aaaa", PodIP: "10.0.0.1",
+			CheckNames: "preflight-dcgm-diag",
+		}, nil)
+		c.addPeerToConfigMap(cm, types.PeerInfo{
+			PodName: "job-workers-0-1-bbbb", PodIP: "10.0.0.2",
+			CheckNames: "preflight-dcgm-diag",
+		}, nil)
+		require.Len(t, ParsePeers(cm.Data[DataKeyPeers]), 2)
+
+		// Gen 2: pods rescheduled with new names. The live-set contains
+		// only the new pods, so the old entries should be pruned.
+		livePods := map[string]bool{
+			"job-workers-0-0-cccc": true,
+			"job-workers-0-1-dddd": true,
+		}
+		c.addPeerToConfigMap(cm, types.PeerInfo{
+			PodName: "job-workers-0-0-cccc", PodIP: "10.0.0.3",
+			CheckNames: "preflight-dcgm-diag",
+		}, livePods)
+
+		parsed := ParsePeers(cm.Data[DataKeyPeers])
+		require.Len(t, parsed, 1, "stale gen-1 entries should be pruned")
+		assert.Equal(t, "job-workers-0-0-cccc", parsed[0].PodName)
+		assert.Contains(t, cm.Data[DataKeyPeers], "job-workers-0-0-cccc;10.0.0.3;0;")
+
+		// Second gen-2 pod registers.
+		c.addPeerToConfigMap(cm, types.PeerInfo{
+			PodName: "job-workers-0-1-dddd", PodIP: "10.0.0.4",
+			CheckNames: "preflight-dcgm-diag",
+		}, livePods)
+
+		parsed = ParsePeers(cm.Data[DataKeyPeers])
+		require.Len(t, parsed, 2, "should have exactly 2 live peers")
+		assert.Equal(t, "job-workers-0-0-cccc", parsed[0].PodName)
+		assert.Equal(t, "job-workers-0-1-dddd", parsed[1].PodName)
+		assert.Contains(t, cm.Data[DataKeyPeers], "job-workers-0-0-cccc;10.0.0.3;0;")
+		assert.Contains(t, cm.Data[DataKeyPeers], "job-workers-0-1-dddd;10.0.0.4;1;")
 	})
 }
 


### PR DESCRIPTION
## Summary

Two independent fixes for the preflight system, each addressing a different failure mode that causes pod rescheduling loops.

### Fix 1: STORE_ONLY gate and zombie DCGM cleanup (commits 1-4, 6)

**Problem — zombie diagnostics:** When a preflight DCGM container crashes mid-diagnostic (e.g., OOMKill), the DCGM host engine keeps the diagnostic running. The next preflight container on the same node calls `RunDiagnostic` and gets "resource in use" / "already running" errors. With `PROCESSING_STRATEGY=STORE_ONLY` (observability mode), the check should log the failure and exit 0 — but the STORE_ONLY gate was broken, so it exited 1 instead. The pod gets rescheduled, potentially lands on the same node, hits the same zombie, and loops.

**Fix:**
- Call `dcgmStopDiagnostic()` before `RunDiagnostic()` to clear any zombie diagnostic left by a crashed container.
- Refactor all three preflight containers (dcgm-diag, nccl-loopback, nccl-allreduce) to use a single STORE_ONLY gate: run the check, and if it fails with STORE_ONLY, log a warning and exit 0.

### Fix 2: Stale gang ConfigMap entries on pod rescheduling (commit 5)

**Problem — stale ConfigMap entries:** When a pod is rescheduled (for any reason — training crash, zombie DCGM failure, node issue), the replacement pod gets a new name. The old pod's entry in the gang ConfigMap is never removed. `addPeerToConfigMap` deduplicates by `PodName`, but rescheduled pods have different names, so stale entries accumulate. Each new generation gets ranks beyond `nnodes` (e.g., `--node_rank=9` with `--nnodes=2`), making `torchrun` rendezvous impossible.

The failure happens at torchrun's elastic agent level (`static_tcp_rendezvous.py` → `TCPStore` — 900s socket timeout), before worker processes are spawned. `__main__.py` is never executed, so no health events are sent and no remediation/cordoning occurs. The Job controller simply restarts the pods, which register more stale entries, creating an infinite retry loop.

**Fix:** When registering a peer, use the live pod list from `DiscoverPeers()` (which only returns Running/Pending pods) to prune ConfigMap entries for pods that no longer exist. When `livePodNames` is nil (backward compatibility), no pruning occurs.

## Evidence (stale ConfigMap bug)

Gang ConfigMap from a 2-pod (`nnodes=2`) pre-training job across 9 reschedulings:

| Time | Pod | my_rank | actual entries | expected | Result |
|------|-----|---------|----------------|----------|--------|
| Gen 1 | `25mgk`/`2ftnk` | 0, 1 | 2 | 2 | **PASSED** |
| 13:38 | `vf28c` | **9** | 10 | 2 | torchrun hung |
| 13:59 | `7v7t4` | **2** | 12 | 2 | torchrun hung |
| 14:20 | `7bxt2` | **2** | 14 | 2 | torchrun hung |
| 14:40 | `j7b82` | **6** | 16 | 2 | torchrun hung |
| 15:07 | `nqmgb` | **7** | 18 | 2 | torchrun hung |

Confirmed via Datadog — every gen 2+ pod shows:
```
[c10d] TCP client failed to connect/validate to host <master_ip>:29500 - timed out (timeout=900000ms)
```
Traceback: `launch_agent → _invoke_run → run → _initialize_workers → _rendezvous → next_rendezvous → TCPStore()`

## Test plan

- [x] All existing coordinator tests pass (30/30)
- [x] New test `prunes_stale_peers_from_rescheduled_pods` verifies stale entries are pruned and ranks reassigned correctly
- [x] `go build ./...` clean
- [x] Validated on Crusoe H200 cluster with preflight-enabled pre-training jobs
- [x] DCGM diag-2 passes end-to-end (exit 0, ~4.5 min)
- [x] NCCL loopback passes with 346 GB/s (threshold 150 GB/s)
- [x] NCCL allreduce passes on clean ConfigMap (first generation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Store Only" processing mode now allows diagnostics and benchmarks to complete without failing overall runs; results are still collected.

* **Bug Fixes**
  * Config maps now remove stale peer entries when pods are rescheduled, keeping peer lists accurate.
  * Attempts to stop lingering GPU diagnostics before runs; failures to emit health events are logged without aborting.

* **Tests**
  * Added tests and mocks to verify peer pruning and diagnostic cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->