### PR TITLE
feat: add NIC driver logs detection to syslog health monitor

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/templates/_helpers.tpl
+++ b/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/templates/_helpers.tpl
@@ -129,6 +129,10 @@ spec:
             - "{{ $root.Values.global.metadataPath }}"
             - "--processing-strategy"
             - "{{ $root.Values.processingStrategy }}"
+            - "--nic-driver-config"
+            - "/etc/nic-driver-syslog/config.toml"
+            - "--sysfs-root"
+            - "/nvsentinel/sys"
           resources:
             {{- toYaml $root.Values.resources | nindent 12 }}
           ports:
@@ -189,6 +193,9 @@ spec:
             - name: sys-vol
               mountPath: /nvsentinel/sys
               readOnly: true
+            - name: nic-driver-config
+              mountPath: /etc/nic-driver-syslog
+              readOnly: true
         {{- if and $root.Values.xidSideCar.enabled (not (semverCompare ">=1.29-0" $root.Capabilities.KubeVersion.Version)) }}
         - name: xid-analyzer-sidecar
           image: {{ $root.Values.xidSideCar.image.repository }}:{{ $root.Values.xidSideCar.image.tag }}
@@ -246,6 +253,9 @@ spec:
           hostPath:
             path: /sys
             type: Directory
+        - name: nic-driver-config
+          configMap:
+            name: {{ include "syslog-health-monitor.fullname" $root }}-nic-driver
         - name: proc-vol    
           hostPath:
             path: /proc

--- a/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/templates/configmap.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "syslog-health-monitor.fullname" . }}-nic-driver
+  name: '{{ include "syslog-health-monitor.fullname" . }}-nic-driver'
   labels:
     {{- include "syslog-health-monitor.labels" . | nindent 4 }}
 data:

--- a/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/templates/configmap.yaml
@@ -28,5 +28,6 @@ data:
     enabled = {{ .enabled }}
     isFatal = {{ .isFatal }}
     recommendedAction = {{ .recommendedAction | quote }}
+    processingStrategy = {{ .processingStrategy | quote }}
     description = {{ .description | quote }}
     {{- end }}

--- a/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/templates/configmap.yaml
@@ -1,0 +1,32 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "syslog-health-monitor.fullname" . }}-nic-driver
+  labels:
+    {{- include "syslog-health-monitor.labels" . | nindent 4 }}
+data:
+  config.toml: |
+    {{- range .Values.nicDriverDetection.patterns }}
+
+    [[nicDriverDetection.patterns]]
+    name = {{ .name | quote }}
+    regex = '''{{ .regex }}'''
+    enabled = {{ .enabled }}
+    isFatal = {{ .isFatal }}
+    recommendedAction = {{ .recommendedAction | quote }}
+    description = {{ .description | quote }}
+    {{- end }}

--- a/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/values.yaml
@@ -31,6 +31,7 @@ enabledChecks:
   - SysLogsXIDError
   - SysLogsSXIDError
   - SysLogsGPUFallenOff
+  - SysLogsNICDriverError
 
 # XID (GPU error) analyzer sidecar configuration
 xidSideCar:
@@ -57,3 +58,80 @@ logLevel: info
 # EXECUTE_REMEDIATION: normal behavior; downstream modules may update cluster state.
 # STORE_ONLY: observability-only behavior; event should be persisted/exported but should not modify cluster resources (i.e., no node conditions, no quarantine, no drain, no remediation).
 processingStrategy: EXECUTE_REMEDIATION
+
+# NIC driver syslog pattern detection configuration.
+# Patterns are evaluated in order; first match wins.
+# Only consumed when SysLogsNICDriverError is in enabledChecks.
+#
+# IMPORTANT: Custom patterns should be NIC/mlx5-specific. Generic PCIe/AER
+# patterns (e.g. 'PCIe Bus Error.*Fatal') are intentionally NOT shipped
+# because they can match GPUs, NVMe, or root ports. The handler does not
+# BDF-gate generic patterns; if you add one, ensure its regex includes an
+# mlx5-specific prefix (mlx5_core, mlx5_cmd_out_err, etc.) so it cannot
+# match other devices.
+nicDriverDetection:
+  patterns:
+    #--------------------------------------------------------------------------
+    # FATAL PATTERNS (3) (isFatal=true, recommendedAction=REPLACE_VM)
+    # Verified against upstream Linux kernel source as always fatal to the
+    # running workload with no automatic in-place recovery.
+    #--------------------------------------------------------------------------
+    - name: cmd_exec_timeout
+      regex: 'mlx5_core.*timeout\. Will cause a leak of a command resource'
+      enabled: true
+      isFatal: true
+      recommendedAction: REPLACE_VM
+      description: "Firmware/driver command timeout - control plane broken"
+
+    - name: health_poll_failed
+      regex: "mlx5_core.*device's health compromised.*reached miss count"
+      enabled: true
+      isFatal: true
+      recommendedAction: REPLACE_VM
+      description: "Firmware heartbeat lost - device health compromised"
+
+    - name: unrecoverable_err
+      regex: 'mlx5_core.*unrecoverable hardware error'
+      enabled: true
+      isFatal: true
+      recommendedAction: REPLACE_VM
+      description: "Unrecoverable hardware error (syndrome 0x8)"
+
+    #--------------------------------------------------------------------------
+    # NON-FATAL PATTERNS (5) (isFatal=false, recommendedAction=NONE)
+    # Diagnostic context or transient/auto-recoverable conditions.
+    #--------------------------------------------------------------------------
+    - name: netdev_watchdog
+      regex: 'NETDEV WATCHDOG.*mlx5_core.*transmit queue.*timed out'
+      enabled: true
+      isFatal: false
+      recommendedAction: NONE
+      description: "TX queue timeout - mlx5 driver has auto-recovery"
+
+    - name: pci_power_insufficient
+      regex: 'mlx5_core.*Detected insufficient power on the PCIe slot'
+      enabled: true
+      isFatal: false
+      recommendedAction: NONE
+      description: "PCIe slot power negotiation issue"
+
+    - name: port_module_high_temp
+      regex: 'mlx5_core.*Port module event.*High Temperature'
+      enabled: true
+      isFatal: false
+      recommendedAction: NONE
+      description: "Port module high temperature warning"
+
+    - name: access_reg_failed
+      regex: 'mlx5_cmd_out_err.*ACCESS_REG.*failed'
+      enabled: true
+      isFatal: false
+      recommendedAction: NONE
+      description: "ACCESS_REG command failed - restricted PF access noise"
+
+    - name: module_unplugged
+      regex: 'mlx5_core.*Port module event.*Cable unplugged'
+      enabled: true
+      isFatal: false
+      recommendedAction: NONE
+      description: "SFP/transceiver cable unplugged"

--- a/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/values.yaml
@@ -81,6 +81,7 @@ nicDriverDetection:
       enabled: true
       isFatal: true
       recommendedAction: REPLACE_VM
+      processingStrategy: EXECUTE_REMEDIATION
       description: "Firmware/driver command timeout - control plane broken"
 
     - name: health_poll_failed
@@ -88,6 +89,7 @@ nicDriverDetection:
       enabled: true
       isFatal: true
       recommendedAction: REPLACE_VM
+      processingStrategy: EXECUTE_REMEDIATION
       description: "Firmware heartbeat lost - device health compromised"
 
     - name: unrecoverable_err
@@ -95,6 +97,7 @@ nicDriverDetection:
       enabled: true
       isFatal: true
       recommendedAction: REPLACE_VM
+      processingStrategy: EXECUTE_REMEDIATION
       description: "Unrecoverable hardware error (syndrome 0x8)"
 
     #--------------------------------------------------------------------------
@@ -106,6 +109,7 @@ nicDriverDetection:
       enabled: true
       isFatal: false
       recommendedAction: NONE
+      processingStrategy: EXECUTE_REMEDIATION
       description: "TX queue timeout - mlx5 driver has auto-recovery"
 
     - name: pci_power_insufficient
@@ -113,6 +117,7 @@ nicDriverDetection:
       enabled: true
       isFatal: false
       recommendedAction: NONE
+      processingStrategy: EXECUTE_REMEDIATION
       description: "PCIe slot power negotiation issue"
 
     - name: port_module_high_temp
@@ -120,6 +125,7 @@ nicDriverDetection:
       enabled: true
       isFatal: false
       recommendedAction: NONE
+      processingStrategy: EXECUTE_REMEDIATION
       description: "Port module high temperature warning"
 
     - name: access_reg_failed
@@ -127,6 +133,7 @@ nicDriverDetection:
       enabled: true
       isFatal: false
       recommendedAction: NONE
+      processingStrategy: EXECUTE_REMEDIATION
       description: "ACCESS_REG command failed - restricted PF access noise"
 
     - name: module_unplugged
@@ -134,4 +141,5 @@ nicDriverDetection:
       enabled: true
       isFatal: false
       recommendedAction: NONE
+      processingStrategy: EXECUTE_REMEDIATION
       description: "SFP/transceiver cable unplugged"

--- a/docs/nic-health-monitor/Overview.md
+++ b/docs/nic-health-monitor/Overview.md
@@ -113,7 +113,7 @@ This monitor uses a binary severity model based on **workload impact**:
 | Severity      | Meaning                                  | Example                                                    |
 |---------------|------------------------------------------|------------------------------------------------------------|
 | **Fatal**     | Workload WILL fail or HAS failed         | NIC DOWN, `cmd_exec timeout`, unrecoverable hardware error |
-| **Non-Fatal** | Degradation detected, workload continues | Symbol errors, congestion, insufficient power              |
+| **Non-Fatal** | Degradation detected, workload continues | Symbol errors, congestion, insufficient power, `NETDEV WATCHDOG` |
 
 **Key Design Principle**: The only question that matters is **"Will the running workload fail because of this?"**
 
@@ -214,8 +214,8 @@ This monitor uses a binary severity model based on **workload impact**:
 
 | Source          | Conditions                                                                         | Severity      | Purpose                               |
 |-----------------|------------------------------------------------------------------------------------|---------------|---------------------------------------|
-| **Log Watcher** | `mlx5_core.*cmd_exec timeout`, `health poll failed`, `unrecoverable`, `PCIe Fatal` | **Fatal**     | Deterministic hardware/driver failure |
-| **Log Watcher** | `insufficient power`, `module absent`, `ACCESS_REG failed`                         | **Non-Fatal** | Diagnostic context for correlation    |
+| **Log Watcher** | `mlx5_core.*cmd_exec timeout`, `health poll failed`, `unrecoverable` | **Fatal**     | Deterministic hardware/driver failure |
+| **Log Watcher** | `insufficient power`, `module absent`, `ACCESS_REG failed`, `NETDEV WATCHDOG` (TX queue timeout - auto-recoverable) | **Non-Fatal** | Diagnostic context for correlation    |
 
 > **Design Note**: Deterministically fatal events in logs trigger `REPLACE_VM` (emitted as `IsFatal=true`). Diagnostic logs are published as non-fatal events (`IsFatal=false`) for correlation and do not directly trigger automated remediation.
 

--- a/docs/nic-health-monitor/Overview.md
+++ b/docs/nic-health-monitor/Overview.md
@@ -110,9 +110,9 @@ The NIC Health Monitor follows NVSentinel's established architectural pattern:
 
 This monitor uses a binary severity model based on **workload impact**:
 
-| Severity      | Meaning                                  | Example                                                    |
-|---------------|------------------------------------------|------------------------------------------------------------|
-| **Fatal**     | Workload WILL fail or HAS failed         | NIC DOWN, `cmd_exec timeout`, unrecoverable hardware error |
+| Severity      | Meaning                                  | Example                                                          |
+|---------------|------------------------------------------|------------------------------------------------------------------|
+| **Fatal**     | Workload WILL fail or HAS failed         | NIC DOWN, `cmd_exec timeout`, unrecoverable hardware error       |
 | **Non-Fatal** | Degradation detected, workload continues | Symbol errors, congestion, insufficient power, `NETDEV WATCHDOG` |
 
 **Key Design Principle**: The only question that matters is **"Will the running workload fail because of this?"**
@@ -212,9 +212,9 @@ This monitor uses a binary severity model based on **workload impact**:
 
 ### Syslog Detection (Fatal & Non-Fatal)
 
-| Source          | Conditions                                                                         | Severity      | Purpose                               |
-|-----------------|------------------------------------------------------------------------------------|---------------|---------------------------------------|
-| **Log Watcher** | `mlx5_core.*cmd_exec timeout`, `health poll failed`, `unrecoverable` | **Fatal**     | Deterministic hardware/driver failure |
+| Source          | Conditions                                                                                                          | Severity      | Purpose                               |
+|-----------------|---------------------------------------------------------------------------------------------------------------------|---------------|---------------------------------------|
+| **Log Watcher** | `mlx5_core.*cmd_exec timeout`, `health poll failed`, `unrecoverable`                                                | **Fatal**     | Deterministic hardware/driver failure |
 | **Log Watcher** | `insufficient power`, `module absent`, `ACCESS_REG failed`, `NETDEV WATCHDOG` (TX queue timeout - auto-recoverable) | **Non-Fatal** | Diagnostic context for correlation    |
 
 > **Design Note**: Deterministically fatal events in logs trigger `REPLACE_VM` (emitted as `IsFatal=true`). Diagnostic logs are published as non-fatal events (`IsFatal=false`) for correlation and do not directly trigger automated remediation.

--- a/docs/nic-health-monitor/syslog-detection-correlation.md
+++ b/docs/nic-health-monitor/syslog-detection-correlation.md
@@ -58,9 +58,9 @@ This document covers the **Syslog Health Monitor** component for NIC driver erro
 
 Following gpud's design and forensic analysis of `mlx5_core` telemetry, kernel log events are classified based on their **determinism of failure**:
 
-| Severity      | Meaning                                       | Example                                                                        |
-|---------------|-----------------------------------------------|--------------------------------------------------------------------------------|
-| **Fatal**     | Deterministically fatal hardware/driver state | `timeout. Will cause a leak`, `unrecoverable hardware error`                    |
+| Severity      | Meaning                                       | Example                                                                           |
+|---------------|-----------------------------------------------|-----------------------------------------------------------------------------------|
+| **Fatal**     | Deterministically fatal hardware/driver state | `timeout. Will cause a leak`, `unrecoverable hardware error`                      |
 | **Non-Fatal** | Diagnostic context or transient issues        | `insufficient power`, `High Temperature`, `ACCESS_REG failed`, `module unplugged` |
 
 > **Key Design Principle**: Only deterministically fatal events in the logs are raised as Fatal (`IsFatal=true`). All other events are raised as Non-Fatal (`IsFatal=false`) to provide diagnostic context without triggering immediate remediation.
@@ -412,6 +412,8 @@ The `NICDriverErrorHandler` follows the same pattern as the existing XID handler
    - `EntityType = "NIC"`, `EntityValue = <device_name>`
 7. **Send event** to Platform Connector (no local aggregation)
 
+> **Why live sysfs lookup instead of metadata collector**: The metadata collector publishes relatively static GPU/NVSwitch inventory. The BDF itself is usually stable during a boot, but the kernel state used for NIC enrichment is not: `/sys/bus/pci/devices/<BDF>/driver` can disappear or reappear when `mlx5_core` is unloaded, reloaded, rebound, or recovered, and the exposed `infiniband/*` or `net/*` names can be recreated. The syslog handler therefore reads the current sysfs state at event-processing time. This lookup is best-effort enrichment only; if it fails, the raw syslog event is still emitted without a `NIC` entity.
+
 ---
 
 ## 5. Monitored Kernel Patterns
@@ -422,16 +424,16 @@ The NIC driver error handler monitors for the following patterns:
 
 Following gpud's design, kernel log events are classified as **Non-Fatal (`IsFatal=false`)** by default. Only deterministic hardware state changes (port drops/flaps) that will cause workload failure are escalated to affect component health.
 
-| Event Name               | Regex Pattern                                            | Severity      | Kernel Source                                                                                                                                                      | Systemic Impact                                                           |
-|--------------------------|----------------------------------------------------------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
-| `pci_power_insufficient` | `mlx5_core.*Detected insufficient power on the PCIe slot` | **Non-Fatal** | [`events.c#L295-L299`](https://github.com/torvalds/linux/blob/ac9c34d1e45a4c25174ced4fc0cfc33ff3ed08c7/drivers/net/ethernet/mellanox/mlx5/core/events.c#L295-L299) | Power negotiation issue. Often transient during boot BIOS/BMC handshake.  |
-| `port_module_high_temp`  | `mlx5_core.*Port module event.*High Temperature`         | **Non-Fatal** | [`events.c#L252-L254`](https://github.com/torvalds/linux/blob/ac9c34d1e45a4c25174ced4fc0cfc33ff3ed08c7/drivers/net/ethernet/mellanox/mlx5/core/events.c#L252-L254) | Thermal warning. May indicate cooling issue or impending PHY throttling.  |
-| `cmd_exec_timeout`       | `mlx5_core.*timeout\. Will cause a leak of a command resource` | **Fatal**     | [`cmd.c`](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/cmd.c)                                                             | Control plane broken. Driver cannot manage device. **Always Fatal**.      |
-| `health_poll_failed`     | `mlx5_core.*device's health compromised.*reached miss count` | **Fatal**     | [`health.c`](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/health.c)                                                       | Firmware heartbeat lost. Device is non-functional. **Always Fatal**.      |
-| `unrecoverable_err`      | `mlx5_core.*unrecoverable hardware error`                | **Fatal**     | [`health.c`](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/health.c)                                                       | Hardware admission of failure. **Always Fatal**.                          |
-| `access_reg_failed`      | `mlx5_cmd_out_err.*ACCESS_REG.*failed`                   | **Non-Fatal** | [`cmd.c`](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/cmd.c)                                                             | Monitoring tool conflict on restricted PFs. **Non-Fatal Noise**.          |
-| `netdev_watchdog`        | `NETDEV WATCHDOG:.*mlx5_core.*transmit queue.*timed out` | **Non-Fatal** | [`sch_generic.c`](https://github.com/torvalds/linux/blob/master/net/sched/sch_generic.c) (generic kernel mechanism)                                                | TX queue stall with auto-recovery via `mlx5e_tx_timeout`. **Non-Fatal**. |
-| `module_unplugged`       | `mlx5_core.*Port module event.*Cable unplugged`          | **Non-Fatal** | [`events.c`](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/events.c)                                                       | SFP/transceiver unplugged. Informational (though port will be DOWN).      |
+| Event Name               | Regex Pattern                                                  | Severity      | Kernel Source                                                                                                                                                      | Systemic Impact                                                          |
+|--------------------------|----------------------------------------------------------------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
+| `pci_power_insufficient` | `mlx5_core.*Detected insufficient power on the PCIe slot`      | **Non-Fatal** | [`events.c#L295-L299`](https://github.com/torvalds/linux/blob/ac9c34d1e45a4c25174ced4fc0cfc33ff3ed08c7/drivers/net/ethernet/mellanox/mlx5/core/events.c#L295-L299) | Power negotiation issue. Often transient during boot BIOS/BMC handshake. |
+| `port_module_high_temp`  | `mlx5_core.*Port module event.*High Temperature`               | **Non-Fatal** | [`events.c#L252-L254`](https://github.com/torvalds/linux/blob/ac9c34d1e45a4c25174ced4fc0cfc33ff3ed08c7/drivers/net/ethernet/mellanox/mlx5/core/events.c#L252-L254) | Thermal warning. May indicate cooling issue or impending PHY throttling. |
+| `cmd_exec_timeout`       | `mlx5_core.*timeout\. Will cause a leak of a command resource` | **Fatal**     | [`cmd.c`](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/cmd.c)                                                             | Control plane broken. Driver cannot manage device. **Always Fatal**.     |
+| `health_poll_failed`     | `mlx5_core.*device's health compromised.*reached miss count`   | **Fatal**     | [`health.c`](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/health.c)                                                       | Firmware heartbeat lost. Device is non-functional. **Always Fatal**.     |
+| `unrecoverable_err`      | `mlx5_core.*unrecoverable hardware error`                      | **Fatal**     | [`health.c`](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/health.c)                                                       | Hardware admission of failure. **Always Fatal**.                         |
+| `access_reg_failed`      | `mlx5_cmd_out_err.*ACCESS_REG.*failed`                         | **Non-Fatal** | [`cmd.c`](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/cmd.c)                                                             | Monitoring tool conflict on restricted PFs. **Non-Fatal Noise**.         |
+| `netdev_watchdog`        | `NETDEV WATCHDOG:.*mlx5_core.*transmit queue.*timed out`       | **Non-Fatal** | [`sch_generic.c`](https://github.com/torvalds/linux/blob/master/net/sched/sch_generic.c) (generic kernel mechanism)                                                | TX queue stall with auto-recovery via `mlx5e_tx_timeout`. **Non-Fatal**. |
+| `module_unplugged`       | `mlx5_core.*Port module event.*Cable unplugged`                | **Non-Fatal** | [`events.c`](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/events.c)                                                       | SFP/transceiver unplugged. Informational (though port will be DOWN).     |
 
 **Full Log Line Examples:**
 
@@ -444,7 +446,7 @@ Following gpud's design, kernel log events are classified as **Non-Fatal (`IsFat
 | `unrecoverable_err`      | `mlx5_core: INFO: synd 0x8: unrecoverable hardware error.`                                                            |
 | `access_reg_failed`      | `mlx5_cmd_out_err:838: ACCESS_REG(0x805) op_mod(0x1) failed, status bad operation(0x2)`                               |
 | `netdev_watchdog`        | `NETDEV WATCHDOG: eth0 (mlx5_core): transmit queue 0 timed out`                                                       |
-| `module_unplugged`       | `mlx5_core 0000:12:00.0: Port module event: module 0, Cable unplugged`                                                         |
+| `module_unplugged`       | `mlx5_core 0000:12:00.0: Port module event: module 0, Cable unplugged`                                                |
 
 > **Design Note**: While gpud internally treats many of these as non-fatal, NVSentinel escalates **deterministically fatal** signals to Fatal (`IsFatal=true`) to trigger proactive remediation (`REPLACE_VM`) before workload failure cascades. Non-fatal signals remain as `IsFatal=false` for diagnostic correlation.
 
@@ -452,9 +454,9 @@ Following gpud's design, kernel log events are classified as **Non-Fatal (`IsFat
 
 Patterns are classified according to their operational impact:
 
-| Category                  | Patterns                                                                       | Severity      | Recommended Action  |
-|---------------------------|--------------------------------------------------------------------------------|---------------|---------------------|
-| **Always Fatal (Device)** | command timeout with resource leak, `health poll failed`, `unrecoverable`                       | **Fatal**     | `REPLACE_VM`        |
+| Category                  | Patterns                                                                                             | Severity      | Recommended Action  |
+|---------------------------|------------------------------------------------------------------------------------------------------|---------------|---------------------|
+| **Always Fatal (Device)** | command timeout with resource leak, `health poll failed`, `unrecoverable`                            | **Fatal**     | `REPLACE_VM`        |
 | **Non-Fatal / Evidence**  | `insufficient power`, `High Temperature`, `ACCESS_REG failed`, `module unplugged`, `NETDEV WATCHDOG` | **Non-Fatal** | `NONE` (Diagnostic) |
 
 > **Key Principle**: Kernel logs provide **diagnostic context**, not **remediation triggers**. The decision to drain/replace a node is based on actual port state (via link state detection), not log messages alone.
@@ -484,11 +486,11 @@ Following gpud's design, kernel log events for diagnostic patterns are emitted a
 
 The Health Events Analyzer can correlate kernel log warnings with port state events:
 
-| Kernel Log (Non-Fatal)                    | Port State Event   | Correlation Insight     |
-|-------------------------------------------|--------------------|-------------------------|
-| `High Temperature` + `health poll failed` | Port DOWN          | Thermal-induced failure |
-| command timeout with resource leak        | Port DOWN          | Driver/firmware failure |
-| `insufficient power`                      | Port DOWN          | Power delivery issue    |
+| Kernel Log (Non-Fatal)                    | Port State Event | Correlation Insight     |
+|-------------------------------------------|------------------|-------------------------|
+| `High Temperature` + `health poll failed` | Port DOWN        | Thermal-induced failure |
+| command timeout with resource leak        | Port DOWN        | Driver/firmware failure |
+| `insufficient power`                      | Port DOWN        | Power delivery issue    |
 
 ### 6.2 Noise Filtering
 
@@ -624,6 +626,7 @@ regex = 'mlx5_core.*timeout\. Will cause a leak of a command resource'
 enabled = true
 isFatal = true
 recommendedAction = "REPLACE_VM"
+processingStrategy = "EXECUTE_REMEDIATION"
 description = "Firmware command timeout with resource leak"
 
 [[nicDriverDetection.patterns]]
@@ -632,19 +635,21 @@ regex = 'NETDEV WATCHDOG:.*mlx5_core.*transmit queue.*timed out'
 enabled = true
 isFatal = false
 recommendedAction = "NONE"
+processingStrategy = "EXECUTE_REMEDIATION"
 description = "TX queue stall with auto-recovery via mlx5e_tx_timeout"
 ```
 
 **Fields:**
 
-| Field               | Type     | Description                                                                 |
-|---------------------|----------|-----------------------------------------------------------------------------|
-| `name`              | `string` | Unique identifier for the pattern                                           |
-| `regex`             | `string` | Regular expression matched against kernel log lines                         |
-| `enabled`           | `bool`   | Whether the pattern is active; set `false` to disable without removing      |
-| `isFatal`           | `bool`   | `true` → `IsFatal=true` + `REPLACE_VM`; `false` → diagnostic context only  |
-| `recommendedAction` | `string` | Action attached to emitted health events (e.g., `REPLACE_VM`, `NONE`)       |
-| `description`       | `string` | Human-readable explanation of the pattern                                   |
+| Field                | Type     | Description                                                                                                                 |
+|----------------------|----------|-----------------------------------------------------------------------------------------------------------------------------|
+| `name`               | `string` | Unique identifier for the pattern                                                                                           |
+| `regex`              | `string` | Regular expression matched against kernel log lines                                                                         |
+| `enabled`            | `bool`   | Whether the pattern is active; set `false` to disable without removing                                                      |
+| `isFatal`            | `bool`   | `true` → `IsFatal=true` + `REPLACE_VM`; `false` → diagnostic context only                                                   |
+| `recommendedAction`  | `string` | Action attached to emitted health events (e.g., `REPLACE_VM`, `NONE`)                                                       |
+| `processingStrategy` | `string` | Optional per-pattern override (`EXECUTE_REMEDIATION` or `STORE_ONLY`); falls back to the monitor-wide strategy when omitted |
+| `description`        | `string` | Human-readable explanation of the pattern                                                                                   |
 
 > **Custom patterns should be NIC/mlx5-specific.** Generic PCIe/AER patterns such as `PCIe Bus Error.*Fatal` are intentionally not shipped because they can match GPUs, NVMe, or root ports. The handler does not BDF-gate generic patterns; if you add one, ensure its regex includes an mlx5-specific prefix (`mlx5_core`, `mlx5_cmd_out_err`, etc.) so it cannot match other devices. This follows gpud's same-decision approach in `kmsg_matcher.go`.
 >
@@ -660,29 +665,29 @@ Events are emitted with severity based on their determinism of failure:
 
 **Example Event Fields (Fatal - command timeout resource leak):**
 
-| Field             | Value                                                   |
-|-------------------|---------------------------------------------------------|
-| Agent             | `syslog-health-monitor`                                 |
-| CheckName         | `SysLogsNICDriverError`                                 |
-| ComponentClass    | `NIC`                                                   |
+| Field             | Value                                                                                        |
+|-------------------|----------------------------------------------------------------------------------------------|
+| Agent             | `syslog-health-monitor`                                                                      |
+| CheckName         | `SysLogsNICDriverError`                                                                      |
+| ComponentClass    | `NIC`                                                                                        |
 | Message           | "mlx5_core 0000:3b:00.0: ENABLE_HCA(0x104) timeout. Will cause a leak of a command resource" |
-| IsFatal           | `true`                                                  |
-| IsHealthy         | `false`                                                 |
-| RecommendedAction | `REPLACE_VM`                                            |
-| EntitiesImpacted  | `[{EntityType: "NIC", EntityValue: "mlx5_0"}]`          |
+| IsFatal           | `true`                                                                                       |
+| IsHealthy         | `false`                                                                                      |
+| RecommendedAction | `REPLACE_VM`                                                                                 |
+| EntitiesImpacted  | `[{EntityType: "NIC", EntityValue: "mlx5_0"}]`                                               |
 
 **Example Event Fields (Non-Fatal - module unplugged):**
 
-| Field             | Value                                                         |
-|-------------------|---------------------------------------------------------------|
-| Agent             | `syslog-health-monitor`                                       |
-| CheckName         | `SysLogsNICDriverError`                                       |
-| ComponentClass    | `NIC`                                                         |
+| Field             | Value                                                                  |
+|-------------------|------------------------------------------------------------------------|
+| Agent             | `syslog-health-monitor`                                                |
+| CheckName         | `SysLogsNICDriverError`                                                |
+| ComponentClass    | `NIC`                                                                  |
 | Message           | "mlx5_core 0000:12:00.0: Port module event: module 0, Cable unplugged" |
-| IsFatal           | `false`                                                       |
-| IsHealthy         | `false`                                                       |
-| RecommendedAction | `NONE` (informational)                                        |
-| EntitiesImpacted  | `[{EntityType: "NIC", EntityValue: "mlx5_0"}]`                |
+| IsFatal           | `false`                                                                |
+| IsHealthy         | `false`                                                                |
+| RecommendedAction | `NONE` (informational)                                                 |
+| EntitiesImpacted  | `[{EntityType: "NIC", EntityValue: "mlx5_0"}]`                         |
 
 ### 9.2 Event Purpose
 
@@ -722,26 +727,26 @@ The syslog monitoring capability operates at the **driver and kernel level only*
 
 The following table shows which hardware failures this monitor detects and how they may impact applications:
 
-| Hardware Failure    | Detection Method                      | Potential Application Impact  |
-|---------------------|---------------------------------------|-------------------------------|
-| **Firmware freeze** | Kernel log: `timeout. Will cause a leak of a command resource` | All NIC operations stall      |
-| **Driver crash**    | Kernel log: `device's health compromised - reached miss count` | NIC becomes unusable          |
-| **TX stall**        | Kernel log: `NETDEV WATCHDOG`         | Network transmission fails    |
+| Hardware Failure    | Detection Method                                               | Potential Application Impact |
+|---------------------|----------------------------------------------------------------|------------------------------|
+| **Firmware freeze** | Kernel log: `timeout. Will cause a leak of a command resource` | All NIC operations stall     |
+| **Driver crash**    | Kernel log: `device's health compromised - reached miss count` | NIC becomes unusable         |
+| **TX stall**        | Kernel log: `NETDEV WATCHDOG`                                  | Network transmission fails   |
 
 ### 10.4 Event Severity Classification
 
 Kernel log events are classified by their determinism of failure:
 
-| Kernel Log Event               | Severity      | Purpose                       | Recommended Action |
-|--------------------------------|---------------|-------------------------------|--------------------|
-| `mlx5_core.*timeout. Will cause a leak` | **Fatal**     | Control plane broken          | `REPLACE_VM`       |
+| Kernel Log Event                         | Severity      | Purpose                       | Recommended Action |
+|------------------------------------------|---------------|-------------------------------|--------------------|
+| `mlx5_core.*timeout. Will cause a leak`  | **Fatal**     | Control plane broken          | `REPLACE_VM`       |
 | `mlx5_core.*device's health compromised` | **Fatal**     | Firmware heartbeat lost       | `REPLACE_VM`       |
-| `mlx5_core unrecoverable`      | **Fatal**     | Hardware admission of failure | `REPLACE_VM`       |
-| `NETDEV WATCHDOG`              | **Non-Fatal** | TX stall with auto-recovery   | `NONE`             |
-| `Detected insufficient power`  | **Non-Fatal** | Power negotiation status      | `NONE`             |
-| `High Temperature`             | **Non-Fatal** | Thermal warning               | `NONE`             |
-| `module unplugged`             | **Non-Fatal** | SFP unplugged                 | `NONE`             |
-| `ACCESS_REG failed`            | **Non-Fatal** | Monitoring noise              | `NONE`             |
+| `mlx5_core unrecoverable`                | **Fatal**     | Hardware admission of failure | `REPLACE_VM`       |
+| `NETDEV WATCHDOG`                        | **Non-Fatal** | TX stall with auto-recovery   | `NONE`             |
+| `Detected insufficient power`            | **Non-Fatal** | Power negotiation status      | `NONE`             |
+| `High Temperature`                       | **Non-Fatal** | Thermal warning               | `NONE`             |
+| `module unplugged`                       | **Non-Fatal** | SFP unplugged                 | `NONE`             |
+| `ACCESS_REG failed`                      | **Non-Fatal** | Monitoring noise              | `NONE`             |
 
 > **Key Principle**: Deterministically fatal events in logs trigger `REPLACE_VM`. Diagnostic logs remain as Non-Fatal (`IsFatal=false`) for diagnostic context.
 
@@ -753,16 +758,16 @@ The following patterns are monitored in the kernel ring buffer (dmesg/kmsg):
 
 ### Kernel Log Pattern Summary
 
-| Pattern                                   | Severity      | Meaning                         | Action                        |
-|-------------------------------------------|---------------|---------------------------------|-------------------------------|
-| `mlx5_core.*timeout\. Will cause a leak of a command resource` | **Fatal**     | Firmware/driver command timeout | `REPLACE_VM`                  |
-| `mlx5_core.*device's health compromised.*reached miss count` | **Fatal**     | Health check missed             | `REPLACE_VM`                  |
-| `mlx5_core.*unrecoverable hardware error`  | **Fatal**     | Hardware error detected         | `REPLACE_VM`                  |
-| `NETDEV WATCHDOG:.*mlx5_core.*timed out`  | **Non-Fatal** | TX queue timeout                | Investigate; persistent stalls caught by link-state-detection |
-| `mlx5_core.*Detected insufficient power`  | **Non-Fatal** | Power negotiation status        | Investigate; can be transient |
-| `mlx5_core.*Port module event.*High Temp` | **Non-Fatal** | Thermal warning                 | Investigate; check cooling    |
-| `mlx5_cmd_out_err.*ACCESS_REG.*failed`    | **Non-Fatal** | Restricted PF access            | Filter/Ignore                 |
-| `mlx5_core.*Port module event.*Cable unplugged` | **Non-Fatal** | SFP/transceiver unplugged       | Monitor port state            |
+| Pattern                                                        | Severity      | Meaning                         | Action                                                        |
+|----------------------------------------------------------------|---------------|---------------------------------|---------------------------------------------------------------|
+| `mlx5_core.*timeout\. Will cause a leak of a command resource` | **Fatal**     | Firmware/driver command timeout | `REPLACE_VM`                                                  |
+| `mlx5_core.*device's health compromised.*reached miss count`   | **Fatal**     | Health check missed             | `REPLACE_VM`                                                  |
+| `mlx5_core.*unrecoverable hardware error`                      | **Fatal**     | Hardware error detected         | `REPLACE_VM`                                                  |
+| `NETDEV WATCHDOG:.*mlx5_core.*timed out`                       | **Non-Fatal** | TX queue timeout                | Investigate; persistent stalls caught by link-state-detection |
+| `mlx5_core.*Detected insufficient power`                       | **Non-Fatal** | Power negotiation status        | Investigate; can be transient                                 |
+| `mlx5_core.*Port module event.*High Temp`                      | **Non-Fatal** | Thermal warning                 | Investigate; check cooling                                    |
+| `mlx5_cmd_out_err.*ACCESS_REG.*failed`                         | **Non-Fatal** | Restricted PF access            | Filter/Ignore                                                 |
+| `mlx5_core.*Port module event.*Cable unplugged`                | **Non-Fatal** | SFP/transceiver unplugged       | Monitor port state                                            |
 
 ### Design Principle
 

--- a/docs/nic-health-monitor/syslog-detection-correlation.md
+++ b/docs/nic-health-monitor/syslog-detection-correlation.md
@@ -14,6 +14,7 @@
 8. [Configuration](#8-configuration)
 9. [Event Management](#9-event-management)
 10. [Monitoring Scope and Limitations](#10-monitoring-scope-and-limitations)
+    - [10.4 Event Severity Classification](#104-event-severity-classification)
 - [Appendix A: Quick Reference - Kernel Log Patterns](#appendix-a-quick-reference---kernel-log-patterns)
 - [Appendix B: Health Events Analyzer Rules for NIC Monitoring](#appendix-b-health-events-analyzer-rules-for-nic-monitoring)
 
@@ -617,7 +618,7 @@ NIC driver error patterns are defined in a TOML configuration file, allowing ope
 **TOML Shape:**
 
 ```toml
-[[patterns]]
+[[nicDriverDetection.patterns]]
 name = "cmd_exec_timeout"
 regex = 'mlx5_core.*timeout\. Will cause a leak of a command resource'
 enabled = true
@@ -625,7 +626,7 @@ isFatal = true
 recommendedAction = "REPLACE_VM"
 description = "Firmware command timeout with resource leak"
 
-[[patterns]]
+[[nicDriverDetection.patterns]]
 name = "netdev_watchdog"
 regex = 'NETDEV WATCHDOG:.*mlx5_core.*transmit queue.*timed out'
 enabled = true
@@ -646,7 +647,7 @@ description = "TX queue stall with auto-recovery via mlx5e_tx_timeout"
 | `description`       | `string` | Human-readable explanation of the pattern                                   |
 
 > **Custom patterns should be NIC/mlx5-specific.** Generic PCIe/AER patterns such as `PCIe Bus Error.*Fatal` are intentionally not shipped because they can match GPUs, NVMe, or root ports. The handler does not BDF-gate generic patterns; if you add one, ensure its regex includes an mlx5-specific prefix (`mlx5_core`, `mlx5_cmd_out_err`, etc.) so it cannot match other devices. This follows gpud's same-decision approach in `kmsg_matcher.go`.
-
+>
 > **Operational Note**: Operators can disable noisy patterns, add site-specific patterns, or reclassify severity (e.g., promote a Non-Fatal pattern to Fatal) by editing the TOML file and restarting the syslog-health-monitor pod. No code changes required.
 
 ---
@@ -727,7 +728,7 @@ The following table shows which hardware failures this monitor detects and how t
 | **Driver crash**    | Kernel log: `device's health compromised - reached miss count` | NIC becomes unusable          |
 | **TX stall**        | Kernel log: `NETDEV WATCHDOG`         | Network transmission fails    |
 
-### 11.4 Event Severity Classification
+### 10.4 Event Severity Classification
 
 Kernel log events are classified by their determinism of failure:
 
@@ -899,6 +900,6 @@ enableRepeatedNICDegradationRule: true
 6. [PCIe AER HOWTO (Linux Kernel)](https://www.kernel.org/doc/html/latest/PCI/pcieaer-howto.html) - PCIe Bus Error log format and BDF identification
 
 ### Vendor Documentation
-3. [ibdiagnet User Manual (NVIDIA)](https://docs.nvidia.com/networking/display/ibdiagnet-infiniband-fabric-diagnostic-tool-user-manual-v2-21.21.pdf)
+1. [ibdiagnet User Manual (NVIDIA)](https://docs.nvidia.com/networking/display/ibdiagnet-infiniband-fabric-diagnostic-tool-user-manual-v2-21.21.pdf)
 
 ---

--- a/docs/nic-health-monitor/syslog-detection-correlation.md
+++ b/docs/nic-health-monitor/syslog-detection-correlation.md
@@ -33,11 +33,11 @@ NIC hardware polling monitors (state checks, counter reads) can miss critical fa
 
 This document covers the **Syslog Health Monitor** component for NIC driver error monitoring, which detects:
 
-- **Driver/Firmware communication failures** - `cmd_exec timeout`, firmware hangs
+- **Driver/Firmware communication failures** - command timeouts (`timeout. Will cause a leak of a command resource`), firmware hangs
 - **Hardware health check failures** - `health poll failed`, unrecoverable errors
-- **PCIe bus errors** - Fatal PCIe errors, device disappearance
+- **Driver/firmware-level PCIe events** - surfaced via `mlx5_core` (e.g., insufficient power); fatal PCIe link loss / device disappearance is covered by [link-state-detection](./link-state-detection.md)
 - **Thermal and power issues** - High temperature warnings, insufficient power
-- **Network watchdog timeouts** - TX queue stalls
+- **Network watchdog timeouts** - TX queue stalls (Non-Fatal diagnostic context; auto-recovery via `mlx5e_tx_timeout`)
 
 ### 1.3 Why Syslog Monitoring is Essential
 
@@ -46,7 +46,7 @@ This document covers the **Syslog Health Monitor** component for NIC driver erro
 │  EXAMPLE: Firmware Failure (NIC Health Monitor sees NOTHING wrong)           │
 │                                                                              │
 │  NIC Health Monitor:     state=ACTIVE, phys_state=LinkUp  <── Looks healthy! │
-│  Syslog Health Monitor:  "mlx5_core cmd_exec timeout"     <── DETECTS FAILURE│
+│  Syslog Health Monitor:  "timeout. Will cause a leak..."  <── DETECTS FAILURE│
 │                                                                              │
 │  Without monitoring kernel logs, this node would appear healthy while unable │
 │  to process any NIC commands. Workloads would fail with mysterious timeouts. │
@@ -59,8 +59,8 @@ Following gpud's design and forensic analysis of `mlx5_core` telemetry, kernel l
 
 | Severity      | Meaning                                       | Example                                                                        |
 |---------------|-----------------------------------------------|--------------------------------------------------------------------------------|
-| **Fatal**     | Deterministically fatal hardware/driver state | `cmd_exec timeout`, `unrecoverable hardware error`, `PCIe Fatal Error`         |
-| **Non-Fatal** | Diagnostic context or transient issues        | `insufficient power`, `High Temperature`, `ACCESS_REG failed`, `module absent` |
+| **Fatal**     | Deterministically fatal hardware/driver state | `timeout. Will cause a leak`, `unrecoverable hardware error`                    |
+| **Non-Fatal** | Diagnostic context or transient issues        | `insufficient power`, `High Temperature`, `ACCESS_REG failed`, `module unplugged` |
 
 > **Key Design Principle**: Only deterministically fatal events in the logs are raised as Fatal (`IsFatal=true`). All other events are raised as Non-Fatal (`IsFatal=false`) to provide diagnostic context without triggering immediate remediation.
 
@@ -78,7 +78,7 @@ Following gpud's design and forensic analysis of `mlx5_core` telemetry, kernel l
 │  │  journald / /var/log/journal                                         │  │
 │  │  ├── Kernel ring buffer (dmesg)                                      │  │
 │  │  │   ├── mlx5_core driver messages                                   │  │
-│  │  │   ├── PCIe bus error messages                                     │  │
+│  │  │   ├── mlx5_core driver/firmware messages                          │  │
 │  │  │   └── Network watchdog messages                                   │  │
 │  │  └── Systemd unit logs                                               │  │
 │  │                                                                      │  │
@@ -92,17 +92,16 @@ Following gpud's design and forensic analysis of `mlx5_core` telemetry, kernel l
 │  │  CHECK: SysLogsNICDriverError                                        │  │
 │  │                                                                      │  │
 │  │  FATAL PATTERNS (IsFatal=true, RecommendedAction=REPLACE_VM):        │  │
-│  │  ├── mlx5_core cmd_exec timeout       → FATAL (control plane broken) │  │
+│  │  ├── mlx5_core command timeout leak   → FATAL (control plane broken) │  │
 │  │  ├── mlx5_core health poll failed     → FATAL (firmware dead)        │  │
-│  │  ├── mlx5_core unrecoverable          → FATAL (hardware failure)     │  │
-│  │  ├── PCIe Bus Error.*Fatal            → FATAL (bus collapsed)        │  │
-│  │  └── NETDEV WATCHDOG.*mlx5_core       → FATAL (data path stalled)    │  │
+│  │  └── mlx5_core unrecoverable          → FATAL (hardware failure)     │  │
 │  │                                                                      │  │
 │  │  NON-FATAL PATTERNS (IsFatal=false, diagnostic context):             │  │
 │  │  ├── High Temperature                 → Non-Fatal (thermal)          │  │
 │  │  ├── Detected insufficient power      → Non-Fatal (power negotiation)│  │
-│  │  ├── module absent                    → Non-Fatal (SFP unplugged)    │  │
-│  │  └── ACCESS_REG.*failed               → Non-Fatal (monitoring noise) │  │
+│  │  ├── module unplugged                 → Non-Fatal (SFP unplugged)    │  │
+│  │  ├── ACCESS_REG.*failed               → Non-Fatal (monitoring noise) │  │
+│  │  └── NETDEV WATCHDOG.*mlx5_core       → Non-Fatal (TX stall)        │  │
 │  │                                                                      │  │
 │  │  EXISTING CHECKS (GPU):                                              │  │
 │  │  ├── SysLogsXIDError                                                 │  │
@@ -143,7 +142,7 @@ The syslog-health-monitor's NIC check follows NVSentinel's established architect
 |-----------------------------|------------------------------------------|--------------------------------------------------------------|
 | **Raw Event Reporting**     | Each kernel log match → immediate event  | Enables centralized correlation with full historical context |
 | **Centralized Correlation** | Health Events Analyzer MongoDB pipelines | Flexible, configurable rules without monitor code changes    |
-| **Temporal Correlation**    | Analyzer rules with time windows         | Correlates `cmd_exec timeout` + `link_down` within seconds   |
+| **Temporal Correlation**    | Analyzer rules with time windows         | Correlates command timeout + `link_down` within seconds      |
 
 ### 2.2 Component Responsibilities
 
@@ -160,12 +159,11 @@ Reads:
 
 NEW CHECK: SysLogsNICDriverError
 Pattern matching for:
-├── mlx5_core cmd_exec timeout    → Firmware communication failure (FATAL)
+├── mlx5_core command timeout leak → Firmware communication failure (FATAL)
 ├── mlx5_core health poll failed  → NIC health check failed (FATAL)
 ├── mlx5_core unrecoverable       → Hardware in error state (FATAL)
-├── PCIe Bus Error.*Fatal         → PCIe link broken (FATAL)
-├── NETDEV WATCHDOG.*mlx5_core    → TX stalled (FATAL)
-├── module absent                 → Transceiver removed (Non-Fatal)
+├── module unplugged              → Transceiver removed (Non-Fatal)
+├── NETDEV WATCHDOG.*mlx5_core    → TX stall, auto-recovery (Non-Fatal)
 ├── High Temperature              → Thermal warning (Non-Fatal)
 └── pci_power_insufficient        → Power negotiation status (Non-Fatal)
 
@@ -196,9 +194,9 @@ Emits: HealthEvents (IsFatal=true/false) → Platform Connector → MongoDB
 │  │  │  • /sys/class/net/          │  │                                 │   │  │
 │  │  │                             │  │  NEW CHECK:                     │   │  │
 │  │  │  CHECKS:                    │  │  • SysLogsNICDriverError        │   │  │
-│  │  │  • InfiniBandStateCheck     │  │    (mlx5_core cmd_exec timeout, │   │  │
+│  │  │  • InfiniBandStateCheck     │  │    (mlx5_core command timeout,  │   │  │
 │  │  │  • InfiniBandDegradationChk │  │     health poll failed,         │   │  │
-│  │  │  • EthernetStateCheck       │  │     unrecoverable, PCIe fatal)  │   │  │
+│  │  │  • EthernetStateCheck       │  │     unrecoverable)              │   │  │
 │  │  │  • EthernetDegradationCheck │  │                                 │   │  │
 │  │  │                             │  │  EXISTING CHECKS:               │   │  │
 │  │  │                             │  │  • SysLogsXIDError              │   │  │
@@ -251,7 +249,7 @@ The combined monitoring approach ensures **no blind spots** by covering both lay
 │  └── NIC Health Monitor Degradation Check: Error rates           │
 │                                                                  │
 │  DRIVER/FIRMWARE INTERFACE (OS <--> NIC Communication):          │
-│  └── Syslog Health Monitor: mlx5_core errors, PCIe AER events   │
+│  └── Syslog Health Monitor: mlx5_core driver/firmware events    │
 │                                                                  │
 │  Driver/firmware failures can occur while packet path appears    │
 │  healthy.                                                        │
@@ -271,7 +269,7 @@ The NVIDIA Mellanox ConnectX series (ConnectX-5 through ConnectX-7) function as 
 
 The primary control pathway is the Command Interface. The driver writes command blocks (e.g., `CREATE_MKEY`, `MODIFY_QP`) to PCI BAR-mapped memory and notifies the firmware via a "doorbell" register.
 
-- **Fatality Mechanism**: If the firmware hangs, the driver's watchdog expires (typically 60s), logging `cmd_exec timeout`.
+- **Fatality Mechanism**: If the firmware hangs, the driver's watchdog expires (typically 60s), logging `timeout. Will cause a leak of a command resource`.
 - **Resource Leaks**: Upon timeout, the driver intentionally "leaks" the command's DMA-mapped memory. Freeing it could lead to silent memory corruption if the firmware later writes to that physical address. This makes `cmd_exec` timeouts **irreversibly fatal** to the driver's device management capability.
 
 ### 3.2 Driver/Firmware Communication Diagram
@@ -306,7 +304,7 @@ The primary control pathway is the Command Interface. The driver writes command 
 │  │              │     (60s timeout)               │                     │  │
 │  │              │                                 │                     │  │
 │  │              │  IF timeout:                    │                     │  │
-│  │              │  └── "cmd_exec timeout"         │                     │  │
+│  │              │  └── "timeout. Will cause..."   │                     │  │
 │  │              │      logged to dmesg            │                     │  │
 │  │              │      (IRREVERSIBLY FATAL)       │                     │  │
 │  │              └───────────────┬─────────────────┘                     │  │
@@ -327,7 +325,7 @@ The primary control pathway is the Command Interface. The driver writes command 
 │  │  │                                                                │  │  │
 │  │  │  IF firmware hangs:                                            │  │  │
 │  │  │  └── Ownership bit never toggles                              │  │  │
-│  │  │      Driver watchdog fires → "cmd_exec timeout"               │  │  │
+│  │  │      Driver watchdog fires → "timeout. Will cause..."         │  │  │
 │  │  │                                                                │  │  │
 │  │  └────────────────────────────────────────────────────────────────┘  │  │
 │  │                       CONNECTX NIC HARDWARE                          │  │
@@ -340,7 +338,7 @@ The primary control pathway is the Command Interface. The driver writes command 
 
 The NIC implements a dedicated ring buffer (EQ) for control plane events (e.g., thermal excursions, port changes). Additionally, a background **Health Poller** thread periodically (1s) reads a "Health Syndrome" register. This dual mechanism ensures that even if the interrupt system fails, the driver detects unrecoverable hardware syndromes.
 
-### 3.4 The `mlx5_core cmd_exec timeout`
+### 3.4 The `mlx5_core` Command Timeout Resource Leak
 
 This is a severe driver-level error indicating **Driver/Firmware Interface failure**. ([Reference: RHEL mlx5_core issues](https://access.redhat.com/solutions/6955682))
 
@@ -348,7 +346,7 @@ This is a severe driver-level error indicating **Driver/Firmware Interface failu
 1. `mlx5_core` driver sends command to NIC firmware via mailbox
 2. Driver waits for firmware to toggle "Ownership bit" indicating completion
 3. If firmware has crashed/hung, bit never toggles
-4. Driver's watchdog expires → logs `cmd_exec timeout` to `dmesg`
+4. Driver's watchdog expires → logs `timeout. Will cause a leak of a command resource` to `dmesg`
 
 **Consequence**: Usually requires driver reload (`systemctl restart openibd`) or full node reboot. This is **always Fatal**—workload cannot proceed if it cannot issue commands to the NIC. The driver intentionally "leaks" command resources because it cannot safely reclaim memory without risk of corruption if the firmware eventually responds.
 
@@ -385,7 +383,7 @@ syslog-health-monitor:
 ```bash
 # Generate synthetic kernel message (requires root)
 # This injects a fake mlx5_core error into dmesg
-echo "<3>mlx5_core 0000:3b:00.0: cmd_exec timeout, status=0x10" > /dev/kmsg
+echo "<3>mlx5_core 0000:3b:00.0: ENABLE_HCA(0x104) timeout. Will cause a leak of a command resource" > /dev/kmsg
 ```
 
 ### 4.4 NIC Driver Error Handler Algorithm
@@ -396,16 +394,17 @@ The `NICDriverErrorHandler` follows the same pattern as the existing XID handler
 
 1. **Receive kernel log line** from journald stream
 2. **Match against NIC error patterns** (see Section 5 for pattern list):
-   - Check if line matches any regex pattern (e.g., `mlx5_core.*cmd_exec timeout`)
+   - Patterns are loaded from a configurable TOML file (see Section 8.3), not hardcoded in source
+   - Check if line matches any regex pattern (e.g., `mlx5_core.*timeout\. Will cause a leak of a command resource`)
    - If no match → skip line, return nil
 3. **Determine severity**:
    - Look up pattern in severity table (Section 5.2)
    - Set `IsFatal` accordingly
 4. **Extract PCI address** from message using regex (e.g., `0000:3b:00.0`)
-5. **Map PCI address to NIC device** name (e.g., `mlx5_0`) by resolving `/sys/bus/pci/devices/<BDF>/driver` symlink
-   - If the driver is `mlx5_core` → proceed (this is a NIC event)
-   - If the driver is not `mlx5_core` (e.g., `nvidia` for GPU, `nvme` for NVMe) → **skip the event**
-   - This filtering is critical for the `PCIe Bus Error.*Fatal` pattern, which is a generic kernel message not scoped to any specific device. Without BDF-based filtering, a GPU PCIe error would incorrectly produce a NIC health event.
+5. **Best-effort NIC entity enrichment** by resolving `/sys/bus/pci/devices/<BDF>/driver` symlink
+   - If the driver is `mlx5_core` → attach NIC entity (e.g., `mlx5_0`) to the event
+   - Otherwise → emit the event with no NIC entity attached
+   - The handler does **not** drop events based on driver type. All shipped patterns are mlx5-specific by regex (e.g., they require `mlx5_core` or `mlx5_cmd_out_err` in the message), so non-mlx5 matches are not expected for built-in patterns. Custom patterns must follow the same convention; see Section 8.3.
 6. **Generate HealthEvent** with:
    - `Agent = "syslog-health-monitor"`
    - `CheckName = "SysLogsNICDriverError"`
@@ -424,15 +423,14 @@ Following gpud's design, kernel log events are classified as **Non-Fatal (`IsFat
 
 | Event Name               | Regex Pattern                                            | Severity      | Kernel Source                                                                                                                                                      | Systemic Impact                                                           |
 |--------------------------|----------------------------------------------------------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
-| `pci_power_insufficient` | `Detected insufficient power on the PCIe slot`           | **Non-Fatal** | [`events.c#L295-L299`](https://github.com/torvalds/linux/blob/ac9c34d1e45a4c25174ced4fc0cfc33ff3ed08c7/drivers/net/ethernet/mellanox/mlx5/core/events.c#L295-L299) | Power negotiation issue. Often transient during boot BIOS/BMC handshake.  |
-| `port_module_high_temp`  | `Port module event.*High Temperature`                    | **Non-Fatal** | [`events.c#L252-L254`](https://github.com/torvalds/linux/blob/ac9c34d1e45a4c25174ced4fc0cfc33ff3ed08c7/drivers/net/ethernet/mellanox/mlx5/core/events.c#L252-L254) | Thermal warning. May indicate cooling issue or impending PHY throttling.  |
-| `cmd_exec_timeout`       | `mlx5_core.*cmd_exec timeout`                            | **Fatal**     | [`cmd.c`](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/cmd.c)                                                             | Control plane broken. Driver cannot manage device. **Always Fatal**.      |
-| `health_poll_failed`     | `mlx5_core.*health poll failed`                          | **Fatal**     | [`health.c`](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/health.c)                                                       | Firmware heartbeat lost. Device is non-functional. **Always Fatal**.      |
-| `unrecoverable_err`      | `mlx5_core.*unrecoverable`                               | **Fatal**     | [`health.c`](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/health.c)                                                       | Hardware admission of failure. **Always Fatal**.                          |
-| `pcie_fatal_error`       | `PCIe Bus Error.*Fatal`                                  | **Fatal**     | [`pcieaer-howto`](https://www.kernel.org/doc/html/latest/PCI/pcieaer-howto.html)                                                                                   | PCIe link broken. Typically triggers system reboot/NMI. **Always Fatal**. |
+| `pci_power_insufficient` | `mlx5_core.*Detected insufficient power on the PCIe slot` | **Non-Fatal** | [`events.c#L295-L299`](https://github.com/torvalds/linux/blob/ac9c34d1e45a4c25174ced4fc0cfc33ff3ed08c7/drivers/net/ethernet/mellanox/mlx5/core/events.c#L295-L299) | Power negotiation issue. Often transient during boot BIOS/BMC handshake.  |
+| `port_module_high_temp`  | `mlx5_core.*Port module event.*High Temperature`         | **Non-Fatal** | [`events.c#L252-L254`](https://github.com/torvalds/linux/blob/ac9c34d1e45a4c25174ced4fc0cfc33ff3ed08c7/drivers/net/ethernet/mellanox/mlx5/core/events.c#L252-L254) | Thermal warning. May indicate cooling issue or impending PHY throttling.  |
+| `cmd_exec_timeout`       | `mlx5_core.*timeout\. Will cause a leak of a command resource` | **Fatal**     | [`cmd.c`](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/cmd.c)                                                             | Control plane broken. Driver cannot manage device. **Always Fatal**.      |
+| `health_poll_failed`     | `mlx5_core.*device's health compromised.*reached miss count` | **Fatal**     | [`health.c`](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/health.c)                                                       | Firmware heartbeat lost. Device is non-functional. **Always Fatal**.      |
+| `unrecoverable_err`      | `mlx5_core.*unrecoverable hardware error`                | **Fatal**     | [`health.c`](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/health.c)                                                       | Hardware admission of failure. **Always Fatal**.                          |
 | `access_reg_failed`      | `mlx5_cmd_out_err.*ACCESS_REG.*failed`                   | **Non-Fatal** | [`cmd.c`](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/cmd.c)                                                             | Monitoring tool conflict on restricted PFs. **Non-Fatal Noise**.          |
-| `netdev_watchdog`        | `NETDEV WATCHDOG:.*mlx5_core.*transmit queue.*timed out` | **Fatal**     | [`sch_generic.c`](https://github.com/torvalds/linux/blob/master/net/sched/sch_generic.c) (generic kernel mechanism)                                                | Data path stalled. Workload will fail. **High Probability Fatal**.        |
-| `module_absent`          | `mlx5_core.*module.*absent`                              | **Non-Fatal** | [`events.c`](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/events.c)                                                       | SFP/transceiver unplugged. Informational (though port will be DOWN).      |
+| `netdev_watchdog`        | `NETDEV WATCHDOG:.*mlx5_core.*transmit queue.*timed out` | **Non-Fatal** | [`sch_generic.c`](https://github.com/torvalds/linux/blob/master/net/sched/sch_generic.c) (generic kernel mechanism)                                                | TX queue stall with auto-recovery via `mlx5e_tx_timeout`. **Non-Fatal**. |
+| `module_unplugged`       | `mlx5_core.*Port module event.*Cable unplugged`          | **Non-Fatal** | [`events.c`](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/events.c)                                                       | SFP/transceiver unplugged. Informational (though port will be DOWN).      |
 
 **Full Log Line Examples:**
 
@@ -443,10 +441,9 @@ Following gpud's design, kernel log events are classified as **Non-Fatal (`IsFat
 | `cmd_exec_timeout`       | `mlx5_core 0000:03:00.0: wait_func:964:(pid 112): ENABLE_HCA(0x104) timeout. Will cause a leak of a command resource` |
 | `health_poll_failed`     | `mlx5_core 0000:d2:00.0: poll_health:174: device's health compromised - reached miss count.`                          |
 | `unrecoverable_err`      | `mlx5_core: INFO: synd 0x8: unrecoverable hardware error.`                                                            |
-| `pcie_fatal_error`       | `PCIe Bus Error: severity=Uncorrectable (Fatal), type=Transaction Layer, (Receiver ID)`                               |
 | `access_reg_failed`      | `mlx5_cmd_out_err:838: ACCESS_REG(0x805) op_mod(0x1) failed, status bad operation(0x2)`                               |
 | `netdev_watchdog`        | `NETDEV WATCHDOG: eth0 (mlx5_core): transmit queue 0 timed out`                                                       |
-| `module_absent`          | `mlx5_core 0000:12:00.0: Port module event: module 0, absent`                                                         |
+| `module_unplugged`       | `mlx5_core 0000:12:00.0: Port module event: module 0, Cable unplugged`                                                         |
 
 > **Design Note**: While gpud internally treats many of these as non-fatal, NVSentinel escalates **deterministically fatal** signals to Fatal (`IsFatal=true`) to trigger proactive remediation (`REPLACE_VM`) before workload failure cascades. Non-fatal signals remain as `IsFatal=false` for diagnostic correlation.
 
@@ -456,10 +453,8 @@ Patterns are classified according to their operational impact:
 
 | Category                  | Patterns                                                                       | Severity      | Recommended Action  |
 |---------------------------|--------------------------------------------------------------------------------|---------------|---------------------|
-| **Always Fatal (Device)** | `cmd_exec timeout`, `health poll failed`, `unrecoverable`                      | **Fatal**     | `REPLACE_VM`        |
-| **Always Fatal (System)** | `PCIe Bus Error.*Fatal`                                                        | **Fatal**     | `REPLACE_VM`        |
-| **Fatal (Service)**       | `NETDEV WATCHDOG`                                                              | **Fatal**     | `REPLACE_VM`        |
-| **Non-Fatal / Evidence**  | `insufficient power`, `High Temperature`, `ACCESS_REG failed`, `module absent` | **Non-Fatal** | `NONE` (Diagnostic) |
+| **Always Fatal (Device)** | command timeout with resource leak, `health poll failed`, `unrecoverable`                       | **Fatal**     | `REPLACE_VM`        |
+| **Non-Fatal / Evidence**  | `insufficient power`, `High Temperature`, `ACCESS_REG failed`, `module unplugged`, `NETDEV WATCHDOG` | **Non-Fatal** | `NONE` (Diagnostic) |
 
 > **Key Principle**: Kernel logs provide **diagnostic context**, not **remediation triggers**. The decision to drain/replace a node is based on actual port state (via link state detection), not log messages alone.
 
@@ -469,7 +464,7 @@ Patterns are classified according to their operational impact:
 # Check for driver/firmware errors in kernel log
 dmesg | grep -E "(mlx5_core|PCIe|AER)"
 # Output:
-# [ 42.123] mlx5_core 0000:3b:00.0: cmd_exec timeout, status=0x10
+# [ 42.123] mlx5_core 0000:3b:00.0: ENABLE_HCA(0x104) timeout. Will cause a leak of a command resource
 
 # Check journald for NIC errors
 journalctl -k | grep -E "(mlx5_core|PCIe)"
@@ -491,9 +486,8 @@ The Health Events Analyzer can correlate kernel log warnings with port state eve
 | Kernel Log (Non-Fatal)                    | Port State Event   | Correlation Insight     |
 |-------------------------------------------|--------------------|-------------------------|
 | `High Temperature` + `health poll failed` | Port DOWN          | Thermal-induced failure |
-| `cmd_exec timeout`                        | Port DOWN          | Driver/firmware failure |
+| command timeout with resource leak        | Port DOWN          | Driver/firmware failure |
 | `insufficient power`                      | Port DOWN          | Power delivery issue    |
-| `PCIe Bus Error`                          | Device disappeared | PCIe link failure       |
 
 ### 6.2 Noise Filtering
 
@@ -510,7 +504,7 @@ Unlike a local correlation engine, all pattern detection is handled by the **Hea
 
 1. **Raw Event Flow**: Syslog-health-monitor sends raw `mlx5_core` non-fatal events to Platform Connector → MongoDB
 2. **Correlation Rules**: Health Events Analyzer queries MongoDB and correlates warnings with port state events
-3. **Example**: `cmd_exec timeout` at 10:00:01 + `port state=DOWN` at 10:00:05 → Analyzer provides correlated diagnostic context
+3. **Example**: command timeout with resource leak at 10:00:01 + `port state=DOWN` at 10:00:05 → Analyzer provides correlated diagnostic context
 
 ### 7.1 Correlation Purpose
 
@@ -545,7 +539,7 @@ Following gpud's design, kernel log warnings are **not escalated to fatal**. Ins
 │  TIME        EVENT SOURCE           EVENT TYPE                                   │
 │  ────        ────────────           ──────────                                   │
 │                                                                                  │
-│  T+0:00      Syslog Monitor         cmd_exec timeout (mlx5_0)                   │
+│  T+0:00      Syslog Monitor         command timeout leak (mlx5_0)               │
 │              │                                                                   │
 │              └──────────────────────────────────────────────────────────────────►│
 │                                                                                  │
@@ -567,18 +561,18 @@ Following gpud's design, kernel log warnings are **not escalated to fatal**. Ins
 │                    │    db.health_events.find({                             │   │
 │                    │      timestamp: {$gt: NOW() - 10s},                    │   │
 │                    │      nodename: 'node-xyz',                             │   │
-│                    │      $or: [{message: /cmd_exec timeout/},              │   │
+│                    │      $or: [{message: /timeout. Will cause a leak/},     │   │
 │                    │            {message: /state=DOWN/}]                    │   │
 │                    │    })                                                   │   │
 │                    │                                                         │   │
 │                    │  Result:                                                │   │
-│                    │    1. cmd_exec timeout at T+0:00                       │   │
+│                    │    1. command timeout leak at T+0:00                   │   │
 │                    │    2. state=DOWN at T+0:05                             │   │
 │                    │                                                         │   │
 │                    │  ┌───────────────────────────────────────────────────┐ │   │
 │                    │  │  CORRELATION DETECTED                             │ │   │
 │                    │  │                                                   │ │   │
-│                    │  │  Pattern: cmd_exec timeout + link_down            │ │   │
+│                    │  │  Pattern: command timeout + link_down             │ │   │
 │                    │  │  within 5 seconds                                 │ │   │
 │                    │  │                                                   │ │   │
 │                    │  │  OUTPUT: DIAGNOSTIC CORRELATION                   │ │   │
@@ -616,6 +610,45 @@ enableRepeatedNICDegradationRule: true
 enableNICDriverErrorCorrelationRule: true
 ```
 
+### 8.3 NIC Driver Pattern Configuration
+
+NIC driver error patterns are defined in a TOML configuration file, allowing operators to disable, add, or reclassify patterns without code changes.
+
+**TOML Shape:**
+
+```toml
+[[patterns]]
+name = "cmd_exec_timeout"
+regex = 'mlx5_core.*timeout\. Will cause a leak of a command resource'
+enabled = true
+isFatal = true
+recommendedAction = "REPLACE_VM"
+description = "Firmware command timeout with resource leak"
+
+[[patterns]]
+name = "netdev_watchdog"
+regex = 'NETDEV WATCHDOG:.*mlx5_core.*transmit queue.*timed out'
+enabled = true
+isFatal = false
+recommendedAction = "NONE"
+description = "TX queue stall with auto-recovery via mlx5e_tx_timeout"
+```
+
+**Fields:**
+
+| Field               | Type     | Description                                                                 |
+|---------------------|----------|-----------------------------------------------------------------------------|
+| `name`              | `string` | Unique identifier for the pattern                                           |
+| `regex`             | `string` | Regular expression matched against kernel log lines                         |
+| `enabled`           | `bool`   | Whether the pattern is active; set `false` to disable without removing      |
+| `isFatal`           | `bool`   | `true` → `IsFatal=true` + `REPLACE_VM`; `false` → diagnostic context only  |
+| `recommendedAction` | `string` | Action attached to emitted health events (e.g., `REPLACE_VM`, `NONE`)       |
+| `description`       | `string` | Human-readable explanation of the pattern                                   |
+
+> **Custom patterns should be NIC/mlx5-specific.** Generic PCIe/AER patterns such as `PCIe Bus Error.*Fatal` are intentionally not shipped because they can match GPUs, NVMe, or root ports. The handler does not BDF-gate generic patterns; if you add one, ensure its regex includes an mlx5-specific prefix (`mlx5_core`, `mlx5_cmd_out_err`, etc.) so it cannot match other devices. This follows gpud's same-decision approach in `kmsg_matcher.go`.
+
+> **Operational Note**: Operators can disable noisy patterns, add site-specific patterns, or reclassify severity (e.g., promote a Non-Fatal pattern to Fatal) by editing the TOML file and restarting the syslog-health-monitor pod. No code changes required.
+
 ---
 
 ## 9. Event Management
@@ -624,27 +657,27 @@ enableNICDriverErrorCorrelationRule: true
 
 Events are emitted with severity based on their determinism of failure:
 
-**Example Event Fields (Fatal - cmd_exec timeout):**
+**Example Event Fields (Fatal - command timeout resource leak):**
 
 | Field             | Value                                                   |
 |-------------------|---------------------------------------------------------|
 | Agent             | `syslog-health-monitor`                                 |
 | CheckName         | `SysLogsNICDriverError`                                 |
 | ComponentClass    | `NIC`                                                   |
-| Message           | "mlx5_core 0000:3b:00.0: cmd_exec timeout, status=0x10" |
+| Message           | "mlx5_core 0000:3b:00.0: ENABLE_HCA(0x104) timeout. Will cause a leak of a command resource" |
 | IsFatal           | `true`                                                  |
 | IsHealthy         | `false`                                                 |
 | RecommendedAction | `REPLACE_VM`                                            |
 | EntitiesImpacted  | `[{EntityType: "NIC", EntityValue: "mlx5_0"}]`          |
 
-**Example Event Fields (Non-Fatal - module absent):**
+**Example Event Fields (Non-Fatal - module unplugged):**
 
 | Field             | Value                                                         |
 |-------------------|---------------------------------------------------------------|
 | Agent             | `syslog-health-monitor`                                       |
 | CheckName         | `SysLogsNICDriverError`                                       |
 | ComponentClass    | `NIC`                                                         |
-| Message           | "mlx5_core 0000:12:00.0: Port module event: module 0, absent" |
+| Message           | "mlx5_core 0000:12:00.0: Port module event: module 0, Cable unplugged" |
 | IsFatal           | `false`                                                       |
 | IsHealthy         | `false`                                                       |
 | RecommendedAction | `NONE` (informational)                                        |
@@ -659,7 +692,7 @@ Kernel log events serve as both **direct failure signals** and **diagnostic cont
 | **Fatal**      | Deterministic hardware/driver failure | Immediate remediation via `REPLACE_VM`                              |
 | **Non-Fatal**  | Diagnostic information / Evidence     | Logged for investigation; provides context for state-based failures |
 
-> **Key Design Principle**: Deterministically fatal events in logs (cmd_exec timeout, unrecoverable hardware error) trigger `REPLACE_VM` directly. Non-fatal events (insufficient power, module absent) remain as `IsFatal=false` for diagnostic correlation.
+> **Key Design Principle**: Deterministically fatal events in logs (command timeout resource leaks, unrecoverable hardware error) trigger `REPLACE_VM` directly. Non-fatal events (insufficient power, module unplugged) remain as `IsFatal=false` for diagnostic correlation.
 
 ---
 
@@ -690,9 +723,8 @@ The following table shows which hardware failures this monitor detects and how t
 
 | Hardware Failure    | Detection Method                      | Potential Application Impact  |
 |---------------------|---------------------------------------|-------------------------------|
-| **Firmware freeze** | Kernel log: `cmd_exec timeout`        | All NIC operations stall      |
-| **Driver crash**    | Kernel log: `health poll failed`      | NIC becomes unusable          |
-| **PCIe errors**     | Kernel log: mlx5_core PCIe AER events | Device may become unavailable |
+| **Firmware freeze** | Kernel log: `timeout. Will cause a leak of a command resource` | All NIC operations stall      |
+| **Driver crash**    | Kernel log: `device's health compromised - reached miss count` | NIC becomes unusable          |
 | **TX stall**        | Kernel log: `NETDEV WATCHDOG`         | Network transmission fails    |
 
 ### 11.4 Event Severity Classification
@@ -701,14 +733,13 @@ Kernel log events are classified by their determinism of failure:
 
 | Kernel Log Event               | Severity      | Purpose                       | Recommended Action |
 |--------------------------------|---------------|-------------------------------|--------------------|
-| `mlx5_core cmd_exec timeout`   | **Fatal**     | Control plane broken          | `REPLACE_VM`       |
-| `mlx5_core health poll failed` | **Fatal**     | Firmware heartbeat lost       | `REPLACE_VM`       |
+| `mlx5_core.*timeout. Will cause a leak` | **Fatal**     | Control plane broken          | `REPLACE_VM`       |
+| `mlx5_core.*device's health compromised` | **Fatal**     | Firmware heartbeat lost       | `REPLACE_VM`       |
 | `mlx5_core unrecoverable`      | **Fatal**     | Hardware admission of failure | `REPLACE_VM`       |
-| `PCIe Bus Error.*Fatal`        | **Fatal**     | PCIe link broken              | `REPLACE_VM`       |
-| `NETDEV WATCHDOG`              | **Fatal**     | Data path stalled             | `REPLACE_VM`       |
+| `NETDEV WATCHDOG`              | **Non-Fatal** | TX stall with auto-recovery   | `NONE`             |
 | `Detected insufficient power`  | **Non-Fatal** | Power negotiation status      | `NONE`             |
 | `High Temperature`             | **Non-Fatal** | Thermal warning               | `NONE`             |
-| `module absent`                | **Non-Fatal** | SFP unplugged                 | `NONE`             |
+| `module unplugged`             | **Non-Fatal** | SFP unplugged                 | `NONE`             |
 | `ACCESS_REG failed`            | **Non-Fatal** | Monitoring noise              | `NONE`             |
 
 > **Key Principle**: Deterministically fatal events in logs trigger `REPLACE_VM`. Diagnostic logs remain as Non-Fatal (`IsFatal=false`) for diagnostic context.
@@ -723,15 +754,14 @@ The following patterns are monitored in the kernel ring buffer (dmesg/kmsg):
 
 | Pattern                                   | Severity      | Meaning                         | Action                        |
 |-------------------------------------------|---------------|---------------------------------|-------------------------------|
-| `mlx5_core.*cmd_exec timeout`             | **Fatal**     | Firmware/driver command timeout | `REPLACE_VM`                  |
-| `mlx5_core.*health poll failed`           | **Fatal**     | Health check missed             | `REPLACE_VM`                  |
-| `mlx5_core.*unrecoverable`                | **Fatal**     | Hardware error detected         | `REPLACE_VM`                  |
-| `PCIe Bus Error.*Fatal`                   | **Fatal**     | PCIe error logged               | `REPLACE_VM`                  |
-| `NETDEV WATCHDOG:.*mlx5_core.*timed out`  | **Fatal**     | TX queue timeout                | `REPLACE_VM`                  |
+| `mlx5_core.*timeout\. Will cause a leak of a command resource` | **Fatal**     | Firmware/driver command timeout | `REPLACE_VM`                  |
+| `mlx5_core.*device's health compromised.*reached miss count` | **Fatal**     | Health check missed             | `REPLACE_VM`                  |
+| `mlx5_core.*unrecoverable hardware error`  | **Fatal**     | Hardware error detected         | `REPLACE_VM`                  |
+| `NETDEV WATCHDOG:.*mlx5_core.*timed out`  | **Non-Fatal** | TX queue timeout                | Investigate; persistent stalls caught by link-state-detection |
 | `mlx5_core.*Detected insufficient power`  | **Non-Fatal** | Power negotiation status        | Investigate; can be transient |
 | `mlx5_core.*Port module event.*High Temp` | **Non-Fatal** | Thermal warning                 | Investigate; check cooling    |
 | `mlx5_cmd_out_err.*ACCESS_REG.*failed`    | **Non-Fatal** | Restricted PF access            | Filter/Ignore                 |
-| `mlx5_core.*module.*absent`               | **Non-Fatal** | SFP/transceiver unplugged       | Monitor port state            |
+| `mlx5_core.*Port module event.*Cable unplugged` | **Non-Fatal** | SFP/transceiver unplugged       | Monitor port state            |
 
 ### Design Principle
 
@@ -742,7 +772,7 @@ The following patterns are monitored in the kernel ring buffer (dmesg/kmsg):
 | **Fatal Counters** (link-counter-detection)   | `true`  | `REPLACE_VM`       | Fatal NIC condition detected       |
 | **Diagnostic Logs**                           | `false` | `NONE`             | Evidence/context for investigation |
 
-> **Key Insight**: Kernel logs for deterministic failures (cmd_exec timeout, etc.) are **Fatal (`IsFatal=true`)** with `RecommendedAction_REPLACE_VM`. Diagnostic logs (insufficient power, High Temperature, module absent) are **Non-Fatal (`IsFatal=false`)**. State and counter conditions are also **Fatal (`IsFatal=true`)** with `RecommendedAction_REPLACE_VM`.
+> **Key Insight**: Kernel logs for deterministic failures (command timeout resource leaks, etc.) are **Fatal (`IsFatal=true`)** with `RecommendedAction_REPLACE_VM`. Diagnostic logs (insufficient power, High Temperature, module unplugged) are **Non-Fatal (`IsFatal=false`)**. State and counter conditions are also **Fatal (`IsFatal=true`)** with `RecommendedAction_REPLACE_VM`.
 
 ---
 
@@ -863,9 +893,9 @@ enableRepeatedNICDegradationRule: true
 ### Linux Kernel & Driver
 1. [sysfs-class-infiniband (Linux Kernel)](https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-class-infiniband)
 2. [RHEL8 mlx5_core Stack Overflow (Red Hat)](https://access.redhat.com/solutions/6955682)
-3. [mlx5_core cmd.c - Command Interface (Linux Kernel)](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/cmd.c) - `cmd_exec timeout`, `ACCESS_REG failed`
-4. [mlx5_core health.c - Health Poller (Linux Kernel)](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/health.c) - `health poll failed`, `unrecoverable`
-5. [mlx5_core events.c - Async Events (Linux Kernel)](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/events.c) - `insufficient power`, `High Temperature`, `module absent`
+3. [mlx5_core cmd.c - Command Interface (Linux Kernel)](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/cmd.c) - command timeout resource leaks, `ACCESS_REG failed`
+4. [mlx5_core health.c - Health Poller (Linux Kernel)](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/health.c) - health compromise miss count, `unrecoverable`
+5. [mlx5_core events.c - Async Events (Linux Kernel)](https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/events.c) - `insufficient power`, `High Temperature`, `module unplugged`
 6. [PCIe AER HOWTO (Linux Kernel)](https://www.kernel.org/doc/html/latest/PCI/pcieaer-howto.html) - PCIe Bus Error log format and BDF identification
 
 ### Vendor Documentation

--- a/docs/nic-health-monitor/syslog-detection-correlation.md
+++ b/docs/nic-health-monitor/syslog-detection-correlation.md
@@ -480,13 +480,13 @@ journalctl -k -f | grep --line-buffered mlx5_core
 
 ## 6. Event Correlation (via Health Events Analyzer)
 
-Following gpud's design, kernel log events for diagnostic patterns are emitted as **Non-Fatal** (`IsFatal=false`). The Health Events Analyzer can correlate these non-fatal events with port state changes to provide richer diagnostic context.
+Fatal syslog events are emitted immediately with their configured remediation action. The Health Events Analyzer can still correlate those raw events with port state changes to provide incident context. Non-Fatal diagnostic syslog events are emitted as `IsFatal=false` and can also be correlated with state changes for operator investigation.
 
 ### 6.1 Correlation Examples
 
-The Health Events Analyzer can correlate kernel log warnings with port state events:
+The Health Events Analyzer can correlate kernel log events with port state events:
 
-| Kernel Log (Non-Fatal)                    | Port State Event | Correlation Insight     |
+| Kernel Log Event                          | Port State Event | Correlation Insight     |
 |-------------------------------------------|------------------|-------------------------|
 | `High Temperature` + `health poll failed` | Port DOWN        | Thermal-induced failure |
 | command timeout with resource leak        | Port DOWN        | Driver/firmware failure |
@@ -503,20 +503,20 @@ Some kernel messages can be filtered to reduce noise:
 
 ## 7. Repeat Failure Detection
 
-Unlike a local correlation engine, all pattern detection is handled by the **Health Events Analyzer**:
+Unlike a local correlation engine, repeat/cross-signal pattern detection is handled by the **Health Events Analyzer**:
 
-1. **Raw Event Flow**: Syslog-health-monitor sends raw `mlx5_core` non-fatal events to Platform Connector → MongoDB
-2. **Correlation Rules**: Health Events Analyzer queries MongoDB and correlates warnings with port state events
-3. **Example**: command timeout with resource leak at 10:00:01 + `port state=DOWN` at 10:00:05 → Analyzer provides correlated diagnostic context
+1. **Raw Event Flow**: Syslog-health-monitor sends raw `mlx5_core` events to Platform Connector → MongoDB
+2. **Correlation Rules**: Health Events Analyzer queries MongoDB and correlates syslog events with port state events
+3. **Example**: command timeout with resource leak at 10:00:01 is emitted immediately as Fatal; `port state=DOWN` at 10:00:05 can be correlated later to provide diagnostic context
 
 ### 7.1 Correlation Purpose
 
-Following gpud's design, kernel log warnings are **not escalated to fatal**. Instead, the Health Events Analyzer correlates them with port state events for diagnostic context:
+Kernel log events are emitted with their configured severity. The Health Events Analyzer can correlate them with port state events for diagnostic context:
 
 ```
 1. Diagnostic Correlation:
-   ├── Purpose: Link kernel log warnings to port state changes
-   ├── Input: Non-fatal events (kernel logs) + Port state events
+   ├── Purpose: Link kernel log events to port state changes
+   ├── Input: Kernel log events + Port state events
    └── Output: Correlated diagnostic information for operators
 
 2. Port Drop/Flap Detection (via Link State Detection):

--- a/health-monitors/syslog-health-monitor/go.mod
+++ b/health-monitors/syslog-health-monitor/go.mod
@@ -19,6 +19,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/health-monitors/syslog-health-monitor/go.sum
+++ b/health-monitors/syslog-health-monitor/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/health-monitors/syslog-health-monitor/main.go
+++ b/health-monitors/syslog-health-monitor/main.go
@@ -74,6 +74,10 @@ var (
 		"Path to GPU metadata JSON file.")
 	processingStrategyFlag = flag.String("processing-strategy", "EXECUTE_REMEDIATION",
 		"Event processing strategy: EXECUTE_REMEDIATION or STORE_ONLY")
+	nicDriverConfigPath = flag.String("nic-driver-config", "/etc/nic-driver-syslog/config.toml",
+		"Path to NIC driver syslog pattern config (TOML). Used only when SysLogsNICDriverError is in --checks.")
+	sysfsRoot = flag.String("sysfs-root", "/nvsentinel/sys",
+		"Root path for sysfs reads (BDF→driver resolution). Typically a container mount point.")
 )
 
 var checks []fd.CheckDefinition
@@ -324,6 +328,8 @@ func createSyslogMonitor(
 		*xidAnalyserEndpoint,
 		*metadataPath,
 		processingStrategy,
+		*nicDriverConfigPath,
+		*sysfsRoot,
 	)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error creating syslog health monitor: %w", err)

--- a/health-monitors/syslog-health-monitor/pkg/nicdriver/bdf.go
+++ b/health-monitors/syslog-health-monitor/pkg/nicdriver/bdf.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nicdriver
+
+import "regexp"
+
+// reBDF matches a PCI Bus:Device.Function address like "0000:3b:00.0".
+// Case-insensitive hex to handle test fixtures and out-of-tree log sources.
+var reBDF = regexp.MustCompile(`\b([0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-9a-fA-F])\b`)
+
+// extractBDF returns the first PCI BDF address found in the log line.
+func extractBDF(line string) (string, bool) {
+	m := reBDF.FindStringSubmatch(line)
+	if len(m) < 2 {
+		return "", false
+	}
+
+	return m[1], true
+}

--- a/health-monitors/syslog-health-monitor/pkg/nicdriver/bdf_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/nicdriver/bdf_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nicdriver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractBDF(t *testing.T) {
+	tests := []struct {
+		name    string
+		line    string
+		wantBDF string
+		wantOK  bool
+	}{
+		{
+			name:    "mlx5_core with BDF",
+			line:    "mlx5_core 0000:3b:00.0: wait_func:1195: timeout. Will cause a leak",
+			wantBDF: "0000:3b:00.0",
+			wantOK:  true,
+		},
+		{
+			name:    "pcieport with BDF",
+			line:    "pcieport 0000:50:00.0: AER: PCIe Bus Error: severity=Uncorrectable (Fatal)",
+			wantBDF: "0000:50:00.0",
+			wantOK:  true,
+		},
+		{
+			name:    "no BDF in line",
+			line:    "mlx5_core: INFO: synd 0x8: unrecoverable hardware error.",
+			wantBDF: "",
+			wantOK:  false,
+		},
+		{
+			name:    "uppercase hex BDF",
+			line:    "mlx5_core 0000:AB:CD.E: some message",
+			wantBDF: "0000:AB:CD.E",
+			wantOK:  true,
+		},
+		{
+			name:    "NETDEV WATCHDOG has no BDF",
+			line:    "NETDEV WATCHDOG: eth0 (mlx5_core): transmit queue 0 timed out",
+			wantBDF: "",
+			wantOK:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bdf, ok := extractBDF(tc.line)
+			assert.Equal(t, tc.wantOK, ok)
+
+			if ok {
+				assert.Equal(t, tc.wantBDF, bdf)
+			}
+		})
+	}
+}

--- a/health-monitors/syslog-health-monitor/pkg/nicdriver/config.go
+++ b/health-monitors/syslog-health-monitor/pkg/nicdriver/config.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nicdriver
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/nvidia/nvsentinel/commons/pkg/configmanager"
+	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
+)
+
+const recommendedActionMarker = "Recommended Action="
+
+// Config is the top-level TOML structure for NIC driver syslog patterns.
+type Config struct {
+	NICDriverDetection PatternDetectionConfig `toml:"nicDriverDetection"`
+}
+
+// PatternDetectionConfig wraps the configurable pattern list.
+type PatternDetectionConfig struct {
+	Patterns []PatternConfig `toml:"patterns"`
+}
+
+// PatternConfig defines a single kernel log pattern to match.
+type PatternConfig struct {
+	Name              string `toml:"name"`
+	Regex             string `toml:"regex"`
+	Enabled           bool   `toml:"enabled"`
+	IsFatal           bool   `toml:"isFatal"`
+	RecommendedAction string `toml:"recommendedAction"`
+	Description       string `toml:"description"`
+}
+
+// CompiledPattern is a validated, ready-to-evaluate pattern produced by LoadConfig.
+type CompiledPattern struct {
+	Name              string
+	Re                *regexp.Regexp
+	IsFatal           bool
+	RecommendedAction pb.RecommendedAction
+	Description       string
+}
+
+// LoadConfig reads and validates the TOML configuration, returning only the
+// enabled patterns with pre-compiled regexes and resolved proto enums.
+func LoadConfig(path string) ([]CompiledPattern, error) {
+	cfg := &Config{}
+	if err := configmanager.LoadTOMLConfig(path, cfg); err != nil {
+		return nil, fmt.Errorf("failed to load NIC driver config: %w", err)
+	}
+
+	return compilePatterns(cfg.NICDriverDetection.Patterns)
+}
+
+func compilePatterns(raw []PatternConfig) ([]CompiledPattern, error) {
+	seen := make(map[string]struct{})
+	var compiled []CompiledPattern
+
+	for i, p := range raw {
+		if !p.Enabled {
+			continue
+		}
+
+		if err := validatePattern(p); err != nil {
+			return nil, fmt.Errorf("patterns[%d] (%q): %w", i, p.Name, err)
+		}
+
+		if _, exists := seen[p.Name]; exists {
+			return nil, fmt.Errorf("patterns[%d]: duplicate pattern name %q", i, p.Name)
+		}
+
+		seen[p.Name] = struct{}{}
+
+		re, err := regexp.Compile(p.Regex)
+		if err != nil {
+			return nil, fmt.Errorf("patterns[%d] (%q): invalid regex: %w", i, p.Name, err)
+		}
+
+		action, err := resolveAction(p.RecommendedAction)
+		if err != nil {
+			return nil, fmt.Errorf("patterns[%d] (%q): %w", i, p.Name, err)
+		}
+
+		compiled = append(compiled, CompiledPattern{
+			Name:              p.Name,
+			Re:                re,
+			IsFatal:           p.IsFatal,
+			RecommendedAction: action,
+			Description:       p.Description,
+		})
+	}
+
+	return compiled, nil
+}
+
+func validatePattern(p PatternConfig) error {
+	if p.Name == "" {
+		return fmt.Errorf("name must not be empty")
+	}
+
+	if p.Regex == "" {
+		return fmt.Errorf("regex must not be empty")
+	}
+
+	if err := validateDescription(p.Description); err != nil {
+		return fmt.Errorf("description: %w", err)
+	}
+
+	return nil
+}
+
+// resolveAction is intentionally strict: configuration typos should fail
+// startup instead of being coerced to a different remediation action.
+func resolveAction(action string) (pb.RecommendedAction, error) {
+	upper := strings.ToUpper(strings.TrimSpace(action))
+
+	val, ok := pb.RecommendedAction_value[upper]
+	if !ok {
+		return 0, fmt.Errorf("recommendedAction %q is not a known RecommendedAction enum value", action)
+	}
+
+	return pb.RecommendedAction(val), nil
+}
+
+func validateDescription(desc string) error {
+	if desc == "" {
+		return fmt.Errorf("must not be empty")
+	}
+
+	if !utf8.ValidString(desc) {
+		return fmt.Errorf("contains invalid UTF-8")
+	}
+
+	if strings.Contains(desc, ";") {
+		return fmt.Errorf("must not contain %q (used as message delimiter by platform-connectors)", ";")
+	}
+
+	if strings.Contains(desc, recommendedActionMarker) {
+		return fmt.Errorf(
+			"must not contain %q (used as message parser marker by platform-connectors)",
+			recommendedActionMarker,
+		)
+	}
+
+	return nil
+}

--- a/health-monitors/syslog-health-monitor/pkg/nicdriver/config.go
+++ b/health-monitors/syslog-health-monitor/pkg/nicdriver/config.go
@@ -68,6 +68,7 @@ func LoadConfig(path string) ([]CompiledPattern, error) {
 
 func compilePatterns(raw []PatternConfig) ([]CompiledPattern, error) {
 	seen := make(map[string]struct{})
+
 	var compiled []CompiledPattern
 
 	for i, p := range raw {

--- a/health-monitors/syslog-health-monitor/pkg/nicdriver/config.go
+++ b/health-monitors/syslog-health-monitor/pkg/nicdriver/config.go
@@ -38,21 +38,24 @@ type PatternDetectionConfig struct {
 
 // PatternConfig defines a single kernel log pattern to match.
 type PatternConfig struct {
-	Name              string `toml:"name"`
-	Regex             string `toml:"regex"`
-	Enabled           bool   `toml:"enabled"`
-	IsFatal           bool   `toml:"isFatal"`
-	RecommendedAction string `toml:"recommendedAction"`
-	Description       string `toml:"description"`
+	Name               string `toml:"name"`
+	Regex              string `toml:"regex"`
+	Enabled            bool   `toml:"enabled"`
+	IsFatal            bool   `toml:"isFatal"`
+	RecommendedAction  string `toml:"recommendedAction"`
+	ProcessingStrategy string `toml:"processingStrategy"`
+	Description        string `toml:"description"`
 }
 
 // CompiledPattern is a validated, ready-to-evaluate pattern produced by LoadConfig.
 type CompiledPattern struct {
-	Name              string
-	Re                *regexp.Regexp
-	IsFatal           bool
-	RecommendedAction pb.RecommendedAction
-	Description       string
+	Name                  string
+	Re                    *regexp.Regexp
+	IsFatal               bool
+	RecommendedAction     pb.RecommendedAction
+	ProcessingStrategy    pb.ProcessingStrategy
+	HasProcessingStrategy bool
+	Description           string
 }
 
 // LoadConfig reads and validates the TOML configuration, returning only the
@@ -96,12 +99,19 @@ func compilePatterns(raw []PatternConfig) ([]CompiledPattern, error) {
 			return nil, fmt.Errorf("patterns[%d] (%q): %w", i, p.Name, err)
 		}
 
+		processingStrategy, hasProcessingStrategy, err := resolveProcessingStrategy(p.ProcessingStrategy)
+		if err != nil {
+			return nil, fmt.Errorf("patterns[%d] (%q): %w", i, p.Name, err)
+		}
+
 		compiled = append(compiled, CompiledPattern{
-			Name:              p.Name,
-			Re:                re,
-			IsFatal:           p.IsFatal,
-			RecommendedAction: action,
-			Description:       p.Description,
+			Name:                  p.Name,
+			Re:                    re,
+			IsFatal:               p.IsFatal,
+			RecommendedAction:     action,
+			ProcessingStrategy:    processingStrategy,
+			HasProcessingStrategy: hasProcessingStrategy,
+			Description:           p.Description,
 		})
 	}
 
@@ -135,6 +145,21 @@ func resolveAction(action string) (pb.RecommendedAction, error) {
 	}
 
 	return pb.RecommendedAction(val), nil
+}
+
+func resolveProcessingStrategy(strategy string) (pb.ProcessingStrategy, bool, error) {
+	if strings.TrimSpace(strategy) == "" {
+		return 0, false, nil
+	}
+
+	upper := strings.ToUpper(strings.TrimSpace(strategy))
+
+	val, ok := pb.ProcessingStrategy_value[upper]
+	if !ok {
+		return 0, false, fmt.Errorf("processingStrategy %q is not a known ProcessingStrategy enum value", strategy)
+	}
+
+	return pb.ProcessingStrategy(val), true, nil
 }
 
 func validateDescription(desc string) error {

--- a/health-monitors/syslog-health-monitor/pkg/nicdriver/config_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/nicdriver/config_test.go
@@ -1,0 +1,223 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nicdriver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
+)
+
+func writeTOML(t *testing.T, dir, content string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+
+	return path
+}
+
+func TestLoadConfig_ValidPatterns(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `
+[[nicDriverDetection.patterns]]
+name = "test_fatal"
+regex = '''mlx5_core.*timeout\. Will cause a leak'''
+enabled = true
+isFatal = true
+recommendedAction = "REPLACE_VM"
+description = "test fatal pattern"
+
+[[nicDriverDetection.patterns]]
+name = "test_nonfatal"
+regex = '''Detected insufficient power'''
+enabled = true
+isFatal = false
+recommendedAction = "NONE"
+description = "test non-fatal pattern"
+`)
+
+	patterns, err := LoadConfig(path)
+	require.NoError(t, err)
+	require.Len(t, patterns, 2)
+
+	assert.Equal(t, "test_fatal", patterns[0].Name)
+	assert.True(t, patterns[0].IsFatal)
+	assert.Equal(t, pb.RecommendedAction_REPLACE_VM, patterns[0].RecommendedAction)
+
+	assert.Equal(t, "test_nonfatal", patterns[1].Name)
+	assert.False(t, patterns[1].IsFatal)
+	assert.Equal(t, pb.RecommendedAction_NONE, patterns[1].RecommendedAction)
+}
+
+func TestLoadConfig_DisabledPatternsFiltered(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `
+[[nicDriverDetection.patterns]]
+name = "enabled_one"
+regex = "test"
+enabled = true
+isFatal = false
+recommendedAction = "NONE"
+description = "enabled"
+
+[[nicDriverDetection.patterns]]
+name = "disabled_one"
+regex = "test2"
+enabled = false
+isFatal = false
+recommendedAction = "NONE"
+description = "disabled"
+`)
+
+	patterns, err := LoadConfig(path)
+	require.NoError(t, err)
+	require.Len(t, patterns, 1)
+	assert.Equal(t, "enabled_one", patterns[0].Name)
+}
+
+func TestLoadConfig_EmptyPatternsAllowed(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `
+[nicDriverDetection]
+`)
+
+	patterns, err := LoadConfig(path)
+	require.NoError(t, err)
+	assert.Empty(t, patterns)
+}
+
+func TestLoadConfig_DuplicateNamesRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `
+[[nicDriverDetection.patterns]]
+name = "dup"
+regex = "a"
+enabled = true
+isFatal = false
+recommendedAction = "NONE"
+description = "first"
+
+[[nicDriverDetection.patterns]]
+name = "dup"
+regex = "b"
+enabled = true
+isFatal = false
+recommendedAction = "NONE"
+description = "second"
+`)
+
+	_, err := LoadConfig(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate pattern name")
+}
+
+func TestLoadConfig_InvalidRegexRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `
+[[nicDriverDetection.patterns]]
+name = "bad_regex"
+regex = "[invalid"
+enabled = true
+isFatal = false
+recommendedAction = "NONE"
+description = "bad regex"
+`)
+
+	_, err := LoadConfig(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid regex")
+}
+
+func TestLoadConfig_UnknownActionRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `
+[[nicDriverDetection.patterns]]
+name = "bad_action"
+regex = "test"
+enabled = true
+isFatal = false
+recommendedAction = "TYPO_ACTION"
+description = "unknown action"
+`)
+
+	_, err := LoadConfig(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a known RecommendedAction")
+}
+
+func TestLoadConfig_EmptyDescriptionRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `
+[[nicDriverDetection.patterns]]
+name = "no_desc"
+regex = "test"
+enabled = true
+isFatal = false
+recommendedAction = "NONE"
+description = ""
+`)
+
+	_, err := LoadConfig(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "description")
+}
+
+func TestLoadConfig_SemicolonInDescriptionRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `
+[[nicDriverDetection.patterns]]
+name = "semi"
+regex = "test"
+enabled = true
+isFatal = false
+recommendedAction = "NONE"
+description = "bad;desc"
+`)
+
+	_, err := LoadConfig(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ";")
+}
+
+func TestLoadConfig_ApostropheInRegex(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `
+[[nicDriverDetection.patterns]]
+name = "health_poll"
+regex = '''mlx5_core.*device's health compromised.*reached miss count'''
+enabled = true
+isFatal = true
+recommendedAction = "REPLACE_VM"
+description = "health poll with apostrophe in regex"
+`)
+
+	patterns, err := LoadConfig(path)
+	require.NoError(t, err)
+	require.Len(t, patterns, 1)
+	assert.True(t, patterns[0].Re.MatchString(
+		"mlx5_core 0000:d2:00.0: poll_health:825: device's health compromised - reached miss count."))
+}
+
+func TestResolveAction_CaseInsensitive(t *testing.T) {
+	action, err := resolveAction("replace_vm")
+	require.NoError(t, err)
+	assert.Equal(t, pb.RecommendedAction_REPLACE_VM, action)
+}

--- a/health-monitors/syslog-health-monitor/pkg/nicdriver/config_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/nicdriver/config_test.go
@@ -43,6 +43,7 @@ regex = '''mlx5_core.*timeout\. Will cause a leak'''
 enabled = true
 isFatal = true
 recommendedAction = "REPLACE_VM"
+processingStrategy = "EXECUTE_REMEDIATION"
 description = "test fatal pattern"
 
 [[nicDriverDetection.patterns]]
@@ -51,6 +52,7 @@ regex = '''Detected insufficient power'''
 enabled = true
 isFatal = false
 recommendedAction = "NONE"
+processingStrategy = "STORE_ONLY"
 description = "test non-fatal pattern"
 `)
 
@@ -61,10 +63,14 @@ description = "test non-fatal pattern"
 	assert.Equal(t, "test_fatal", patterns[0].Name)
 	assert.True(t, patterns[0].IsFatal)
 	assert.Equal(t, pb.RecommendedAction_REPLACE_VM, patterns[0].RecommendedAction)
+	assert.True(t, patterns[0].HasProcessingStrategy)
+	assert.Equal(t, pb.ProcessingStrategy_EXECUTE_REMEDIATION, patterns[0].ProcessingStrategy)
 
 	assert.Equal(t, "test_nonfatal", patterns[1].Name)
 	assert.False(t, patterns[1].IsFatal)
 	assert.Equal(t, pb.RecommendedAction_NONE, patterns[1].RecommendedAction)
+	assert.True(t, patterns[1].HasProcessingStrategy)
+	assert.Equal(t, pb.ProcessingStrategy_STORE_ONLY, patterns[1].ProcessingStrategy)
 }
 
 func TestLoadConfig_DisabledPatternsFiltered(t *testing.T) {
@@ -161,6 +167,42 @@ description = "unknown action"
 	_, err := LoadConfig(path)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not a known RecommendedAction")
+}
+
+func TestLoadConfig_UnknownProcessingStrategyRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `
+[[nicDriverDetection.patterns]]
+name = "bad_strategy"
+regex = "test"
+enabled = true
+isFatal = false
+recommendedAction = "NONE"
+processingStrategy = "TYPO_STRATEGY"
+description = "unknown strategy"
+`)
+
+	_, err := LoadConfig(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a known ProcessingStrategy")
+}
+
+func TestLoadConfig_MissingProcessingStrategyAllowed(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTOML(t, dir, `
+[[nicDriverDetection.patterns]]
+name = "missing_strategy"
+regex = "test"
+enabled = true
+isFatal = false
+recommendedAction = "NONE"
+description = "missing strategy"
+`)
+
+	patterns, err := LoadConfig(path)
+	require.NoError(t, err)
+	require.Len(t, patterns, 1)
+	assert.False(t, patterns[0].HasProcessingStrategy)
 }
 
 func TestLoadConfig_EmptyDescriptionRejected(t *testing.T) {

--- a/health-monitors/syslog-health-monitor/pkg/nicdriver/handler.go
+++ b/health-monitors/syslog-health-monitor/pkg/nicdriver/handler.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nicdriver
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
+)
+
+const mlx5CoreDriver = "mlx5_core"
+
+// NewNICDriverHandler creates a handler from the configured pattern file and
+// sysfs root. Invalid pattern configuration is treated as a startup error.
+func NewNICDriverHandler(
+	nodeName, defaultAgentName, checkName, configPath, sysfsRoot string,
+	processingStrategy pb.ProcessingStrategy,
+) (*NICDriverHandler, error) {
+	patterns, err := LoadConfig(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load NIC driver pattern config from %s: %w", configPath, err)
+	}
+
+	slog.Info("Loaded NIC driver syslog patterns",
+		"configPath", configPath,
+		"enabledPatterns", len(patterns))
+
+	resolver := NewSysfsResolver(sysfsRoot)
+
+	PreInitialize(nodeName, patterns)
+
+	return newWithDeps(nodeName, defaultAgentName, checkName, patterns, resolver, processingStrategy), nil
+}
+
+// newWithDeps creates a handler with pre-built dependencies for focused tests.
+func newWithDeps(
+	nodeName, defaultAgentName, checkName string,
+	patterns []CompiledPattern,
+	resolver Resolver,
+	processingStrategy pb.ProcessingStrategy,
+) *NICDriverHandler {
+	return &NICDriverHandler{
+		nodeName:           nodeName,
+		defaultAgentName:   defaultAgentName,
+		checkName:          checkName,
+		processingStrategy: processingStrategy,
+		patterns:           patterns,
+		resolver:           resolver,
+	}
+}
+
+// ProcessLine evaluates the kernel log message against configured patterns.
+// First match wins. Returns nil when no pattern matches.
+//
+// All shipped default patterns include an mlx5-specific prefix in the regex
+// (mlx5_core, mlx5_cmd_out_err, NETDEV WATCHDOG.*mlx5_core, etc.), so they
+// cannot match other devices. The BDF lookup that follows is best-effort
+// entity enrichment only; it does not gate event emission.
+func (h *NICDriverHandler) ProcessLine(message string) (*pb.HealthEvents, error) {
+	for i := range h.patterns {
+		p := &h.patterns[i]
+		if !p.Re.MatchString(message) {
+			continue
+		}
+
+		bdf, hasBDF := extractBDF(message)
+
+		return h.buildEvent(p, message, bdf, hasBDF), nil
+	}
+
+	return nil, nil
+}
+
+func (h *NICDriverHandler) buildEvent(
+	p *CompiledPattern, message, bdf string, hasBDF bool,
+) *pb.HealthEvents {
+	var entities []*pb.Entity
+
+	// Best-effort NIC entity enrichment. Defensive guard: only attach a NIC
+	// entity if the BDF actually resolves to mlx5_core. This prevents an
+	// operator-supplied generic regex from accidentally tagging a GPU/NVMe
+	// BDF with a NIC entity.
+	if hasBDF {
+		if driver, device, ok := h.resolver.Resolve(bdf); ok && driver == mlx5CoreDriver && device != "" {
+			entities = append(entities, &pb.Entity{
+				EntityType:  "NIC",
+				EntityValue: device,
+			})
+		}
+	}
+
+	sev := "non_fatal"
+	if p.IsFatal {
+		sev = "fatal"
+	}
+
+	nicDriverEventCounter.WithLabelValues(h.nodeName, p.Name, sev).Inc()
+
+	event := &pb.HealthEvent{
+		Version:            1,
+		Agent:              h.defaultAgentName,
+		CheckName:          h.checkName,
+		ComponentClass:     componentClassNIC,
+		GeneratedTimestamp: timestamppb.New(time.Now()),
+		EntitiesImpacted:   entities,
+		Message:            message,
+		IsFatal:            p.IsFatal,
+		IsHealthy:          false,
+		NodeName:           h.nodeName,
+		RecommendedAction:  p.RecommendedAction,
+		ErrorCode:          []string{p.Name},
+		ProcessingStrategy: h.processingStrategy,
+	}
+
+	return &pb.HealthEvents{
+		Version: 1,
+		Events:  []*pb.HealthEvent{event},
+	}
+}

--- a/health-monitors/syslog-health-monitor/pkg/nicdriver/handler.go
+++ b/health-monitors/syslog-health-monitor/pkg/nicdriver/handler.go
@@ -112,6 +112,11 @@ func (h *NICDriverHandler) buildEvent(
 
 	nicDriverEventCounter.WithLabelValues(h.nodeName, p.Name, sev).Inc()
 
+	processingStrategy := h.processingStrategy
+	if p.HasProcessingStrategy {
+		processingStrategy = p.ProcessingStrategy
+	}
+
 	event := &pb.HealthEvent{
 		Version:            1,
 		Agent:              h.defaultAgentName,
@@ -125,7 +130,7 @@ func (h *NICDriverHandler) buildEvent(
 		NodeName:           h.nodeName,
 		RecommendedAction:  p.RecommendedAction,
 		ErrorCode:          []string{p.Name},
-		ProcessingStrategy: h.processingStrategy,
+		ProcessingStrategy: processingStrategy,
 	}
 
 	return &pb.HealthEvents{

--- a/health-monitors/syslog-health-monitor/pkg/nicdriver/handler_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/nicdriver/handler_test.go
@@ -55,52 +55,68 @@ func (m *mockResolver) Resolve(bdf string) (string, string, bool) {
 
 var defaultTestPatterns = []CompiledPattern{
 	{
-		Name:              "cmd_exec_timeout",
-		Re:                regexp.MustCompile(`mlx5_core.*timeout\. Will cause a leak of a command resource`),
-		IsFatal:           true,
-		RecommendedAction: pb.RecommendedAction_REPLACE_VM,
+		Name:                  "cmd_exec_timeout",
+		Re:                    regexp.MustCompile(`mlx5_core.*timeout\. Will cause a leak of a command resource`),
+		IsFatal:               true,
+		RecommendedAction:     pb.RecommendedAction_REPLACE_VM,
+		ProcessingStrategy:    pb.ProcessingStrategy_EXECUTE_REMEDIATION,
+		HasProcessingStrategy: true,
 	},
 	{
-		Name:              "health_poll_failed",
-		Re:                regexp.MustCompile(`mlx5_core.*device's health compromised.*reached miss count`),
-		IsFatal:           true,
-		RecommendedAction: pb.RecommendedAction_REPLACE_VM,
+		Name:                  "health_poll_failed",
+		Re:                    regexp.MustCompile(`mlx5_core.*device's health compromised.*reached miss count`),
+		IsFatal:               true,
+		RecommendedAction:     pb.RecommendedAction_REPLACE_VM,
+		ProcessingStrategy:    pb.ProcessingStrategy_EXECUTE_REMEDIATION,
+		HasProcessingStrategy: true,
 	},
 	{
-		Name:              "unrecoverable_err",
-		Re:                regexp.MustCompile(`mlx5_core.*unrecoverable hardware error`),
-		IsFatal:           true,
-		RecommendedAction: pb.RecommendedAction_REPLACE_VM,
+		Name:                  "unrecoverable_err",
+		Re:                    regexp.MustCompile(`mlx5_core.*unrecoverable hardware error`),
+		IsFatal:               true,
+		RecommendedAction:     pb.RecommendedAction_REPLACE_VM,
+		ProcessingStrategy:    pb.ProcessingStrategy_EXECUTE_REMEDIATION,
+		HasProcessingStrategy: true,
 	},
 	{
-		Name:              "netdev_watchdog",
-		Re:                regexp.MustCompile(`NETDEV WATCHDOG.*mlx5_core.*transmit queue.*timed out`),
-		IsFatal:           false,
-		RecommendedAction: pb.RecommendedAction_NONE,
+		Name:                  "netdev_watchdog",
+		Re:                    regexp.MustCompile(`NETDEV WATCHDOG.*mlx5_core.*transmit queue.*timed out`),
+		IsFatal:               false,
+		RecommendedAction:     pb.RecommendedAction_NONE,
+		ProcessingStrategy:    pb.ProcessingStrategy_EXECUTE_REMEDIATION,
+		HasProcessingStrategy: true,
 	},
 	{
-		Name:              "pci_power_insufficient",
-		Re:                regexp.MustCompile(`mlx5_core.*Detected insufficient power on the PCIe slot`),
-		IsFatal:           false,
-		RecommendedAction: pb.RecommendedAction_NONE,
+		Name:                  "pci_power_insufficient",
+		Re:                    regexp.MustCompile(`mlx5_core.*Detected insufficient power on the PCIe slot`),
+		IsFatal:               false,
+		RecommendedAction:     pb.RecommendedAction_NONE,
+		ProcessingStrategy:    pb.ProcessingStrategy_EXECUTE_REMEDIATION,
+		HasProcessingStrategy: true,
 	},
 	{
-		Name:              "port_module_high_temp",
-		Re:                regexp.MustCompile(`mlx5_core.*Port module event.*High Temperature`),
-		IsFatal:           false,
-		RecommendedAction: pb.RecommendedAction_NONE,
+		Name:                  "port_module_high_temp",
+		Re:                    regexp.MustCompile(`mlx5_core.*Port module event.*High Temperature`),
+		IsFatal:               false,
+		RecommendedAction:     pb.RecommendedAction_NONE,
+		ProcessingStrategy:    pb.ProcessingStrategy_EXECUTE_REMEDIATION,
+		HasProcessingStrategy: true,
 	},
 	{
-		Name:              "access_reg_failed",
-		Re:                regexp.MustCompile(`mlx5_cmd_out_err.*ACCESS_REG.*failed`),
-		IsFatal:           false,
-		RecommendedAction: pb.RecommendedAction_NONE,
+		Name:                  "access_reg_failed",
+		Re:                    regexp.MustCompile(`mlx5_cmd_out_err.*ACCESS_REG.*failed`),
+		IsFatal:               false,
+		RecommendedAction:     pb.RecommendedAction_NONE,
+		ProcessingStrategy:    pb.ProcessingStrategy_EXECUTE_REMEDIATION,
+		HasProcessingStrategy: true,
 	},
 	{
-		Name:              "module_unplugged",
-		Re:                regexp.MustCompile(`mlx5_core.*Port module event.*Cable unplugged`),
-		IsFatal:           false,
-		RecommendedAction: pb.RecommendedAction_NONE,
+		Name:                  "module_unplugged",
+		Re:                    regexp.MustCompile(`mlx5_core.*Port module event.*Cable unplugged`),
+		IsFatal:               false,
+		RecommendedAction:     pb.RecommendedAction_NONE,
+		ProcessingStrategy:    pb.ProcessingStrategy_EXECUTE_REMEDIATION,
+		HasProcessingStrategy: true,
 	},
 }
 
@@ -291,6 +307,25 @@ func TestProcessLine_ProcessingStrategyPassthrough(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, events)
 	assert.Equal(t, pb.ProcessingStrategy_STORE_ONLY, events.Events[0].ProcessingStrategy)
+}
+
+func TestProcessLine_PatternProcessingStrategyOverridesHandlerDefault(t *testing.T) {
+	pattern := []CompiledPattern{{
+		Name:                  "test",
+		Re:                    regexp.MustCompile(`test_pattern`),
+		IsFatal:               false,
+		RecommendedAction:     pb.RecommendedAction_NONE,
+		ProcessingStrategy:    pb.ProcessingStrategy_EXECUTE_REMEDIATION,
+		HasProcessingStrategy: true,
+	}}
+
+	h := newWithDeps("node", "agent", "check", pattern, newMockResolver(nil),
+		pb.ProcessingStrategy_STORE_ONLY)
+
+	events, err := h.ProcessLine("test_pattern")
+	require.NoError(t, err)
+	require.NotNil(t, events)
+	assert.Equal(t, pb.ProcessingStrategy_EXECUTE_REMEDIATION, events.Events[0].ProcessingStrategy)
 }
 
 func TestProcessLine_FirstMatchWins(t *testing.T) {

--- a/health-monitors/syslog-health-monitor/pkg/nicdriver/handler_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/nicdriver/handler_test.go
@@ -1,0 +1,298 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nicdriver
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
+)
+
+func makeHandler(t *testing.T, patterns []CompiledPattern, resolver Resolver) *NICDriverHandler {
+	t.Helper()
+
+	return newWithDeps("test-node", "syslog-health-monitor", "SysLogsNICDriverError",
+		patterns, resolver, pb.ProcessingStrategy_EXECUTE_REMEDIATION)
+}
+
+var defaultTestPatterns = []CompiledPattern{
+	{
+		Name:              "cmd_exec_timeout",
+		Re:                regexp.MustCompile(`mlx5_core.*timeout\. Will cause a leak of a command resource`),
+		IsFatal:           true,
+		RecommendedAction: pb.RecommendedAction_REPLACE_VM,
+	},
+	{
+		Name:              "health_poll_failed",
+		Re:                regexp.MustCompile(`mlx5_core.*device's health compromised.*reached miss count`),
+		IsFatal:           true,
+		RecommendedAction: pb.RecommendedAction_REPLACE_VM,
+	},
+	{
+		Name:              "unrecoverable_err",
+		Re:                regexp.MustCompile(`mlx5_core.*unrecoverable hardware error`),
+		IsFatal:           true,
+		RecommendedAction: pb.RecommendedAction_REPLACE_VM,
+	},
+	{
+		Name:              "netdev_watchdog",
+		Re:                regexp.MustCompile(`NETDEV WATCHDOG.*mlx5_core.*transmit queue.*timed out`),
+		IsFatal:           false,
+		RecommendedAction: pb.RecommendedAction_NONE,
+	},
+	{
+		Name:              "pci_power_insufficient",
+		Re:                regexp.MustCompile(`mlx5_core.*Detected insufficient power on the PCIe slot`),
+		IsFatal:           false,
+		RecommendedAction: pb.RecommendedAction_NONE,
+	},
+	{
+		Name:              "port_module_high_temp",
+		Re:                regexp.MustCompile(`mlx5_core.*Port module event.*High Temperature`),
+		IsFatal:           false,
+		RecommendedAction: pb.RecommendedAction_NONE,
+	},
+	{
+		Name:              "access_reg_failed",
+		Re:                regexp.MustCompile(`mlx5_cmd_out_err.*ACCESS_REG.*failed`),
+		IsFatal:           false,
+		RecommendedAction: pb.RecommendedAction_NONE,
+	},
+	{
+		Name:              "module_unplugged",
+		Re:                regexp.MustCompile(`mlx5_core.*Port module event.*Cable unplugged`),
+		IsFatal:           false,
+		RecommendedAction: pb.RecommendedAction_NONE,
+	},
+}
+
+func TestProcessLine_FatalPatterns(t *testing.T) {
+	resolver := newMockResolver(map[string]mockResult{
+		"0000:03:00.0": {driver: "mlx5_core", device: "mlx5_0"},
+		"0000:d2:00.0": {driver: "mlx5_core", device: "mlx5_1"},
+	})
+	h := makeHandler(t, defaultTestPatterns, resolver)
+
+	tests := []struct {
+		name        string
+		message     string
+		wantPattern string
+		wantFatal   bool
+		wantAction  pb.RecommendedAction
+	}{
+		{
+			name:        "cmd_exec_timeout",
+			message:     "mlx5_core 0000:03:00.0: wait_func:1195:(pid 1967079): ENABLE_HCA(0x104) timeout. Will cause a leak of a command resource",
+			wantPattern: "cmd_exec_timeout",
+			wantFatal:   true,
+			wantAction:  pb.RecommendedAction_REPLACE_VM,
+		},
+		{
+			name:        "health_poll_failed",
+			message:     "mlx5_core 0000:d2:00.0: poll_health:825: device's health compromised - reached miss count.",
+			wantPattern: "health_poll_failed",
+			wantFatal:   true,
+			wantAction:  pb.RecommendedAction_REPLACE_VM,
+		},
+		{
+			name:        "unrecoverable_err",
+			message:     "mlx5_core: INFO: synd 0x8: unrecoverable hardware error.",
+			wantPattern: "unrecoverable_err",
+			wantFatal:   true,
+			wantAction:  pb.RecommendedAction_REPLACE_VM,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			events, err := h.ProcessLine(tc.message)
+			require.NoError(t, err)
+			require.NotNil(t, events)
+			require.Len(t, events.Events, 1)
+
+			event := events.Events[0]
+			assert.Equal(t, tc.wantFatal, event.IsFatal)
+			assert.False(t, event.IsHealthy)
+			assert.Equal(t, tc.wantAction, event.RecommendedAction)
+			assert.Equal(t, componentClassNIC, event.ComponentClass)
+			assert.Equal(t, []string{tc.wantPattern}, event.ErrorCode)
+			assert.Equal(t, tc.message, event.Message)
+			assert.Equal(t, pb.ProcessingStrategy_EXECUTE_REMEDIATION, event.ProcessingStrategy)
+		})
+	}
+}
+
+func TestProcessLine_NonFatalPatterns(t *testing.T) {
+	resolver := newMockResolver(map[string]mockResult{
+		"0000:12:00.0": {driver: "mlx5_core", device: "mlx5_0"},
+		"0000:41:00.1": {driver: "mlx5_core", device: "mlx5_1"},
+	})
+	h := makeHandler(t, defaultTestPatterns, resolver)
+
+	tests := []struct {
+		name        string
+		message     string
+		wantPattern string
+	}{
+		{
+			name:        "netdev_watchdog",
+			message:     "NETDEV WATCHDOG: eth0 (mlx5_core): transmit queue 0 timed out",
+			wantPattern: "netdev_watchdog",
+		},
+		{
+			name:        "pci_power_insufficient",
+			message:     "mlx5_core 0000:12:00.0: mlx5_pcie_event:299: Detected insufficient power on the PCIe slot (27W).",
+			wantPattern: "pci_power_insufficient",
+		},
+		{
+			name:        "port_module_high_temp",
+			message:     "mlx5_core 0000:5c:00.0: Port module event[error]: module 0, Cable error, High Temperature",
+			wantPattern: "port_module_high_temp",
+		},
+		{
+			name:        "access_reg_failed",
+			message:     "mlx5_cmd_out_err:838:(pid 1441871): ACCESS_REG(0x805) op_mod(0x1) failed, status bad operation(0x2), syndrome (0x305684), err(-22)",
+			wantPattern: "access_reg_failed",
+		},
+		{
+			name:        "module_unplugged",
+			message:     "mlx5_core 0000:41:00.1: Port module event: module 1, Cable unplugged",
+			wantPattern: "module_unplugged",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			events, err := h.ProcessLine(tc.message)
+			require.NoError(t, err)
+			require.NotNil(t, events)
+			require.Len(t, events.Events, 1)
+
+			event := events.Events[0]
+			assert.False(t, event.IsFatal)
+			assert.Equal(t, pb.RecommendedAction_NONE, event.RecommendedAction)
+			assert.Equal(t, []string{tc.wantPattern}, event.ErrorCode)
+		})
+	}
+}
+
+func TestProcessLine_NoMatch(t *testing.T) {
+	h := makeHandler(t, defaultTestPatterns, newMockResolver(nil))
+
+	events, err := h.ProcessLine("some random kernel message that matches nothing")
+	require.NoError(t, err)
+	assert.Nil(t, events)
+}
+
+// TestProcessLine_NoBDFStillEmits verifies that a regex match without a BDF
+// in the line still emits an event, but without NIC entity enrichment.
+func TestProcessLine_NoBDFStillEmits(t *testing.T) {
+	h := makeHandler(t, defaultTestPatterns, newMockResolver(nil))
+
+	events, err := h.ProcessLine(
+		"mlx5_core: INFO: synd 0x8: unrecoverable hardware error.")
+	require.NoError(t, err)
+	require.NotNil(t, events, "unrecoverable_err with no BDF should still emit")
+	assert.Empty(t, events.Events[0].EntitiesImpacted, "no BDF means no NIC entity")
+}
+
+// TestProcessLine_NonMlx5BDFNoEntity verifies that a regex match on a line
+// whose BDF resolves to a non-mlx5 driver (e.g. nvidia, nvme) still emits
+// the event but does not attach a NIC entity. This protects against an
+// operator-supplied generic regex matching a GPU/NVMe log line.
+func TestProcessLine_NonMlx5BDFNoEntity(t *testing.T) {
+	resolver := newMockResolver(map[string]mockResult{
+		"0000:b3:00.0": {driver: "nvidia", device: "gpu0"},
+	})
+
+	customPattern := []CompiledPattern{{
+		Name:              "custom_generic",
+		Re:                regexp.MustCompile(`some generic kernel message`),
+		IsFatal:           false,
+		RecommendedAction: pb.RecommendedAction_NONE,
+	}}
+
+	h := makeHandler(t, customPattern, resolver)
+
+	events, err := h.ProcessLine("0000:b3:00.0: some generic kernel message about a GPU")
+	require.NoError(t, err)
+	require.NotNil(t, events, "match emits event regardless of BDF driver type")
+	assert.Empty(t, events.Events[0].EntitiesImpacted,
+		"non-mlx5 BDF must not be tagged with a NIC entity")
+}
+
+func TestProcessLine_EntityEnrichment(t *testing.T) {
+	resolver := newMockResolver(map[string]mockResult{
+		"0000:03:00.0": {driver: "mlx5_core", device: "mlx5_0"},
+	})
+	h := makeHandler(t, defaultTestPatterns, resolver)
+
+	events, err := h.ProcessLine(
+		"mlx5_core 0000:03:00.0: wait_func:1195:(pid 100): ENABLE_HCA(0x104) timeout. Will cause a leak of a command resource")
+	require.NoError(t, err)
+	require.NotNil(t, events)
+	require.Len(t, events.Events[0].EntitiesImpacted, 1)
+
+	entity := events.Events[0].EntitiesImpacted[0]
+	assert.Equal(t, "NIC", entity.EntityType)
+	assert.Equal(t, "mlx5_0", entity.EntityValue)
+}
+
+func TestProcessLine_ProcessingStrategyPassthrough(t *testing.T) {
+	pattern := []CompiledPattern{{
+		Name:              "test",
+		Re:                regexp.MustCompile(`test_pattern`),
+		IsFatal:           false,
+		RecommendedAction: pb.RecommendedAction_NONE,
+	}}
+
+	h := newWithDeps("node", "agent", "check", pattern, newMockResolver(nil),
+		pb.ProcessingStrategy_STORE_ONLY)
+
+	events, err := h.ProcessLine("test_pattern")
+	require.NoError(t, err)
+	require.NotNil(t, events)
+	assert.Equal(t, pb.ProcessingStrategy_STORE_ONLY, events.Events[0].ProcessingStrategy)
+}
+
+func TestProcessLine_FirstMatchWins(t *testing.T) {
+	patterns := []CompiledPattern{
+		{
+			Name:              "specific",
+			Re:                regexp.MustCompile(`mlx5_core.*timeout\. Will cause`),
+			IsFatal:           true,
+			RecommendedAction: pb.RecommendedAction_REPLACE_VM,
+		},
+		{
+			Name:              "general",
+			Re:                regexp.MustCompile(`mlx5_core`),
+			IsFatal:           false,
+			RecommendedAction: pb.RecommendedAction_NONE,
+		},
+	}
+
+	h := makeHandler(t, patterns, newMockResolver(nil))
+
+	events, err := h.ProcessLine(
+		"mlx5_core 0000:03:00.0: timeout. Will cause a leak of a command resource")
+	require.NoError(t, err)
+	require.NotNil(t, events)
+	assert.Equal(t, "specific", events.Events[0].ErrorCode[0])
+	assert.True(t, events.Events[0].IsFatal)
+}

--- a/health-monitors/syslog-health-monitor/pkg/nicdriver/handler_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/nicdriver/handler_test.go
@@ -31,6 +31,28 @@ func makeHandler(t *testing.T, patterns []CompiledPattern, resolver Resolver) *N
 		patterns, resolver, pb.ProcessingStrategy_EXECUTE_REMEDIATION)
 }
 
+type mockResolver struct {
+	results map[string]mockResult
+}
+
+type mockResult struct {
+	driver string
+	device string
+}
+
+func newMockResolver(results map[string]mockResult) Resolver {
+	return &mockResolver{results: results}
+}
+
+func (m *mockResolver) Resolve(bdf string) (string, string, bool) {
+	r, ok := m.results[bdf]
+	if !ok {
+		return "", "", false
+	}
+
+	return r.driver, r.device, true
+}
+
 var defaultTestPatterns = []CompiledPattern{
 	{
 		Name:              "cmd_exec_timeout",

--- a/health-monitors/syslog-health-monitor/pkg/nicdriver/metrics.go
+++ b/health-monitors/syslog-health-monitor/pkg/nicdriver/metrics.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nicdriver
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var nicDriverEventCounter = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "syslog_health_monitor_nic_driver_errors",
+		Help: "Total number of NIC driver/firmware errors detected from kernel logs",
+	},
+	[]string{"node", "event", "severity"},
+)
+
+// PreInitialize materializes zero-value counters for all loaded patterns so
+// backends that establish a baseline from the first ingested sample (e.g.
+// Google Managed Prometheus) do not drop the first real occurrence.
+func PreInitialize(nodeName string, patterns []CompiledPattern) {
+	for _, p := range patterns {
+		sev := "non_fatal"
+		if p.IsFatal {
+			sev = "fatal"
+		}
+
+		nicDriverEventCounter.WithLabelValues(nodeName, p.Name, sev).Add(0)
+	}
+}

--- a/health-monitors/syslog-health-monitor/pkg/nicdriver/pcilookup.go
+++ b/health-monitors/syslog-health-monitor/pkg/nicdriver/pcilookup.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nicdriver
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Resolver maps a PCI BDF address to its driver name and Linux NIC identifier.
+type Resolver interface {
+	// Resolve returns the driver name (e.g. "mlx5_core"), the InfiniBand
+	// device or net interface name (e.g. "mlx5_0" or "eth0"), and whether
+	// the lookup succeeded.
+	// A missing or broken driver symlink returns ok=false.
+	Resolve(bdf string) (driver string, device string, ok bool)
+}
+
+// NewSysfsResolver returns a Resolver backed by a real sysfs tree.
+// sysfsRoot is typically "/nvsentinel/sys" in containerized deployments.
+func NewSysfsResolver(sysfsRoot string) Resolver {
+	return &sysfsResolver{root: sysfsRoot}
+}
+
+type sysfsResolver struct {
+	root string
+}
+
+func (r *sysfsResolver) Resolve(bdf string) (string, string, bool) {
+	deviceDir := filepath.Join(r.root, "bus", "pci", "devices", bdf)
+
+	driverName, ok := readDriverName(filepath.Join(deviceDir, "driver"))
+	if !ok {
+		return "", "", false
+	}
+
+	device := resolveDeviceName(deviceDir)
+
+	return driverName, device, true
+}
+
+// readDriverName resolves the "driver" symlink and returns the basename
+// (e.g. "mlx5_core"). Returns ok=false if the symlink is missing or broken.
+func readDriverName(driverSymlink string) (string, bool) {
+	target, err := os.Readlink(driverSymlink)
+	if err != nil {
+		return "", false
+	}
+
+	return filepath.Base(target), true
+}
+
+// resolveDeviceName attempts to find the Linux NIC identifier for the BDF.
+// Precedence: infiniband/ dir → net/ dir → empty string.
+func resolveDeviceName(deviceDir string) string {
+	if name := firstEntry(filepath.Join(deviceDir, "infiniband")); name != "" {
+		return name
+	}
+
+	if name := firstEntry(filepath.Join(deviceDir, "net")); name != "" {
+		return name
+	}
+
+	return ""
+}
+
+func firstEntry(dir string) string {
+	entries, err := os.ReadDir(dir)
+	if err != nil || len(entries) == 0 {
+		return ""
+	}
+
+	return entries[0].Name()
+}
+
+// mockResolver is used by tests to supply deterministic results.
+type mockResolver struct {
+	results map[string]mockResult
+}
+
+type mockResult struct {
+	driver string
+	device string
+}
+
+func newMockResolver(results map[string]mockResult) Resolver {
+	return &mockResolver{results: results}
+}
+
+func (m *mockResolver) Resolve(bdf string) (string, string, bool) {
+	r, ok := m.results[bdf]
+	if !ok {
+		return "", "", false
+	}
+
+	return r.driver, r.device, true
+}

--- a/health-monitors/syslog-health-monitor/pkg/nicdriver/pcilookup.go
+++ b/health-monitors/syslog-health-monitor/pkg/nicdriver/pcilookup.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package nicdriver implements syslog-based detection of mlx5_core NIC
+// driver and firmware errors. It loads configurable TOML patterns, matches
+// them against kernel log lines, and emits structured HealthEvents with
+// optional NIC entity enrichment via sysfs BDF resolution.
 package nicdriver
 
 import (
@@ -83,27 +87,4 @@ func firstEntry(dir string) string {
 	}
 
 	return entries[0].Name()
-}
-
-// mockResolver is used by tests to supply deterministic results.
-type mockResolver struct {
-	results map[string]mockResult
-}
-
-type mockResult struct {
-	driver string
-	device string
-}
-
-func newMockResolver(results map[string]mockResult) Resolver {
-	return &mockResolver{results: results}
-}
-
-func (m *mockResolver) Resolve(bdf string) (string, string, bool) {
-	r, ok := m.results[bdf]
-	if !ok {
-		return "", "", false
-	}
-
-	return r.driver, r.device, true
 }

--- a/health-monitors/syslog-health-monitor/pkg/nicdriver/pcilookup_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/nicdriver/pcilookup_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nicdriver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupSysfs(t *testing.T, root, bdf, driver string, ibDevices, netDevices []string) {
+	t.Helper()
+
+	deviceDir := filepath.Join(root, "bus", "pci", "devices", bdf)
+	require.NoError(t, os.MkdirAll(deviceDir, 0755))
+
+	if driver != "" {
+		driverTarget := filepath.Join(root, "drivers", driver)
+		require.NoError(t, os.MkdirAll(driverTarget, 0755))
+		require.NoError(t, os.Symlink(driverTarget, filepath.Join(deviceDir, "driver")))
+	}
+
+	if len(ibDevices) > 0 {
+		ibDir := filepath.Join(deviceDir, "infiniband")
+		require.NoError(t, os.MkdirAll(ibDir, 0755))
+
+		for _, dev := range ibDevices {
+			require.NoError(t, os.MkdirAll(filepath.Join(ibDir, dev), 0755))
+		}
+	}
+
+	if len(netDevices) > 0 {
+		netDir := filepath.Join(deviceDir, "net")
+		require.NoError(t, os.MkdirAll(netDir, 0755))
+
+		for _, dev := range netDevices {
+			require.NoError(t, os.MkdirAll(filepath.Join(netDir, dev), 0755))
+		}
+	}
+}
+
+func TestSysfsResolver_Mlx5WithIB(t *testing.T) {
+	root := t.TempDir()
+	setupSysfs(t, root, "0000:3b:00.0", "mlx5_core", []string{"mlx5_0"}, nil)
+
+	r := NewSysfsResolver(root)
+	driver, device, ok := r.Resolve("0000:3b:00.0")
+
+	assert.True(t, ok)
+	assert.Equal(t, "mlx5_core", driver)
+	assert.Equal(t, "mlx5_0", device)
+}
+
+func TestSysfsResolver_Mlx5WithNet(t *testing.T) {
+	root := t.TempDir()
+	setupSysfs(t, root, "0000:3b:00.0", "mlx5_core", nil, []string{"eth0"})
+
+	r := NewSysfsResolver(root)
+	driver, device, ok := r.Resolve("0000:3b:00.0")
+
+	assert.True(t, ok)
+	assert.Equal(t, "mlx5_core", driver)
+	assert.Equal(t, "eth0", device)
+}
+
+func TestSysfsResolver_Mlx5WithBothPreferIB(t *testing.T) {
+	root := t.TempDir()
+	setupSysfs(t, root, "0000:3b:00.0", "mlx5_core", []string{"mlx5_2"}, []string{"ib0"})
+
+	r := NewSysfsResolver(root)
+	_, device, ok := r.Resolve("0000:3b:00.0")
+
+	assert.True(t, ok)
+	assert.Equal(t, "mlx5_2", device)
+}
+
+func TestSysfsResolver_NvidiaGPU(t *testing.T) {
+	root := t.TempDir()
+	setupSysfs(t, root, "0000:b3:00.0", "nvidia", nil, nil)
+
+	r := NewSysfsResolver(root)
+	driver, _, ok := r.Resolve("0000:b3:00.0")
+
+	assert.True(t, ok)
+	assert.Equal(t, "nvidia", driver)
+}
+
+func TestSysfsResolver_MissingDriverSymlink(t *testing.T) {
+	root := t.TempDir()
+	deviceDir := filepath.Join(root, "bus", "pci", "devices", "0000:00:00.0")
+	require.NoError(t, os.MkdirAll(deviceDir, 0755))
+
+	r := NewSysfsResolver(root)
+	_, _, ok := r.Resolve("0000:00:00.0")
+
+	assert.False(t, ok)
+}
+
+func TestSysfsResolver_NonExistentBDF(t *testing.T) {
+	root := t.TempDir()
+
+	r := NewSysfsResolver(root)
+	_, _, ok := r.Resolve("0000:ff:ff.f")
+
+	assert.False(t, ok)
+}
+
+func TestSysfsResolver_Mlx5NoSubdevices(t *testing.T) {
+	root := t.TempDir()
+	setupSysfs(t, root, "0000:3b:00.0", "mlx5_core", nil, nil)
+
+	r := NewSysfsResolver(root)
+	driver, device, ok := r.Resolve("0000:3b:00.0")
+
+	assert.True(t, ok)
+	assert.Equal(t, "mlx5_core", driver)
+	assert.Empty(t, device)
+}

--- a/health-monitors/syslog-health-monitor/pkg/nicdriver/types.go
+++ b/health-monitors/syslog-health-monitor/pkg/nicdriver/types.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nicdriver
+
+import (
+	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
+)
+
+const componentClassNIC = "NIC"
+
+// NICDriverHandler processes syslog lines for NIC driver/firmware error patterns.
+type NICDriverHandler struct {
+	nodeName           string
+	defaultAgentName   string
+	checkName          string
+	processingStrategy pb.ProcessingStrategy
+	patterns           []CompiledPattern
+	resolver           Resolver
+}

--- a/health-monitors/syslog-health-monitor/pkg/syslog-monitor/syslogmonitor.go
+++ b/health-monitors/syslog-health-monitor/pkg/syslog-monitor/syslogmonitor.go
@@ -33,6 +33,7 @@ import (
 
 	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	"github.com/nvidia/nvsentinel/health-monitors/syslog-health-monitor/pkg/gpufallen"
+	"github.com/nvidia/nvsentinel/health-monitors/syslog-health-monitor/pkg/nicdriver"
 	"github.com/nvidia/nvsentinel/health-monitors/syslog-health-monitor/pkg/sxid"
 	"github.com/nvidia/nvsentinel/health-monitors/syslog-health-monitor/pkg/types"
 	"github.com/nvidia/nvsentinel/health-monitors/syslog-health-monitor/pkg/xid"
@@ -50,11 +51,14 @@ func NewSyslogMonitor(
 	xidAnalyserEndpoint string,
 	metadataPath string,
 	processingStrategy pb.ProcessingStrategy,
+	nicDriverConfigPath string,
+	sysfsRoot string,
 ) (*SyslogMonitor, error) {
 	return NewSyslogMonitorWithFactory(nodeName, checks, pcClient, defaultAgentName,
 		defaultComponentClass, pollingInterval, stateFilePath, GetDefaultJournalFactory(),
 		xidAnalyserEndpoint, metadataPath,
 		processingStrategy,
+		nicDriverConfigPath, sysfsRoot,
 	)
 }
 
@@ -71,6 +75,8 @@ func NewSyslogMonitorWithFactory(
 	xidAnalyserEndpoint string,
 	metadataPath string,
 	processingStrategy pb.ProcessingStrategy,
+	nicDriverConfigPath string,
+	sysfsRoot string,
 ) (*SyslogMonitor, error) {
 	// Load state from file
 	state, err := loadState(stateFilePath)
@@ -103,7 +109,8 @@ func NewSyslogMonitorWithFactory(
 	}
 
 	if err := initHandlers(sm, checks, nodeName, defaultAgentName, defaultComponentClass,
-		xidAnalyserEndpoint, metadataPath, processingStrategy); err != nil {
+		xidAnalyserEndpoint, metadataPath, processingStrategy,
+		nicDriverConfigPath, sysfsRoot); err != nil {
 		return nil, err
 	}
 
@@ -127,10 +134,13 @@ func initHandlers(
 	xidAnalyserEndpoint string,
 	metadataPath string,
 	processingStrategy pb.ProcessingStrategy,
+	nicDriverConfigPath string,
+	sysfsRoot string,
 ) error {
 	for _, check := range checks {
 		handler, err := initHandlerForCheck(check, nodeName, defaultAgentName, defaultComponentClass,
-			xidAnalyserEndpoint, metadataPath, processingStrategy)
+			xidAnalyserEndpoint, metadataPath, processingStrategy,
+			nicDriverConfigPath, sysfsRoot)
 		if err != nil {
 			return err
 		}
@@ -155,6 +165,8 @@ func initHandlerForCheck(
 	xidAnalyserEndpoint string,
 	metadataPath string,
 	processingStrategy pb.ProcessingStrategy,
+	nicDriverConfigPath string,
+	sysfsRoot string,
 ) (types.Handler, error) {
 	switch check.Name {
 	case XIDErrorCheck:
@@ -181,6 +193,15 @@ func initHandlerForCheck(
 		if err != nil {
 			slog.Error("Error initializing GPU Fallen Off handler", "error", err.Error())
 			return nil, fmt.Errorf("failed to initialize GPU Fallen Off handler: %w", err)
+		}
+
+		return h, nil
+	case NICDriverErrorCheck:
+		h, err := nicdriver.NewNICDriverHandler(nodeName, defaultAgentName, check.Name,
+			nicDriverConfigPath, sysfsRoot, processingStrategy)
+		if err != nil {
+			slog.Error("Error initializing NIC Driver handler", "error", err.Error())
+			return nil, fmt.Errorf("failed to initialize NIC Driver handler: %w", err)
 		}
 
 		return h, nil

--- a/health-monitors/syslog-health-monitor/pkg/syslog-monitor/syslogmonitor_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/syslog-monitor/syslogmonitor_test.go
@@ -307,7 +307,7 @@ func TestNewSyslogMonitor(t *testing.T) {
 	filePath := testStateFile
 
 	monitor, err := NewSyslogMonitor(args.NodeName,
-		args.Checks, args.PcClient, args.DefaultAgentName, args.DefaultComponentClass, args.PollingInterval, filePath, "http://localhost:8080", "/tmp/metadata.json", pb.ProcessingStrategy_STORE_ONLY)
+		args.Checks, args.PcClient, args.DefaultAgentName, args.DefaultComponentClass, args.PollingInterval, filePath, "http://localhost:8080", "/tmp/metadata.json", pb.ProcessingStrategy_STORE_ONLY, "", "")
 	assert.NoError(t, err)
 	assert.NotNil(t, monitor)
 	assert.Equal(t, args.NodeName, monitor.nodeName)
@@ -327,7 +327,7 @@ func TestNewSyslogMonitor(t *testing.T) {
 
 	filePath = testStateFile2
 	monitor, err = NewSyslogMonitorWithFactory(args.NodeName,
-		args.Checks, args.PcClient, args.DefaultAgentName, args.DefaultComponentClass, args.PollingInterval, filePath, fakeJournalFactory, "http://localhost:8080", "/tmp/metadata.json", pb.ProcessingStrategy_EXECUTE_REMEDIATION)
+		args.Checks, args.PcClient, args.DefaultAgentName, args.DefaultComponentClass, args.PollingInterval, filePath, fakeJournalFactory, "http://localhost:8080", "/tmp/metadata.json", pb.ProcessingStrategy_EXECUTE_REMEDIATION, "", "")
 	assert.NoError(t, err)
 	assert.NotNil(t, monitor)
 	assert.Equal(t, fakeJournalFactory, monitor.journalFactory)
@@ -400,6 +400,7 @@ func TestJournalProcessingLogic(t *testing.T) {
 		"http://localhost:8080",
 		"/tmp/metadata.json",
 		pb.ProcessingStrategy_EXECUTE_REMEDIATION,
+		"", "",
 	)
 	assert.NoError(t, err)
 
@@ -503,6 +504,7 @@ func TestJournalStateManagement(t *testing.T) {
 		"http://localhost:8080",
 		"/tmp/metadata.json",
 		pb.ProcessingStrategy_EXECUTE_REMEDIATION,
+		"", "",
 	)
 	assert.NoError(t, err)
 
@@ -535,6 +537,7 @@ func TestJournalStateManagement(t *testing.T) {
 		"http://localhost:8080",
 		"/tmp/metadata.json",
 		pb.ProcessingStrategy_EXECUTE_REMEDIATION,
+		"", "",
 	)
 	assert.NoError(t, err)
 
@@ -583,6 +586,7 @@ func TestBootIDChangeHandling(t *testing.T) {
 		"http://localhost:8080",
 		"/tmp/metadata.json",
 		pb.ProcessingStrategy_EXECUTE_REMEDIATION,
+		"", "",
 	)
 	assert.NoError(t, err)
 
@@ -633,6 +637,7 @@ func TestRunMultipleChecks(t *testing.T) {
 		"http://localhost:8080",
 		"/tmp/metadata.json",
 		pb.ProcessingStrategy_EXECUTE_REMEDIATION,
+		"", "",
 	)
 	assert.NoError(t, err)
 
@@ -674,6 +679,7 @@ func TestGPUFallenOffHandlerInitialization(t *testing.T) {
 		"http://localhost:8080",
 		"/tmp/metadata.json",
 		pb.ProcessingStrategy_EXECUTE_REMEDIATION,
+		"", "",
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, sm.checkToHandlerMap[GPUFallenOffCheck], "GPU Fallen Off handler should be initialized")

--- a/health-monitors/syslog-health-monitor/pkg/syslog-monitor/types.go
+++ b/health-monitors/syslog-health-monitor/pkg/syslog-monitor/types.go
@@ -31,9 +31,10 @@ const (
 	FieldSyslogFacility = "SYSLOG_FACILITY"
 	FieldSystemdUnit    = "_SYSTEMD_UNIT"
 
-	XIDErrorCheck     = "SysLogsXIDError"
-	SXIDErrorCheck    = "SysLogsSXIDError"
-	GPUFallenOffCheck = "SysLogsGPUFallenOff"
+	XIDErrorCheck       = "SysLogsXIDError"
+	SXIDErrorCheck      = "SysLogsSXIDError"
+	GPUFallenOffCheck   = "SysLogsGPUFallenOff"
+	NICDriverErrorCheck = "SysLogsNICDriverError"
 )
 
 // syslogMonitorState represents the persistent state of the syslog monitor


### PR DESCRIPTION
## Summary

Adds a new `SysLogsNICDriverError` check to the syslog-health-monitor that detects mlx5_core NIC driver/firmware errors from kernel logs. Patterns are operator-configurable via a TOML ConfigMap. Ships 8 defaults (3 Fatal, 5 Non-Fatal) verified against upstream Linux kernel source. Refrr to design doc here: [Design](https://github.com/KaivalyaMDabhadkar/NVSentinel/blob/642-nic-monitor-design/docs/nic-health-monitor/syslog-detection-correlation.md)

### Tests

- 28 unit tests in `pkg/nicdriver/`
- Existing syslog-monitor tests pass with no regressions
- Tilt/e2e tests to follow in a separate MR

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NIC driver syslog error detection using configurable TOML patterns; events can include resolved NIC entity details when available
  * Chart/DaemonSet support to supply NIC-driver pattern config and enable the NIC-driver check
  * Prometheus metrics for NIC driver error events

* **Documentation**
  * Updated severity model and expanded NIC syslog detection and correlation guidance

* **Tests**
  * Added unit tests for pattern loading, BDF extraction, resolver logic, and event generation

* **Chores**
  * Added TOML parsing dependency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->