### PR TITLE
fix: fault remediation cold start behaviour

### DIFF
--- a/fault-remediation/pkg/crstatus/checker.go
+++ b/fault-remediation/pkg/crstatus/checker.go
@@ -31,6 +31,15 @@ type CRStatusChecker struct {
 	dryRun             bool
 }
 
+type CRState string
+
+const (
+	CRStateNotFound   CRState = "NotFound"
+	CRStateInProgress CRState = "InProgress"
+	CRStateSucceeded  CRState = "Succeeded"
+	CRStateFailed     CRState = "Failed"
+)
+
 func NewCRStatusChecker(
 	client client.Client,
 	remediationActions map[string]config.MaintenanceResource,
@@ -43,17 +52,22 @@ func NewCRStatusChecker(
 	}
 }
 
-// ShouldSkipCRCreation returns true if the CR exists and is not in a terminal state otherwise returns false.
+// ShouldSkipCRCreation returns true if an existing CR should suppress creation of a new CR.
 func (c *CRStatusChecker) ShouldSkipCRCreation(ctx context.Context, actionName string, crName string) bool {
+	state := c.GetCRState(ctx, actionName, crName)
+	return state == CRStateInProgress || state == CRStateSucceeded
+}
+
+func (c *CRStatusChecker) GetCRState(ctx context.Context, actionName string, crName string) CRState {
 	resource, exists := c.remediationActions[actionName]
 	if !exists {
 		slog.ErrorContext(ctx, "No remediation configuration found for action", "action", actionName)
-		return false
+		return CRStateNotFound
 	}
 
 	if c.dryRun {
 		slog.InfoContext(ctx, "DRY-RUN: CR doesn't exist (dry-run mode)", "crName", crName, "action", actionName)
-		return false
+		return CRStateNotFound
 	}
 
 	gvk := schema.GroupVersionKind{
@@ -69,26 +83,33 @@ func (c *CRStatusChecker) ShouldSkipCRCreation(ctx context.Context, actionName s
 
 	if err := c.client.Get(ctx, key, obj); err != nil {
 		slog.WarnContext(ctx, "Failed to get CR, allowing create", "crName", crName, "gvk", gvk.String(), "error", err)
-		return false
+		return CRStateNotFound
 	}
 
 	return c.checkCondition(obj, resource)
 }
 
-func (c *CRStatusChecker) checkCondition(obj *unstructured.Unstructured, resource config.MaintenanceResource) bool {
+func (c *CRStatusChecker) checkCondition(obj *unstructured.Unstructured, resource config.MaintenanceResource) CRState {
 	status, found, err := unstructured.NestedMap(obj.Object, "status")
 	if err != nil || !found {
-		return true
+		return CRStateInProgress
 	}
 
 	conditions, found, err := unstructured.NestedSlice(status, "conditions")
 	if err != nil || !found {
-		return true
+		return CRStateInProgress
 	}
 
 	conditionStatus := c.findConditionStatus(conditions, resource.CompleteConditionType)
 
-	return !c.isTerminal(conditionStatus)
+	switch conditionStatus {
+	case "True":
+		return CRStateSucceeded
+	case "False":
+		return CRStateFailed
+	default:
+		return CRStateInProgress
+	}
 }
 
 func (c *CRStatusChecker) findConditionStatus(conditions []any, completeConditionType string) string {
@@ -106,8 +127,4 @@ func (c *CRStatusChecker) findConditionStatus(conditions []any, completeConditio
 	}
 
 	return ""
-}
-
-func (c *CRStatusChecker) isTerminal(conditionStatus string) bool {
-	return conditionStatus == "True" || conditionStatus == "False"
 }

--- a/fault-remediation/pkg/crstatus/crstatus_interface.go
+++ b/fault-remediation/pkg/crstatus/crstatus_interface.go
@@ -22,4 +22,5 @@ import (
 
 type CRStatusCheckerInterface interface {
 	ShouldSkipCRCreation(context.Context, string, string) bool
+	GetCRState(context.Context, string, string) CRState
 }

--- a/fault-remediation/pkg/crstatus/crstatus_test.go
+++ b/fault-remediation/pkg/crstatus/crstatus_test.go
@@ -36,7 +36,7 @@ func TestCheckCondition(t *testing.T) {
 	tests := []struct {
 		name     string
 		cr       *unstructured.Unstructured
-		expected bool
+		expected CRState
 	}{
 		{
 			name: "no status returns skip - in progress",
@@ -45,7 +45,7 @@ func TestCheckCondition(t *testing.T) {
 					"metadata": map[string]any{"name": "test-cr"},
 				},
 			},
-			expected: true,
+			expected: CRStateInProgress,
 		},
 		{
 			name: "condition true returns allow create - success",
@@ -61,7 +61,7 @@ func TestCheckCondition(t *testing.T) {
 					},
 				},
 			},
-			expected: false,
+			expected: CRStateSucceeded,
 		},
 		{
 			name: "condition false returns allow create - failed",
@@ -77,7 +77,7 @@ func TestCheckCondition(t *testing.T) {
 					},
 				},
 			},
-			expected: false,
+			expected: CRStateFailed,
 		},
 		{
 			name: "condition unknown returns skip - in progress",
@@ -93,7 +93,7 @@ func TestCheckCondition(t *testing.T) {
 					},
 				},
 			},
-			expected: true,
+			expected: CRStateInProgress,
 		},
 		{
 			name: "condition not found returns skip - in progress",
@@ -109,7 +109,7 @@ func TestCheckCondition(t *testing.T) {
 					},
 				},
 			},
-			expected: true,
+			expected: CRStateInProgress,
 		},
 	}
 

--- a/fault-remediation/pkg/reconciler/reconciler.go
+++ b/fault-remediation/pkg/reconciler/reconciler.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -40,6 +41,7 @@ import (
 	"github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	"github.com/nvidia/nvsentinel/fault-remediation/pkg/annotation"
 	"github.com/nvidia/nvsentinel/fault-remediation/pkg/common"
+	"github.com/nvidia/nvsentinel/fault-remediation/pkg/crstatus"
 	"github.com/nvidia/nvsentinel/fault-remediation/pkg/events"
 	"github.com/nvidia/nvsentinel/fault-remediation/pkg/metrics"
 	"github.com/nvidia/nvsentinel/fault-remediation/pkg/remediation"
@@ -50,7 +52,9 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const coldStartBatchSize = 1000
+const (
+	coldStartBatchSize = 1000
+)
 
 type ReconcilerConfig struct {
 	DataStoreConfig    datastore.DataStoreConfig
@@ -454,7 +458,8 @@ func (r *FaultRemediationReconciler) handleRemediationEvent(
 		return res, err
 	}
 
-	shouldCreateCR, existingCR, err := r.checkExistingCRStatus(ctx, healthEvent, groupConfig)
+	shouldCreateCR, existingCR, existingCRRemediated, err := r.checkExistingCRStatus(ctx, healthEvent,
+		healthEventWithStatus.CreatedAt, groupConfig)
 	if err != nil {
 		metrics.ProcessingErrors.WithLabelValues("cr_status_check_error", nodeName).Inc()
 		slog.ErrorContext(ctx, "Error checking existing CR status", "node", nodeName, "error", err)
@@ -469,7 +474,8 @@ func (r *FaultRemediationReconciler) handleRemediationEvent(
 	}
 
 	if !shouldCreateCR {
-		return r.handleExistingCRSkip(ctx, eventWithToken, watcherInstance, nodeName, existingCR)
+		return r.handleExistingCRSkip(ctx, eventWithToken, watcherInstance, healthEventStore, nodeName, existingCR,
+			existingCRRemediated)
 	}
 
 	result, err := r.runLogCollectorAndRemediate(ctx, healthEvent, healthEventWithStatus, eventWithToken,
@@ -682,7 +688,9 @@ func (r *FaultRemediationReconciler) handleExistingCRSkip(
 	ctx context.Context,
 	eventWithToken datastore.EventWithToken,
 	watcherInstance datastore.ChangeStreamWatcher,
+	healthEventStore datastore.HealthEventStore,
 	nodeName, existingCR string,
+	existingCRRemediated bool,
 ) (ctrl.Result, error) {
 	span := tracing.SpanFromContext(ctx)
 	slog.InfoContext(ctx, "Skipping event for node due to existing CR",
@@ -695,6 +703,12 @@ func (r *FaultRemediationReconciler) handleExistingCRSkip(
 	)
 
 	metrics.EventsProcessed.WithLabelValues(metrics.CRStatusSkipped, nodeName).Inc()
+
+	if existingCRRemediated {
+		if err := r.updateNodeRemediatedStatus(ctx, healthEventStore, eventWithToken, true); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
 
 	if err := safeMarkProcessed(ctx, watcherInstance, eventWithToken.ResumeToken, nodeName); err != nil {
 		return ctrl.Result{}, err
@@ -863,57 +877,102 @@ func (r *FaultRemediationReconciler) updateNodeRemediatedStatus(
 }
 
 func (r *FaultRemediationReconciler) checkExistingCRStatus(ctx context.Context, healthEvent *protos.HealthEvent,
-	groupConfig *common.EquivalenceGroupConfig) (bool, string, error) {
+	eventCreatedAt time.Time, groupConfig *common.EquivalenceGroupConfig) (bool, string, bool, error) {
 	nodeName := healthEvent.NodeName
 
 	if groupConfig == nil {
-		return true, "", nil
+		return true, "", false, nil
 	}
 
 	state, _, err := r.annotationManager.GetRemediationState(ctx, nodeName)
 	if err != nil {
 		slog.ErrorContext(ctx, "Error getting remediation state", "node", nodeName, "error", err)
-		return true, "", fmt.Errorf("error getting remediation state: %w", err)
+		return true, "", false, fmt.Errorf("error getting remediation state: %w", err)
 	}
 
 	if state == nil {
 		slog.WarnContext(ctx, "Remediation state is nil for node, allowing CR creation",
 			"node", nodeName)
 
-		return true, "", nil
+		return true, "", false, nil
 	}
 
 	statusChecker := r.Config.RemediationClient.GetStatusChecker()
 	if statusChecker == nil {
 		slog.WarnContext(ctx, "Status checker is not available, allowing creation")
-		return true, "", nil
+		return true, "", false, nil
 	}
 
-	groupStates := common.FilterEquivalenceGroupStates(groupConfig, state)
+	groupStates := sortedEquivalenceGroupStates(common.FilterEquivalenceGroupStates(groupConfig, state))
 
 	var groupsToRemove []string
 
-	for groupName, groupState := range groupStates {
-		shouldSkip := statusChecker.ShouldSkipCRCreation(ctx, groupState.ActionName, groupState.MaintenanceCR)
-		if shouldSkip {
+	for _, groupState := range groupStates {
+		crState := statusChecker.GetCRState(ctx, groupState.state.ActionName, groupState.state.MaintenanceCR)
+		if crState == crstatus.CRStateInProgress {
 			slog.InfoContext(ctx, "CR exists and is in progress, skipping event",
-				"node", nodeName, "crName", groupState.MaintenanceCR)
+				"node", nodeName, "crName", groupState.state.MaintenanceCR)
 
-			return false, groupState.MaintenanceCR, nil
+			return false, groupState.state.MaintenanceCR, false, nil
 		}
 
-		slog.InfoContext(ctx, "CR completed or failed, allowing retry", "node", nodeName, "crName", groupState.MaintenanceCR)
+		if crState == crstatus.CRStateSucceeded {
+			if eventCoveredByRemediationSession(eventCreatedAt, groupState.state.CreatedAt) {
+				slog.InfoContext(ctx, "CR completed successfully, marking same-session equivalent event remediated",
+					"node", nodeName, "crName", groupState.state.MaintenanceCR)
 
-		groupsToRemove = append(groupsToRemove, groupName)
+				return false, groupState.state.MaintenanceCR, true, nil
+			}
+
+			slog.InfoContext(ctx, "CR completed successfully but event is outside remediation session, allowing new CR",
+				"node", nodeName, "crName", groupState.state.MaintenanceCR)
+
+			groupsToRemove = append(groupsToRemove, groupState.name)
+
+			continue
+		}
+
+		slog.InfoContext(ctx, "CR completed or failed, allowing retry", "node", nodeName, "crName",
+			groupState.state.MaintenanceCR)
+
+		groupsToRemove = append(groupsToRemove, groupState.name)
 	}
 
 	if len(groupsToRemove) > 0 {
 		if err := r.annotationManager.RemoveGroupsFromState(ctx, nodeName, groupsToRemove); err != nil {
-			return true, "", fmt.Errorf("failed to remove groups from annotation: %w", err)
+			return true, "", false, fmt.Errorf("failed to remove groups from annotation: %w", err)
 		}
 	}
 
-	return true, "", nil
+	return true, "", false, nil
+}
+
+func eventCoveredByRemediationSession(eventCreatedAt, remediationCreatedAt time.Time) bool {
+	if eventCreatedAt.IsZero() || remediationCreatedAt.IsZero() {
+		return false
+	}
+
+	return !eventCreatedAt.After(remediationCreatedAt)
+}
+
+type namedEquivalenceGroupState struct {
+	name  string
+	state annotation.EquivalenceGroupState
+}
+
+func sortedEquivalenceGroupStates(
+	groupStates map[string]annotation.EquivalenceGroupState,
+) []namedEquivalenceGroupState {
+	sortedStates := make([]namedEquivalenceGroupState, 0, len(groupStates))
+	for groupName, groupState := range groupStates {
+		sortedStates = append(sortedStates, namedEquivalenceGroupState{name: groupName, state: groupState})
+	}
+
+	sort.Slice(sortedStates, func(i, j int) bool {
+		return sortedStates[i].state.CreatedAt.After(sortedStates[j].state.CreatedAt)
+	})
+
+	return sortedStates
 }
 
 // parseHealthEvent extracts and parses health event from change stream event

--- a/fault-remediation/pkg/reconciler/reconciler.go
+++ b/fault-remediation/pkg/reconciler/reconciler.go
@@ -151,7 +151,8 @@ func (r *FaultRemediationReconciler) Reconcile(
 	nodeQuarantined := healthEventWithStatus.HealthEventStatus.NodeQuarantined
 
 	if nodeQuarantined == string(model.UnQuarantined) || nodeQuarantined == string(model.Cancelled) {
-		return r.handleCancellationEvent(ctx, nodeName, model.Status(nodeQuarantined), r.Watcher, event.ResumeToken)
+		return r.handleCancellationEvent(ctx, nodeName, model.Status(nodeQuarantined), r.Watcher, event.ResumeToken,
+			r.healthEventStore)
 	}
 
 	return r.handleRemediationEvent(ctx, &healthEventWithStatus, *event, r.Watcher, r.healthEventStore)
@@ -373,6 +374,7 @@ func (r *FaultRemediationReconciler) handleCancellationEvent(
 	status model.Status,
 	watcherInstance datastore.ChangeStreamWatcher,
 	resumeToken []byte,
+	healthEventStore datastore.HealthEventStore,
 ) (ctrl.Result, error) {
 	ctx, span := tracing.StartSpan(ctx, "fault_remediation.cancellation_event")
 	defer span.End()
@@ -380,6 +382,24 @@ func (r *FaultRemediationReconciler) handleCancellationEvent(
 	slog.InfoContext(ctx, "Cancellation event received, clearing all remediation state",
 		"node", nodeName,
 		"status", status)
+
+	remediationState, _, err := r.annotationManager.GetRemediationState(ctx, nodeName)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to get remediation state for node",
+			"node", nodeName,
+			"error", err)
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("fault_remediation.error.type", "get_remediation_state_error"),
+			attribute.String("fault_remediation.error.message", err.Error()),
+		)
+
+		return ctrl.Result{}, fmt.Errorf("failed to get remediation state for node: %w", err)
+	}
+
+	if err := r.closeStaleEquivalentEvents(ctx, nodeName, status, remediationState, healthEventStore); err != nil {
+		return ctrl.Result{}, err
+	}
 
 	if err := r.annotationManager.ClearRemediationState(ctx, nodeName); err != nil {
 		slog.ErrorContext(ctx, "Failed to clear remediation state for node",
@@ -424,7 +444,8 @@ func (r *FaultRemediationReconciler) handleRemediationEvent(
 			"error", err, "event", healthEventWithStatus.ID)
 	}
 
-	res, err, done := r.trySkipEvent(ctx, healthEventWithStatus, groupConfig, eventWithToken, watcherInstance, nodeName)
+	res, err, done := r.trySkipEvent(ctx, healthEventWithStatus, groupConfig, eventWithToken, watcherInstance,
+		healthEventStore, nodeName)
 	if done {
 		span.SetAttributes(
 			attribute.String("fault_remediation.status", "skipped"),
@@ -473,6 +494,7 @@ func (r *FaultRemediationReconciler) trySkipEvent(
 	groupConfig *common.EquivalenceGroupConfig,
 	eventWithToken datastore.EventWithToken,
 	watcherInstance datastore.ChangeStreamWatcher,
+	healthEventStore datastore.HealthEventStore,
 	nodeName string,
 ) (ctrl.Result, error, bool) {
 	if !r.shouldSkipEvent(ctx, healthEventWithStatus.HealthEventWithStatus, groupConfig) {
@@ -482,11 +504,177 @@ func (r *FaultRemediationReconciler) trySkipEvent(
 	ctx, skipSpan := tracing.StartSpan(ctx, "fault_remediation.skip_event")
 	defer skipSpan.End()
 
+	if shouldMarkSkippedEventUnsupported(healthEventWithStatus.HealthEventWithStatus, groupConfig) {
+		if err := r.updateNodeRemediatedStatus(ctx, healthEventStore, eventWithToken, false); err != nil {
+			return ctrl.Result{}, err, true
+		}
+	}
+
 	if err := safeMarkProcessed(ctx, watcherInstance, eventWithToken.ResumeToken, nodeName); err != nil {
 		return ctrl.Result{}, err, true
 	}
 
 	return ctrl.Result{}, nil, true
+}
+
+func shouldMarkSkippedEventUnsupported(healthEventWithStatus model.HealthEventWithStatus,
+	groupConfig *common.EquivalenceGroupConfig) bool {
+	if healthEventWithStatus.HealthEvent == nil || groupConfig != nil {
+		return false
+	}
+
+	if healthEventWithStatus.HealthEvent.RecommendedAction == protos.RecommendedAction_NONE {
+		return false
+	}
+
+	if healthEventWithStatus.HealthEventStatus != nil && healthEventWithStatus.HealthEventStatus.FaultRemediated != nil &&
+		healthEventWithStatus.HealthEventStatus.FaultRemediated.GetValue() {
+		return false
+	}
+
+	return true
+}
+
+// closeStaleEquivalentEvents closes unresolved remediation-ready events that were
+// covered by the remediation groups recorded on the node annotation.
+//
+// This runs when FQ sends UnQuarantined/Cancelled. At that point the quarantine
+// session is over, so events skipped behind an equivalent in-progress CR must
+// become durable terminal records; otherwise FR cold start can replay them and
+// create duplicate maintenance CRs after the node is schedulable again.
+//
+// The cleanup is equivalence-group scoped. It only closes events whose computed
+// remediation group, or a configured superseding group, matches a group from the
+// remediation annotation snapshot.
+func (r *FaultRemediationReconciler) closeStaleEquivalentEvents(
+	ctx context.Context,
+	nodeName string,
+	status model.Status,
+	remediationState *annotation.RemediationStateAnnotation,
+	healthEventStore datastore.HealthEventStore,
+) error {
+	if healthEventStore == nil || remediationState == nil || len(remediationState.EquivalenceGroups) == 0 {
+		return nil
+	}
+
+	coveredGroups := make(map[string]struct{}, len(remediationState.EquivalenceGroups))
+	for groupName := range remediationState.EquivalenceGroups {
+		coveredGroups[groupName] = struct{}{}
+	}
+
+	remediated := status == model.UnQuarantined
+	q := unresolvedRemediationReadyEventsQuery(nodeName)
+
+	now := time.Now().UTC()
+
+	closeBatch := func(batch []datastore.HealthEventWithStatus) error {
+		return r.closeStaleEquivalentEventBatch(ctx, healthEventStore, nodeName, coveredGroups, remediated, now, batch)
+	}
+
+	return healthEventStore.FindHealthEventsByQueryBatched(ctx, q, coldStartBatchSize, closeBatch)
+}
+
+// closeStaleEquivalentEventBatch evaluates one datastore batch from
+// closeStaleEquivalentEvents and writes the terminal remediation status for
+// matching events.
+func (r *FaultRemediationReconciler) closeStaleEquivalentEventBatch(
+	ctx context.Context,
+	healthEventStore datastore.HealthEventStore,
+	nodeName string,
+	coveredGroups map[string]struct{},
+	remediated bool,
+	now time.Time,
+	batch []datastore.HealthEventWithStatus,
+) error {
+	for _, event := range batch {
+		parsedEvent, err := eventutil.ParseHealthEventFromEvent(event.RawEvent)
+		if err != nil {
+			slog.WarnContext(ctx, "Skipping stale event cleanup for unparsable health event",
+				"node", nodeName,
+				"error", err)
+
+			continue
+		}
+
+		groupConfig, err := common.GetGroupConfigForEvent(
+			r.Config.RemediationClient.GetConfig().RemediationActions,
+			parsedEvent.HealthEvent,
+		)
+		if err != nil || groupConfig == nil || !groupConfigMatchesAny(groupConfig, coveredGroups) {
+			continue
+		}
+
+		documentID, err := utils.ExtractDocumentID(event.RawEvent)
+		if err != nil {
+			slog.WarnContext(ctx, "Skipping stale event cleanup for health event without document ID",
+				"node", nodeName,
+				"error", err)
+
+			continue
+		}
+
+		statusUpdate := datastore.HealthEventStatus{
+			FaultRemediated: &remediated,
+		}
+		if remediated {
+			statusUpdate.LastRemediationTimestamp = timestamppb.New(now)
+		}
+
+		if err := healthEventStore.UpdateHealthEventStatus(ctx, documentID, statusUpdate); err != nil {
+			return fmt.Errorf("failed to close stale equivalent event %s for node %s: %w",
+				documentID, nodeName, err)
+		}
+
+		slog.InfoContext(ctx, "Closed stale equivalent remediation event",
+			"node", nodeName,
+			"eventID", documentID,
+			"remediated", remediated)
+	}
+
+	return nil
+}
+
+// groupConfigMatchesAny reports whether the event's effective remediation group
+// is covered by one of the groups already remediated for this quarantine session.
+// Superseding groups count as coverage; for example, a node restart can cover a
+// GPU reset event when reset declares restart as a superseding equivalence group.
+func groupConfigMatchesAny(groupConfig *common.EquivalenceGroupConfig, groups map[string]struct{}) bool {
+	if _, ok := groups[groupConfig.EffectiveEquivalenceGroup]; ok {
+		return true
+	}
+
+	for _, groupName := range groupConfig.SupersedingEquivalenceGroups {
+		if _, ok := groups[groupName]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// unresolvedRemediationReadyEventsQuery returns the cold-start-style query for
+// events that are drained/quarantined and still lack a fault-remediation terminal
+// status. When nodeName is non-empty, it scopes the query to that node.
+func unresolvedRemediationReadyEventsQuery(nodeName string) datastore.QueryBuilder {
+	return query.New().Build(unresolvedRemediationReadyEventsCondition(nodeName))
+}
+
+// unresolvedRemediationReadyEventsCondition is the reusable condition form of
+// unresolvedRemediationReadyEventsQuery, used when composing larger queries.
+func unresolvedRemediationReadyEventsCondition(nodeName string) query.Condition {
+	conditions := []query.Condition{
+		query.In("healtheventstatus.nodequarantined",
+			[]interface{}{string(model.Quarantined), string(model.AlreadyQuarantined)}),
+		query.In("healtheventstatus.userpodsevictionstatus.status",
+			[]interface{}{string(model.StatusSucceeded), string(model.AlreadyDrained)}),
+		query.Eq("healtheventstatus.faultremediated", nil),
+	}
+
+	if nodeName != "" {
+		conditions = append([]query.Condition{query.Eq("healthevent.nodename", nodeName)}, conditions...)
+	}
+
+	return query.And(conditions...)
 }
 
 // handleExistingCRSkip logs, records metrics, marks the event processed, and returns.
@@ -844,13 +1032,7 @@ func (r *FaultRemediationReconciler) HandleColdStart(ctx context.Context) {
 	q := query.New().Build(
 		query.Or(
 			// Quarantined + drained but not yet remediated
-			query.And(
-				query.In("healtheventstatus.nodequarantined",
-					[]interface{}{string(model.Quarantined), string(model.AlreadyQuarantined)}),
-				query.In("healtheventstatus.userpodsevictionstatus.status",
-					[]interface{}{string(model.StatusSucceeded), string(model.AlreadyDrained)}),
-				query.Eq("healtheventstatus.faultremediated", nil),
-			),
+			unresolvedRemediationReadyEventsCondition(""),
 			// Cancelled/unquarantined events (need cleanup)
 			query.In("healtheventstatus.nodequarantined",
 				[]interface{}{string(model.UnQuarantined), string(model.Cancelled)}),

--- a/fault-remediation/pkg/reconciler/reconciler.go
+++ b/fault-remediation/pkg/reconciler/reconciler.go
@@ -908,34 +908,15 @@ func (r *FaultRemediationReconciler) checkExistingCRStatus(ctx context.Context, 
 	var groupsToRemove []string
 
 	for _, groupState := range groupStates {
-		crState := statusChecker.GetCRState(ctx, groupState.state.ActionName, groupState.state.MaintenanceCR)
-		if crState == crstatus.CRStateInProgress {
-			slog.InfoContext(ctx, "CR exists and is in progress, skipping event",
-				"node", nodeName, "crName", groupState.state.MaintenanceCR)
-
-			return false, groupState.state.MaintenanceCR, false, nil
+		decision := r.evaluateExistingCR(ctx, statusChecker, groupState, eventCreatedAt, nodeName)
+		if !decision.shouldCreate {
+			return false, decision.crName, decision.remediated, nil
 		}
 
-		if crState == crstatus.CRStateSucceeded {
-			if eventCoveredByRemediationSession(eventCreatedAt, groupState.state.CreatedAt) {
-				slog.InfoContext(ctx, "CR completed successfully, marking same-session equivalent event remediated",
-					"node", nodeName, "crName", groupState.state.MaintenanceCR)
-
-				return false, groupState.state.MaintenanceCR, true, nil
-			}
-
-			slog.InfoContext(ctx, "CR completed successfully but event is outside remediation session, allowing new CR",
-				"node", nodeName, "crName", groupState.state.MaintenanceCR)
-
+		if decision.removeGroup {
 			groupsToRemove = append(groupsToRemove, groupState.name)
-
 			continue
 		}
-
-		slog.InfoContext(ctx, "CR completed or failed, allowing retry", "node", nodeName, "crName",
-			groupState.state.MaintenanceCR)
-
-		groupsToRemove = append(groupsToRemove, groupState.name)
 	}
 
 	if len(groupsToRemove) > 0 {
@@ -945,6 +926,61 @@ func (r *FaultRemediationReconciler) checkExistingCRStatus(ctx context.Context, 
 	}
 
 	return true, "", false, nil
+}
+
+type existingCRDecision struct {
+	shouldCreate bool
+	crName       string
+	remediated   bool
+	removeGroup  bool
+}
+
+func (r *FaultRemediationReconciler) evaluateExistingCR(
+	ctx context.Context,
+	statusChecker crstatus.CRStatusCheckerInterface,
+	groupState namedEquivalenceGroupState,
+	eventCreatedAt time.Time,
+	nodeName string,
+) existingCRDecision {
+	crName := groupState.state.MaintenanceCR
+	crState := statusChecker.GetCRState(ctx, groupState.state.ActionName, crName)
+
+	switch crState {
+	case crstatus.CRStateInProgress:
+		slog.InfoContext(ctx, "CR exists and is in progress, skipping event", "node", nodeName, "crName", crName)
+
+		return existingCRDecision{shouldCreate: false, crName: crName}
+	case crstatus.CRStateSucceeded:
+		return r.evaluateSucceededCR(ctx, groupState, eventCreatedAt, nodeName)
+	case crstatus.CRStateNotFound, crstatus.CRStateFailed:
+		slog.InfoContext(ctx, "CR completed or failed, allowing retry", "node", nodeName, "crName", crName)
+
+		return existingCRDecision{shouldCreate: true, removeGroup: true}
+	default:
+		slog.WarnContext(ctx, "Unknown CR state, allowing retry", "node", nodeName, "crName", crName, "state", crState)
+
+		return existingCRDecision{shouldCreate: true, removeGroup: true}
+	}
+}
+
+func (r *FaultRemediationReconciler) evaluateSucceededCR(
+	ctx context.Context,
+	groupState namedEquivalenceGroupState,
+	eventCreatedAt time.Time,
+	nodeName string,
+) existingCRDecision {
+	crName := groupState.state.MaintenanceCR
+	if eventCoveredByRemediationSession(eventCreatedAt, groupState.state.CreatedAt) {
+		slog.InfoContext(ctx, "CR completed successfully, marking same-session equivalent event remediated",
+			"node", nodeName, "crName", crName)
+
+		return existingCRDecision{shouldCreate: false, crName: crName, remediated: true}
+	}
+
+	slog.InfoContext(ctx, "CR completed successfully but event is outside remediation session, allowing new CR",
+		"node", nodeName, "crName", crName)
+
+	return existingCRDecision{shouldCreate: true, removeGroup: true}
 }
 
 func eventCoveredByRemediationSession(eventCreatedAt, remediationCreatedAt time.Time) bool {

--- a/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
@@ -153,11 +153,11 @@ func (m *MockChangeStreamWatcher) GetCallCounts() (int, int, int, int) {
 
 // MockHealthEventStore provides a mock implementation of datastore.HealthEventStore for testing
 type MockHealthEventStore struct {
-	UpdateHealthEventStatusFn          func(ctx context.Context, id string, status datastore.HealthEventStatus) error
-	FindHealthEventsByQueryFn          func(ctx context.Context, builder datastore.QueryBuilder) ([]datastore.HealthEventWithStatus, error)
-	FindHealthEventsByQueryBatchedFn   func(ctx context.Context, builder datastore.QueryBuilder, batchSize int, fn func([]datastore.HealthEventWithStatus) error) error
-	updateCalled                       int
-	findHealthEventsByQueryCalls       int
+	UpdateHealthEventStatusFn        func(ctx context.Context, id string, status datastore.HealthEventStatus) error
+	FindHealthEventsByQueryFn        func(ctx context.Context, builder datastore.QueryBuilder) ([]datastore.HealthEventWithStatus, error)
+	FindHealthEventsByQueryBatchedFn func(ctx context.Context, builder datastore.QueryBuilder, batchSize int, fn func([]datastore.HealthEventWithStatus) error) error
+	updateCalled                     int
+	findHealthEventsByQueryCalls     int
 }
 
 // UpdateHealthEventStatus updates a health event status (mock implementation)
@@ -497,7 +497,7 @@ func TestCRBasedDeduplication_Integration(t *testing.T) {
 		updateRebootNodeStatus(ctx, t, firstCRName, "InProgress")
 
 		// Event 2: Should be skipped
-		shouldCreateCR, existingCR, err := r.checkExistingCRStatus(ctx, event1.HealthEventWithStatus.HealthEvent, groupConfig)
+		shouldCreateCR, existingCR, _, err := r.checkExistingCRStatus(ctx, event1.HealthEventWithStatus.HealthEvent, time.Now(), groupConfig)
 		assert.NoError(t, err)
 		assert.False(t, shouldCreateCR, "Second event should be skipped")
 		assert.Equal(t, firstCRName, existingCR)
@@ -558,7 +558,7 @@ func TestCRBasedDeduplication_Integration(t *testing.T) {
 		updateRebootNodeStatus(ctx, t, firstCRName, "Failed")
 
 		// Event 2: Should create new CR after cleanup
-		shouldCreateCR, _, err := r.checkExistingCRStatus(ctx, event1.HealthEventWithStatus.HealthEvent, groupConfig)
+		shouldCreateCR, _, _, err := r.checkExistingCRStatus(ctx, event1.HealthEventWithStatus.HealthEvent, time.Now(), groupConfig)
 		assert.NoError(t, err)
 		assert.True(t, shouldCreateCR, "Should allow retry after CR failed")
 
@@ -662,7 +662,7 @@ func TestCRBasedDeduplication_Integration(t *testing.T) {
 			event2Health)
 		assert.NoError(t, err)
 
-		shouldCreateCR, existingCR, err := r.checkExistingCRStatus(ctx, event2Health, groupConfig2)
+		shouldCreateCR, existingCR, _, err := r.checkExistingCRStatus(ctx, event2Health, time.Now(), groupConfig2)
 		assert.NoError(t, err)
 		assert.False(t, shouldCreateCR, "RESTART_BM should be deduplicated with RESTART_VM (same group)")
 		assert.Equal(t, firstCRName, existingCR)
@@ -747,7 +747,7 @@ func TestEventSequenceWithAnnotations_Integration(t *testing.T) {
 	groupConfig, err = common.GetGroupConfigForEvent(cfg.RemediationClient.GetConfig().RemediationActions,
 		event2)
 	assert.NoError(t, err)
-	shouldCreate, existingCR, err := r.checkExistingCRStatus(ctx, event2, groupConfig)
+	shouldCreate, existingCR, _, err := r.checkExistingCRStatus(ctx, event2, time.Now(), groupConfig)
 	assert.NoError(t, err)
 	assert.False(t, shouldCreate, "RESTART_VM should be skipped (same group as RESTART_BM)")
 	assert.Equal(t, crName1, existingCR)
@@ -757,7 +757,7 @@ func TestEventSequenceWithAnnotations_Integration(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, crName1, state.EquivalenceGroups["restart"].MaintenanceCR)
 
-	// Event 3: CR succeeds - subsequent event should be created
+	// Event 3: CR succeeds - subsequent equivalent event should be marked covered, not retried
 	updateRebootNodeStatus(ctx, t, crName1, "Succeeded")
 
 	event3 := &protos.HealthEvent{
@@ -767,9 +767,11 @@ func TestEventSequenceWithAnnotations_Integration(t *testing.T) {
 	groupConfig, err = common.GetGroupConfigForEvent(cfg.RemediationClient.GetConfig().RemediationActions,
 		event3)
 	assert.NoError(t, err)
-	shouldCreate, _, err = r.checkExistingCRStatus(ctx, event3, groupConfig)
+	shouldCreate, _, remediatedByExistingCR, err := r.checkExistingCRStatus(ctx, event3, time.Now().Add(-time.Minute),
+		groupConfig)
 	assert.NoError(t, err)
-	assert.True(t, shouldCreate, "RESTART_BM should be skipped (CR succeeded)")
+	assert.False(t, shouldCreate, "RESTART_BM should be skipped (CR succeeded)")
+	assert.True(t, remediatedByExistingCR, "successful existing CR should cover equivalent event")
 
 	// Event 4: CR fails - annotation cleaned, retry allowed
 	updateRebootNodeStatus(ctx, t, crName1, "Failed")
@@ -781,7 +783,7 @@ func TestEventSequenceWithAnnotations_Integration(t *testing.T) {
 	groupConfig, err = common.GetGroupConfigForEvent(cfg.RemediationClient.GetConfig().RemediationActions,
 		event4)
 	assert.NoError(t, err)
-	shouldCreate, _, err = r.checkExistingCRStatus(ctx, event4, groupConfig)
+	shouldCreate, _, _, err = r.checkExistingCRStatus(ctx, event4, time.Now(), groupConfig)
 	assert.NoError(t, err)
 	assert.True(t, shouldCreate, "Should allow retry after failure")
 
@@ -899,7 +901,7 @@ func TestEventSequenceWithSupersedingGroup(t *testing.T) {
 	assert.NoError(t, err)
 	shouldSkip := r.shouldSkipEvent(ctx, event2, groupConfig)
 	assert.False(t, shouldSkip, "Shouldn't valid health event")
-	shouldCreate, existingCR, err := r.checkExistingCRStatus(ctx, event2.HealthEvent, groupConfig)
+	shouldCreate, existingCR, _, err := r.checkExistingCRStatus(ctx, event2.HealthEvent, time.Now(), groupConfig)
 	assert.NoError(t, err)
 	assert.False(t, shouldCreate, "COMPONENT_RESET should be skipped (same group as RESTART_BM)")
 	assert.Equal(t, crName1, existingCR)
@@ -910,7 +912,7 @@ func TestEventSequenceWithSupersedingGroup(t *testing.T) {
 	assert.Equal(t, crName1, state.EquivalenceGroups["restart"].MaintenanceCR)
 	assert.Equal(t, "RESTART_BM", state.EquivalenceGroups["restart"].ActionName)
 
-	// Event 3: COMPONENT_RESET in group reset with superseding group restart should be created after CR-1 succeeds
+	// Event 3: COMPONENT_RESET in group reset with superseding group restart should be covered after CR-1 succeeds
 	updateRebootNodeStatus(ctx, t, crName1, "Succeeded")
 
 	event3 := &protos.HealthEvent{
@@ -926,9 +928,11 @@ func TestEventSequenceWithSupersedingGroup(t *testing.T) {
 	groupConfig, err = common.GetGroupConfigForEvent(cfg.RemediationClient.GetConfig().RemediationActions,
 		event3)
 	assert.NoError(t, err)
-	shouldCreate, _, err = r.checkExistingCRStatus(ctx, event3, groupConfig)
+	shouldCreate, _, remediatedByExistingCR, err := r.checkExistingCRStatus(ctx, event3, time.Now().Add(-time.Minute),
+		groupConfig)
 	assert.NoError(t, err)
-	assert.True(t, shouldCreate, "COMPONENT_RESET should be created (CR succeeded)")
+	assert.False(t, shouldCreate, "COMPONENT_RESET should be skipped (superseding CR succeeded)")
+	assert.True(t, remediatedByExistingCR, "successful superseding CR should cover reset event")
 
 	// Event 4: COMPONENT_RESET in group reset with superseding group restart should be created after CR-1 fails
 	updateRebootNodeStatus(ctx, t, crName1, "Failed")
@@ -946,7 +950,7 @@ func TestEventSequenceWithSupersedingGroup(t *testing.T) {
 	groupConfig, err = common.GetGroupConfigForEvent(cfg.RemediationClient.GetConfig().RemediationActions,
 		event4)
 	assert.NoError(t, err)
-	shouldCreate, _, err = r.checkExistingCRStatus(ctx, event4, groupConfig)
+	shouldCreate, _, _, err = r.checkExistingCRStatus(ctx, event4, time.Now(), groupConfig)
 	assert.NoError(t, err)
 	assert.True(t, shouldCreate, "Should allow retry after failure")
 
@@ -999,7 +1003,7 @@ func TestEventSequenceWithSupersedingGroup(t *testing.T) {
 	groupConfig, err = common.GetGroupConfigForEvent(cfg.RemediationClient.GetConfig().RemediationActions,
 		event6)
 	assert.NoError(t, err)
-	shouldCreate, existingCR, err = r.checkExistingCRStatus(ctx, event6, groupConfig)
+	shouldCreate, existingCR, _, err = r.checkExistingCRStatus(ctx, event6, time.Now(), groupConfig)
 	assert.NoError(t, err)
 	assert.False(t, shouldCreate, "COMPONENT_RESET should be skipped (same group as previous COMPONENT_RESET)")
 	assert.Equal(t, crName2, existingCR)
@@ -1029,7 +1033,7 @@ func TestEventSequenceWithSupersedingGroup(t *testing.T) {
 	groupConfig, err = common.GetGroupConfigForEvent(cfg.RemediationClient.GetConfig().RemediationActions,
 		event7.HealthEvent)
 	assert.NoError(t, err)
-	shouldCreate, existingCR, err = r.checkExistingCRStatus(ctx, event7.HealthEvent, groupConfig)
+	shouldCreate, existingCR, _, err = r.checkExistingCRStatus(ctx, event7.HealthEvent, time.Now(), groupConfig)
 	assert.NoError(t, err)
 	assert.True(t, shouldCreate, "COMPONENT_RESET should be allowed (different group as previous COMPONENT_RESET)")
 
@@ -1069,7 +1073,7 @@ func TestEventSequenceWithSupersedingGroup(t *testing.T) {
 	groupConfig, err = common.GetGroupConfigForEvent(cfg.RemediationClient.GetConfig().RemediationActions,
 		event8)
 	assert.NoError(t, err)
-	shouldCreate, existingCR, err = r.checkExistingCRStatus(ctx, event8, groupConfig)
+	shouldCreate, existingCR, _, err = r.checkExistingCRStatus(ctx, event8, time.Now(), groupConfig)
 	assert.NoError(t, err)
 	assert.True(t, shouldCreate, "COMPONENT_RESET should be allowed (same group as previous "+
 		"COMPONENT_RESET that completed)")
@@ -1339,9 +1343,9 @@ func createCustomActionQuarantineEvent(eventID, nodeName, customAction string) d
 				"nodequarantined": model.Quarantined,
 			},
 			"healthevent": map[string]interface{}{
-				"nodename":                  nodeName,
-				"recommendedaction":         int32(protos.RecommendedAction_CUSTOM),
-				"customrecommendedaction":   customAction,
+				"nodename":                nodeName,
+				"recommendedaction":       int32(protos.RecommendedAction_CUSTOM),
+				"customrecommendedaction": customAction,
 			},
 		},
 	}

--- a/fault-remediation/pkg/reconciler/reconciler_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_test.go
@@ -65,15 +65,38 @@ func (m *MockK8sClient) GetStatusChecker() crstatus.CRStatusCheckerInterface {
 
 type mockStatusChecker struct {
 	shouldSkip []bool
+	states     []crstatus.CRState
+	stateByCR  map[string]crstatus.CRState
 	callCount  int
 }
 
 func (statusChecker *mockStatusChecker) ShouldSkipCRCreation(context.Context, string, string) bool {
+	return statusChecker.GetCRState(context.Background(), "", "") != crstatus.CRStateFailed
+}
+
+func (statusChecker *mockStatusChecker) GetCRState(_ context.Context, _ string, crName string) crstatus.CRState {
+	if statusChecker.stateByCR != nil {
+		return statusChecker.stateByCR[crName]
+	}
+
+	if statusChecker.states != nil {
+		state := statusChecker.states[statusChecker.callCount]
+		if statusChecker.callCount < len(statusChecker.states)-1 {
+			statusChecker.callCount++
+		}
+
+		return state
+	}
+
 	shouldSkip := statusChecker.shouldSkip[statusChecker.callCount]
 	if statusChecker.callCount < len(statusChecker.shouldSkip)-1 {
 		statusChecker.callCount++
 	}
-	return shouldSkip
+	if shouldSkip {
+		return crstatus.CRStateInProgress
+	}
+
+	return crstatus.CRStateFailed
 }
 
 func (m *MockK8sClient) GetConfig() *config.TomlConfig {
@@ -124,7 +147,9 @@ func (w *MockCRStatusCheckerWrapper) IsSuccessful(ctx context.Context, crName st
 }
 
 type MockNodeAnnotationManager struct {
-	existingCRs map[string]string
+	existingCRs       map[string]string
+	existingCRCreated time.Time
+	createdByGroup    map[string]time.Time
 }
 
 func (m *MockNodeAnnotationManager) GetRemediationState(ctx context.Context, nodeName string) (*annotation.RemediationStateAnnotation, *corev1.Node, error) {
@@ -137,10 +162,18 @@ func (m *MockNodeAnnotationManager) GetRemediationState(ctx context.Context, nod
 	annotationState := &annotation.RemediationStateAnnotation{
 		EquivalenceGroups: make(map[string]annotation.EquivalenceGroupState),
 	}
+	createdAt := m.existingCRCreated
+	if createdAt.IsZero() {
+		createdAt = time.Now()
+	}
 	for groupName, crName := range m.existingCRs {
+		groupCreatedAt := createdAt
+		if createdAtForGroup, ok := m.createdByGroup[groupName]; ok {
+			groupCreatedAt = createdAtForGroup
+		}
 		annotationState.EquivalenceGroups[groupName] = annotation.EquivalenceGroupState{
 			MaintenanceCR: crName,
-			CreatedAt:     time.Now(),
+			CreatedAt:     groupCreatedAt,
 		}
 	}
 	return annotationState, nil, nil
@@ -932,11 +965,17 @@ func TestCRBasedDeduplication(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name                   string
-		existingCRs            map[string]string
-		shouldSkipCRCreation   []bool // if nil we will not provide a StatusChecker instances
-		groupConfig            *common.EquivalenceGroupConfig
-		expectedShouldCreateCR bool
+		name                      string
+		existingCRs               map[string]string
+		shouldSkipCRCreation      []bool // if nil we will not provide a StatusChecker instances
+		crStates                  []crstatus.CRState
+		crStateByName             map[string]crstatus.CRState
+		groupConfig               *common.EquivalenceGroupConfig
+		eventCreatedAt            time.Time
+		remediationCreatedAt      time.Time
+		remediationCreatedByGroup map[string]time.Time
+		expectedShouldCreateCR    bool
+		expectedRemediated        bool
 	}{
 		{
 			name:                   "NoStatusChecker_AllowRemediation",
@@ -994,12 +1033,50 @@ func TestCRBasedDeduplication(t *testing.T) {
 			groupConfig:            getGroupConfig("restart", []string{"reset-GPU-123"}),
 			expectedShouldCreateCR: true,
 		},
+		{
+			name:                   "CRSucceeded_SameSession_MarksRemediated",
+			existingCRs:            map[string]string{"restart": "maintenance-node-123"},
+			crStates:               []crstatus.CRState{crstatus.CRStateSucceeded},
+			groupConfig:            getGroupConfig("restart", nil),
+			eventCreatedAt:         time.Date(2026, 5, 14, 10, 0, 0, 0, time.UTC),
+			remediationCreatedAt:   time.Date(2026, 5, 14, 10, 1, 0, 0, time.UTC),
+			expectedShouldCreateCR: false,
+			expectedRemediated:     true,
+		},
+		{
+			name:                   "CRSucceeded_FutureSession_AllowsRemediation",
+			existingCRs:            map[string]string{"restart": "maintenance-node-123"},
+			crStates:               []crstatus.CRState{crstatus.CRStateSucceeded},
+			groupConfig:            getGroupConfig("restart", nil),
+			eventCreatedAt:         time.Date(2026, 5, 14, 10, 10, 1, 0, time.UTC),
+			remediationCreatedAt:   time.Date(2026, 5, 14, 10, 0, 0, 0, time.UTC),
+			expectedShouldCreateCR: true,
+			expectedRemediated:     false,
+		},
+		{
+			name:        "MultipleMatchingGroups_NewestStateEvaluatedFirst",
+			existingCRs: map[string]string{"restart": "maintenance-restart", "reset-GPU-123": "maintenance-reset"},
+			crStateByName: map[string]crstatus.CRState{
+				"maintenance-restart": crstatus.CRStateFailed,
+				"maintenance-reset":   crstatus.CRStateInProgress,
+			},
+			groupConfig:            getGroupConfig("reset-GPU-123", []string{"restart"}),
+			eventCreatedAt:         time.Date(2026, 5, 14, 10, 0, 0, 0, time.UTC),
+			expectedShouldCreateCR: false,
+			expectedRemediated:     false,
+			remediationCreatedByGroup: map[string]time.Time{
+				"restart":       time.Date(2026, 5, 14, 10, 0, 0, 0, time.UTC),
+				"reset-GPU-123": time.Date(2026, 5, 14, 10, 1, 0, 0, time.UTC),
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockAnnotationManager := &MockNodeAnnotationManager{
-				existingCRs: tt.existingCRs,
+				existingCRs:       tt.existingCRs,
+				existingCRCreated: tt.remediationCreatedAt,
+				createdByGroup:    tt.remediationCreatedByGroup,
 			}
 
 			mockK8sClient := &MockK8sClient{
@@ -1011,6 +1088,16 @@ func TestCRBasedDeduplication(t *testing.T) {
 					shouldSkip: tt.shouldSkipCRCreation,
 				}
 			}
+			if tt.crStates != nil {
+				mockK8sClient.mockStatusChecker = &mockStatusChecker{
+					states: tt.crStates,
+				}
+			}
+			if tt.crStateByName != nil {
+				mockK8sClient.mockStatusChecker = &mockStatusChecker{
+					stateByCR: tt.crStateByName,
+				}
+			}
 
 			cfg := ReconcilerConfig{RemediationClient: mockK8sClient}
 			r := NewFaultRemediationReconciler(nil, nil, nil, cfg, false)
@@ -1018,9 +1105,10 @@ func TestCRBasedDeduplication(t *testing.T) {
 			healthEvent := &protos.HealthEvent{
 				NodeName: "test-node",
 			}
-			shouldCreateCR, _, err := r.checkExistingCRStatus(ctx, healthEvent, tt.groupConfig)
+			shouldCreateCR, _, remediated, err := r.checkExistingCRStatus(ctx, healthEvent, tt.eventCreatedAt, tt.groupConfig)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedShouldCreateCR, shouldCreateCR)
+			assert.Equal(t, tt.expectedRemediated, remediated)
 		})
 	}
 }

--- a/fault-remediation/pkg/reconciler/reconciler_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_test.go
@@ -1025,6 +1025,211 @@ func TestCRBasedDeduplication(t *testing.T) {
 	}
 }
 
+func TestCloseStaleEquivalentEvents(t *testing.T) {
+	ctx := context.Background()
+	nodeName := "test-node"
+
+	tests := []struct {
+		name              string
+		status            model.Status
+		state             *annotation.RemediationStateAnnotation
+		rawEvents         []datastore.Event
+		expectedUpdates   map[string]bool
+		expectTimestamp   bool
+		unexpectedUpdates []string
+	}{
+		{
+			name:   "UnQuarantined closes only equivalent restart events as remediated",
+			status: model.UnQuarantined,
+			// This annotation is what fault-remediation writes when it creates a maintenance CR.
+			// In production this means "there is/was a restart remediation covering this node".
+			// When fault-quarantine later unquarantines the node, skipped stale events in the
+			// same equivalence group should be closed so cold start cannot replay them.
+			state: &annotation.RemediationStateAnnotation{
+				EquivalenceGroups: map[string]annotation.EquivalenceGroupState{
+					"restart": {MaintenanceCR: "maintenance-test-node-event-a", ActionName: "RESTART_BM"},
+				},
+			},
+			// event-a is the stale event: it needs RESTART_BM, which maps to the restart group,
+			// so the prior restart CR covers it. event-contact-support is intentionally unrelated:
+			// it has no configured remediation group and must not be swept up by node-level cleanup.
+			rawEvents: []datastore.Event{
+				testRawHealthEvent("event-a", nodeName, protos.RecommendedAction_RESTART_BM),
+				testRawHealthEvent("event-contact-support", nodeName, protos.RecommendedAction_CONTACT_SUPPORT),
+			},
+			expectedUpdates: map[string]bool{
+				"event-a": true,
+			},
+			expectTimestamp:   true,
+			unexpectedUpdates: []string{"event-contact-support"},
+		},
+		{
+			name:   "Cancelled closes equivalent restart events as not remediated",
+			status: model.Cancelled,
+			// Cancelled is the external/manual cancellation path, for example someone
+			// manually uncordoned the node. Unlike UnQuarantined, it does not prove the
+			// fault was remediated. FR still needs a durable terminal value so cold start
+			// does not replay the stale event, but that value must be faultremediated=false.
+			state: &annotation.RemediationStateAnnotation{
+				EquivalenceGroups: map[string]annotation.EquivalenceGroupState{
+					"restart": {MaintenanceCR: "maintenance-test-node-event-a", ActionName: "RESTART_BM"},
+				},
+			},
+			rawEvents: []datastore.Event{
+				testRawHealthEvent("event-a", nodeName, protos.RecommendedAction_RESTART_BM),
+			},
+			// expectedUpdates maps event ID -> expected healtheventstatus.faultremediated value.
+			// false here means "terminal, but not successfully remediated".
+			expectedUpdates: map[string]bool{
+				"event-a": false,
+			},
+		},
+		{
+			name:   "No remediation state does not close events",
+			status: model.UnQuarantined,
+			// Without a remediation annotation, FR has no equivalence-group evidence that an
+			// earlier maintenance CR covered these events. The cleanup must therefore do nothing.
+			state: &annotation.RemediationStateAnnotation{
+				EquivalenceGroups: map[string]annotation.EquivalenceGroupState{},
+			},
+			rawEvents: []datastore.Event{
+				testRawHealthEvent("event-a", nodeName, protos.RecommendedAction_RESTART_BM),
+			},
+			expectedUpdates: map[string]bool{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updates := make(map[string]datastore.HealthEventStatus)
+			mockStore := &MockHealthEventStore{
+				FindHealthEventsByQueryBatchedFn: func(_ context.Context, _ datastore.QueryBuilder, _ int,
+					fn func([]datastore.HealthEventWithStatus) error) error {
+					batch := make([]datastore.HealthEventWithStatus, 0, len(tt.rawEvents))
+					for _, rawEvent := range tt.rawEvents {
+						batch = append(batch, datastore.HealthEventWithStatus{RawEvent: rawEvent})
+					}
+
+					return fn(batch)
+				},
+				UpdateHealthEventStatusFn: func(_ context.Context, id string, status datastore.HealthEventStatus) error {
+					updates[id] = status
+					return nil
+				},
+			}
+
+			mockK8sClient := &MockK8sClient{}
+			cfg := ReconcilerConfig{RemediationClient: mockK8sClient}
+			r := NewFaultRemediationReconciler(nil, nil, mockStore, cfg, false)
+
+			err := r.closeStaleEquivalentEvents(ctx, nodeName, tt.status, tt.state, mockStore)
+			assert.NoError(t, err)
+
+			assert.Len(t, updates, len(tt.expectedUpdates))
+			for id, expectedRemediated := range tt.expectedUpdates {
+				status, ok := updates[id]
+				assert.True(t, ok, "expected update for %s", id)
+				assert.NotNil(t, status.FaultRemediated)
+				assert.Equal(t, expectedRemediated, *status.FaultRemediated)
+				if tt.expectTimestamp {
+					assert.NotNil(t, status.LastRemediationTimestamp)
+				} else {
+					assert.Nil(t, status.LastRemediationTimestamp)
+				}
+			}
+
+			for _, id := range tt.unexpectedUpdates {
+				_, ok := updates[id]
+				assert.False(t, ok, "did not expect update for %s", id)
+			}
+		})
+	}
+}
+
+func TestUnsupportedActionSkipMarksEventTerminal(t *testing.T) {
+	ctx := context.Background()
+	nodeName := "test-node"
+	eventID := "unsupported-event"
+	updated := false
+
+	// CONTACT_SUPPORT is not configured as a maintenance action for FR. That is an
+	// intentional skip, but it still needs a durable terminal status; otherwise cold
+	// start will keep replaying the same unsupported event because faultremediated is nil.
+	mockK8sClient := &MockK8sClient{}
+	cfg := ReconcilerConfig{
+		RemediationClient: mockK8sClient,
+		StateManager: &statemanager.MockStateManager{
+			UpdateNVSentinelStateNodeLabelFn: func(context.Context, string,
+				statemanager.NVSentinelStateLabelValue, bool) (bool, error) {
+				return true, nil
+			},
+		},
+	}
+	r := NewFaultRemediationReconciler(nil, nil, nil, cfg, false)
+	mockWatcher := &MockChangeStreamWatcher{}
+	mockStore := &MockHealthEventStore{
+		UpdateHealthEventStatusFn: func(_ context.Context, id string, status datastore.HealthEventStatus) error {
+			assert.Equal(t, eventID, id)
+			assert.NotNil(t, status.FaultRemediated)
+			assert.False(t, *status.FaultRemediated)
+			updated = true
+
+			return nil
+		},
+	}
+	healthEventDoc := &events.HealthEventDoc{
+		ID: eventID,
+		HealthEventWithStatus: model.HealthEventWithStatus{
+			HealthEvent: &protos.HealthEvent{
+				NodeName:          nodeName,
+				RecommendedAction: protos.RecommendedAction_CONTACT_SUPPORT,
+			},
+			HealthEventStatus: &protos.HealthEventStatus{},
+		},
+	}
+	eventWithToken := datastore.EventWithToken{
+		Event:       testRawHealthEvent(eventID, nodeName, protos.RecommendedAction_CONTACT_SUPPORT),
+		ResumeToken: []byte("resume-token"),
+	}
+
+	_, err, done := r.trySkipEvent(ctx, healthEventDoc, nil, eventWithToken, mockWatcher, mockStore, nodeName)
+	assert.True(t, done)
+	assert.NoError(t, err)
+	assert.True(t, updated)
+	_, markProcessedCount, _, _ := mockWatcher.GetCallCounts()
+	assert.Equal(t, 1, markProcessedCount)
+}
+
+func testRawHealthEvent(id, nodeName string, action protos.RecommendedAction) datastore.Event {
+	return datastore.Event{
+		"_id": id,
+		"healthevent": map[string]interface{}{
+			"version":           1,
+			"agent":             "test-agent",
+			"componentclass":    "GPU",
+			"checkname":         "test-check",
+			"isfatal":           true,
+			"ishealthy":         false,
+			"message":           "test event",
+			"recommendedaction": int32(action),
+			"errorcode":         []interface{}{"REPRO"},
+			"entitiesimpacted": []interface{}{
+				map[string]interface{}{
+					"entitytype":  "GPU_UUID",
+					"entityvalue": "GPU-test",
+				},
+			},
+			"nodename": nodeName,
+		},
+		"healtheventstatus": map[string]interface{}{
+			"nodequarantined": string(model.AlreadyQuarantined),
+			"userpodsevictionstatus": map[string]interface{}{
+				"status": string(model.AlreadyDrained),
+			},
+		},
+	}
+}
+
 // TestLogCollectorOnlyCalledWhenShouldCreateCR verifies that log collector is only called
 // when shouldCreateCR is true (Issue #441 - prevent duplicate log-collector jobs)
 // This tests the logic that log collector runs AFTER checkExistingCRStatus, not before


### PR DESCRIPTION
## Summary
Fix fault-remediation cold-start replay for events that were intentionally skipped but left without a terminal remediation status.

Previously, some skip paths only advanced the change-stream token. The health event document still had `healtheventstatus.faultremediated == nil`, so a later fault-remediation restart could cold-start the stale event and process it again. This could create duplicate remediation CRs after fault-quarantine had already uncordoned the node, allowing workloads to be scheduled back before an unwanted reboot was triggered.

### Changes

- On `UnQuarantined` / `Cancelled`, FR now uses the existing node remediation annotation to close stale events for the covered equivalence groups before clearing the annotation.
- UnQuarantined marks covered stale events as `faultremediated=true`.
- Cancelled marks covered stale events as `faultremediated=false`, because manual/external cancellation does not prove the fault was remediated.
- Unsupported recommended actions, such as CONTACT_SUPPORT, are now made terminal with `faultremediated=false` instead of remaining cold-start eligible.
- The cold-start “unresolved remediation-ready event” query was extracted into a shared helper so cold start and cleanup use the same criteria.
- A succeeded existing CR only covers events that were created before the remediation annotation for that equivalence group was created. Later events are treated as a new remediation session and can create a new CR.
- Matching remediation annotation groups are evaluated deterministically by newest `CreatedAt` first.

### How the changes fixed the bugs

This prevents two related replay bugs:

- A skipped event behind an equivalent in-progress CR could later create a duplicate RebootNode after FR restart.
- Unsupported actions could repeatedly replay on FR restart and reapply remediation-failed to a node after recovery.

The cleanup is equivalence-group scoped, not node-wide, so unrelated remediation actions on the same node are not incorrectly closed.

The successful-CR dedupe path is also session-bounded. An old successful CR from a previous remediation session will not suppress a future event for the same node/equivalence group.
## Testing
### Duplicate CR:
```
$ bash bug-reprod.sh duplicate-cr
[08:23:51] Node: kwok-node-8
[08:23:51] Run ID: frrepro-1778747030
[08:23:51] === Repro: equivalent event skipped, then duplicate CR on FR cold start ===
[08:23:53] Sending event check=frrepro-1778747030-RestartA action=24 fatal=true healthy=false
[08:23:54] Sending event check=frrepro-1778747030-RestartB action=24 fatal=true healthy=false
[08:23:54] Waiting for RebootNode count for kwok-node-8 to be >= 1
[08:24:10] RebootNode count is 1
[08:24:11] First CR: maintenance-kwok-node-8-6a058699b540838e4a93ae68
[08:24:11] Patching maintenance-kwok-node-8-6a058699b540838e4a93ae68 status to NodeReady=Unknown so FR treats it as in-progress
[08:24:12] Waiting for FR log pattern: Skipping event for node due to existing CR|maintenance-kwok-node-8-6a058699b540838e4a93ae68
[08:24:15] Observed FR log pattern
[08:24:15] Patching maintenance-kwok-node-8-6a058699b540838e4a93ae68 status to NodeReady=True
[08:24:16] Restarting FR before healthy recovery; fixed FR should not create another CR
[08:24:16] Restarting fault-remediation by deleting pod
[08:24:19] Deleting old fault-remediation pod fault-remediation-64ddcfd797-sc42q
[08:24:19] Waiting for replacement fault-remediation pod
[08:24:40] fault-remediation restarted as fault-remediation-64ddcfd797-h9hsl
[08:24:45] Asserting RebootNode count for kwok-node-8 stays at 1 for 60s
[08:25:53] RebootNode count stayed at 1
[08:25:54] Node state: unschedulable=true, dgxc.nvidia.com/nvsentinel-state=remediation-succeeded
[08:25:54] Sending healthy event for creator check=frrepro-1778747030-RestartA
[08:25:54] Sending event check=frrepro-1778747030-RestartA action=24 fatal=true healthy=true
[08:25:54] Sending healthy event for skipped check=frrepro-1778747030-RestartB to simulate syslog boot-ID recovery
[08:25:54] Sending event check=frrepro-1778747030-RestartB action=24 fatal=true healthy=true
[08:25:54] Waiting for kwok-node-8 to be uncordoned
[08:25:54] Node is uncordoned
[08:25:54] After healthy event and uncordon, FR state label is still present:
[08:25:54] Node state: unschedulable=false, dgxc.nvidia.com/nvsentinel-state=<unset>
[08:25:54] Restarting FR after healthy recovery; fixed FR should still not create another CR
[08:25:54] Restarting fault-remediation by deleting pod
[08:25:55] Deleting old fault-remediation pod fault-remediation-64ddcfd797-h9hsl
[08:25:55] Waiting for replacement fault-remediation pod
[08:26:10] fault-remediation restarted as fault-remediation-64ddcfd797-mmcln
[08:26:15] Asserting RebootNode count for kwok-node-8 stays at 1 for 60s
[08:27:23] RebootNode count stayed at 1
[08:27:23] PASS: duplicate CR did not reproduce. CRs for node:
maintenance-kwok-node-8-6a058699b540838e4a93ae68
[08:27:24] Done




rs0 [primary] HealthEventsDatabase> db.HealthEvents.find({"healthevent.nodename": "kwok-node-8", "healthevent.isfatal": true, "healthevent.ishealthy": false})
[
  {
    _id: ObjectId('6a058699b540838e4a93ae68'),
    createdAt: ISODate('2026-05-14T08:23:53.882Z'),
    healthevent: {
      version: Long('1'),
      agent: 'gpu-health-monitor',
      componentclass: 'GPU',
      checkname: 'frrepro-1778747030-RestartA',
      isfatal: true,
      ishealthy: false,
      message: 'frrepro-1778747030-RestartA frrepro-1778747030',
      recommendedaction: 24,
      errorcode: [ 'REPRO' ],
      entitiesimpacted: [
        { entitytype: 'PCI', entityvalue: '0000:04:00' },
        {
          entitytype: 'GPU_UUID',
          entityvalue: 'GPU-frrepro-1778747030-frrepro-1778747030-RestartA'
        }
      ],
      metadata: { trace_id: '00000000000000000000000000000000' },
      generatedtimestamp: { seconds: Long('1778747033'), nanos: 719932554 },
      nodename: 'kwok-node-8',
      quarantineoverrides: null,
      drainoverrides: null,
      processingstrategy: 1,
      id: '',
      customrecommendedaction: ''
    },
    healtheventstatus: {
      nodequarantined: 'Quarantined',
      quarantinefinishtimestamp: { seconds: Long('1778747034'), nanos: 180236733 },
      userpodsevictionstatus: { status: 'Succeeded', message: '' },
      drainfinishtimestamp: { seconds: Long('1778747035'), nanos: 840249508 },
      faultremediated: { value: true },
      lastremediationtimestamp: { seconds: Long('1778747049'), nanos: 50901575 },
      spanids: {
        'platform-connector': '',
        'fault-quarantine': '',
        'node-drainer': ''
      }
    }
  },
  {
    _id: ObjectId('6a05869ab540838e4a93ae69'),
    createdAt: ISODate('2026-05-14T08:23:54.277Z'),
    healthevent: {
      version: Long('1'),
      agent: 'gpu-health-monitor',
      componentclass: 'GPU',
      checkname: 'frrepro-1778747030-RestartB',
      isfatal: true,
      ishealthy: false,
      message: 'frrepro-1778747030-RestartB frrepro-1778747030',
      recommendedaction: 24,
      errorcode: [ 'REPRO' ],
      entitiesimpacted: [
        { entitytype: 'PCI', entityvalue: '0000:04:00' },
        {
          entitytype: 'GPU_UUID',
          entityvalue: 'GPU-frrepro-1778747030-frrepro-1778747030-RestartB'
        }
      ],
      metadata: { trace_id: '00000000000000000000000000000000' },
      generatedtimestamp: { seconds: Long('1778747034'), nanos: 273121166 },
      nodename: 'kwok-node-8',
      quarantineoverrides: null,
      drainoverrides: null,
      processingstrategy: 1,
      id: '',
      customrecommendedaction: ''
    },
    healtheventstatus: {
      nodequarantined: 'AlreadyQuarantined',
      quarantinefinishtimestamp: { seconds: Long('1778747035'), nanos: 183746305 },
      userpodsevictionstatus: { status: 'AlreadyDrained', message: '' },
      drainfinishtimestamp: { seconds: Long('1778747035'), nanos: 920652164 },
      faultremediated: { value: true },
      lastremediationtimestamp: { nanos: 218736556, seconds: Long('1778747085') },
      spanids: {
        'platform-connector': '',
        'fault-quarantine': '',
        'node-drainer': ''
      }
    }
  }
]

```

In the second event, we've `faultremediated: { value: true },` which stop FR to pull in that event upon cold restart.

### For `dgxc.nvidia.com/nvsentinel-state:remediation-failed`
```
$ bash bug-reprod.sh contact-support
[08:29:51] Node: kwok-node-9
[08:29:51] Run ID: frrepro-1778747391
[08:29:51] === Repro: unsupported CONTACT_SUPPORT stale replay reapplies remediation-failed ===
[08:29:52] Node state: unschedulable=false, dgxc.nvidia.com/nvsentinel-state=<unset>
[08:29:52] Sending event check=frrepro-1778747391-ContactSupport action=5 fatal=true healthy=false
[08:29:52] Waiting for FR log pattern: Unsupported recommended action.*CONTACT_SUPPORT|Unsupported recommended action
[08:29:52] Observed FR log pattern
[08:29:52] Waiting for dgxc.nvidia.com/nvsentinel-state=remediation-failed
[08:29:53] Node state: unschedulable=true, dgxc.nvidia.com/nvsentinel-state=remediation-failed
[08:29:53] Restarting FR before healthy recovery; fixed FR should not replay unsupported event
[08:29:53] Restarting fault-remediation by deleting pod
[08:29:54] Deleting old fault-remediation pod fault-remediation-64ddcfd797-mmcln
[08:29:54] Waiting for replacement fault-remediation pod
[08:30:10] fault-remediation restarted as fault-remediation-64ddcfd797-mrf7d
[08:30:15] Asserting FR log pattern does not appear for 30s: Unsupported recommended action.*CONTACT_SUPPORT|Unsupported recommended action
[08:30:45] No matching FR log observed
[08:30:45] Sending healthy CONTACT_SUPPORT event so FQ recovers and uncordons the node
[08:30:45] Sending event check=frrepro-1778747391-ContactSupport action=5 fatal=true healthy=true
[08:30:45] Waiting for kwok-node-9 to be uncordoned
[08:30:46] Node is uncordoned
[08:30:46] Waiting for dgxc.nvidia.com/nvsentinel-state to be cleared
[08:30:46] Node state: unschedulable=false, dgxc.nvidia.com/nvsentinel-state=<unset>
[08:30:46] Restarting FR after healthy recovery; fixed FR should not reapply remediation-failed
[08:30:46] Restarting fault-remediation by deleting pod
[08:30:47] Deleting old fault-remediation pod fault-remediation-64ddcfd797-mrf7d
[08:30:47] Waiting for replacement fault-remediation pod
[08:31:02] fault-remediation restarted as fault-remediation-64ddcfd797-2rxnj
[08:31:07] Asserting FR log pattern does not appear for 30s: Unsupported recommended action.*CONTACT_SUPPORT|Unsupported recommended action
[08:31:37] No matching FR log observed
[08:31:37] Waiting for dgxc.nvidia.com/nvsentinel-state to be cleared
[08:31:37] Node state: unschedulable=false, dgxc.nvidia.com/nvsentinel-state=<unset>
[08:31:37] PASS: CONTACT_SUPPORT replay did not reapply remediation-failed
[08:31:37] Done


rs0 [primary] HealthEventsDatabase> db.HealthEvents.find({"healthevent.nodename": "kwok-node-9", "healthevent.isfatal": true, "healthevent.ishealthy": false})
[
  {
    _id: ObjectId('6a058800b540838e4a93ae7b'),
    createdAt: ISODate('2026-05-14T08:29:52.093Z'),
    healthevent: {
      version: Long('1'),
      agent: 'gpu-health-monitor',
      componentclass: 'GPU',
      checkname: 'frrepro-1778747391-ContactSupport',
      isfatal: true,
      ishealthy: false,
      message: 'frrepro-1778747391-ContactSupport frrepro-1778747391',
      recommendedaction: 5,
      errorcode: [ 'REPRO' ],
      entitiesimpacted: [
        { entitytype: 'PCI', entityvalue: '0000:04:00' },
        {
          entitytype: 'GPU_UUID',
          entityvalue: 'GPU-frrepro-1778747391-frrepro-1778747391-ContactSupport'
        }
      ],
      metadata: { trace_id: '00000000000000000000000000000000' },
      generatedtimestamp: { seconds: Long('1778747392'), nanos: 77353200 },
      nodename: 'kwok-node-9',
      quarantineoverrides: null,
      drainoverrides: null,
      processingstrategy: 1,
      id: '',
      customrecommendedaction: ''
    },
    healtheventstatus: {
      nodequarantined: 'Quarantined',
      quarantinefinishtimestamp: { seconds: Long('1778747392'), nanos: 211738664 },
      userpodsevictionstatus: { status: 'Succeeded', message: '' },
      drainfinishtimestamp: { seconds: Long('1778747392'), nanos: 328911234 },
      faultremediated: { value: false },
      lastremediationtimestamp: null,
      spanids: {
        'platform-connector': '',
        'fault-quarantine': '',
        'node-drainer': ''
      }
    }
  }
]


```

Both of these are reproducible if I switch images to main:

Remdiation failed label:
```
$ bash bug-reprod.sh contact-support
[03:53:29] Node: kwok-node-7
[03:53:29] Run ID: frrepro-1778730809
[03:53:29] === Repro: unsupported CONTACT_SUPPORT stale replay reapplies remediation-failed ===
[03:53:29] Node state: unschedulable=false, dgxc.nvidia.com/nvsentinel-state=<unset>
[03:53:29] Sending event check=frrepro-1778730809-ContactSupport action=5 fatal=true healthy=false
[03:53:30] Waiting for FR log pattern: Unsupported recommended action.*CONTACT_SUPPORT|Unsupported recommended action
[03:53:30] Observed FR log pattern
[03:53:30] Waiting for dgxc.nvidia.com/nvsentinel-state=remediation-failed
[03:53:31] Node state: unschedulable=true, dgxc.nvidia.com/nvsentinel-state=remediation-failed
[03:53:31] Sending healthy CONTACT_SUPPORT event so FQ recovers and uncordons the node
[03:53:31] Sending event check=frrepro-1778730809-ContactSupport action=5 fatal=true healthy=true
[03:53:31] Waiting for kwok-node-7 to be uncordoned
[03:53:31] Node is uncordoned
[03:53:31] Waiting for dgxc.nvidia.com/nvsentinel-state to be cleared
[03:53:32] Node state: unschedulable=false, dgxc.nvidia.com/nvsentinel-state=<unset>
[03:53:32] Restarting fault-remediation by deleting pod
[03:53:32] Deleting old fault-remediation pod fault-remediation-76dcfc7ccc-xzwgz
[03:53:32] Waiting for replacement fault-remediation pod
[03:53:50] fault-remediation restarted as fault-remediation-76dcfc7ccc-p65sm
[03:53:55] Waiting for stale CONTACT_SUPPORT replay to reapply remediation-failed
[03:53:55] Waiting for dgxc.nvidia.com/nvsentinel-state=remediation-failed
[03:53:56] Node state: unschedulable=false, dgxc.nvidia.com/nvsentinel-state=remediation-failed
[03:53:56] PASS: CONTACT_SUPPORT replay reproduced via post-recovery remediation-failed label
[03:53:56] Done

$ kd no kwok-node-7 | grep nvsentinel-state
                    dgxc.nvidia.com/nvsentinel-state=remediation-failed
```

Duplicate CRs:
```
$ bash bug-reprod.sh duplicate-cr
[03:55:37] Node: kwok-node-8
[03:55:37] Run ID: frrepro-1778730937
[03:55:37] === Repro: equivalent event skipped, then duplicate CR on FR cold start ===
[03:55:37] Sending event check=frrepro-1778730937-RestartA action=24 fatal=true healthy=false
[03:55:37] Sending event check=frrepro-1778730937-RestartB action=24 fatal=true healthy=false
[03:55:37] Waiting for RebootNode count for kwok-node-8 to be >= 1
[03:55:49] RebootNode count is 1
[03:55:49] First CR: maintenance-kwok-node-8-6a0547b9bdb654758f2f91d7
[03:55:49] Patching maintenance-kwok-node-8-6a0547b9bdb654758f2f91d7 status to NodeReady=Unknown so FR treats it as in-progress
[03:55:49] Waiting for FR log pattern: Skipping event for node due to existing CR|maintenance-kwok-node-8-6a0547b9bdb654758f2f91d7
[03:55:49] Observed FR log pattern
[03:55:49] Patching maintenance-kwok-node-8-6a0547b9bdb654758f2f91d7 status to NodeReady=True
[03:55:50] Node state: unschedulable=true, dgxc.nvidia.com/nvsentinel-state=remediation-succeeded
[03:55:50] Sending healthy event for creator check=frrepro-1778730937-RestartA
[03:55:50] Sending event check=frrepro-1778730937-RestartA action=24 fatal=true healthy=true
[03:55:50] Sending healthy event for skipped check=frrepro-1778730937-RestartB to simulate syslog boot-ID recovery
[03:55:50] Sending event check=frrepro-1778730937-RestartB action=24 fatal=true healthy=true
[03:55:50] Waiting for kwok-node-8 to be uncordoned
[03:55:50] Node is uncordoned
[03:55:50] After healthy event and uncordon, FR state label is still present:
[03:55:51] Node state: unschedulable=false, dgxc.nvidia.com/nvsentinel-state=<unset>
[03:55:51] Restarting fault-remediation by deleting pod
[03:55:51] Deleting old fault-remediation pod fault-remediation-76dcfc7ccc-p65sm
[03:55:52] Waiting for replacement fault-remediation pod
[03:56:09] fault-remediation restarted as fault-remediation-76dcfc7ccc-lsltv
[03:56:14] Waiting for RebootNode count for kwok-node-8 to be >= 2
[03:56:14] RebootNode count is 2
[03:56:14] PASS: duplicate CR reproduced. CRs for node:
maintenance-kwok-node-8-6a0547b9bdb654758f2f91d7
maintenance-kwok-node-8-6a0547b9bdb654758f2f91d8
[03:56:14] Done
```

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cancel/unquarantine now closes stale equivalent health events and cleans up node remediation state; skipping unsupported recommended actions marks events terminal before processing.

* **Behavior Changes**
  * Skip logic treats succeeded remediation resources as covering equivalent events to avoid duplicate remediation; CR status now models explicit states (NotFound/InProgress/Succeeded/Failed) and uses them for skip decisions.

* **Tests**
  * Added tests validating stale-event cleanup, unsupported-action skip, and expanded deduplication/e2e scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NVSentinel/pull/1281)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->