### PR TITLE
fix: Fix health event faultRemediated decoding for wrapped BoolValue records

### DIFF
--- a/commons/go.mod
+++ b/commons/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/yandex/protoc-gen-crd v1.1.0 // indirect
+	go.mongodb.org/mongo-driver v1.17.9 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect

--- a/commons/pkg/eventutil/parser.go
+++ b/commons/pkg/eventutil/parser.go
@@ -28,43 +28,14 @@ import (
 func ParseHealthEventFromEvent(event datastore.Event) (model.HealthEventWithStatus, error) {
 	var healthEventWithStatus model.HealthEventWithStatus
 
-	// Determine what to unmarshal: check if this is a change stream event with fullDocument
-	var documentToUnmarshal interface{}
-	if fullDoc, ok := event["fullDocument"]; ok {
-		// This is a change stream event, extract the fullDocument
-		documentToUnmarshal = fullDoc
-	} else {
-		// This is already the document itself
-		documentToUnmarshal = event
-	}
-
-	// Convert to JSON to inspect structure
-	jsonBytes, err := json.Marshal(documentToUnmarshal)
+	tempMap, err := healthEventDocumentMap(event)
 	if err != nil {
-		return healthEventWithStatus, fmt.Errorf("failed to marshal event to JSON: %w", err)
-	}
-
-	// Check if the data is nested inside a "document" field (PostgreSQL format)
-	var tempMap map[string]interface{}
-	if err := json.Unmarshal(jsonBytes, &tempMap); err != nil {
-		return healthEventWithStatus, fmt.Errorf("failed to unmarshal to map: %w", err)
-	}
-
-	// If there's a "document" field, extract it
-	if doc, ok := tempMap["document"]; ok {
-		jsonBytes, err = json.Marshal(doc)
-		if err != nil {
-			return healthEventWithStatus, fmt.Errorf("failed to marshal document field: %w", err)
-		}
-
-		if err := json.Unmarshal(jsonBytes, &tempMap); err != nil {
-			return healthEventWithStatus, fmt.Errorf("failed to unmarshal document field to map: %w", err)
-		}
+		return healthEventWithStatus, err
 	}
 
 	normalizeProtoWrapperBoolFields(tempMap)
 
-	jsonBytes, err = json.Marshal(tempMap)
+	jsonBytes, err := json.Marshal(tempMap)
 	if err != nil {
 		return healthEventWithStatus, fmt.Errorf("failed to marshal normalized health event: %w", err)
 	}
@@ -85,6 +56,44 @@ func ParseHealthEventFromEvent(event datastore.Event) (model.HealthEventWithStat
 	}
 
 	return healthEventWithStatus, nil
+}
+
+func healthEventDocumentMap(event datastore.Event) (map[string]interface{}, error) {
+	documentToUnmarshal := healthEventDocument(event)
+
+	tempMap, err := toMap(documentToUnmarshal, "event")
+	if err != nil {
+		return nil, err
+	}
+
+	// PostgreSQL watcher events store the actual health event under "document".
+	if doc, ok := tempMap["document"]; ok {
+		return toMap(doc, "document field")
+	}
+
+	return tempMap, nil
+}
+
+func healthEventDocument(event datastore.Event) interface{} {
+	if fullDoc, ok := event["fullDocument"]; ok {
+		return fullDoc
+	}
+
+	return event
+}
+
+func toMap(value interface{}, name string) (map[string]interface{}, error) {
+	jsonBytes, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal %s to JSON: %w", name, err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(jsonBytes, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal %s to map: %w", name, err)
+	}
+
+	return result, nil
 }
 
 func normalizeProtoWrapperBoolFields(document map[string]interface{}) {

--- a/commons/pkg/eventutil/parser.go
+++ b/commons/pkg/eventutil/parser.go
@@ -56,6 +56,17 @@ func ParseHealthEventFromEvent(event datastore.Event) (model.HealthEventWithStat
 		if err != nil {
 			return healthEventWithStatus, fmt.Errorf("failed to marshal document field: %w", err)
 		}
+
+		if err := json.Unmarshal(jsonBytes, &tempMap); err != nil {
+			return healthEventWithStatus, fmt.Errorf("failed to unmarshal document field to map: %w", err)
+		}
+	}
+
+	normalizeProtoWrapperBoolFields(tempMap)
+
+	jsonBytes, err = json.Marshal(tempMap)
+	if err != nil {
+		return healthEventWithStatus, fmt.Errorf("failed to marshal normalized health event: %w", err)
 	}
 
 	// Now unmarshal to the actual structure
@@ -74,4 +85,28 @@ func ParseHealthEventFromEvent(event datastore.Event) (model.HealthEventWithStat
 	}
 
 	return healthEventWithStatus, nil
+}
+
+func normalizeProtoWrapperBoolFields(document map[string]interface{}) {
+	for _, statusKey := range []string{"healtheventstatus", "healthEventStatus", "HealthEventStatus"} {
+		status, ok := document[statusKey].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		normalizeWrappedBoolField(status, "faultremediated")
+		normalizeWrappedBoolField(status, "faultRemediated")
+		normalizeWrappedBoolField(status, "FaultRemediated")
+	}
+}
+
+func normalizeWrappedBoolField(document map[string]interface{}, field string) {
+	value, ok := document[field]
+	if !ok {
+		return
+	}
+
+	if boolValue, ok := value.(bool); ok {
+		document[field] = map[string]interface{}{"value": boolValue}
+	}
 }

--- a/commons/pkg/eventutil/parser_test.go
+++ b/commons/pkg/eventutil/parser_test.go
@@ -108,6 +108,97 @@ func TestParseHealthEventFromEvent(t *testing.T) {
 			},
 		},
 		{
+			name: "parse direct document with legacy plain faultRemediated bool",
+			event: datastore.Event{
+				"healtheventstatus": map[string]interface{}{
+					"nodequarantined": "Quarantined",
+					"faultremediated": true,
+				},
+				"healthevent": map[string]interface{}{
+					"nodename":       "legacy-node",
+					"checkname":      "GpuXidError",
+					"componentclass": "GPU",
+				},
+			},
+			expectError: false,
+			checkResult: func(t *testing.T, result model.HealthEventWithStatus) {
+				assert.Equal(t, "legacy-node", result.HealthEvent.NodeName)
+				require.NotNil(t, result.HealthEventStatus.FaultRemediated)
+				assert.True(t, result.HealthEventStatus.FaultRemediated.GetValue())
+			},
+		},
+		{
+			name: "parse change stream event with legacy plain faultRemediated bool",
+			event: datastore.Event{
+				"operationType": "update",
+				"fullDocument": map[string]interface{}{
+					"healtheventstatus": map[string]interface{}{
+						"nodequarantined": "Quarantined",
+						"faultremediated": false,
+					},
+					"healthevent": map[string]interface{}{
+						"nodename":       "legacy-change-stream-node",
+						"checkname":      "GpuXidError",
+						"componentclass": "GPU",
+					},
+				},
+			},
+			expectError: false,
+			checkResult: func(t *testing.T, result model.HealthEventWithStatus) {
+				assert.Equal(t, "legacy-change-stream-node", result.HealthEvent.NodeName)
+				require.NotNil(t, result.HealthEventStatus.FaultRemediated)
+				assert.False(t, result.HealthEventStatus.FaultRemediated.GetValue())
+			},
+		},
+		{
+			name: "parse PostgreSQL document field with legacy plain faultRemediated bool",
+			event: datastore.Event{
+				"operationType": "insert",
+				"fullDocument": map[string]interface{}{
+					"document": map[string]interface{}{
+						"healtheventstatus": map[string]interface{}{
+							"nodequarantined": "Quarantined",
+							"faultremediated": true,
+						},
+						"healthevent": map[string]interface{}{
+							"nodename":       "postgres-legacy-node",
+							"checkname":      "GpuXidError",
+							"componentclass": "GPU",
+						},
+					},
+				},
+			},
+			expectError: false,
+			checkResult: func(t *testing.T, result model.HealthEventWithStatus) {
+				assert.Equal(t, "postgres-legacy-node", result.HealthEvent.NodeName)
+				require.NotNil(t, result.HealthEventStatus.FaultRemediated)
+				assert.True(t, result.HealthEventStatus.FaultRemediated.GetValue())
+			},
+		},
+		{
+			name: "parse change stream event with wrapped faultRemediated bool",
+			event: datastore.Event{
+				"operationType": "update",
+				"fullDocument": map[string]interface{}{
+					"healtheventstatus": map[string]interface{}{
+						"nodequarantined": "Quarantined",
+						"faultremediated": map[string]interface{}{"value": true},
+					},
+					"healthevent": map[string]interface{}{
+						"nodename":       "wrapped-node",
+						"checkname":      "GpuXidError",
+						"componentclass": "GPU",
+					},
+				},
+			},
+			expectError: false,
+			checkResult: func(t *testing.T, result model.HealthEventWithStatus) {
+				assert.Equal(t, "wrapped-node", result.HealthEvent.NodeName)
+				require.NotNil(t, result.HealthEventStatus.FaultRemediated)
+				assert.True(t, result.HealthEventStatus.FaultRemediated.GetValue())
+			},
+		},
+		{
 			name: "handle nil NodeQuarantined with default value",
 			event: datastore.Event{
 				"operationType": "insert",

--- a/health-events-analyzer/pkg/parser/parser_test.go
+++ b/health-events-analyzer/pkg/parser/parser_test.go
@@ -36,9 +36,9 @@ func TestParseSequenceString(t *testing.T) {
 		{
 			name: "criteria with fault remediation check and .this reference",
 			criteria: map[string]any{
-				"healtheventstatus.faultremediated": true,
-				"healthevent.nodename":              "this.healthevent.nodename",
-				"healthevent.isfatal":               "this.healthevent.isfatal",
+				"healtheventstatus.faultremediated.value": true,
+				"healthevent.nodename":                    "this.healthevent.nodename",
+				"healthevent.isfatal":                     "this.healthevent.isfatal",
 			},
 			event: datamodels.HealthEventWithStatus{
 				HealthEvent: &protos.HealthEvent{
@@ -49,9 +49,9 @@ func TestParseSequenceString(t *testing.T) {
 					FaultRemediated: wrapperspb.Bool(remediated)},
 			},
 			want: map[string]interface{}{
-				"healtheventstatus.faultremediated": true,
-				"healthevent.nodename":              "gpu-node-1",
-				"healthevent.isfatal":               true,
+				"healtheventstatus.faultremediated.value": true,
+				"healthevent.nodename":                    "gpu-node-1",
+				"healthevent.isfatal":                     true,
 			},
 			wantErr: false,
 		},
@@ -393,14 +393,14 @@ func TestGetValueFromPath(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "nested struct field",
-			path: "healtheventstatus.faultremediated",
+			name: "nested BoolValue field",
+			path: "healtheventstatus.faultremediated.value",
 			event: datamodels.HealthEventWithStatus{
 				HealthEventStatus: &protos.HealthEventStatus{
 					FaultRemediated: remediated,
 				},
 			},
-			want:    remediated,
+			want:    true,
 			wantErr: false,
 		},
 		{

--- a/health-events-analyzer/pkg/reconciler/reconciler_test.go
+++ b/health-events-analyzer/pkg/reconciler/reconciler_test.go
@@ -169,7 +169,7 @@ var (
 			Description: "check multiple remediations are completed within 2 minutes",
 			Stage: []string{
 				`{"$match": {"$expr": {"$gte": ["$healthevent.generatedtimestamp.seconds", {"$subtract": [{"$divide": [{"$toLong": "$$NOW"}, 1000]}, 120]}]}}}`,
-				`{"$match": {"healtheventstatus.faultremediated": true, "healthevent.nodename": "this.healthevent.nodename"}}`,
+				`{"$match": {"healtheventstatus.faultremediated.value": true, "healthevent.nodename": "this.healthevent.nodename"}}`,
 				`{"$count": "count"}`,
 				`{"$match": {"count": {"$gte": 5}}}`,
 			},

--- a/store-client/POSTGRESQL_IMPLEMENTATION.md
+++ b/store-client/POSTGRESQL_IMPLEMENTATION.md
@@ -419,7 +419,7 @@ cursor, err := dbClient.Find(ctx, filter, nil)
 ```go
 // Using query builders (recommended)
 q := query.New().Build(query.Eq("_id", eventID))
-u := query.NewUpdate().Set("healtheventstatus.faultremediated", true)
+u := query.NewUpdate().Set("healtheventstatus.faultremediated.value", true)
 
 err := healthStore.UpdateHealthEventsByQuery(ctx, q, u)
 
@@ -427,7 +427,7 @@ err := healthStore.UpdateHealthEventsByQuery(ctx, q, u)
 filter := map[string]interface{}{"_id": eventID}
 update := map[string]interface{}{
     "$set": map[string]interface{}{
-        "healtheventstatus.faultremediated": true,
+        "healtheventstatus.faultremediated.value": true,
     },
 }
 _, err := dbClient.UpdateDocument(ctx, filter, update)

--- a/store-client/README.md
+++ b/store-client/README.md
@@ -302,7 +302,7 @@ cursor, err := dbClient.Find(ctx, filter, nil)
 // Database-agnostic updates (recommended)
 q := query.New().Build(query.Eq("_id", eventID))
 u := query.NewUpdate().
-    Set("healtheventstatus.faultremediated", true).
+    Set("healtheventstatus.faultremediated.value", true).
     Set("healtheventstatus.remediatedAt", time.Now())
 
 err := healthStore.UpdateHealthEventsByQuery(ctx, q, u)
@@ -311,7 +311,7 @@ err := healthStore.UpdateHealthEventsByQuery(ctx, q, u)
 filter := map[string]interface{}{"_id": id}
 update := map[string]interface{}{
     "$set": map[string]interface{}{
-        "healtheventstatus.faultremediated": true,
+        "healtheventstatus.faultremediated.value": true,
     },
 }
 result, err := dbClient.UpdateDocument(ctx, filter, update)

--- a/store-client/pkg/client/mongodb_client.go
+++ b/store-client/pkg/client/mongodb_client.go
@@ -519,9 +519,9 @@ func (c *MongoDBClient) buildDirectFieldUpdate(statusPath string, status interfa
 // buildStructFieldUpdates extracts individual fields from a status struct for granular updates
 // This prevents overwriting other fields when doing partial status updates
 // Used by store methods like UpdateHealthEventStatus
-// Example: statusPath="healtheventstatus", status=HealthEventStatus{FaultRemediated: true}
+// Example: statusPath="healtheventstatus", status=HealthEventStatus{FaultRemediated: &faultRemediated}
 //
-//	→ {"healtheventstatus.faultremediated": true}
+//	→ {"healtheventstatus.faultremediated": {"value": true}}
 func (c *MongoDBClient) buildStructFieldUpdates(basePath string, status interface{}) bson.M {
 	updateFields := bson.M{}
 

--- a/store-client/pkg/datastore/providers/postgresql/pipeline_filter.go
+++ b/store-client/pkg/datastore/providers/postgresql/pipeline_filter.go
@@ -172,7 +172,7 @@ func (f *PipelineFilter) matchesCondition(event map[string]interface{}, key stri
 		result := f.matchesAnd(event, expectedValue)
 		return result
 	default:
-		// Handle field path matching (e.g., "operationType", "fullDocument.healtheventstatus.faultremediated")
+		// Handle field path matching (e.g., "operationType", "fullDocument.healtheventstatus.faultremediated.value")
 		actualValue := f.getFieldValue(event, key)
 
 		result := f.matchesValue(actualValue, expectedValue)

--- a/store-client/pkg/datastore/types_codec.go
+++ b/store-client/pkg/datastore/types_codec.go
@@ -105,34 +105,27 @@ func (h *HealthEventStatus) UnmarshalJSON(data []byte) error {
 
 	var faultRemediated *bool
 
-	for _, key := range []string{"faultremediated", "faultRemediated", "FaultRemediated"} {
-		value, ok := raw[key]
-		if !ok {
-			continue
-		}
-
+	if value, ok := raw["faultremediated"]; ok {
 		decoded, err := decodeJSONBoolValue(value)
 		if err != nil {
-			return fmt.Errorf("failed to decode %s: %w", key, err)
+			return fmt.Errorf("failed to decode faultremediated: %w", err)
 		}
 
 		faultRemediated = decoded
 
-		delete(raw, key)
-
-		break
+		delete(raw, "faultremediated")
 	}
 
 	remainingBytes, err := json.Marshal(raw)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to marshal remaining JSON fields: %w", err)
 	}
 
 	type alias HealthEventStatus
 
 	var decoded alias
 	if err := json.Unmarshal(remainingBytes, &decoded); err != nil {
-		return err
+		return fmt.Errorf("failed to unmarshal remaining JSON fields: %w", err)
 	}
 
 	*h = HealthEventStatus(decoded)

--- a/store-client/pkg/datastore/types_codec.go
+++ b/store-client/pkg/datastore/types_codec.go
@@ -1,0 +1,217 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastore
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// MarshalBSON preserves the public *bool API while writing nullable booleans in
+// the protobuf BoolValue shape expected by proto-based consumers.
+func (h HealthEventStatus) MarshalBSON() ([]byte, error) {
+	return bson.Marshal(healthEventStatusBSON{
+		NodeQuarantined:           h.NodeQuarantined,
+		QuarantineFinishTimestamp: h.QuarantineFinishTimestamp,
+		UserPodsEvictionStatus:    h.UserPodsEvictionStatus,
+		DrainFinishTimestamp:      h.DrainFinishTimestamp,
+		FaultRemediated:           encodeWrappedBool(h.FaultRemediated),
+		LastRemediationTimestamp:  h.LastRemediationTimestamp,
+		SpanIds:                   h.SpanIds,
+	})
+}
+
+// UnmarshalBSON accepts both historical and current on-disk encodings for
+// nullable boolean fields while preserving the public datastore API.
+func (h *HealthEventStatus) UnmarshalBSON(data []byte) error {
+	var raw bson.D
+	if err := bson.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	var faultRemediated *bool
+
+	remaining := make(bson.D, 0, len(raw))
+
+	for _, elem := range raw {
+		if elem.Key == "faultremediated" {
+			value, err := decodeBSONBoolValue(elem.Value)
+			if err != nil {
+				return fmt.Errorf("failed to decode faultremediated: %w", err)
+			}
+
+			faultRemediated = value
+
+			continue
+		}
+
+		remaining = append(remaining, elem)
+	}
+
+	remainingBytes, err := bson.Marshal(remaining)
+	if err != nil {
+		return err
+	}
+
+	type alias HealthEventStatus
+
+	var decoded alias
+	if err := bson.Unmarshal(remainingBytes, &decoded); err != nil {
+		return err
+	}
+
+	*h = HealthEventStatus(decoded)
+	h.FaultRemediated = faultRemediated
+
+	return nil
+}
+
+// MarshalJSON preserves the public *bool API while writing nullable booleans in
+// the protobuf BoolValue shape expected by proto-based consumers.
+func (h HealthEventStatus) MarshalJSON() ([]byte, error) {
+	return json.Marshal(healthEventStatusJSON{
+		NodeQuarantined:           h.NodeQuarantined,
+		QuarantineFinishTimestamp: h.QuarantineFinishTimestamp,
+		UserPodsEvictionStatus:    h.UserPodsEvictionStatus,
+		DrainFinishTimestamp:      h.DrainFinishTimestamp,
+		FaultRemediated:           encodeWrappedBool(h.FaultRemediated),
+		LastRemediationTimestamp:  h.LastRemediationTimestamp,
+		SpanIds:                   h.SpanIds,
+	})
+}
+
+// UnmarshalJSON accepts both historical and current JSON encodings for
+// nullable boolean fields while preserving the public datastore API.
+func (h *HealthEventStatus) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	var faultRemediated *bool
+
+	for _, key := range []string{"faultremediated", "faultRemediated", "FaultRemediated"} {
+		value, ok := raw[key]
+		if !ok {
+			continue
+		}
+
+		decoded, err := decodeJSONBoolValue(value)
+		if err != nil {
+			return fmt.Errorf("failed to decode %s: %w", key, err)
+		}
+
+		faultRemediated = decoded
+
+		delete(raw, key)
+
+		break
+	}
+
+	remainingBytes, err := json.Marshal(raw)
+	if err != nil {
+		return err
+	}
+
+	type alias HealthEventStatus
+
+	var decoded alias
+	if err := json.Unmarshal(remainingBytes, &decoded); err != nil {
+		return err
+	}
+
+	*h = HealthEventStatus(decoded)
+	h.FaultRemediated = faultRemediated
+
+	return nil
+}
+
+type healthEventStatusBSON struct {
+	NodeQuarantined           *Status                `bson:"nodequarantined"`
+	QuarantineFinishTimestamp *timestamppb.Timestamp `bson:"quarantinefinishtimestamp,omitempty"`
+	UserPodsEvictionStatus    OperationStatus        `bson:"userpodsevictionstatus"`
+	DrainFinishTimestamp      *timestamppb.Timestamp `bson:"drainfinishtimestamp,omitempty"`
+	FaultRemediated           interface{}            `bson:"faultremediated"`
+	LastRemediationTimestamp  *timestamppb.Timestamp `bson:"lastremediationtimestamp,omitempty"`
+	SpanIds                   map[string]string      `bson:"spanids,omitempty"`
+}
+
+type healthEventStatusJSON struct {
+	NodeQuarantined           *Status                `json:"nodequarantined"`
+	QuarantineFinishTimestamp *timestamppb.Timestamp `json:"quarantinefinishtimestamp,omitempty"`
+	UserPodsEvictionStatus    OperationStatus        `json:"userpodsevictionstatus"`
+	DrainFinishTimestamp      *timestamppb.Timestamp `json:"drainfinishtimestamp,omitempty"`
+	FaultRemediated           interface{}            `json:"faultremediated"`
+	LastRemediationTimestamp  *timestamppb.Timestamp `json:"lastremediationtimestamp,omitempty"`
+	SpanIds                   map[string]string      `json:"spanids,omitempty"`
+}
+
+func encodeWrappedBool(value *bool) interface{} {
+	if value == nil {
+		return nil
+	}
+
+	return map[string]bool{"value": *value}
+}
+
+func decodeBSONBoolValue(value interface{}) (*bool, error) {
+	switch v := value.(type) {
+	case nil:
+		return nil, nil
+	case bool:
+		return &v, nil
+	case bson.D:
+		for _, elem := range v {
+			if elem.Key != "value" {
+				continue
+			}
+
+			boolValue, ok := elem.Value.(bool)
+			if !ok {
+				return nil, fmt.Errorf("value field is %T, not bool", elem.Value)
+			}
+
+			return &boolValue, nil
+		}
+
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unsupported BSON type %T", value)
+	}
+}
+
+func decodeJSONBoolValue(data json.RawMessage) (*bool, error) {
+	if string(data) == "null" {
+		return nil, nil
+	}
+
+	var plain bool
+	if err := json.Unmarshal(data, &plain); err == nil {
+		return &plain, nil
+	}
+
+	var wrapped struct {
+		Value *bool `json:"value"`
+	}
+
+	if err := json.Unmarshal(data, &wrapped); err != nil {
+		return nil, err
+	}
+
+	return wrapped.Value, nil
+}

--- a/store-client/pkg/datastore/types_codec_test.go
+++ b/store-client/pkg/datastore/types_codec_test.go
@@ -140,13 +140,6 @@ func TestHealthEventStatus_UnmarshalJSON_WrappedBool(t *testing.T) {
 	assert.False(t, *status.FaultRemediated)
 }
 
-func TestHealthEventStatus_UnmarshalJSON_CamelCaseWrappedBool(t *testing.T) {
-	status := unmarshalHealthEventStatusJSON(t, `{"faultRemediated": {"value": true}}`)
-
-	require.NotNil(t, status.FaultRemediated)
-	assert.True(t, *status.FaultRemediated)
-}
-
 func TestHealthEventStatus_UnmarshalJSON_NullBool(t *testing.T) {
 	status := unmarshalHealthEventStatusJSON(t, `{"faultremediated": null}`)
 

--- a/store-client/pkg/datastore/types_codec_test.go
+++ b/store-client/pkg/datastore/types_codec_test.go
@@ -1,0 +1,211 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastore
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestHealthEventStatus_UnmarshalBSON_PlainBool(t *testing.T) {
+	status := unmarshalHealthEventStatusBSON(t, bson.D{{Key: "faultremediated", Value: true}})
+
+	require.NotNil(t, status.FaultRemediated)
+	assert.True(t, *status.FaultRemediated)
+}
+
+func TestHealthEventStatus_MarshalBSON_WrappedBool(t *testing.T) {
+	faultRemediated := true
+	status := HealthEventStatus{FaultRemediated: &faultRemediated}
+
+	data, err := bson.Marshal(status)
+	require.NoError(t, err)
+
+	var doc bson.M
+	require.NoError(t, bson.Unmarshal(data, &doc))
+
+	value, ok := doc["faultremediated"].(bson.M)
+	require.True(t, ok, "faultremediated should be an embedded document, got %T", doc["faultremediated"])
+	assert.Equal(t, true, value["value"])
+}
+
+func TestHealthEventStatus_MarshalBSON_NilBool(t *testing.T) {
+	data, err := bson.Marshal(HealthEventStatus{})
+	require.NoError(t, err)
+
+	var doc bson.M
+	require.NoError(t, bson.Unmarshal(data, &doc))
+
+	assert.Contains(t, doc, "faultremediated")
+	assert.Nil(t, doc["faultremediated"])
+}
+
+func TestHealthEventStatus_UnmarshalBSON_WrappedBool(t *testing.T) {
+	status := unmarshalHealthEventStatusBSON(t, bson.D{
+		{Key: "faultremediated", Value: bson.D{{Key: "value", Value: false}}},
+	})
+
+	require.NotNil(t, status.FaultRemediated)
+	assert.False(t, *status.FaultRemediated)
+}
+
+func TestHealthEventStatus_UnmarshalBSON_NullBool(t *testing.T) {
+	status := unmarshalHealthEventStatusBSON(t, bson.D{{Key: "faultremediated", Value: nil}})
+
+	assert.Nil(t, status.FaultRemediated)
+}
+
+func TestHealthEventStatus_UnmarshalBSON_MissingBool(t *testing.T) {
+	status := unmarshalHealthEventStatusBSON(t, bson.D{})
+
+	assert.Nil(t, status.FaultRemediated)
+}
+
+func TestHealthEventStatus_UnmarshalBSON_PreservesOtherFields(t *testing.T) {
+	status := unmarshalHealthEventStatusBSON(t, bson.D{
+		{Key: "nodequarantined", Value: "Quarantined"},
+		{Key: "userpodsevictionstatus", Value: bson.D{
+			{Key: "status", Value: "Succeeded"},
+			{Key: "message", Value: "drain complete"},
+		}},
+		{Key: "faultremediated", Value: bson.D{{Key: "value", Value: true}}},
+	})
+
+	require.NotNil(t, status.NodeQuarantined)
+	assert.Equal(t, Quarantined, *status.NodeQuarantined)
+	assert.Equal(t, StatusSucceeded, status.UserPodsEvictionStatus.Status)
+	assert.Equal(t, "drain complete", status.UserPodsEvictionStatus.Message)
+	require.NotNil(t, status.FaultRemediated)
+	assert.True(t, *status.FaultRemediated)
+}
+
+func TestHealthEventWithStatus_UnmarshalBSON_WrappedBool(t *testing.T) {
+	data, err := bson.Marshal(bson.D{
+		{Key: "healtheventstatus", Value: bson.D{
+			{Key: "faultremediated", Value: bson.D{{Key: "value", Value: false}}},
+		}},
+	})
+	require.NoError(t, err)
+
+	var event HealthEventWithStatus
+	require.NoError(t, bson.Unmarshal(data, &event))
+	require.NotNil(t, event.HealthEventStatus.FaultRemediated)
+	assert.False(t, *event.HealthEventStatus.FaultRemediated)
+}
+
+func TestHealthEventStatus_UnmarshalJSON_PlainBool(t *testing.T) {
+	status := unmarshalHealthEventStatusJSON(t, `{"faultremediated": true}`)
+
+	require.NotNil(t, status.FaultRemediated)
+	assert.True(t, *status.FaultRemediated)
+}
+
+func TestHealthEventStatus_MarshalJSON_WrappedBool(t *testing.T) {
+	faultRemediated := true
+	status := HealthEventStatus{FaultRemediated: &faultRemediated}
+
+	data, err := json.Marshal(status)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"nodequarantined": null, "userpodsevictionstatus": {"status": ""}, "faultremediated": {"value": true}}`, string(data))
+}
+
+func TestHealthEventStatus_MarshalJSON_NilBool(t *testing.T) {
+	data, err := json.Marshal(HealthEventStatus{})
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"nodequarantined": null, "userpodsevictionstatus": {"status": ""}, "faultremediated": null}`, string(data))
+}
+
+func TestHealthEventStatus_UnmarshalJSON_WrappedBool(t *testing.T) {
+	status := unmarshalHealthEventStatusJSON(t, `{"faultremediated": {"value": false}}`)
+
+	require.NotNil(t, status.FaultRemediated)
+	assert.False(t, *status.FaultRemediated)
+}
+
+func TestHealthEventStatus_UnmarshalJSON_CamelCaseWrappedBool(t *testing.T) {
+	status := unmarshalHealthEventStatusJSON(t, `{"faultRemediated": {"value": true}}`)
+
+	require.NotNil(t, status.FaultRemediated)
+	assert.True(t, *status.FaultRemediated)
+}
+
+func TestHealthEventStatus_UnmarshalJSON_NullBool(t *testing.T) {
+	status := unmarshalHealthEventStatusJSON(t, `{"faultremediated": null}`)
+
+	assert.Nil(t, status.FaultRemediated)
+}
+
+func TestHealthEventStatus_UnmarshalJSON_MissingBool(t *testing.T) {
+	status := unmarshalHealthEventStatusJSON(t, `{}`)
+
+	assert.Nil(t, status.FaultRemediated)
+}
+
+func TestHealthEventStatus_UnmarshalJSON_PreservesOtherFields(t *testing.T) {
+	status := unmarshalHealthEventStatusJSON(t, `{
+		"nodequarantined": "Quarantined",
+		"userpodsevictionstatus": {
+			"status": "Succeeded",
+			"message": "drain complete"
+		},
+		"faultremediated": {"value": true}
+	}`)
+
+	require.NotNil(t, status.NodeQuarantined)
+	assert.Equal(t, Quarantined, *status.NodeQuarantined)
+	assert.Equal(t, StatusSucceeded, status.UserPodsEvictionStatus.Status)
+	assert.Equal(t, "drain complete", status.UserPodsEvictionStatus.Message)
+	require.NotNil(t, status.FaultRemediated)
+	assert.True(t, *status.FaultRemediated)
+}
+
+func TestHealthEventWithStatus_UnmarshalJSON_WrappedBool(t *testing.T) {
+	var event HealthEventWithStatus
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"healtheventstatus": {
+			"faultremediated": {"value": false}
+		}
+	}`), &event))
+	require.NotNil(t, event.HealthEventStatus.FaultRemediated)
+	assert.False(t, *event.HealthEventStatus.FaultRemediated)
+}
+
+func unmarshalHealthEventStatusBSON(t *testing.T, doc bson.D) HealthEventStatus {
+	t.Helper()
+
+	data, err := bson.Marshal(doc)
+	require.NoError(t, err)
+
+	var status HealthEventStatus
+	require.NoError(t, bson.Unmarshal(data, &status))
+
+	return status
+}
+
+func unmarshalHealthEventStatusJSON(t *testing.T, doc string) HealthEventStatus {
+	t.Helper()
+
+	var status HealthEventStatus
+	require.NoError(t, json.Unmarshal([]byte(doc), &status))
+
+	return status
+}


### PR DESCRIPTION
## Summary

- Fixes health event status decoding when `healtheventstatus.faultremediated` is stored as a protobuf `BoolValue` document (`{"value": false}`) while the datastore model exposes it as `*bool`.
- Adds JSON/BSON compatibility handling so both wrapped and plain boolean shapes decode safely, while writers continue emitting the wrapped shape expected by proto/change-stream consumers.
- Normalizes legacy plain boolean `faultremediated` values before proto unmarshalling in the shared event parser.

## Testing

Added unit tests to cover these cases:
- `store-client/pkg/datastore/types_codec_test.go`
  - Verifies `HealthEventStatus` can decode `faultremediated` from both plain bool and wrapped `{"value": bool}` BSON shapes.
  - Verifies `HealthEventStatus` can decode both plain and wrapped JSON shapes.
  - Verifies `HealthEventStatus` marshals `faultremediated` back to the wrapped `{"value": bool}` shape.
  - Verifies nested `HealthEventWithStatus` decoding works with wrapped `faultremediated`, matching the node-drainer query path.

- `commons/pkg/eventutil/parser_test.go`
  - Verifies direct health event documents with plain bool `faultremediated` parse successfully.
  - Verifies Mongo change-stream `fullDocument` payloads with plain bool `faultremediated` parse successfully.
  - Verifies PostgreSQL `document` payloads with plain bool `faultremediated` parse successfully.
  - Verifies wrapped `{"value": bool}` `faultremediated` payloads continue to parse successfully.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Database-agnostic query/update API and cross-database pipeline support for health events
  * Robust marshaling/unmarshaling for health event status to tolerate nested/wrapped boolean representations

* **Bug Fixes**
  * Improved parsing and normalization of wrapped/nested boolean fields across storage formats
  * Query predicates updated to target the nested boolean value path

* **Tests**
  * Extensive tests covering nested/wrapped boolean parsing and serialization

* **Documentation**
  * Examples and migration guidance updated for nested boolean field paths
<!-- end of auto-generated comment: release notes by coderabbit.ai -->