### PR TITLE
fix(ci): add frozen version content to preview build and fix error handling

### DIFF
--- a/.github/workflows/fern-docs-preview-build.yml
+++ b/.github/workflows/fern-docs-preview-build.yml
@@ -60,6 +60,21 @@ jobs:
           echo "$HEAD_REF" > preview-metadata/head_ref
           git diff --name-only "origin/main...HEAD" -- '*.md' > preview-metadata/changed_md_files 2>/dev/null || true
 
+      - name: Checkout frozen version content
+        run: |
+          set -eo pipefail
+          for version_file in fern/versions/v*.yml; do
+            [ -f "$version_file" ] || continue
+            version=$(basename "$version_file" .yml)
+            if git rev-parse "$version" >/dev/null 2>&1; then
+              mkdir -p "fern/versions/${version}-content"
+              git archive "$version" -- docs/ | tar -x --strip-components=1 -C "fern/versions/${version}-content"
+              echo "Extracted docs from $version"
+            else
+              echo "::warning::Tag $version not found — skipping content checkout"
+            fi
+          done
+
       - name: Upload fern sources and metadata
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:

--- a/.github/workflows/fern-docs-preview-build.yml
+++ b/.github/workflows/fern-docs-preview-build.yml
@@ -66,9 +66,9 @@ jobs:
           for version_file in fern/versions/v*.yml; do
             [ -f "$version_file" ] || continue
             version=$(basename "$version_file" .yml)
-            if git rev-parse "$version" >/dev/null 2>&1; then
+            if git rev-parse -q --verify "refs/tags/$version" >/dev/null 2>&1; then
               mkdir -p "fern/versions/${version}-content"
-              git archive "$version" -- docs/ | tar -x --strip-components=1 -C "fern/versions/${version}-content"
+              git archive "refs/tags/$version" -- docs/ | tar -x --strip-components=1 -C "fern/versions/${version}-content"
               echo "Extracted docs from $version"
             else
               echo "::warning::Tag $version not found — skipping content checkout"

--- a/.github/workflows/fern-docs-preview-comment.yml
+++ b/.github/workflows/fern-docs-preview-comment.yml
@@ -55,9 +55,9 @@ jobs:
           HEAD_REF: ${{ steps.metadata.outputs.head_ref }}
         working-directory: ./fern
         run: |
-          OUTPUT=$(fern generate --docs --preview --id "$HEAD_REF" 2>&1)
-          echo "$OUTPUT"
-          URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K.*(?= \()')
+          set -o pipefail
+          fern generate --docs --preview --id "$HEAD_REF" 2>&1 | tee /tmp/fern-output.log
+          URL=$(grep -oP 'Published docs to \K.*(?= \()' /tmp/fern-output.log || true)
           if [ -z "$URL" ]; then
             echo "::error::Failed to generate preview URL. See fern output above."
             exit 1

--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -36,9 +36,9 @@ jobs:
           set -o pipefail
           for version_file in fern/versions/v*.yml; do
             version=$(basename "$version_file" .yml)
-            if git rev-parse "$version" >/dev/null 2>&1; then
+            if git rev-parse -q --verify "refs/tags/$version" >/dev/null 2>&1; then
               mkdir -p "fern/versions/${version}-content"
-              git archive "$version" -- docs/ | tar -x --strip-components=1 -C "fern/versions/${version}-content"
+              git archive "refs/tags/$version" -- docs/ | tar -x --strip-components=1 -C "fern/versions/${version}-content"
               echo "Extracted docs from $version"
             else
               echo "::error::Tag $version not found — cannot pin frozen docs content"


### PR DESCRIPTION
## Summary

Two fixes for the Fern preview pipeline:

1. **Preview build missing frozen version content** — Adds the `git archive` loop from the publish workflow so versioned docs (v1.2.0, v1.3.0, v1.4.0) are included in the preview artifact. Uses warning instead of error for missing tags.

2. **Preview comment swallows fern errors** — Switches from `OUTPUT=$(fern generate ... 2>&1)` to `tee`-based streaming, matching the publish workflow pattern. Errors are now visible in CI logs.

Same issues found and fixed in NVIDIA/topograph#322.

Fixes #1284

## Type of Change
- [x] 🐛 Bug fix
- [x] 🔨 Build/CI

## Component(s) Affected
- [x] Documentation/CI

## Testing
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable documentation previews: frozen-version docs are now detected and included when available, and missing versions are safely skipped with warnings.
  * Improved preview generation and publishing: command output is streamed to logs and parsed more robustly to extract published docs links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NVSentinel/pull/1285)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->