### PR TITLE
feat: fallback to a reboot if a GPU reset fails

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/janitor/crds/janitor.dgxc.nvidia.com_gpuresets.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/crds/janitor.dgxc.nvidia.com_gpuresets.yaml
@@ -28,11 +28,11 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - description: The target node for the GPU reset
+    - description: Target node for GPU reset
       jsonPath: .spec.nodeName
       name: Node
       type: string
-    - description: The current status of the reset
+    - description: Current status of reset
       jsonPath: .status.phase
       name: Status
       type: string

--- a/distros/kubernetes/nvsentinel/charts/janitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/templates/configmap.yaml
@@ -85,6 +85,7 @@ data:
       {{- end }}
       {{- if .Values.config.controllers.gpuReset.resetJob }}
       resetJob:
+        writeSysLogEvent: "{{ .Values.config.controllers.gpuReset.resetJob.writeSysLogEvent }}"
         runtimeClassName: "{{ .Values.config.controllers.gpuReset.resetJob.runtimeClassName }}"
         imageConfig:
           image: "{{ .Values.config.controllers.gpuReset.resetJob.image.repository }}:{{ .Values.config.controllers.gpuReset.resetJob.image.tag | default ((.Values.global).image).tag | default .Chart.AppVersion }}"

--- a/distros/kubernetes/nvsentinel/charts/janitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/values.yaml
@@ -165,6 +165,7 @@ config:
       serviceManager:
         name: "gpu-operator"
       resetJob:
+        writeSysLogEvent: true
         runtimeClassName: "nvidia"
         # imagePullSecrets can be specified under image.imagePullSecrets, otherwise we will
         # fall back to global.imagePullSecrets.

--- a/distros/kubernetes/nvsentinel/values-tilt.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt.yaml
@@ -3777,6 +3777,7 @@ janitor:
               enabledValue: "true"
               disabledValue: "false"
         resetJob:
+          writeSysLogEvent: false
           runtimeClassName: ""
           image:
             repository: "public.ecr.aws/docker/library/alpine"

--- a/gpu-reset/gpu_reset.sh
+++ b/gpu-reset/gpu_reset.sh
@@ -163,10 +163,13 @@ DURATION=$(printf "%.3f" "$DURATION_RAW")
 
 if [ "$FINAL_EXIT_STATUS" -ne 0 ]; then
   log "FAILED: GPU reset workflow failed in ${DURATION}s."
+  SYSLOG_SUCCESS="false"
 else
   log "SUCCESS: GPU reset workflow completed in ${DURATION}s."
+  SYSLOG_SUCCESS="true"
+fi
 
-  # Write "GPU reset executed" message to notify syslog-health-monitor of GPU reset success
+if [ "${WRITE_SYSLOG_EVENT:-true}" = "true" ]; then
   ORIGINAL_IFS=$IFS
   IFS=','
   for UUID in $TARGET_UUIDS; do
@@ -177,11 +180,13 @@ else
       continue
     fi
 
-    log "Writing reset success for ${UUID} to syslog"
-    logger -p daemon.err "GPU reset executed: ${UUID}"
+    log "Writing reset result for ${UUID} to syslog (success: ${SYSLOG_SUCCESS})"
+    logger -p daemon.err "GPU reset executed: ${UUID}, success: ${SYSLOG_SUCCESS}"
 
   done
   IFS=$ORIGINAL_IFS
+else
+  log "Skipping writing reset result (success: ${SYSLOG_SUCCESS}) to syslog: WRITE_SYSLOG_EVENT is not true"
 fi
 
 exit "$FINAL_EXIT_STATUS"

--- a/health-monitors/syslog-health-monitor/pkg/xid/types.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/types.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	reNvrmMap   = regexp.MustCompile(`NVRM: GPU at PCI:([0-9a-fA-F:.]+): (GPU-[0-9a-fA-F-]+)`)
-	gpuResetMap = regexp.MustCompile(`GPU reset executed: (GPU-[0-9a-fA-F-]+)`)
+	gpuResetMap = regexp.MustCompile(`GPU reset executed: (GPU-[0-9a-fA-F-]+), success: (true|false)`)
 )
 
 type XIDHandler struct {

--- a/health-monitors/syslog-health-monitor/pkg/xid/xid_handler.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/xid_handler.go
@@ -32,6 +32,8 @@ import (
 
 const (
 	healthyHealthEventMessage = "No Health Failures"
+	gpuResetFailureErrorCode  = "GPU_RESET_FAILURE"
+	gpuResetFailureMessage    = "GPU reset failed, proceeding with a node reboot"
 )
 
 func NewXIDHandler(nodeName, defaultAgentName,
@@ -83,9 +85,9 @@ func (xidHandler *XIDHandler) ProcessLine(message string) (*pb.HealthEvents, err
 		return nil, nil
 	}
 
-	if uuid := xidHandler.parseGPUResetLine(message); len(uuid) != 0 {
-		slog.Info("GPU was reset, creating healthy HealthEvent", "GPU_UUID", uuid)
-		return xidHandler.createHealthEventGPUResetEvent(uuid)
+	if uuid, success := xidHandler.parseGPUResetLine(message); len(uuid) != 0 {
+		slog.Info("GPU reset syslog event received, creating HealthEvent", "GPU_UUID", uuid, "success", success)
+		return xidHandler.createHealthEventGPUResetEvent(uuid, success)
 	}
 
 	xidResp, err := xidHandler.parser.Parse(message)
@@ -105,13 +107,13 @@ func (xidHandler *XIDHandler) ProcessLine(message string) (*pb.HealthEvents, err
 	return xidHandler.createHealthEventFromResponse(xidResp, message), nil
 }
 
-func (xidHandler *XIDHandler) parseGPUResetLine(message string) string {
+func (xidHandler *XIDHandler) parseGPUResetLine(message string) (uuid string, success bool) {
 	m := gpuResetMap.FindStringSubmatch(message)
-	if len(m) >= 2 {
-		return m[1]
+	if len(m) >= 3 {
+		return m[1], m[2] == "true"
 	}
 
-	return ""
+	return "", false
 }
 
 func (xidHandler *XIDHandler) parseNVRMGPUMapLine(message string) (string, string) {
@@ -175,7 +177,7 @@ remediation action.
 
 Healthy event generation:
 1. GPU reset occurs in syslog which includes the GPU UUID:
-GPU reset executed: GPU-455d8f70-2051-db6c-0430-ffc457bff834
+GPU reset executed: GPU-455d8f70-2051-db6c-0430-ffc457bff834, success: true
 
 2. Using the metadata-collector, look up the corresponding PCI for the given GPU UUID.
 
@@ -259,7 +261,68 @@ func (xidHandler *XIDHandler) createHealthEventFromResponse(
 	}
 }
 
-func (xidHandler *XIDHandler) createHealthEventGPUResetEvent(uuid string) (*pb.HealthEvents, error) {
+/*
+A COMPONENT_RESET remediation will result in the following log line being emitted to syslog and consumed by the
+syslog-health-monitor (regardless of which health-monitor created the original COMPONENT_RESET unhealthy event):
+
+GPU reset executed: GPU-455d8f70-2051-db6c-0430-ffc457bff834, success: <true/false>
+
+1. Successful resets: will result in a healthy event that can clear XID errors from the SysLogsXIDError check for
+matching impacted entities (GPU UUID and PCI ID). Note that if a different health-monitor emitted the original event,
+it would need to also check syslog or implement a different detection mechanism for GPU resets (for example the
+gpu-health-monitor relies on resets fixing the underlying DCGM watch or by having the nvidia-dcgm pod restarted as part
+of the GPU reset workflow).
+
+2. Failed resets: will result in a new unhealthy event from the SysLogsXIDError check with the same impacted entities
+(GPU UUID and PCI ID) as the original health event and a RESTART_VM recommended action. Note that this flow will be
+triggered regardless of which health-monitor emitted the original COMPONENT_RESET event. This serves as a fallback
+where we will reboot a node if a GPU reset fails. This will result in the node being cordoned due to 2 events which are
+the original XID event and this subsequent GPU reset failed event. The syslog-health-monitor has logic to clear all
+unhealthy events for each of its checks in response to a reboot by sending a healthy event with empty impacted entities.
+As a result, we should expect that the node will be uncordoned after the reboot completes.
+
+Example event:
+
+	{
+	  createdAt: ISODate('2026-04-30T10:46:50.263Z'),
+	  healthevent: {
+	    agent: 'syslog-health-monitor',
+	    componentclass: 'GPU',
+	    checkname: 'SysLogsXIDError',
+	    isfatal: true,
+	    ishealthy: false,
+	    message: ‘GPU reset failed, proceeding with a node reboot',
+	    recommendedaction: RESTART_VM,
+	    errorcode: [
+	      'GPU_RESET_FAILURE'
+	    ],
+	    entitiesimpacted: [
+	      {
+	        entitytype: 'PCI',
+	        entityvalue: '000b:00:00'
+	      },
+	      {
+	        entitytype: 'GPU_UUID',
+	        entityvalue: 'GPU-123’
+	      }
+	    ],
+	    nodename: ‘node-123’,
+	  }
+	}
+
+Notes:
+- A follow-up unhealthy event is required to trigger a full drain in node-drainer because the original COMPONENT_RESET
+event would've done a partial drain only against pods using the GPU needing reset.
+- If a burst of XIDs occur with both COMPONENT_RESET and RESTART_VM recommended actions and the GPU reset fails, this
+logic is not necessary because a reboot would already be triggered. We will rely on the existing fault-remediation
+de-duplication logic to only process one of the reboots.
+- This logic is meant as a fallback when there are one of more XIDs with COMPONENT_RESET recommended actions which all
+result in failed GPU resets. When this logic is triggered, the following steps should be followed:
+  - Fix the underlying cause for the GPU reset failure.
+  - If the reset failure is isolated to a given XID, override the recommended action from COMPONENT_RESET to RESTART_VM.
+  - If the GPU reset failure is not unique to a specific XID error, disable the GPU reset feature to always reboot.
+*/
+func (xidHandler *XIDHandler) createHealthEventGPUResetEvent(uuid string, success bool) (*pb.HealthEvents, error) {
 	gpuInfo, err := xidHandler.metadataReader.GetInfoByUUID(uuid)
 	// There's no point in sending a healthy HealthEvent with only GPU UUID and not PCI because that healthy HealthEvent
 	// will not match all impacted entities tracked by the fault-quarantine-module so we will return an error rather than
@@ -274,6 +337,7 @@ func (xidHandler *XIDHandler) createHealthEventGPUResetEvent(uuid string) (*pb.H
 
 	normPCI := xidHandler.normalizePCI(gpuInfo.PCIAddress)
 	entities := getDefaultImpactedEntities(normPCI, uuid)
+
 	event := &pb.HealthEvent{
 		Version:            1,
 		Agent:              xidHandler.defaultAgentName,
@@ -281,11 +345,21 @@ func (xidHandler *XIDHandler) createHealthEventGPUResetEvent(uuid string) (*pb.H
 		ComponentClass:     xidHandler.defaultComponentClass,
 		GeneratedTimestamp: timestamppb.New(time.Now()),
 		EntitiesImpacted:   entities,
-		Message:            healthyHealthEventMessage,
-		IsFatal:            false,
-		IsHealthy:          true,
 		NodeName:           xidHandler.nodeName,
-		RecommendedAction:  pb.RecommendedAction_NONE,
+		ProcessingStrategy: xidHandler.processingStrategy,
+	}
+
+	if success {
+		event.Message = healthyHealthEventMessage
+		event.IsFatal = false
+		event.IsHealthy = true
+		event.RecommendedAction = pb.RecommendedAction_NONE
+	} else {
+		event.ErrorCode = []string{gpuResetFailureErrorCode}
+		event.Message = gpuResetFailureMessage
+		event.IsFatal = true
+		event.IsHealthy = false
+		event.RecommendedAction = pb.RecommendedAction_RESTART_VM
 	}
 
 	return &pb.HealthEvents{

--- a/health-monitors/syslog-health-monitor/pkg/xid/xid_handler_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/xid_handler_test.go
@@ -159,31 +159,42 @@ func TestParseGPUResetLine(t *testing.T) {
 	xidHandler := &XIDHandler{}
 
 	testCases := []struct {
-		name  string
-		line  string
-		gpuId string
+		name    string
+		line    string
+		gpuId   string
+		success bool
 	}{
 		{
-			name:  "Valid GPU Reset Line",
-			line:  "GPU reset executed: GPU-123",
-			gpuId: "GPU-123",
+			name:    "Valid GPU Reset Line Success",
+			line:    "GPU reset executed: GPU-123, success: true",
+			gpuId:   "GPU-123",
+			success: true,
 		},
 		{
-			name:  "Invalid GPU Reset Line",
-			line:  "GPU reset executed:",
-			gpuId: "",
+			name:    "Valid GPU Reset Line Failure",
+			line:    "GPU reset executed: GPU-123, success: false",
+			gpuId:   "GPU-123",
+			success: false,
 		},
 		{
-			name:  "XID Log Line GPU",
-			line:  "NVRM: GPU at PCI:0000:00:08.0: GPU-123",
-			gpuId: "",
+			name:    "Invalid GPU Reset Line",
+			line:    "GPU reset executed:",
+			gpuId:   "",
+			success: false,
+		},
+		{
+			name:    "XID Log Line GPU",
+			line:    "NVRM: GPU at PCI:0000:00:08.0: GPU-123",
+			gpuId:   "",
+			success: false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gpuId := xidHandler.parseGPUResetLine(tc.line)
+			gpuId, success := xidHandler.parseGPUResetLine(tc.line)
 			assert.Equal(t, tc.gpuId, gpuId)
+			assert.Equal(t, tc.success, success)
 		})
 	}
 }
@@ -333,7 +344,7 @@ func TestProcessLine(t *testing.T) {
 		},
 		{
 			name:    "Valid GPU Reset Message",
-			message: "GPU reset executed: GPU-123",
+			message: "GPU reset executed: GPU-123, success: true",
 			setupHandler: func() *XIDHandler {
 				h, _ := NewXIDHandler("test-node", "test-agent", "GPU", "xid-check", "", metadataFile, pb.ProcessingStrategy_EXECUTE_REMEDIATION)
 				return h
@@ -359,11 +370,53 @@ func TestProcessLine(t *testing.T) {
 							EntityValue: "GPU-123",
 						},
 					},
-					Message:           healthyHealthEventMessage,
-					IsFatal:           false,
-					IsHealthy:         true,
-					NodeName:          "test-node",
-					RecommendedAction: pb.RecommendedAction_NONE,
+					Message:            healthyHealthEventMessage,
+					IsFatal:            false,
+					IsHealthy:          true,
+					NodeName:           "test-node",
+					RecommendedAction:  pb.RecommendedAction_NONE,
+					ProcessingStrategy: pb.ProcessingStrategy_EXECUTE_REMEDIATION,
+				}
+				assert.NotNil(t, event.GeneratedTimestamp)
+				event.GeneratedTimestamp = nil
+				assert.Equal(t, expectedEvent, event)
+			},
+		},
+		{
+			name:    "GPU Reset Failure Message",
+			message: "GPU reset executed: GPU-123, success: false",
+			setupHandler: func() *XIDHandler {
+				h, _ := NewXIDHandler("test-node", "test-agent", "GPU", "xid-check", "", metadataFile, pb.ProcessingStrategy_EXECUTE_REMEDIATION)
+				return h
+			},
+			expectEvent: true,
+			expectError: false,
+			validateEvent: func(t *testing.T, events *pb.HealthEvents) {
+				require.NotNil(t, events)
+				require.Len(t, events.Events, 1)
+				event := events.Events[0]
+				expectedEvent := &pb.HealthEvent{
+					Version:        1,
+					Agent:          "test-agent",
+					CheckName:      "xid-check",
+					ComponentClass: "GPU",
+					EntitiesImpacted: []*pb.Entity{
+						{
+							EntityType:  "PCI",
+							EntityValue: "0000:00:08",
+						},
+						{
+							EntityType:  "GPU_UUID",
+							EntityValue: "GPU-123",
+						},
+					},
+					ErrorCode:          []string{gpuResetFailureErrorCode},
+					Message:            gpuResetFailureMessage,
+					IsFatal:            true,
+					IsHealthy:          false,
+					NodeName:           "test-node",
+					RecommendedAction:  pb.RecommendedAction_RESTART_VM,
+					ProcessingStrategy: pb.ProcessingStrategy_EXECUTE_REMEDIATION,
 				}
 				assert.NotNil(t, event.GeneratedTimestamp)
 				event.GeneratedTimestamp = nil
@@ -372,7 +425,7 @@ func TestProcessLine(t *testing.T) {
 		},
 		{
 			name:    "Valid GPU Reset Message with Metadata Collector not Initialized",
-			message: "GPU reset executed: GPU-123",
+			message: "GPU reset executed: GPU-123, success: true",
 			setupHandler: func() *XIDHandler {
 				h, _ := NewXIDHandler("test-node", "test-agent", "GPU", "xid-check", "", "/tmp/metadata.json", pb.ProcessingStrategy_EXECUTE_REMEDIATION)
 				return h
@@ -382,7 +435,7 @@ func TestProcessLine(t *testing.T) {
 		},
 		{
 			name:    "Valid GPU Reset Message with Metadata Collector missing GPU UUID",
-			message: "GPU reset executed: GPU-456",
+			message: "GPU reset executed: GPU-456, success: true",
 			setupHandler: func() *XIDHandler {
 				h, _ := NewXIDHandler("test-node", "test-agent", "GPU", "xid-check", "", metadataFile, pb.ProcessingStrategy_EXECUTE_REMEDIATION)
 				return h
@@ -392,7 +445,7 @@ func TestProcessLine(t *testing.T) {
 		},
 		{
 			name:    "Valid GPU Reset Message with Metadata Collector not containing PCI",
-			message: "GPU reset executed: GPU-123",
+			message: "GPU reset executed: GPU-123, success: true",
 			setupHandler: func() *XIDHandler {
 				h, _ := NewXIDHandler("test-node", "test-agent", "GPU", "xid-check", "", metadataFileMissingPCI, pb.ProcessingStrategy_EXECUTE_REMEDIATION)
 				return h

--- a/janitor/pkg/config/config.go
+++ b/janitor/pkg/config/config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/viper"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/nvidia/nvsentinel/janitor/pkg/gpuservices"
 )
@@ -113,6 +114,7 @@ type ResetJobConfig struct {
 	ImageConfig      ImageConfig          `mapstructure:"imageConfig" json:"imageConfig"`
 	Resources        ResourceRequirements `mapstructure:"resources" json:"resources"`
 	RuntimeClassName string               `mapstructure:"runtimeClassName" json:"runtimeClassName"`
+	WriteSysLogEvent *bool                `mapstructure:"writeSysLogEvent" json:"writeSysLogEvent"`
 }
 
 type ResourceRequirements struct {
@@ -175,9 +177,15 @@ func LoadConfig(configPath string, namespace string) (*Config, error) {
 			return nil, fmt.Errorf("ResetJob.ImageConfig.Image is required but not set")
 		}
 
-		jobTemplate, err := getDefaultGPUResetJobTemplate(namespace,
-			config.GPUReset.ResetJob.ImageConfig.Image, config.GPUReset.ResetJob.ImageConfig.ImagePullSecrets,
-			config.GPUReset.ResetJob.Resources, config.GPUReset.ResetJob.RuntimeClassName)
+		if config.GPUReset.ResetJob.WriteSysLogEvent == nil {
+			config.GPUReset.ResetJob.WriteSysLogEvent = ptr.To(true)
+		}
+
+		resetJobConfig := config.GPUReset.ResetJob
+
+		jobTemplate, err := getDefaultGPUResetJobTemplate(namespace, resetJobConfig.ImageConfig.Image,
+			resetJobConfig.ImageConfig.ImagePullSecrets, resetJobConfig.Resources, resetJobConfig.RuntimeClassName,
+			*resetJobConfig.WriteSysLogEvent)
 		if err != nil {
 			return nil, err
 		}

--- a/janitor/pkg/config/config_test.go
+++ b/janitor/pkg/config/config_test.go
@@ -147,6 +147,7 @@ gpuResetController:
       critical: "true"
   cspProviderHost: janitor-provider.nvsentinel.svc.cluster.local:50054
   resetJob:
+    writeSysLogEvent: true
     runtimeClassName: "nvidia"
     imageConfig:
       image: "alpine:latest"
@@ -233,7 +234,7 @@ gpuResetController:
 		},
 	}
 	expectedJobTemplate, err := getDefaultGPUResetJobTemplate(testNamespace, "alpine:latest", imagePullSecrets,
-		resourceRequirements, "nvidia")
+		resourceRequirements, "nvidia", true)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedJobTemplate, config.GPUReset.ResolvedJobTemplate)
 
@@ -300,7 +301,7 @@ gpuResetController:
 	assert.True(t, config.GPUReset.Enabled)
 
 	expectedJobTemplate, err := getDefaultGPUResetJobTemplate(testNamespace, "alpine:latest", nil,
-		ResourceRequirements{}, "")
+		ResourceRequirements{}, "", true)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedJobTemplate, config.GPUReset.ResolvedJobTemplate)
 
@@ -351,7 +352,7 @@ gpuResetController:
 	assert.True(t, config.GPUReset.Enabled)
 
 	expectedJobTemplate, err := getDefaultGPUResetJobTemplate(testNamespace, "alpine:latest", nil,
-		ResourceRequirements{}, "")
+		ResourceRequirements{}, "", true)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedJobTemplate, config.GPUReset.ResolvedJobTemplate)
 
@@ -393,6 +394,58 @@ gpuResetController:
 	config, err := LoadConfig(configPath, testNamespace)
 	require.Error(t, err)
 	require.Nil(t, config)
+}
+
+func TestLoadConfig_GPUResetEnabledWriteSysLogEventFalse(t *testing.T) {
+	// Create a temporary config file
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "janitor-config.yaml")
+
+	configContent := `
+global:
+  timeout: 30m
+  manualMode: true
+  nodes:
+    exclusions:
+      - matchLabels:
+          environment: production
+          critical: "true"
+  cspProviderHost: janitor-provider.nvsentinel.svc.cluster.local:50051
+
+rebootNodeController:
+  enabled: true
+
+terminateNodeController:
+  enabled: true
+
+gpuResetController:
+  enabled: true
+  resetJob:
+    writeSysLogEvent: false
+    runtimeClassName: ""
+    imageConfig:
+      image: "alpine:latest"
+  serviceManager:
+    name: "gpu-operator"
+`
+
+	err := os.WriteFile(configPath, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	// Load the config
+	config, err := LoadConfig(configPath, testNamespace)
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	// Verify GPUReset config
+	assert.True(t, config.GPUReset.Enabled)
+
+	expectedJobTemplate, err := getDefaultGPUResetJobTemplate(testNamespace, "alpine:latest", nil,
+		ResourceRequirements{}, "", false)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedJobTemplate, config.GPUReset.ResolvedJobTemplate)
+
+	assert.Equal(t, gpuservices.Manager{Name: "gpu-operator"}, config.GPUReset.ServiceManager)
 }
 
 func TestLoadConfig_GPUResetInvalidResources(t *testing.T) {

--- a/janitor/pkg/config/default.go
+++ b/janitor/pkg/config/default.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -26,11 +27,12 @@ import (
 )
 
 const (
-	GPUResetContainerName = "gpu-reset"
-	HostDevVolumeName     = "host-dev"
-	HostDevPath           = "/dev"
-	HostDevLogVolumeName  = "dev-log"
-	HostDevLogPath        = "/run/systemd/journal/dev-log"
+	GPUResetContainerName  = "gpu-reset"
+	HostDevVolumeName      = "host-dev"
+	HostDevPath            = "/dev"
+	HostDevLogVolumeName   = "dev-log"
+	HostDevLogPath         = "/run/systemd/journal/dev-log"
+	WriteSyslogEventEnvVar = "WRITE_SYSLOG_EVENT"
 )
 
 func applyConfigDefaults(config *Config) {
@@ -178,7 +180,7 @@ func getImagePullSecrets(imagePullSecrets []ImagePullSecret) []corev1.LocalObjec
 
 // getDefaultGPUResetJobTemplate returns the default JobTemplateSpec for GPU reset jobs.
 func getDefaultGPUResetJobTemplate(namespace string, image string, secrets []ImagePullSecret,
-	resources ResourceRequirements, runtimeClassName string) (*batchv1.JobTemplateSpec, error) {
+	resources ResourceRequirements, runtimeClassName string, writeSyslogEvent bool) (*batchv1.JobTemplateSpec, error) {
 	imagePullSecrets := getImagePullSecrets(secrets)
 
 	containerResources, err := getResources(resources)
@@ -220,6 +222,12 @@ func getDefaultGPUResetJobTemplate(namespace string, image string, secrets []Ima
 							Image:           image,
 							ImagePullPolicy: corev1.PullAlways,
 							Resources:       *containerResources,
+							Env: []corev1.EnvVar{
+								{
+									Name:  WriteSyslogEventEnvVar,
+									Value: strconv.FormatBool(writeSyslogEvent),
+								},
+							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      HostDevVolumeName,

--- a/tests/gpu_reset_test.go
+++ b/tests/gpu_reset_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -181,6 +182,26 @@ func TestGPUReset(t *testing.T) {
 			}
 		}
 		assert.True(t, foundCompleteCondition, "Did not find Complete condition on CR", gpuReset.GetName())
+
+		// We explicitly set writeSysLogEvent to false in values-tilt.yaml to test that the Helm chart values
+		// propagate to the WRITE_SYSLOG_EVENT environment variable. Note that if the value isn't set in the Janitor
+		// configmap, we will default to true so setting false ensures the value is consumed from Helm.
+		jobName, _, _ := unstructured.NestedString(gpuReset.Object, "status", "jobRef", "name")
+		jobNamespace, _, _ := unstructured.NestedString(gpuReset.Object, "status", "jobRef", "namespace")
+		assert.NotEmpty(t, jobName, "expected jobName in GPUReset status")
+		assert.NotEmpty(t, jobNamespace, "expected jobNamespace in GPUReset status")
+		var resetJob batchv1.Job
+		jobErr := client.Resources().Get(ctx, jobName, jobNamespace, &resetJob)
+		assert.NoError(t, jobErr, "failed to get GPU reset job")
+		var foundEnvVar bool
+		for _, envVar := range resetJob.Spec.Template.Spec.Containers[0].Env {
+			if envVar.Name == "WRITE_SYSLOG_EVENT" {
+				assert.Equal(t, "false", envVar.Value, "WRITE_SYSLOG_EVENT should be false in GPU reset job")
+				foundEnvVar = true
+				break
+			}
+		}
+		assert.True(t, foundEnvVar, "WRITE_SYSLOG_EVENT not found in GPU reset job")
 
 		// ensure gpu-operator pods are restored
 		newDCGMPod, err := helpers.GetPodOnWorkerNode(ctx, t, client, "gpu-operator", "nvidia-dcgm")

--- a/tests/syslog_health_monitor_test.go
+++ b/tests/syslog_health_monitor_test.go
@@ -87,16 +87,95 @@ func TestSyslogHealthMonitorXIDDetection(t *testing.T) {
 		return ctx
 	})
 
-	feature.Assess("Inject GPU reset event", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+	feature.Assess("Inject successful GPU reset event", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		client, err := c.NewClient()
 		require.NoError(t, err, "failed to create kubernetes client")
 
 		nodeName := ctx.Value(keySyslogNodeName).(string)
 		gpuResetMessages := []string{
-			"kernel: [16450076.435595] GPU reset executed: GPU-22222222-2222-2222-2222-222222222222",
+			"kernel: [16450076.435595] GPU reset executed: GPU-22222222-2222-2222-2222-222222222222, success: true",
 		}
 
 		helpers.InjectSyslogMessages(t, helpers.StubJournalHTTPPort, gpuResetMessages)
+
+		t.Logf("Waiting for SysLogsXIDError condition to be cleared from node %s", nodeName)
+		require.Eventually(t, func() bool {
+			condition, err := helpers.CheckNodeConditionExists(ctx, client, nodeName,
+				"SysLogsXIDError", "SysLogsXIDErrorIsHealthy")
+			if err != nil {
+				return false
+			}
+			return condition != nil && condition.Status == v1.ConditionFalse
+		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval, "SysLogsXIDError condition should be cleared")
+
+		return ctx
+	})
+
+	feature.Assess("Inject XID error requiring GPU reset", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err, "failed to create kubernetes client")
+
+		nodeName := ctx.Value(keySyslogNodeName).(string)
+		xidMessages := []string{
+			"kernel: [16450076.435595] NVRM: Xid (PCI:0002:00:00): 119, pid=1582259, name=nvc:[driver], Timeout after 6s of waiting for RPC response from GPU1 GSP! Expected function 76 (GSP_RM_CONTROL) (0x20802a02 0x8).",
+		}
+		expectedSequencePatterns := []string{
+			`ErrorCode:119 PCI:0002:00:00 GPU_UUID:GPU-22222222-2222-2222-2222-222222222222 kernel:.*?NVRM: Xid \(PCI:0002:00:00\): 119.*?Recommended Action=COMPONENT_RESET`,
+		}
+
+		helpers.InjectSyslogMessages(t, helpers.StubJournalHTTPPort, xidMessages)
+
+		t.Log("Verifying node condition contains XID error with GPU UUID using regex pattern")
+		require.Eventually(t, func() bool {
+			return helpers.VerifyNodeConditionMatchesSequence(t, ctx, client, nodeName,
+				"SysLogsXIDError", "SysLogsXIDErrorIsNotHealthy", expectedSequencePatterns)
+		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval, "Node condition should contain XID error with GPU UUID")
+
+		return ctx
+	})
+
+	feature.Assess("Inject failed GPU reset event", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err, "failed to create kubernetes client")
+
+		nodeName := ctx.Value(keySyslogNodeName).(string)
+		gpuResetMessages := []string{
+			"kernel: [16450076.435595] GPU reset executed: GPU-22222222-2222-2222-2222-222222222222, success: false",
+		}
+
+		helpers.InjectSyslogMessages(t, helpers.StubJournalHTTPPort, gpuResetMessages)
+
+		expectedSequencePatterns := []string{
+			`ErrorCode:119 PCI:0002:00:00 GPU_UUID:GPU-22222222-2222-2222-2222-222222222222 kernel:.*?NVRM: Xid \(PCI:0002:00:00\): 119.*?Recommended Action=COMPONENT_RESET`,
+			"ErrorCode:GPU_RESET_FAILURE PCI:0002:00:00 GPU_UUID:GPU-22222222-2222-2222-2222-222222222222 GPU reset failed, proceeding with a node reboot.*?Recommended Action=RESTART_VM",
+		}
+
+		t.Log("Verifying node condition contains 2 health events for the original XID error and a failed GPU reset")
+		require.Eventually(t, func() bool {
+			return helpers.VerifyNodeConditionMatchesSequence(t, ctx, client, nodeName,
+				"SysLogsXIDError", "SysLogsXIDErrorIsNotHealthy", expectedSequencePatterns)
+		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval, "Node condition should contain XID error and failed GPU reset condition")
+
+		return ctx
+	})
+
+	feature.Assess("Simulating healthy event from SysLogsXIDError post reboot", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err, "failed to create kubernetes client")
+
+		nodeName := ctx.Value(keySyslogNodeName).(string)
+
+		t.Logf("Sending healthy SysLogsXIDError event to clear all errors")
+		healthyEvent := helpers.NewHealthEvent(nodeName).
+			WithCheckName("SysLogsXIDError").
+			WithAgent("syslog-health-monitor").
+			WithComponentClass("GPU").
+			WithHealthy(true).
+			WithFatal(false).
+			WithMessage("No Health Failures").
+			WithEntitiesImpacted([]helpers.EntityImpacted{}) // Empty entities clears all
+
+		helpers.SendHealthEvent(ctx, t, healthyEvent)
 
 		t.Logf("Waiting for SysLogsXIDError condition to be cleared from node %s", nodeName)
 		require.Eventually(t, func() bool {

--- a/tests/uat/tests.sh
+++ b/tests/uat/tests.sh
@@ -442,6 +442,9 @@ test_xid_monitoring_syslog_gpu_reset() {
 
     log "Selected GPU node: $gpu_node (has healthy syslog-health-monitor)"
 
+    local initial_boot_id
+    initial_boot_id=$(get_boot_id "$gpu_node")
+    log "Original boot ID: $initial_boot_id"
 
     local dcgm_pod
     dcgm_pod=$(kubectl get pods -n gpu-operator -l app=nvidia-dcgm \
@@ -474,6 +477,16 @@ test_xid_monitoring_syslog_gpu_reset() {
 
     log "Waiting for node to GPU reset and recover..."
     wait_for_gpu_reset "$gpu_node" "$uuid" "$current_ts"
+
+    # If the GPU reset job fails, we will write a syslog event which results in a new unhealthy health event with a
+    # RESTART_VM recommended action. We will confirm the node bootID does not change during the test execution to
+    # ensure that a GPU reset and not a reboot recovered the node.
+    local final_boot_id
+    final_boot_id=$(get_boot_id "$gpu_node")
+    if [[ "$final_boot_id" != "$initial_boot_id" ]]; then
+        error "Boot ID changed during GPU reset. Original: $initial_boot_id, Final: $final_boot_id"
+    fi
+    log "Boot ID unchanged: $final_boot_id"
 
     log "Test 3 PASSED ✓"
 }


### PR DESCRIPTION
## Summary

This PR adds logic to fallback to a reboot if a GPU reset fails.

**1. Create a RESTART_VM event when GPU resets fail:** currently, a healthy event is emitted by the syslog-health-monitor when it detects that a GPU was successfully reset by consuming a syslog event written by the GPU reset job. Now, we will also start emitting an unhealthy event with a RESTART_VM recommended action by the syslog-health-monitor when it detects that a GPU failed to be reset. The resulting reboot will clear both events for the initial XID needing a reset and subsequent failed reset event needing a reboot and the node will be uncordoned.
**2. Add a new writeSyslogEvent option to the Janitor config:** this gpuResetController config property defaults to true if not explicitly set. If true, the GPU reset job will write syslog events for successful and failed resets that will be consumed by the syslog-health-monitor. If false, the GPU reset will not write syslog events which will prevent automatic uncordoning for successful resets and reboot fallbacks for failed resets. Opting out of the syslog writing behavior might be desirable for GPUResets triggered outside of NVSentinel so that debugging failed resets can occur without reboots being triggered.
```
  apiVersion: janitor.dgxc.nvidia.com/v1alpha1                                                                                                                                                                                                                                                                    
  kind: GPUReset                                                                                                                                                                                                                                                                                                  
  metadata:                                                                                                                                                                                                                                                                                                       
    name: maintenance-my-node-abc123                                                                                                                                                                                                                                                                              
    annotations:                    
      nvsentinel.nvidia.com/trace-id: "some-trace-id"                                                                                                                                                                                                                                                             
      nvsentinel.nvidia.com/span-id: "some-span-id"                                                                                                                                                                                                                                                               
  spec:                                                                                                                                                                                                                                                                                                           
    nodeName: my-node                                                                                                                                                                                                                                                                                             
    selector:                                                                                                                                                                                                                                                                                                     
      uuids:                                                                                                                                                                                                                                                                                                      
        - GPU-455d8f70-2051-db6c-0430-ffc457bff834
    writeSyslogEvent: false 
```

## Overview for the reboot fallback

A COMPONENT_RESET remediation will result in the following log line being emitted to syslog and consumed by the syslog-health-monitor (regardless of which health-monitor created the original COMPONENT_RESET unhealthy event):

```
GPU reset executed: GPU-455d8f70-2051-db6c-0430-ffc457bff834, success: <true/false>
```

1. Successful resets: will result in a healthy event that can clear XID errors from the SysLogsXIDError check for matching impacted entities (GPU UUID and PCI ID). Note that if a different health-monitor emitted the original event, it would need to also check syslog or implement a different detection mechanism for GPU resets (for example the gpu-health-monitor relies on resets fixing the underlying DCGM watch or by having the nvidia-dcgm pod restarted as part of the GPU reset workflow). 
4. Failed resets: will result in a new unhealthy event from the SysLogsXIDError check with the same impacted entities (GPU UUID and PCI ID) as the original health event and a RESTART_VM recommended action. Note that this flow will be triggered regardless of which health-monitor emitted the original COMPONENT_RESET event. This serves as a fallback where we will reboot a node if a GPU reset fails. This will result in the node being cordoned due to 2 events which are the original XID event and this subsequent GPU reset failed event. The syslog-health-monitor has logic to clear all unhealthy events for each of its checks in response to a reboot by sending a healthy event with empty impacted entities. As a result, we should expect that the node will be uncordoned after the reboot completes.

Example event:
```
	{
	  createdAt: ISODate('2026-04-30T10:46:50.263Z'),
	  healthevent: {
	    agent: 'syslog-health-monitor',
	    componentclass: 'GPU',
	    checkname: 'SysLogsXIDError',
	    isfatal: true,
	    ishealthy: false,
	    message: ‘GPU reset failed, proceeding with a node reboot',
	    recommendedaction: RESTART_VM,
	    errorcode: [
	      'GPU_RESET_FAILURE'
	    ],
	    entitiesimpacted: [
	      {
	        entitytype: 'PCI',
	        entityvalue: '000b:00:00'
	      },
	      {
	        entitytype: 'GPU_UUID',
	        entityvalue: 'GPU-123’
	      }
	    ],
	    nodename: ‘node-123’,
	  }
	}
```
Notes:

- A follow-up unhealthy event is required to trigger a full drain in node-drainer because the original COMPONENT_RESET event would've done a partial drain only against pods using the GPU needing reset.
- If a burst of XIDs occur with both COMPONENT_RESET and RESTART_VM recommended actions and the GPU reset fails, this logic is not necessary because a reboot would already be triggered. We will rely on the existing fault-remediation de-duplication logic to only process one of the reboots.
- This logic is meant as a fallback when there are one of more XIDs with COMPONENT_RESET recommended actions which all result in failed GPU resets. When this logic is triggered, the following steps should be followed:
   - Fix the underlying cause for the GPU reset failure.
   - If the reset failure is isolated to a given XID, override the recommended action from COMPONENT_RESET to RESTART_VM.
   - If the GPU reset failure is not unique to a specific XID error, disable the GPU reset feature to always reboot.

## Type of Change
- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ X] Health Monitors
- [X] Janitor
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPU reset syslog entries now include a success/failure flag and can be disabled (default: enabled).
  * GPU reset job exposes a configurable option to control syslog emission.

* **Behavior Changes / Health**
  * Health monitor distinguishes successful vs failed GPU resets and emits appropriate health events and recommended actions.

* **Tests**
  * Expanded unit, integration, and UAT coverage for success/failure flows and boot-ID verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->