### PR TITLE
fix(ci): add MDX safety check for non-self-closing img tags

### DIFF
--- a/.github/workflows/fern-docs-ci.yml
+++ b/.github/workflows/fern-docs-ci.yml
@@ -56,6 +56,16 @@ jobs:
       - name: Install Fern CLI
         run: npm install -g fern-api@4.42.1
 
+      - name: Check MDX safety
+        # Intentionally inline — a composite action would add indirection without benefit for a single grep.
+        run: |
+          BAD=$(grep -rn '<img\b[^>]*[^/]>' docs/ fern/ --include="*.md" --include="*.mdx" || true)
+          if [ -n "$BAD" ]; then
+            echo "::error::Non-self-closing <img> tags found (MDX requires <img ... />):"
+            echo "$BAD"
+            exit 1
+          fi
+
       - name: Validate Fern configuration
         run: fern check
 


### PR DESCRIPTION
## Summary

Add a grep-based MDX safety step to `fern-docs-ci.yml` that catches non-self-closing `<img>` tags before merge. Covers `docs/` and `fern/` for both `*.md` and `*.mdx` files.

`fern check` validates Fern configuration only — non-self-closing `<img>` tags pass `fern check` but cause `fern generate` to fail with `Unexpected closing tag </p>`. Root-caused from a live failure in NVIDIA/topograph#281, fixed in NVIDIA/aicr#620.

Fixes #1214

## Type of Change
- [x] 🐛 Bug fix
- [x] 🔨 Build/CI

## Component(s) Affected
- [x] Documentation/CI

## Testing
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added validation step to CI pipeline to check documentation files for improperly formatted image tags, ensuring consistent code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->