### PR TITLE
fix: Add FQ rules for NIC and syslog NIC driver fatal errors

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/fault-quarantine/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-quarantine/values.yaml
@@ -126,7 +126,20 @@ ruleSets:
     match:
       all:
         - kind: "HealthEvent"
-          expression: "event.agent == 'syslog-health-monitor' && event.componentClass == 'GPU' && event.isFatal == true"
+          expression: "event.agent == 'syslog-health-monitor' && (event.componentClass == 'GPU' || event.componentClass == 'NIC') && event.isFatal == true"
+        - kind: "Node"
+          expression: |
+            !('k8saas.nvidia.com/ManagedByNVSentinel' in node.metadata.labels && node.metadata.labels['k8saas.nvidia.com/ManagedByNVSentinel'] == "false")
+    cordon:
+      shouldCordon: true
+
+  - enabled: true
+    version: "1"
+    name: "NIC health monitor fatal error ruleset"
+    match:
+      all:
+        - kind: "HealthEvent"
+          expression: "event.agent == 'nic-health-monitor' && event.isFatal == true"
         - kind: "Node"
           expression: |
             !('k8saas.nvidia.com/ManagedByNVSentinel' in node.metadata.labels && node.metadata.labels['k8saas.nvidia.com/ManagedByNVSentinel'] == "false")

--- a/distros/kubernetes/nvsentinel/values-full.yaml
+++ b/distros/kubernetes/nvsentinel/values-full.yaml
@@ -510,7 +510,21 @@ fault-quarantine:
       match:
         all:
           - kind: "HealthEvent"
-            expression: "event.agent == 'syslog-health-monitor' && event.componentClass == 'GPU' && event.isFatal == true"
+            expression: "event.agent == 'syslog-health-monitor' && (event.componentClass == 'GPU' || event.componentClass == 'NIC') && event.isFatal == true"
+          - kind: "Node"
+            expression: |
+              !('k8saas.nvidia.com/ManagedByNVSentinel' in node.metadata.labels && node.metadata.labels['k8saas.nvidia.com/ManagedByNVSentinel'] == "false")
+      cordon:
+        shouldCordon: true
+
+    # Example rule 4: Quarantine nodes with NIC health monitor fatal errors
+    - enabled: true
+      version: "1"
+      name: "NIC health monitor fatal error ruleset"
+      match:
+        all:
+          - kind: "HealthEvent"
+            expression: "event.agent == 'nic-health-monitor' && event.isFatal == true"
           - kind: "Node"
             expression: |
               !('k8saas.nvidia.com/ManagedByNVSentinel' in node.metadata.labels && node.metadata.labels['k8saas.nvidia.com/ManagedByNVSentinel'] == "false")

--- a/node-drainer/pkg/reconciler/reconciler.go
+++ b/node-drainer/pkg/reconciler/reconciler.go
@@ -759,6 +759,8 @@ func (r *Reconciler) executeUpdateStatus(ctx context.Context, healthEvent model.
 			attribute.String("node_drainer.error.type", "label_update_error"),
 			attribute.String("node_drainer.error.message", err.Error()),
 		)
+
+		return fmt.Errorf("failed to update node %s label to %s: %w", nodeName, nodeDrainLabelValue, err)
 	}
 
 	return r.updateNodeUserPodsEvictedStatus(ctx, database, event, podsEvictionStatus,

--- a/node-drainer/pkg/reconciler/reconciler.go
+++ b/node-drainer/pkg/reconciler/reconciler.go
@@ -747,8 +747,9 @@ func (r *Reconciler) executeUpdateStatus(ctx context.Context, healthEvent model.
 		nodeDrainLabelValue = statemanager.DrainFailedLabelValue
 	}
 
-	if _, err := r.Config.StateManager.UpdateNVSentinelStateNodeLabel(ctx,
-		nodeName, nodeDrainLabelValue, false); err != nil {
+	nodeLabelModified, err := r.Config.StateManager.UpdateNVSentinelStateNodeLabel(ctx,
+		nodeName, nodeDrainLabelValue, false)
+	if err != nil {
 		slog.ErrorContext(ctx, "Failed to update node label",
 			"label", nodeDrainLabelValue,
 			"node", nodeName,
@@ -760,7 +761,9 @@ func (r *Reconciler) executeUpdateStatus(ctx context.Context, healthEvent model.
 			attribute.String("node_drainer.error.message", err.Error()),
 		)
 
-		return fmt.Errorf("failed to update node %s label to %s: %w", nodeName, nodeDrainLabelValue, err)
+		if !nodeLabelModified {
+			return fmt.Errorf("failed to update node %s label to %s: %w", nodeName, nodeDrainLabelValue, err)
+		}
 	}
 
 	return r.updateNodeUserPodsEvictedStatus(ctx, database, event, podsEvictionStatus,

--- a/tests/helpers/nic-health-monitor.go
+++ b/tests/helpers/nic-health-monitor.go
@@ -153,6 +153,14 @@ func TearDownNICHealthMonitor(ctx context.Context, t *testing.T,
 		t.Logf("Clearing stale NIC conditions from node %s", state.NodeName)
 		clearNICConditions(ctx, t, state.NodeName)
 
+		t.Logf("Waiting for node %s to be uncordoned after NIC condition cleanup", state.NodeName)
+		AssertQuarantineState(ctx, t, client, state.NodeName, QuarantineAssertion{
+			ExpectCordoned: false,
+			AnnotationChecks: []AnnotationCheck{
+				{Key: QuarantineHealthEventAnnotationKey, ShouldExist: false},
+			},
+		})
+
 		t.Logf("Removing ManagedByNVSentinel label from node %s", state.NodeName)
 
 		if err := RemoveNodeManagedByNVSentinelLabel(ctx, client, state.NodeName); err != nil {

--- a/tests/nic_health_monitor_test.go
+++ b/tests/nic_health_monitor_test.go
@@ -91,6 +91,18 @@ func TestNICHealthMonitorRoCEStateDetection(t *testing.T) {
 		helpers.WaitForNodeConditionWithCheckName(ctx, t, client, nodeName,
 			ethCheckName, "RoCE port mlx5_8 port 1", "", corev1.ConditionTrue)
 
+		t.Log("Verifying fatal EthernetStateCheck cordons the node")
+		helpers.AssertQuarantineState(ctx, t, client, nodeName, helpers.QuarantineAssertion{
+			ExpectCordoned: true,
+			AnnotationChecks: []helpers.AnnotationCheck{
+				{
+					Key:         helpers.QuarantineHealthEventAnnotationKey,
+					Pattern:     "EthernetStateCheck",
+					ShouldExist: true,
+				},
+			},
+		})
+
 		return ctx
 	})
 
@@ -108,6 +120,14 @@ func TestNICHealthMonitorRoCEStateDetection(t *testing.T) {
 		t.Log("Verifying EthernetStateCheck condition returns to False (healthy)")
 		helpers.WaitForNodeConditionWithCheckName(ctx, t, client, nodeName,
 			ethCheckName, "", "", corev1.ConditionFalse)
+
+		t.Log("Verifying EthernetStateCheck recovery uncordons the node")
+		helpers.AssertQuarantineState(ctx, t, client, nodeName, helpers.QuarantineAssertion{
+			ExpectCordoned: false,
+			AnnotationChecks: []helpers.AnnotationCheck{
+				{Key: helpers.QuarantineHealthEventAnnotationKey, ShouldExist: false},
+			},
+		})
 
 		return ctx
 	})
@@ -182,6 +202,18 @@ func TestNICHealthMonitorIBStateDetection(t *testing.T) {
 		helpers.WaitForNodeConditionWithCheckName(ctx, t, client, nodeName,
 			ibCheckName, "Port mlx5_0 port 1", "", corev1.ConditionTrue)
 
+		t.Log("Verifying fatal InfiniBandStateCheck cordons the node")
+		helpers.AssertQuarantineState(ctx, t, client, nodeName, helpers.QuarantineAssertion{
+			ExpectCordoned: true,
+			AnnotationChecks: []helpers.AnnotationCheck{
+				{
+					Key:         helpers.QuarantineHealthEventAnnotationKey,
+					Pattern:     "InfiniBandStateCheck",
+					ShouldExist: true,
+				},
+			},
+		})
+
 		return ctx
 	})
 
@@ -199,6 +231,14 @@ func TestNICHealthMonitorIBStateDetection(t *testing.T) {
 		t.Log("Verifying InfiniBandStateCheck condition returns to False (healthy)")
 		helpers.WaitForNodeConditionWithCheckName(ctx, t, client, nodeName,
 			ibCheckName, "", "", corev1.ConditionFalse)
+
+		t.Log("Verifying InfiniBandStateCheck recovery uncordons the node")
+		helpers.AssertQuarantineState(ctx, t, client, nodeName, helpers.QuarantineAssertion{
+			ExpectCordoned: false,
+			AnnotationChecks: []helpers.AnnotationCheck{
+				{Key: helpers.QuarantineHealthEventAnnotationKey, ShouldExist: false},
+			},
+		})
 
 		return ctx
 	})
@@ -606,7 +646,7 @@ func TestNICHealthMonitorMultipleDownRecoveryCycles(t *testing.T) {
 				nodeName, "mlx5_0", "1", "4: ACTIVE", "5: LinkUp")
 
 			helpers.WaitForNodeConditionWithCheckName(ctx, t, client, nodeName,
-			ibCheckName, "", "", corev1.ConditionFalse)
+				ibCheckName, "", "", corev1.ConditionFalse)
 		}
 
 		return ctx

--- a/tests/scale_test.go
+++ b/tests/scale_test.go
@@ -332,6 +332,8 @@ func TestScaleHealthEvents(t *testing.T) {
 			helpers.RestoreFQDeployment(ctx, t, client, originalDeployment)
 		}
 
+		helpers.RestoreQuarantineConfig(ctx, t, c)
+
 		originalCBState := ctx.Value(keyOriginalCBState).(string)
 		if originalCBState != "" {
 			helpers.SetCircuitBreakerState(ctx, t, c, originalCBState, string(cursorModeResume))

--- a/tests/syslog_health_monitor_test.go
+++ b/tests/syslog_health_monitor_test.go
@@ -657,7 +657,9 @@ func TestSyslogHealthMonitorNICDriverDetection(t *testing.T) {
 		client, err := c.NewClient()
 		require.NoError(t, err, "failed to create kubernetes client")
 
-		testNodeName, syslogPod, stopChan, originalArgs := helpers.SetUpSyslogHealthMonitor(ctx, t, client, nil, false)
+		// ManagedByNVSentinel=true is required for the fault-quarantine
+		// syslog ruleset to cordon this test node.
+		testNodeName, syslogPod, stopChan, originalArgs := helpers.SetUpSyslogHealthMonitor(ctx, t, client, nil, true)
 
 		ctx = context.WithValue(ctx, keySyslogNodeName, testNodeName)
 		ctx = context.WithValue(ctx, keySyslogPodName, syslogPod.Name)
@@ -691,6 +693,18 @@ func TestSyslogHealthMonitorNICDriverDetection(t *testing.T) {
 				"SysLogsNICDriverError", "SysLogsNICDriverErrorIsNotHealthy", expectedPatterns)
 		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval,
 			"Node condition should contain all fatal NIC driver patterns")
+
+		t.Log("Verifying fatal NIC driver syslog event cordons the node")
+		helpers.AssertQuarantineState(ctx, t, client, nodeName, helpers.QuarantineAssertion{
+			ExpectCordoned: true,
+			AnnotationChecks: []helpers.AnnotationCheck{
+				{
+					Key:         helpers.QuarantineHealthEventAnnotationKey,
+					Pattern:     "cmd_exec_timeout",
+					ShouldExist: true,
+				},
+			},
+		})
 
 		return ctx
 	})
@@ -772,6 +786,14 @@ func TestSyslogHealthMonitorNICDriverDetection(t *testing.T) {
 			return condition != nil && condition.Status == v1.ConditionFalse
 		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval,
 			"SysLogsNICDriverError condition should be cleared")
+
+		t.Logf("Verifying node %s is uncordoned after SysLogsNICDriverError recovery", nodeName)
+		helpers.AssertQuarantineState(ctx, t, client, nodeName, helpers.QuarantineAssertion{
+			ExpectCordoned: false,
+			AnnotationChecks: []helpers.AnnotationCheck{
+				{Key: helpers.QuarantineHealthEventAnnotationKey, ShouldExist: false},
+			},
+		})
 
 		t.Logf("Cleaning up metadata from node %s", nodeName)
 		helpers.DeleteMetadata(t, ctx, client, helpers.NVSentinelNamespace, nodeName)


### PR DESCRIPTION
## Summary

- Update fault-quarantine syslog rules to cordon fatal `syslog-health-monitor` events for both `GPU` and `NIC` component classes.
- Add a new fault-quarantine ruleset for fatal `nic-health-monitor` events.
- Extend E2E coverage to verify fatal NIC syslog and NIC health monitor events cordon nodes, and recovery paths uncordon them.
- Restore the original fault-quarantine ConfigMap after the scale E2E test so later tests do not inherit the temporary `Basic-Match-Rule` config.
- (Unrelated to main change fix due to test flake) Prevent node-drainer from marking drain status terminal when updating the node state label fails, allowing the event to be retried instead of leaving DB and node state inconsistent.

## Tests
- Verified that the newly modified E2E tests pass locally

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Syslog fatal-error detection now treats NIC events like GPU events, causing nodes to be cordoned on fatal NIC detections and uncordoned after recovery.
  * Reconciler now surfaces a failure when a node label update does not take effect, preventing continued eviction-state updates.

* **Tests**
  * Tests expanded to assert node cordon/uncordon and quarantine annotation presence/absence for NIC/GPU scenarios; teardown restores quarantine configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NVSentinel/pull/1288)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->