### PR TITLE
feat: inject GPU devices with HostPath volumes rather than using NVIDIA_VISIBLE_DEVICES

### DIFF
--- a/gpu-reset/gpu_reset.sh
+++ b/gpu-reset/gpu_reset.sh
@@ -12,35 +12,49 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set -eou pipefail
 
 # Performs a robust NVIDIA GPU reset workflow. This includes
-# safely managing persistence mode (PM), executing the reset,
-# restoring PM, and running a post-reset health check.
+# executing the reset and running a post-reset health check.
 #
 # USAGE:
-#   1. Reset all GPUs (default if NVIDIA_GPU_RESETS is unset or empty):
-#      ./gpu_reset.sh
+#   Mode 1: nvidia-container-toolkit (NVIDIA_VISIBLE_DEVICES=all):
+#     ./gpu_reset.sh
+#     NVIDIA_GPU_RESETS="GPU-123,GPU-456" ./gpu_reset.sh
 #
-#   2. Reset specific GPUs:
-#      NVIDIA_GPU_RESETS="GPU-123,GPU-456" ./gpu_reset.sh
+#   Mode 2: HostPath driver mount (NVIDIA_VISIBLE_DEVICES=void):
+#     Requires HostPath volumes:
+#       - From /run/nvidia/driver to /run/nvidia/driver
+#       - From /sys to /run/nvidia/driver/sys
+#     Examples:
+#       DRIVER_ROOT=/run/nvidia/driver ./gpu_reset.sh
+#       DRIVER_ROOT=/run/nvidia/driver NVIDIA_GPU_RESETS="GPU-123,GPU-456" ./gpu_reset.sh
 #
 # NOTES:
 #   - Requires root
-#   - Requires 'nvidia-smi'
+#   - Supports x86_64 and aarch64
 
+set -eou pipefail
+
+DRIVER_ROOT="${DRIVER_ROOT:-/}"
 START_TIME=$(date +%s.%N)
 
 log() {
   printf "(%s) %s\n" "$(date '+%Y-%m-%d %H:%M:%S')" "$*"
 }
 
+nvidia_smi_helper() {
+  chroot "$DRIVER_ROOT" nvidia-smi "$@"
+}
+
+log "INFO: Using DRIVER_ROOT=$DRIVER_ROOT"
+log "INFO: Testing nvidia-smi invocation: chroot $DRIVER_ROOT nvidia-smi --version"
+nvidia_smi_helper --version
+
 RESET_STATUS=0
 FINAL_EXIT_STATUS=0
-PM_STATES_FILE=$(mktemp)
 RESET_OUTPUT_FILE=$(mktemp)
 HEALTH_CHECK_OUTPUT_FILE=$(mktemp)
-trap 'rm -f -- "$PM_STATES_FILE" "$RESET_OUTPUT_FILE" "$HEALTH_CHECK_OUTPUT_FILE"' EXIT
+trap 'rm -f -- "$RESET_OUTPUT_FILE" "$HEALTH_CHECK_OUTPUT_FILE"' EXIT
 
 log "INFO: Starting GPU reset workflow..."
 
@@ -52,7 +66,7 @@ log "INFO: Determining target devices..."
 IDS="${NVIDIA_GPU_RESETS:-}"
 
 if [ -z "$IDS" ]; then
-  IDS=$(nvidia-smi --query-gpu=uuid --format=csv,noheader | sed 's/^[[:space:]]*//' | tr '\n' ',' | sed 's/,$//')
+  IDS=$(nvidia_smi_helper --query-gpu=uuid --format=csv,noheader | sed 's/^[[:space:]]*//' | tr '\n' ',' | sed 's/,$//')
 
   if [ -z "$IDS" ]; then
     log "ERROR: No specific devices provided, and no GPUs found on the node."
@@ -66,47 +80,13 @@ TARGET_UUIDS="$IDS"
 log "INFO: Targets:"
 echo "${TARGET_UUIDS}" | tr ',' '\n' | sed 's/^/  /'
 
-#-------------------------------------------
-# PRE-RESET PERSISTENCE MODE (PM) MANAGEMENT
-#-------------------------------------------
-
-log "INFO: Running pre-reset persistence mode (PM) management..."
-
-ORIGINAL_IFS=$IFS
-IFS=','
-for UUID in $TARGET_UUIDS; do
-  # Trim leading/trailing whitespace from UUID
-  UUID=$(echo "$UUID" | xargs)
-
-  if [ -z "$UUID" ]; then
-    continue
-  fi
-
-  if ! nvidia-smi -i "$UUID" >/dev/null 2>&1; then
-    log "WARN: Device not found or inaccessible: ${UUID}"
-    continue
-  fi
-
-  PM_STATUS=$(nvidia-smi -i "$UUID" --query-gpu=persistence_mode --format=csv,noheader | tr -d ' \r\n')
-
-  # Store original status for re-enabling
-  echo "${UUID}:${PM_STATUS}" >> "${PM_STATES_FILE}"
-
-  if [ "${PM_STATUS}" = "Enabled" ]; then
-    nvidia-smi -i "${UUID}" -pm 0 | grep -v "All done." | sed -e 's/\.$//' -e 's/^/  /'
-  fi
-done
-IFS=$ORIGINAL_IFS
-
-log "INFO: Pre-reset persistence mode (PM) management complete."
-
 #----------------
 # RESET EXECUTION
 #----------------
 
 log "INFO: Resetting GPUs..."
 
-if nvidia-smi --gpu-reset -i "${TARGET_UUIDS}" > "$RESET_OUTPUT_FILE" 2>&1; then
+if nvidia_smi_helper --gpu-reset -i "${TARGET_UUIDS}" > "$RESET_OUTPUT_FILE" 2>&1; then
   # shellcheck disable=SC2002
   cat "$RESET_OUTPUT_FILE" | grep -v "All done." | sed -e 's/\.$//' -e 's/^/  /'
   log "INFO: GPU reset complete."
@@ -118,23 +98,6 @@ else
   cat "$RESET_OUTPUT_FILE" | grep -v "All done." | sed 's/\.$//' | grep .
 fi
 
-#--------------------------------------------
-# POST-RESET PERSISTENCE MODE (PM) MANAGEMENT
-#--------------------------------------------
-
-log "INFO: Running post-reset persistence mode (PM) management..."
-
-while IFS= read -r line; do
-  ID=$(echo "$line" | cut -d: -f1)
-  ORIGINAL_STATUS=$(echo "$line" | cut -d: -f2)
-
-  if [ "${ORIGINAL_STATUS}" = "Enabled" ]; then
-    nvidia-smi -i "${ID}" -pm 1 | grep -v "All done." | sed -e 's/\.$//' -e 's/^/  /'
-  fi
-done < "${PM_STATES_FILE}"
-
-log "INFO: Post-reset persistence mode (PM) management complete."
-
 #------------------------
 # POST-RESET HEALTH CHECK
 #------------------------
@@ -142,7 +105,7 @@ log "INFO: Post-reset persistence mode (PM) management complete."
 if [ "$FINAL_EXIT_STATUS" -eq 0 ]; then
   log "INFO: Running post-reset health check..."
 
-  if nvidia-smi -q -i "$TARGET_UUIDS" > "$HEALTH_CHECK_OUTPUT_FILE" 2>&1; then
+  if nvidia_smi_helper -q -i "$TARGET_UUIDS" > "$HEALTH_CHECK_OUTPUT_FILE" 2>&1; then
     log "INFO: Post-reset health check passed."
   else
     log "ERROR: Post-reset health check failed. See details below:"

--- a/janitor/pkg/config/default.go
+++ b/janitor/pkg/config/default.go
@@ -32,6 +32,10 @@ const (
 	HostDevPath            = "/dev"
 	HostDevLogVolumeName   = "dev-log"
 	HostDevLogPath         = "/run/systemd/journal/dev-log"
+	DriverRootVolumeName   = "driver-root"
+	DriverRootPath         = "/run/nvidia/driver"
+	HostSysVolumeName      = "host-sys"
+	HostSysPath            = "/sys"
 	WriteSyslogEventEnvVar = "WRITE_SYSLOG_EVENT"
 )
 
@@ -215,6 +219,22 @@ func getDefaultGPUResetJobTemplate(namespace string, image string, secrets []Ima
 								},
 							},
 						},
+						{
+							Name: DriverRootVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: DriverRootPath,
+								},
+							},
+						},
+						{
+							Name: HostSysVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: HostSysPath,
+								},
+							},
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -223,6 +243,14 @@ func getDefaultGPUResetJobTemplate(namespace string, image string, secrets []Ima
 							ImagePullPolicy: corev1.PullAlways,
 							Resources:       *containerResources,
 							Env: []corev1.EnvVar{
+								{
+									Name:  "NVIDIA_VISIBLE_DEVICES",
+									Value: "void",
+								},
+								{
+									Name:  "DRIVER_ROOT",
+									Value: DriverRootPath,
+								},
 								{
 									Name:  WriteSyslogEventEnvVar,
 									Value: strconv.FormatBool(writeSyslogEvent),
@@ -237,6 +265,14 @@ func getDefaultGPUResetJobTemplate(namespace string, image string, secrets []Ima
 									Name:      HostDevLogVolumeName,
 									MountPath: HostDevLogPath,
 								},
+								{
+									Name:      DriverRootVolumeName,
+									MountPath: DriverRootPath,
+								},
+								{
+									Name:      HostSysVolumeName,
+									MountPath: DriverRootPath + HostSysPath,
+								},
 							},
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: ptr.To(true),
@@ -244,7 +280,6 @@ func getDefaultGPUResetJobTemplate(namespace string, image string, secrets []Ima
 						},
 					},
 					RestartPolicy:    corev1.RestartPolicyOnFailure,
-					HostNetwork:      true,
 					ImagePullSecrets: imagePullSecrets,
 					Tolerations: []corev1.Toleration{
 						{Operator: corev1.TolerationOpExists},

--- a/janitor/pkg/gpuservices/manager.go
+++ b/janitor/pkg/gpuservices/manager.go
@@ -87,6 +87,12 @@ var Registry = map[string]ManagerSpec{
 				EnabledValue:  "true",
 				DisabledValue: "false",
 			},
+			{
+				AppSelector:   map[string]string{"app": "gpu-feature-discovery"},
+				NodeLabel:     "nvidia.com/gpu.deploy.gpu-feature-discovery",
+				EnabledValue:  "true",
+				DisabledValue: "false",
+			},
 		},
 		TeardownTimeout: 5 * time.Minute,
 		RestoreTimeout:  10 * time.Minute,


### PR DESCRIPTION
## Summary
This PR includes 3 changes to the GPU reset workflow:
1. Start injecting GPU devices with HostPath volumes rather than using NVIDIA_VISIBLE_DEVICES. Note that we're keeping the runtimeClassName=nvidia, eventually we could remove this runtime and only set NVIDIA_VISIBLE_DEVICES=void (to account for if the default runtime is nvidia).
2. Remove manual toggling of persistence mode on GPUs being reset. The nvidia-smi --gpu-reset command will automatically detect if persistence mode is enabled on GPUs being reset and handle disabling and enabling it on the GPU being reset as long as the /run/nvidia-persistenced is available in the container
3. Start evicting the gpu-feature-discovery pod in addition to nvidia-device-plugin, nvidia-dgcm, and nvidia-dcgm-exporter. Note that gpu-feature-discovery creates an NVML client in a loop so it's possible that a GPU reset could fail if the device handles exist during the reset.

#### Why do we need to remove the nvidia-container-toolkit?

We have observed that the GPU reset privileged pod is unable to have GPUs injected into the reset container using the NVIDIA_VISIBLE_DEVICES env var when the given GPU has certain XIDs requiring reset.
 
We were unable to start our reset job which needed GPUs injected from nvidia-container-toolkit:
```
message: 'failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error running prestart hook #0: exit status 1, stdout: , stderr: nvidia-container-cli.real: detection error: nvml error: gpu requires reset: unknown'
```

#### How to support GPU reset inside a container

1. Using container-toolkit (current mode):
- Set NVIDIA_VISIBLE_DEVICES=all which will inject GPU devices, nvidia-smi, libnvidia-ml.so.1, and /run/nvidia-persistenced into the container. If /run/nvidia-persistenced is not available, nvidia-smi cannot either manually toggle persistence mode via nvidia-smi -pm or automatically toggle it when running nvidia-smi -r.
- Create a HostPath volume from /sys to /sys inside the container or set HostNetwork=true.

2a. Using HostPath volumes and relative paths with chroot (new mode):
- Set NVIDIA_VISIBLE_DEVICES=void
- Create a HostPath volume from /run/nvidia/driver to /run/nvidia/driver
- Create a HostPath volume from /sys to /run/nvidia/driver/sys
- There is no need to manually mount /run/nvidia-persistenced since it is available at /run/nvidia/driver/run/nvidia-persistenced
- Run nvidia-smi commands using chroot: chroot /run/nvidia/driver nvidia-smi --gpu-reset -i 0

2b. Using HostPath volumes and absolute paths (not chosen):
- Set NVIDIA_VISIBLE_DEVICES=void
- Create a HostPath volume from /run/nvidia/driver to /run/nvidia/driver
- Create a HostPath volume from /sys to /sys or use HostNetwork=true
- Create a HostPath volume from /run/nvidia-persistenced to /run/nvidia-persistenced OR explore if it's possible to pass an explicit path for the nvidia-persistenced directory at /run/nvidia/driver/run/nvidia-persistenced (similar to what we're doing below with LD_PRELOAD).
- Run nvidia-smi commands using absolute paths: env -i LD_PRELOAD=/run/nvidia/driver/lib/x86_64-linux-gnu/libnvidia-ml.so.1 /run/nvidia/driver/usr/bin/nvidia-smi --gpu-reset -i 0 
- Note that we'd have to correctly find the path depending on if the architecture is x86_64 or aarch64 like what the DRA driver is doing: https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/blob/main/hack/kubelet-plugin-prestart.sh#L44

#### Testing

1. Confirmed persistence mode is enabled and is holding GPU device handles:
```
# nvidia-smi -pm 1
Persistence mode is already Enabled for GPU 00000000:0F:00.0.
Persistence mode is already Enabled for GPU 00000000:2D:00.0.
Persistence mode is already Enabled for GPU 00000000:44:00.0.
Persistence mode is already Enabled for GPU 00000000:5B:00.0.
Persistence mode is already Enabled for GPU 00000000:89:00.0.
Persistence mode is already Enabled for GPU 00000000:A8:00.0.
Persistence mode is already Enabled for GPU 00000000:C0:00.0.
Persistence mode is already Enabled for GPU 00000000:D8:00.0.
All done.

262276 -> nvidia-persistenced --persistence-mode
    /dev/nvidia0
    /dev/nvidia1
    /dev/nvidia2
    /dev/nvidia3
    /dev/nvidia4
    /dev/nvidia5
    /dev/nvidia6
    /dev/nvidia7
    /dev/nvidiactl
```
2. Issued a GPU reset:
```
 % kubectl logs gpureset-10.0.7.36-reset-job-z4826 -n dgxc-janitor-system -f
(2026-04-23 18:49:13) INFO: Using DRIVER_ROOT=/run/nvidia/driver
(2026-04-23 18:49:13) INFO: Testing nvidia-smi invocation: chroot /run/nvidia/driver nvidia-smi --version
NVIDIA-SMI version  : 580.95.05
NVML version        : 580.95
DRIVER version      : 580.95.05
CUDA Version        : 13.0
(2026-04-23 18:49:14) INFO: Starting GPU reset workflow...
(2026-04-23 18:49:14) INFO: Determining target devices...
(2026-04-23 18:49:14) INFO: Targets:
  GPU-4f60ecd4-e5da-28b6-256f-f517bbc5eb6a
(2026-04-23 18:49:15) INFO: Resetting GPUs...
  GPU 00000000:0F:00.0 was successfully reset
(2026-04-23 18:50:01) INFO: GPU reset complete.
(2026-04-23 18:50:01) INFO: Running post-reset health check...
(2026-04-23 18:50:10) INFO: Post-reset health check passed.
(2026-04-23 18:50:10) SUCCESS: GPU reset workflow completed in 56.856s.
(2026-04-23 18:50:10) Writing reset success for GPU-4f60ecd4-e5da-28b6-256f-f517bbc5eb6a to syslog
```
3. Confirmed that expected pods were torn down: 
- gpu-feature-discovery
- nvidia-dcgm-exporter
- nvidia-dcgm
- nvidia-driver-daemonset
```
nherz@DP66VX7CLX cluster-access % kubectl get pods -n gpu-operator \
  --field-selector spec.nodeName=$NODE
NAME                                               READY   STATUS      RESTARTS       AGE
gpu-feature-discovery-2pmnt                        1/1     Running     0              45s
gpu-operator-node-feature-discovery-worker-xqwsq   1/1     Running     3              36d
nvidia-container-toolkit-daemonset-648xk           1/1     Running     0              22d
nvidia-cuda-validator-q4vxf                        0/1     Completed   0              22d
nvidia-dcgm-exporter-dnxgw                         1/1     Running     0              45s
nvidia-dcgm-fjbpz                                  1/1     Running     0              45s
nvidia-device-plugin-daemonset-cgh6f               1/1     Running     0              45s
nvidia-driver-daemonset-69j8k                      3/3     Running     18 (22d ago)   36d
nvidia-mig-manager-h8js9                           1/1     Running     0              22d
nvidia-operator-validator-qvsxf                    1/1     Running     0              22d
```



## Type of Change
- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [X] Janitor
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPU reset can run inside a configurable driver-root environment for improved isolation
  * Added management support for the gpu-feature-discovery service

* **Improvements**
  * GPU reset jobs now mount driver and host system paths for more reliable device access
  * Simplified reset workflow by removing persistence-mode capture/restore and the host-network requirement
<!-- end of auto-generated comment: release notes by coderabbit.ai -->