### PR TITLE
fix: fix node condition cleanup for truncated entity messages

### DIFF
--- a/platform-connectors/pkg/connectors/kubernetes/k8s_platform_connector_test.go
+++ b/platform-connectors/pkg/connectors/kubernetes/k8s_platform_connector_test.go
@@ -595,6 +595,39 @@ func TestRemoveImpactedEntitiesMessagesScoped(t *testing.T) {
 				"ErrorCode:98 GPU:0 unrelated Recommended Action=RESTART_VM;",
 			},
 		},
+		{
+			name: "Tier 1 truncated entity cleared by healthy event",
+			messages: []string{
+				"ErrorCode:POD_STUCK_AFTER_DELETION v1/Pod:prod/61f345d08c9a432a-134... Recommended Action=RESTART_VM;",
+				"ErrorCode:48 GPU:1 some error Recommended Action=DRAIN;",
+			},
+			entities:   []protos.Entity{{EntityType: "v1/Pod", EntityValue: "prod/61f345d08c9a432a-134a464884734f90"}},
+			errorCodes: []string{"POD_STUCK_AFTER_DELETION"},
+			expected: []string{
+				"ErrorCode:48 GPU:1 some error Recommended Action=DRAIN;",
+			},
+		},
+		{
+			name: "Tier 2 byte-truncated entity cleared by healthy event",
+			messages: []string{
+				"ErrorCode:POD_STUCK v1/Pod:prod/61f345d08c9a432a-134",
+			},
+			entities:   []protos.Entity{{EntityType: "v1/Pod", EntityValue: "prod/61f345d08c9a432a-134a464884734f90"}},
+			errorCodes: nil,
+			expected:   nil,
+		},
+		{
+			name: "complete shorter entity NOT falsely cleared by longer entity healthy event",
+			messages: []string{
+				"ErrorCode:48 v1/Pod:prod/app-a error Recommended Action=DRAIN;",
+				"ErrorCode:48 v1/Pod:prod/app-abcdef error Recommended Action=DRAIN;",
+			},
+			entities:   []protos.Entity{{EntityType: "v1/Pod", EntityValue: "prod/app-abcdef"}},
+			errorCodes: nil,
+			expected: []string{
+				"ErrorCode:48 v1/Pod:prod/app-a error Recommended Action=DRAIN;",
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -1719,10 +1752,10 @@ func TestCompactMessageField(t *testing.T) {
 			expected: "ErrorCode:DCGM_FR_NVLINK_DOWN GPU:3 Link down Recommended Action=RESTART_VM",
 		},
 		{
-			name:     "Long message - truncated to maxLen",
+			name:     "Long diagnostic - only diagnostic text truncated",
 			msg:      "ErrorCode:DCGM_FR_NVLINK_DOWN GPU:3 GPU 3's NvLink link 0 is currently down Check DCGM and system logs for errors. Reset GPU. Restart DCGM. Rerun diagnostics. Recommended Action=RESTART_VM",
 			maxLen:   80,
-			expected: "ErrorCode:DCGM_FR_NVLINK_DOWN GPU:3 GPU 3's NvLink link 0 is currently down Chec... Recommended Action=RESTART_VM",
+			expected: "ErrorCode:DCGM_FR_NVLINK_DOWN GPU:3 GPU 3's NvLink link 0 is currently down C... Recommended Action=RESTART_VM",
 		},
 		{
 			name:     "No Recommended Action marker - returned as-is",
@@ -1731,10 +1764,22 @@ func TestCompactMessageField(t *testing.T) {
 			expected: "some unstructured message without the marker",
 		},
 		{
-			name:     "Message with multiple entities - truncated to maxLen",
+			name:     "Multiple entities preserved - only diagnostic truncated",
 			msg:      "ErrorCode:DCGM_FR_NVLINK_DOWN GPU:3 PCI:0000:c4:00.0 GPU_UUID:GPU-8614c5d9-371d-1d8a-9bab-78d0434427ec GPU 3's NvLink link 0 is currently down Check DCGM and system logs for errors. Recommended Action=RESTART_VM",
 			maxLen:   128,
-			expected: "ErrorCode:DCGM_FR_NVLINK_DOWN GPU:3 PCI:0000:c4:00.0 GPU_UUID:GPU-8614c5d9-371d-1d8a-9bab-78d0434427ec GPU 3's NvLink link 0 is ... Recommended Action=RESTART_VM",
+			expected: "ErrorCode:DCGM_FR_NVLINK_DOWN GPU:3 PCI:0000:c4:00.0 GPU_UUID:GPU-8614c5d9-371d-1d8a-9bab-78d0434427ec GPU 3's NvLink link 0 ... Recommended Action=RESTART_VM",
+		},
+		{
+			name:     "Identity exceeds maxLen - full identity preserved with no diagnostic",
+			msg:      "ErrorCode:POD_STUCK_AFTER_DELETION v1/Pod:prod/61f345d08c9a432a-134a464884734f90 Pod is stuck after deletion timeout Recommended Action=RESTART_VM",
+			maxLen:   72,
+			expected: "ErrorCode:POD_STUCK_AFTER_DELETION v1/Pod:prod/61f345d08c9a432a-134a464884734f90 ... Recommended Action=RESTART_VM",
+		},
+		{
+			name:     "Short entity types - identity fits within maxLen",
+			msg:      "ErrorCode:48 GPU:0 Xid error 48 on GPU 0 with some extra diagnostic text that makes it long Recommended Action=DRAIN",
+			maxLen:   72,
+			expected: "ErrorCode:48 GPU:0 Xid error 48 on GPU 0 with some extra diagnostic t... Recommended Action=DRAIN",
 		},
 	}
 
@@ -1747,6 +1792,114 @@ func TestCompactMessageField(t *testing.T) {
 				assert.Contains(t, result, recommendedActionMarker,
 					"Recommended Action must always be preserved")
 			}
+		})
+	}
+}
+
+func TestIsStructuredEntityToken(t *testing.T) {
+	tests := []struct {
+		token    string
+		expected bool
+	}{
+		{"GPU:0", true},
+		{"PCI:0000:c1:00.0", true},
+		{"v1/Pod:prod/my-pod-name", true},
+		{"NIC:mlx5_0", true},
+		{"NVSWITCH:0", true},
+		{"IB:mlx5_0", true},
+		{"GPU_UUID:GPU-8614c5d9-371d-1d8a-9bab-78d0434427ec", true},
+		{"ErrorCode:48", false},
+		{"ErrorCode:DCGM_FR_NVLINK_DOWN", false},
+		{"novalue:", false},
+		{":nokey", false},
+		{"nocolon", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.token, func(t *testing.T) {
+			assert.Equal(t, tc.expected, isStructuredEntityToken(tc.token))
+		})
+	}
+}
+
+func TestEntityMatchesMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		msg      string
+		entity   *protos.Entity
+		expected bool
+	}{
+		{
+			name:     "Exact match with trailing space",
+			msg:      "ErrorCode:48 GPU:0 Xid error Recommended Action=DRAIN",
+			entity:   &protos.Entity{EntityType: "GPU", EntityValue: "0"},
+			expected: true,
+		},
+		{
+			name:     "Exact match - PCI address",
+			msg:      "ErrorCode:48 GPU:0 PCI:0000:c1:00.0 Xid error Recommended Action=DRAIN",
+			entity:   &protos.Entity{EntityType: "PCI", EntityValue: "0000:c1:00.0"},
+			expected: true,
+		},
+		{
+			name:     "No match - different entity value",
+			msg:      "ErrorCode:48 GPU:0 Xid error Recommended Action=DRAIN",
+			entity:   &protos.Entity{EntityType: "GPU", EntityValue: "1"},
+			expected: false,
+		},
+		{
+			name:     "No match - different entity type",
+			msg:      "ErrorCode:48 GPU:0 Xid error Recommended Action=DRAIN",
+			entity:   &protos.Entity{EntityType: "NIC", EntityValue: "0"},
+			expected: false,
+		},
+		{
+			name:     "Tier 1 truncated match - entity ends with ...",
+			msg:      "ErrorCode:POD_STUCK v1/Pod:prod/61f345d08c9a432a-134... Recommended Action=RESTART_VM",
+			entity:   &protos.Entity{EntityType: "v1/Pod", EntityValue: "prod/61f345d08c9a432a-134a464884734f90"},
+			expected: true,
+		},
+		{
+			name:     "Tier 2 truncated match - entity is last token (byte-truncated)",
+			msg:      "ErrorCode:POD_STUCK v1/Pod:prod/61f345d08c9a432a-134",
+			entity:   &protos.Entity{EntityType: "v1/Pod", EntityValue: "prod/61f345d08c9a432a-134a464884734f90"},
+			expected: true,
+		},
+		{
+			name:     "False positive guard - complete shorter entity must NOT match longer",
+			msg:      "ErrorCode:48 v1/Pod:prod/app-a Xid error Recommended Action=DRAIN",
+			entity:   &protos.Entity{EntityType: "v1/Pod", EntityValue: "prod/app-abcdef"},
+			expected: false,
+		},
+		{
+			name:     "False positive guard - complete shorter entity before Recommended Action must NOT match longer",
+			msg:      "ErrorCode:48 v1/Pod:prod/app-a Recommended Action=DRAIN",
+			entity:   &protos.Entity{EntityType: "v1/Pod", EntityValue: "prod/app-abcdef"},
+			expected: false,
+		},
+		{
+			name:     "Entity type prefix only with no value - no match",
+			msg:      "ErrorCode:48 GPU: Xid error Recommended Action=DRAIN",
+			entity:   &protos.Entity{EntityType: "GPU", EntityValue: "0"},
+			expected: false,
+		},
+		{
+			name:     "Truncated PCI address match",
+			msg:      "ErrorCode:48 GPU:3 PCI:0000:c4:00... Recommended Action=RESTART_VM",
+			entity:   &protos.Entity{EntityType: "PCI", EntityValue: "0000:c4:00.0"},
+			expected: true,
+		},
+		{
+			name:     "GPU type should not match GPU_UUID type",
+			msg:      "ErrorCode:48 GPU_UUID:GPU-8614c5d9-371d... Recommended Action=DRAIN",
+			entity:   &protos.Entity{EntityType: "GPU", EntityValue: "UUID:GPU-8614c5d9-371d"},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, entityMatchesMessage(tc.msg, tc.entity))
 		})
 	}
 }

--- a/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
+++ b/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
@@ -351,6 +351,47 @@ func deduplicateMessagesByIdentity(messages []string) []string {
 	return result
 }
 
+// entityMatchesMessage reports whether msg contains the entity token, handling
+// both exact matches and truncated tokens. Prefix matching only activates when
+// there is evidence of truncation (token ends with "..." or the message was
+// byte-truncated before the Recommended Action marker) to prevent false
+// positives against complete but shorter entity values.
+func entityMatchesMessage(msg string, entity *protos.Entity) bool {
+	fullToken := fmt.Sprintf("%s:%s ", entity.EntityType, entity.EntityValue)
+	if strings.Contains(msg, fullToken) {
+		return true
+	}
+
+	prefix := msg
+
+	hasRecommendedAction := false
+	if raIdx := strings.LastIndex(msg, recommendedActionMarker); raIdx >= 0 {
+		hasRecommendedAction = true
+		prefix = msg[:raIdx]
+	}
+
+	entityToken := fmt.Sprintf("%s:%s", entity.EntityType, entity.EntityValue)
+	typePrefix := entity.EntityType + ":"
+
+	tokens := strings.Fields(prefix)
+
+	for i, tok := range tokens {
+		if !strings.HasPrefix(tok, typePrefix) {
+			continue
+		}
+
+		isTruncated := strings.HasSuffix(tok, truncationSuffix) || (!hasRecommendedAction && i == len(tokens)-1)
+
+		candidate := strings.TrimSuffix(tok, truncationSuffix)
+
+		if isTruncated && len(candidate) > len(typePrefix) && strings.HasPrefix(entityToken, candidate) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // removeImpactedEntitiesMessagesScoped removes messages that mention any
 // supplied entity. When errorCodes is non-empty, the message must also carry
 // a matching ErrorCode token; this prevents an "X cancels Y" rule from
@@ -366,9 +407,7 @@ func (r *K8sConnector) removeImpactedEntitiesMessagesScoped(
 		entityFound := false
 
 		for _, entity := range entities {
-			entityPrefix := fmt.Sprintf("%s:%s ", entity.EntityType, entity.EntityValue)
-
-			if strings.Contains(msg, entityPrefix) {
+			if entityMatchesMessage(msg, entity) {
 				entityFound = true
 				break
 			}
@@ -817,9 +856,67 @@ func totalMessageLength(messages []string) int {
 	return total
 }
 
-// compactMessageField truncates the message content before the Recommended Action
-// suffix to maxLen bytes, preserving the Recommended Action suffix needed for
-// recovery matching.
+// isStructuredEntityToken reports whether a whitespace-delimited token matches
+// the TYPE:VALUE pattern produced by constructHealthEventMessage.
+func isStructuredEntityToken(token string) bool {
+	if strings.HasPrefix(token, "ErrorCode:") {
+		return false
+	}
+
+	colonIdx := strings.Index(token, ":")
+
+	return colonIdx > 0 && colonIdx < len(token)-1
+}
+
+func splitIdentityAndDiagnostic(beforeRA string) (string, string) {
+	tokens := strings.Fields(beforeRA)
+
+	var identityEnd int
+
+	for i, tok := range tokens {
+		if strings.HasPrefix(tok, "ErrorCode:") || isStructuredEntityToken(tok) {
+			identityEnd = i + 1
+		} else {
+			break
+		}
+	}
+
+	return strings.Join(tokens[:identityEnd], " "), strings.Join(tokens[identityEnd:], " ")
+}
+
+func truncateWithSuffix(text string, maxLen int) string {
+	if maxLen <= len(truncationSuffix) {
+		return truncationSuffix
+	}
+
+	if len(text) > maxLen-len(truncationSuffix) {
+		return text[:maxLen-len(truncationSuffix)] + truncationSuffix
+	}
+
+	return text
+}
+
+func compactMessagePrefix(identityPrefix, diagnosticText string, maxLen int) string {
+	if identityPrefix == "" {
+		return truncateWithSuffix(diagnosticText, maxLen)
+	}
+
+	if len(identityPrefix) >= maxLen {
+		return identityPrefix + " " + truncationSuffix
+	}
+
+	available := maxLen - len(identityPrefix) - 1 // -1 for space between identity and diagnostic
+	if available <= 0 || diagnosticText == "" {
+		return identityPrefix + " " + truncationSuffix
+	}
+
+	return identityPrefix + " " + truncateWithSuffix(diagnosticText, available)
+}
+
+// compactMessageField truncates the diagnostic free-text while preserving
+// identity tokens (ErrorCode and entity tokens) and the Recommended Action
+// suffix needed for recovery matching. Identity tokens are never byte-truncated;
+// maxLen is treated as a target for diagnostic text compaction only.
 //
 // Input format:  "ErrorCode:X GPU:3 PCI:addr <diagnostic text> Recommended Action=Y"
 // Output format: "ErrorCode:X GPU:3 PCI:addr <truncated>... Recommended Action=Y"
@@ -836,7 +933,9 @@ func compactMessageField(msg string, maxLen int) string {
 		return msg
 	}
 
-	return beforeRA[:maxLen] + truncationSuffix + " " + raPart
+	identityPrefix, diagnosticText := splitIdentityAndDiagnostic(beforeRA)
+
+	return compactMessagePrefix(identityPrefix, diagnosticText, maxLen) + " " + raPart
 }
 
 // truncateNodeConditionMessage builds the node condition message while respecting the max node condition

--- a/tests/helpers/platform_connector.go
+++ b/tests/helpers/platform_connector.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/e2e-framework/klient"
+)
+
+// UpsertNodeCondition adds or replaces a node condition through the status subresource.
+func UpsertNodeCondition(
+	ctx context.Context,
+	t *testing.T,
+	client klient.Client,
+	nodeName string,
+	condition v1.NodeCondition,
+) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			node, nodeErr := GetNodeByName(ctx, client, nodeName)
+			if nodeErr != nil {
+				return nodeErr
+			}
+
+			now := metav1.Now()
+			if condition.LastHeartbeatTime.IsZero() {
+				condition.LastHeartbeatTime = now
+			}
+
+			if condition.LastTransitionTime.IsZero() {
+				condition.LastTransitionTime = now
+			}
+
+			replaced := false
+
+			for i := range node.Status.Conditions {
+				if node.Status.Conditions[i].Type == condition.Type {
+					node.Status.Conditions[i] = condition
+					replaced = true
+
+					break
+				}
+			}
+
+			if !replaced {
+				node.Status.Conditions = append(node.Status.Conditions, condition)
+			}
+
+			return client.Resources().UpdateStatus(ctx, node)
+		})
+		if err != nil {
+			t.Logf("Failed to upsert node condition: %v", err)
+
+			return false
+		}
+
+		return true
+	}, EventuallyWaitTimeout, WaitInterval, "failed to upsert node condition")
+}

--- a/tests/platform_connector_node_condition_test.go
+++ b/tests/platform_connector_node_condition_test.go
@@ -1,0 +1,129 @@
+//go:build amd64_group
+// +build amd64_group
+
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"tests/helpers"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
+)
+
+const (
+	truncatedEntityRegressionCheckName = "PodStuckAfterDeletionRegression"
+	truncatedEntityRegressionErrorCode = "POD_STUCK_AFTER_DELETION"
+	truncatedEntityRegressionType      = "v1/Pod"
+	truncatedEntityRegressionValue     = "prod/61f345d08c9a432a-134a464884734f90"
+)
+
+// TestPlatformConnectorClearsCompactedLongEntityCondition verifies that platform-connector
+// can clear node conditions written by the old compaction behavior. The test seeds a
+// node condition directly with a truncated entity token:
+//
+//	v1/Pod:prod/61f345d08c9a432a-134...
+//
+// Then it sends a healthy event with the full entity value. Without truncation-aware
+// matching, the connector searches for the full token, does not find it in the
+// stored condition message, and leaves the condition stuck as unhealthy.
+func TestPlatformConnectorClearsCompactedLongEntityCondition(t *testing.T) {
+	feature := features.New("Platform Connector - Clears Truncated Long Entity Condition").
+		WithLabel("suite", "platform-connector").
+		WithLabel("component", "node-condition")
+
+	var nodeName string
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err, "failed to create kubernetes client")
+
+		nodeName = helpers.AcquireNodeFromPool(ctx, t, client, helpers.DefaultExpiry)
+		sendTruncatedEntityClearEvent(ctx, t, nodeName)
+
+		return ctx
+	})
+
+	feature.Assess("Healthy event clears a pre-existing condition whose entity was truncated", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err, "failed to create kubernetes client")
+
+		helpers.UpsertNodeCondition(ctx, t, client, nodeName, v1.NodeCondition{
+			Type:    v1.NodeConditionType(truncatedEntityRegressionCheckName),
+			Status:  v1.ConditionTrue,
+			Reason:  truncatedEntityRegressionCheckName + "IsNotHealthy",
+			Message: "ErrorCode:POD_STUCK_AFTER_DELETION v1/Pod:prod/61f345d08c9a432a-134... Recommended Action=NONE;",
+		})
+
+		healthyEvent := helpers.NewHealthEvent(nodeName).
+			WithAgent("platform-connector-regression").
+			WithComponentClass("Pod").
+			WithCheckName(truncatedEntityRegressionCheckName).
+			WithFatal(false).
+			WithHealthy(true).
+			WithErrorCode(truncatedEntityRegressionErrorCode).
+			WithEntitiesImpacted([]helpers.EntityImpacted{{
+				EntityType:  truncatedEntityRegressionType,
+				EntityValue: truncatedEntityRegressionValue,
+			}}).
+			WithMessage("pod recovered").
+			WithRecommendedAction(int(pb.RecommendedAction_NONE))
+
+		helpers.SendHealthEvent(ctx, t, healthyEvent)
+
+		helpers.WaitForNodeConditionWithCheckName(ctx, t, client, nodeName,
+			truncatedEntityRegressionCheckName,
+			"No Health Failures",
+			truncatedEntityRegressionCheckName+"IsHealthy",
+			v1.ConditionFalse)
+
+		return ctx
+	})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		if nodeName != "" {
+			sendTruncatedEntityClearEvent(ctx, t, nodeName)
+		}
+
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}
+
+func sendTruncatedEntityClearEvent(ctx context.Context, t *testing.T, nodeName string) {
+	t.Helper()
+
+	clearEvent := helpers.NewHealthEvent(nodeName).
+		WithAgent("platform-connector-regression").
+		WithComponentClass("Pod").
+		WithCheckName(truncatedEntityRegressionCheckName).
+		WithFatal(false).
+		WithHealthy(true).
+		WithErrorCode(truncatedEntityRegressionErrorCode).
+		WithEntitiesImpacted(nil).
+		WithMessage("No health failures").
+		WithRecommendedAction(int(pb.RecommendedAction_NONE))
+
+	helpers.SendHealthEvent(ctx, t, clearEvent)
+}


### PR DESCRIPTION
## Summary

## Problem

When multiple health events exceed `MaxNodeConditionMessageLength` (1024 bytes), the platform connector compacts messages in two stages:

- **Tier 1 (per-message compaction):** Each individual message's content before `Recommended Action=` is cut to `CompactedHealthEventMsgLen` (72 bytes), appending `...` as a truncation marker.
- **Tier 2 (byte-level hard limit):** After all messages are compacted, if the combined `;`-joined string still exceeds `MaxNodeConditionMessageLength` (1024 bytes), the last message entry is cut at an arbitrary byte boundary to fit the limit.

For entity types with long values like `v1/Pod:prod/61f345d08c9a432a-134a464884734f90`, the Tier 1 byte cut lands inside the entity value:

```
ErrorCode:POD_STUCK_AFTER_DELETION v1/Pod:prod/61f345d08c9a432a-134... Recommended Action=RESTART_VM
```

When a healthy event arrives to clear that entity, the cleanup code searches for the full token `v1/Pod:prod/61f345d08c9a432a-134a464884734f90 ` via exact substring match. Since only the truncated form exists in the stored condition, the match fails and the condition remains stuck as unhealthy indefinitely.

## Fix

### Forward fix -- identity-aware compaction

`compactMessageField` is rewritten to parse the structured identity prefix (ErrorCode + entity tokens) and only truncate the trailing diagnostic free-text. Identity tokens are never byte-truncated.

**Before (old behavior):**

```
Input:    "ErrorCode:POD_STUCK_AFTER_DELETION v1/Pod:prod/61f345d08c9a432a-134a464884734f90 Pod stuck after deletion timeout exceeded Recommended Action=RESTART_VM"
                                                                                          ^--- blind cut at byte 72
Output:   "ErrorCode:POD_STUCK_AFTER_DELETION v1/Pod:prod/61f345d08c9a432a-134... Recommended Action=RESTART_VM"
```

Entity name is damaged. Future healthy events cannot clear this condition.

**After (new behavior):**

```
Input:    "ErrorCode:POD_STUCK_AFTER_DELETION v1/Pod:prod/61f345d08c9a432a-134a464884734f90 Pod stuck after deletion timeout exceeded Recommended Action=RESTART_VM"

Identity: "ErrorCode:POD_STUCK_AFTER_DELETION v1/Pod:prod/61f345d08c9a432a-134a464884734f90"  (preserved in full)
Diagnostic: "Pod stuck after deletion timeout exceeded"  (truncated)

Output:   "ErrorCode:POD_STUCK_AFTER_DELETION v1/Pod:prod/61f345d08c9a432a-134a464884734f90 ... Recommended Action=RESTART_VM"
```

Entity name intact. Only the human-readable diagnostic is removed. `MaxNodeConditionMessageLength` is still enforced by Tier 2.

### Backward fix -- truncation-tolerant entity matching

Nodes that already have truncated conditions stored (from before this fix, or from Tier 2 byte-level truncation) need to be clearable. The new `entityMatchesMessage` helper falls back to prefix matching when exact match fails, but only when there is evidence of truncation.

**Example -- Tier 1 truncation (entity ends with `...`):**

```
Stored condition: "ErrorCode:POD_STUCK v1/Pod:prod/61f345d08c9a432a-134... Recommended Action=RESTART_VM"
Healthy event:    entity = v1/Pod:prod/61f345d08c9a432a-134a464884734f90

Step 1: Exact match for "v1/Pod:prod/61f345d08c9a432a-134a464884734f90 " → NOT FOUND
Step 2: Tokenize prefix, find "v1/Pod:prod/61f345d08c9a432a-134..."
        - Ends with "..." → evidence of truncation
        - Strip "...", candidate = "v1/Pod:prod/61f345d08c9a432a-134"
        - Full entity starts with candidate? YES → MATCH
Result: Condition is cleared.
```

**Example -- Tier 2 truncation (entity is last token, no `Recommended Action=`):**

```
Stored condition: "ErrorCode:POD_STUCK v1/Pod:prod/61f345d08c9a432a-134"
Healthy event:    entity = v1/Pod:prod/61f345d08c9a432a-134a464884734f90

Step 1: Exact match for "v1/Pod:prod/61f345d08c9a432a-134a464884734f90 " → NOT FOUND
Step 2: Tokenize prefix, find "v1/Pod:prod/61f345d08c9a432a-134"
        - No "Recommended Action=" in message AND token is last → evidence of Tier 2 truncation
        - candidate = "v1/Pod:prod/61f345d08c9a432a-134"
        - Full entity starts with candidate? YES → MATCH
Result: Condition is cleared.
```

**Example -- false positive prevention (complete shorter entity):**

```
Stored condition: "ErrorCode:48 v1/Pod:prod/app-a error Recommended Action=DRAIN"
Healthy event:    entity = v1/Pod:prod/app-abcdef

Step 1: Exact match for "v1/Pod:prod/app-abcdef " → NOT FOUND
Step 2: Tokenize prefix, find "v1/Pod:prod/app-a"
        - Does NOT end with "..."
        - Message HAS "Recommended Action=" so last-token rule does not apply
        - isTruncated = false → skip prefix matching
Result: No match. Condition for app-a is NOT incorrectly cleared.
```

## Testing

- **Unit tests (`make test` in `platform-connectors/`):** 245 tests pass including all envtest/kubebuilder integration tests. New test functions: `TestIsStructuredEntityToken`, `TestEntityMatchesMessage`, and truncation cases added to `TestRemoveImpactedEntitiesMessagesScoped` and `TestCompactMessageField`.
- **Lint (`golangci-lint`):** Passes for both `platform-connectors/` and `tests/`.
- **Tilt/e2e regression test:** Seeds a pre-truncated node condition directly via the Kubernetes status subresource, sends a scoped healthy event, and verifies clearance. Verified on a Kind cluster:
  - With the fix stashed (old code running): condition stays stuck as `ConditionTrue`, test times out and fails.
  - With the fix unstashed (new code running): condition clears to `ConditionFalse` with "No Health Failures" in ~5 seconds, test passes.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
