### PR TITLE
feat(metadata-augmentor): include Topograph topology labels by default

### DIFF
--- a/distros/kubernetes/nvsentinel/values-full.yaml
+++ b/distros/kubernetes/nvsentinel/values-full.yaml
@@ -339,7 +339,13 @@ platformConnector:
         - "cloud.google.com/gce-topology-block"
         - "cloud.google.com/gce-topology-host"
         - "cloud.google.com/gce-topology-subblock"
-    
+        # Topograph-applied topology labels (present when Topograph is deployed in the cluster;
+        # see https://github.com/NVIDIA/topograph/blob/main/docs/reference/node-labels.md)
+        - "network.topology.nvidia.com/accelerator"
+        - "network.topology.nvidia.com/leaf"
+        - "network.topology.nvidia.com/spine"
+        - "network.topology.nvidia.com/core"
+
     # Property overrides configuration
     # Uses CEL expressions to modify health event properties
     # Allows operators to suppress errors or change recommended actions

--- a/distros/kubernetes/nvsentinel/values.yaml
+++ b/distros/kubernetes/nvsentinel/values.yaml
@@ -277,7 +277,13 @@ platformConnector:
         - "cloud.google.com/gce-topology-block"
         - "cloud.google.com/gce-topology-host"
         - "cloud.google.com/gce-topology-subblock"
-    
+        # Topograph-applied topology labels (present when Topograph is deployed in the cluster;
+        # see https://github.com/NVIDIA/topograph/blob/main/docs/reference/node-labels.md)
+        - "network.topology.nvidia.com/accelerator"
+        - "network.topology.nvidia.com/leaf"
+        - "network.topology.nvidia.com/spine"
+        - "network.topology.nvidia.com/core"
+
     # Property overrides - uses CEL expressions to override event properties
     OverrideTransformer:
       rules: []

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -735,6 +735,21 @@ userNamespaces:
 
 **Configuration Location:** `distros/kubernetes/nvsentinel/charts/node-drainer/values.yaml`
 
+## Topology Awareness (Topograph)
+
+When [Topograph](https://github.com/NVIDIA/topograph) is deployed in the cluster, it applies four node labels describing the physical network topology:
+
+- `network.topology.nvidia.com/accelerator` — NVLink domain (clique) ID
+- `network.topology.nvidia.com/leaf` — leaf switch identifier
+- `network.topology.nvidia.com/spine` — spine switch identifier
+- `network.topology.nvidia.com/core` — core switch identifier
+
+These keys are included by default in the Metadata Augmentor's `allowedLabels`, so NVSentinel automatically propagates them into health event metadata on clusters where Topograph has applied them. On clusters without Topograph, the labels are absent and the Metadata Augmentor simply skips them — no configuration change is required either way.
+
+Downstream consumers of NVSentinel events (fault-quarantine CEL rules, remediation custom resources, dashboards, blast-radius analysis) can then reason about topological locality. For example, a CEL rule can compare the `network.topology.nvidia.com/accelerator` value across a set of recent events to determine whether a fault is isolated to a single NVLink domain or spans multiple.
+
+The authoritative reference for these labels — value semantics, hashing behavior for long identifiers, and provider matrix — is [topograph's `docs/reference/node-labels.md`](https://github.com/NVIDIA/topograph/blob/main/docs/reference/node-labels.md).
+
 ## Error Code Mapping Reference
 
 NVSentinel maps DCGM error codes to recommended actions using a canonical CSV file.

--- a/platform-connectors/pkg/transformers/metadata/transformer_test.go
+++ b/platform-connectors/pkg/transformers/metadata/transformer_test.go
@@ -251,6 +251,42 @@ func TestAugmentorTransform(t *testing.T) {
 			},
 		},
 		{
+			name: "topograph topology labels",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node-7",
+					Labels: map[string]string{
+						"network.topology.nvidia.com/accelerator": "clique-7",
+						"network.topology.nvidia.com/leaf":        "leaf-42",
+						"network.topology.nvidia.com/spine":       "spine-3",
+						"network.topology.nvidia.com/core":        "core-1",
+						"node.kubernetes.io/instance-type":        "p5.48xlarge",
+					},
+				},
+				Spec: corev1.NodeSpec{ProviderID: "aws:///us-west-2a/i-topograph1"},
+			},
+			config: &Config{
+				CacheSize: 100,
+				CacheTTL:  1 * time.Hour,
+				AllowedLabels: []string{
+					"network.topology.nvidia.com/accelerator",
+					"network.topology.nvidia.com/leaf",
+					"network.topology.nvidia.com/spine",
+					"network.topology.nvidia.com/core",
+				},
+			},
+			eventNodeName: "test-node-7",
+			expectError:   false,
+			validateResult: func(t *testing.T, event *pb.HealthEvent) {
+				assert.Equal(t, "aws:///us-west-2a/i-topograph1", event.Metadata["providerID"])
+				assert.Equal(t, "clique-7", event.Metadata["network.topology.nvidia.com/accelerator"])
+				assert.Equal(t, "leaf-42", event.Metadata["network.topology.nvidia.com/leaf"])
+				assert.Equal(t, "spine-3", event.Metadata["network.topology.nvidia.com/spine"])
+				assert.Equal(t, "core-1", event.Metadata["network.topology.nvidia.com/core"])
+				assert.NotContains(t, event.Metadata, "node.kubernetes.io/instance-type", "should not include non-allowed labels")
+			},
+		},
+		{
 			name: "multiple nodes enrichment",
 			nodes: []*corev1.Node{
 				{


### PR DESCRIPTION
## Summary

Include the four node labels written by [NVIDIA/topograph](https://github.com/NVIDIA/topograph) in the Metadata Augmentor's default `allowedLabels`:

- `network.topology.nvidia.com/accelerator` — NVLink domain (clique) ID
- `network.topology.nvidia.com/leaf`, `/spine`, `/core` — switch hierarchy levels

When Topograph is deployed, these labels describe the cluster's physical network topology. With them allowed by default, NVSentinel propagates them into health event metadata so downstream consumers (CEL rules, remediation CRs, dashboards, blast-radius analysis) can reason about topological locality without operator-side configuration.

Implements Option 1 (default-on in Metadata Augmentor) from #1205, per @XRFXLP's and @lalitadithya's guidance.

On clusters without Topograph the labels are absent and the Metadata Augmentor simply skips them — no behavior change there.

## Type of Change
- [x] ✨ New feature
- [x] 📚 Documentation

## Component(s) Affected
- [x] Core Services (Platform Connectors / Metadata Augmentor)
- [x] Documentation/CI (`docs/INTEGRATIONS.md`)

## Testing

- [x] `helm template` against both `distros/kubernetes/nvsentinel/values.yaml` and `values-full.yaml` — confirms the four keys render into the platform-connectors ConfigMap's `allowedLabels`
- [x] `helm lint distros/kubernetes/nvsentinel` — no new findings
- [x] `go test ./platform-connectors/pkg/transformers/metadata/...` passes on Go 1.26.2, including a new `topograph topology labels` test case that mirrors the existing `cloud-specific topology labels` case
- [x] No breaking changes — the Metadata Augmentor's behavior on clusters without topograph labels is unchanged (absent labels are simply not copied)

## Checklist

- [x] Self-review completed
- [x] Documentation updated — new "Topology Awareness (Topograph)" section in `docs/INTEGRATIONS.md`; topograph labels also added inline (with comment + link) in both default values files
- [x] Ready for review

## Related

- Closes (addresses Option 1 from): #1205
- Topograph label reference (authoritative): <https://github.com/NVIDIA/topograph/blob/main/docs/reference/node-labels.md>
- Companion doc-clarification PR on topograph side (tightening the AWS Capacity Block phrasing raised in #1205): [NVIDIA/topograph#289](https://github.com/NVIDIA/topograph/pull/289)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended metadata enrichment to include Topograph-based topology labels for improved fault locality analysis and cluster topology awareness.

* **Documentation**
  * Added integration guide detailing topology label support, usage scenarios, and downstream consumer applications.

* **Tests**
  * Added test coverage for topology label augmentation and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->