### PR TITLE
fix: cache only successful parse but retry for failures for fetching metadata from syslog HM

### DIFF
--- a/health-monitors/syslog-health-monitor/pkg/metadata/reader.go
+++ b/health-monitors/syslog-health-monitor/pkg/metadata/reader.go
@@ -28,8 +28,8 @@ import (
 type Reader struct {
 	path string
 
-	once    sync.Once
-	loadErr error
+	mu     sync.Mutex
+	loaded bool
 
 	metadata *model.GPUMetadata
 
@@ -50,11 +50,19 @@ func NewReader(path string) *Reader {
 }
 
 func (r *Reader) ensureLoaded() error {
-	r.once.Do(func() {
-		r.loadErr = r.load()
-	})
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
-	return r.loadErr
+	if r.loaded {
+		return nil
+	}
+
+	if err := r.load(); err != nil {
+		return err
+	}
+
+	r.loaded = true
+	return nil
 }
 
 func (r *Reader) load() error {

--- a/health-monitors/syslog-health-monitor/pkg/metadata/reader.go
+++ b/health-monitors/syslog-health-monitor/pkg/metadata/reader.go
@@ -62,6 +62,7 @@ func (r *Reader) ensureLoaded() error {
 	}
 
 	r.loaded = true
+
 	return nil
 }
 

--- a/health-monitors/syslog-health-monitor/pkg/metadata/reader_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/metadata/reader_test.go
@@ -332,18 +332,21 @@ func TestReaderMalformedJSON(t *testing.T) {
 	require.Contains(t, err.Error(), "failed to parse metadata JSON")
 }
 
-func TestReaderErrorCaching(t *testing.T) {
-	reader := NewReader("/nonexistent/file.json")
+func TestReaderRetriesAfterLoadFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	metadataFile := filepath.Join(tmpDir, "gpu_metadata.json")
+	reader := NewReader(metadataFile)
 
-	_, err1 := reader.GetGPUByPCI("0000:17:00.0")
-	_, err2 := reader.GetGPUByPCI("0000:65:00.0")
+	_, err := reader.GetGPUByPCI("0000:17:00.0")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to load metadata for PCI lookup 0000:17:00.0")
+	require.Contains(t, err.Error(), "failed to read metadata file")
 
-	require.Error(t, err1)
-	require.Error(t, err2)
-	require.Contains(t, err1.Error(), "failed to load metadata for PCI lookup 0000:17:00.0")
-	require.Contains(t, err2.Error(), "failed to load metadata for PCI lookup 0000:65:00.0")
-	require.Contains(t, err1.Error(), "failed to read metadata file")
-	require.Contains(t, err2.Error(), "failed to read metadata file")
+	require.NoError(t, os.WriteFile(metadataFile, []byte(testMetadataJSON), 0600))
+
+	gpu, err := reader.GetGPUByPCI("0000:65:00.0")
+	require.NoError(t, err)
+	require.Equal(t, "GPU-11111111-1111-1111-1111-111111111111", gpu.UUID)
 }
 
 func TestGetGPUByNVSwitchLinkErrorWrapping(t *testing.T) {


### PR DESCRIPTION
## Summary

Prior to this change, we were caching the metadata from metadata collector irrespective of whether the parsing is successful or failure resulting in https://github.com/NVIDIA/NVSentinel/issues/1287

With this change, we only cache if syslog health monitor has successfully parsed the data `/var/lib/nvsentinel/metadata.json`

## Testing

1. Set up a cluster using `make dev-env`
2. Deleted metadata file from the node and restarted syslog health monitor pod
3. Injected XID 79 so syslog health monitor has to lookup for PCI
```
$ curl -X POST --data-binary \
'kernel: [2.0] NVRM: Xid (PCI:0000:17:00): 79, pid=123, name=test, GPU has fallen off the bus.' \
http://localhost:9091/add
```
4. Check whether syslog health monitor errors out for PCI lookup:
```
$ kubectl logs -n nvsentinel syslog-health-monitor-regular-z5j5q -c syslog-health-monitor | grep 'Error getting GPU UUID from metadata'
{"time":"2026-05-18T08:27:15.08345554Z","level":"ERROR","msg":"Error getting GPU UUID from metadata","module":"syslog-health-monitor","version":"dev","pci":"0000:17:00","error":"failed to load metadata for PCI lookup 0000:17:00: failed to read metadata file: open /var/lib/nvsentinel/gpu_metadata.json: no such file or directory"}
```
5. Added metadata in the designated path (`/host/var/lib/nvsentinel/gpu_metadata.json`)
6. Verified that metadata is loaded now:
```
$ kubectl logs -n "$NS" "$POD" -c syslog-health-monitor | grep 'GPU metadata loaded'
{"time":"2026-05-18T08:30:45.081062276Z","level":"INFO","msg":"GPU metadata loaded","module":"syslog-health-monitor","version":"dev","gpus":1,"nvswitches":0,"chassis_serial":true}
```



## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Metadata loading now retries after an initial failure, allowing the system to recover automatically if metadata becomes available later instead of remaining stuck in an error state.

* **Tests**
  * Test suite updated to verify that metadata loading can succeed on a subsequent attempt after an initial load failure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NVSentinel/pull/1302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->