### PR TITLE
fix(ci): harden Fern docs CI and configure custom domain

### DIFF
--- a/.github/workflows/fern-docs-ci.yml
+++ b/.github/workflows/fern-docs-ci.yml
@@ -54,12 +54,12 @@ jobs:
           node-version: '20'
 
       - name: Install Fern CLI
-        run: npm install -g fern-api@4.42.1
+        run: npm install -g fern-api@$(jq -r .version fern/fern.config.json)
 
       - name: Check MDX safety
         # Intentionally inline — a composite action would add indirection without benefit for a single grep.
         run: |
-          BAD=$(grep -rn '<img\b[^>]*[^/]>' docs/ fern/ --include="*.md" --include="*.mdx" || true)
+          BAD=$(grep -rn '<img\b[^>]*[^/]>\|<img>' docs/ fern/ --include="*.md" --include="*.mdx" || true)
           if [ -n "$BAD" ]; then
             echo "::error::Non-self-closing <img> tags found (MDX requires <img ... />):"
             echo "$BAD"

--- a/.github/workflows/fern-docs-preview-comment.yml
+++ b/.github/workflows/fern-docs-preview-comment.yml
@@ -46,7 +46,7 @@ jobs:
           node-version: '20'
 
       - name: Install Fern CLI
-        run: npm install -g fern-api@4.42.1
+        run: npm install -g fern-api@$(jq -r .version fern/fern.config.json)
 
       - name: Generate preview URL
         id: generate-docs

--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: '20'
 
       - name: Install Fern CLI
-        run: npm install -g fern-api@4.42.1
+        run: npm install -g fern-api@$(jq -r .version fern/fern.config.json)
 
       - name: Publish docs
         env:

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -5,8 +5,12 @@
 
 instances:
   - url: nvsentinel.docs.buildwithfern.com/nvsentinel
+    custom-domain: docs.nvidia.com/nvsentinel
 
 title: NVIDIA NVSentinel Documentation
+
+metadata:
+  canonical-host: "docs.nvidia.com/nvsentinel"
 
 products:
   - display-name: NVSentinel


### PR DESCRIPTION
## Summary

Harden the Fern docs CI workflows and configure the production custom domain.

Fixes #1250

## Type of Change
- [x] 🐛 Bug fix
- [x] 🔨 Build/CI

## Component(s) Affected
- [x] Documentation/CI

## Testing
- [x] Tests pass locally
- [x] No breaking changes (or documented)

## Implementation Notes

- Bare `<img>` tag (no attributes) escaped the `[^/]>` regex. Added `\|<img>` alternation.
- Replaced hardcoded `fern-api@4.42.1` with `fern-api@$(jq -r .version fern/fern.config.json)` in all three workflows (ci, publish, preview-comment).
- Added `custom-domain: docs.nvidia.com/nvsentinel` and `canonical-host` metadata.

## Checklist
- [x] Self-review completed
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to dynamically pull Fern CLI version from configuration instead of using pinned fixed versions, ensuring consistency across deployment pipelines.
  * Enhanced MDX safety checks to detect additional invalid image tag patterns in documentation.

* **Documentation**
  * Added custom domain and canonical host configuration for the documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->