### PR TITLE
chore: standarize base image to debian 13

### DIFF
--- a/demos/local-custom-remediation-demo/memory-pressure-monitor/Dockerfile
+++ b/demos/local-custom-remediation-demo/memory-pressure-monitor/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM public.ecr.aws/docker/library/golang:1.25 AS builder
+FROM public.ecr.aws/docker/library/golang:1.25-trixie AS builder
 
 WORKDIR /go/src/nvsentinel
 
@@ -27,7 +27,7 @@ COPY data-models/ data-models/
 RUN cd demos/local-custom-remediation-demo/memory-pressure-monitor && \
     CGO_ENABLED=0 go build -ldflags="-s -w" -o memory-pressure-monitor main.go
 
-FROM gcr.io/distroless/static-debian12
+FROM gcr.io/distroless/static-debian13
 
 COPY --from=builder /go/src/nvsentinel/demos/local-custom-remediation-demo/memory-pressure-monitor/memory-pressure-monitor /memory-pressure-monitor
 

--- a/demos/local-custom-remediation-demo/memory-reclaim-controller/Dockerfile
+++ b/demos/local-custom-remediation-demo/memory-reclaim-controller/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.25 AS builder
+FROM golang:1.25-trixie AS builder
 
 WORKDIR /go/src/app
 
@@ -24,7 +24,7 @@ COPY demos/local-custom-remediation-demo/memory-reclaim-controller/ .
 
 RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /memory-reclaim-controller .
 
-FROM gcr.io/distroless/static-debian12
+FROM gcr.io/distroless/static-debian13
 
 COPY --from=builder /memory-reclaim-controller /memory-reclaim-controller
 

--- a/health-monitors/gpu-health-monitor/Dockerfile
+++ b/health-monitors/gpu-health-monitor/Dockerfile
@@ -18,7 +18,7 @@ ARG VERSION="0.1.0"
 ARG GIT_COMMIT="none"
 ARG BUILD_DATE=$(date -u +%FT%TZ)
 
-FROM public.ecr.aws/docker/library/python:3.13-bookworm AS build
+FROM public.ecr.aws/docker/library/python:3.13-trixie AS build
 
 ARG VERSION
 

--- a/health-monitors/syslog-health-monitor/Dockerfile
+++ b/health-monitors/syslog-health-monitor/Dockerfile
@@ -49,7 +49,7 @@ RUN cd health-monitors/syslog-health-monitor && \
     CGO_ENABLED=1 go build -tags "${BUILD_TAGS}" -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${GIT_COMMIT} -X main.date=${BUILD_DATE}" -o syslog-health-monitor main.go
 
 # Runtime stage - using Debian slim for systemd journal support
-FROM public.ecr.aws/docker/library/debian:bookworm-slim AS runtime
+FROM public.ecr.aws/docker/library/debian:trixie-slim AS runtime
 
 # Install required system libraries for systemd journal
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/metadata-collector/Dockerfile
+++ b/metadata-collector/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM public.ecr.aws/docker/library/golang:1.26-bookworm AS builder
+FROM public.ecr.aws/docker/library/golang:1.26-trixie AS builder
 
 ARG VERSION="dev"
 ARG GIT_COMMIT="none"

--- a/preflight-checks/dcgm-diag/Dockerfile
+++ b/preflight-checks/dcgm-diag/Dockerfile
@@ -17,7 +17,7 @@ ARG VERSION="0.1.0"
 ARG GIT_COMMIT="none"
 ARG BUILD_DATE=$(date -u +%FT%TZ)
 
-FROM public.ecr.aws/docker/library/python:3.13-bookworm AS build
+FROM public.ecr.aws/docker/library/python:3.13-trixie AS build
 
 ARG VERSION
 

--- a/preflight-checks/nccl-allreduce/Dockerfile
+++ b/preflight-checks/nccl-allreduce/Dockerfile
@@ -29,7 +29,7 @@ ARG VERSION="0.1.0"
 # =============================================================================
 # Build stage: Install Python dependencies
 # =============================================================================
-FROM public.ecr.aws/docker/library/python:3.13-bookworm AS build
+FROM public.ecr.aws/docker/library/python:3.13-trixie AS build
 
 ARG VERSION
 

--- a/preflight-checks/nccl-loopback/Dockerfile
+++ b/preflight-checks/nccl-loopback/Dockerfile
@@ -21,7 +21,7 @@ ARG NCCL_TESTS_VERSION=v2.13.11
 # =============================================================================
 # Build stage: Compile Go binary
 # =============================================================================
-FROM public.ecr.aws/docker/library/golang:1.26-bookworm AS go-builder
+FROM public.ecr.aws/docker/library/golang:1.26-trixie AS go-builder
 
 ARG VERSION="dev"
 ARG GIT_COMMIT="none"

--- a/tilt/csp-api-mock/Dockerfile
+++ b/tilt/csp-api-mock/Dockerfile
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 COPY . .
 RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o csp-api-mock .
 
-FROM public.ecr.aws/docker/library/debian:bookworm-slim AS runtime
+FROM public.ecr.aws/docker/library/debian:trixie-slim AS runtime
 
 COPY --from=builder /app/csp-api-mock /app/csp-api-mock
 


### PR DESCRIPTION
## Summary

This PR update base images of containers from Debian 12 (bookworm, going to be end of full support in June 10th 2026) to Debian 13 (trixie).

Ref: https://www.debian.org/releases/bookworm/, https://www.debian.org/releases/trixie/

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated base container images across health monitors, preflight checks, metadata collection, demo services, and local test mocks to newer OS and language runtime releases to improve security, patching, and runtime stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->