### PR TITLE
fix: E2E TestFatalHealthEvent times out waiting for node cordon

### DIFF
--- a/commons/pkg/annotation/prefix.go
+++ b/commons/pkg/annotation/prefix.go
@@ -46,3 +46,10 @@ func FindAllPrefixMatches(annotations map[string]string, prefixes []string) map[
 
 	return matches
 }
+
+// IsEmptyValue reports whether an annotation value should be treated as absent.
+// Kubernetes annotations are strings; some controllers serialize an empty list as "[]".
+func IsEmptyValue(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	return trimmed == "" || trimmed == "[]"
+}

--- a/commons/pkg/annotation/prefix_test.go
+++ b/commons/pkg/annotation/prefix_test.go
@@ -226,3 +226,26 @@ func TestFindAllPrefixMatches(t *testing.T) {
 		})
 	}
 }
+
+func TestIsEmptyValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "empty string", value: "", want: true},
+		{name: "whitespace", value: " \n\t ", want: true},
+		{name: "empty JSON array", value: "[]", want: true},
+		{name: "empty JSON array with whitespace", value: "  []\n", want: true},
+		{name: "non-empty JSON array", value: `[{"checkName":"GpuXidError"}]`, want: false},
+		{name: "non-array value", value: "value", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsEmptyValue(tt.value); got != tt.want {
+				t.Fatalf("IsEmptyValue(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}

--- a/commons/pkg/auditlogger/roundtripper.go
+++ b/commons/pkg/auditlogger/roundtripper.go
@@ -68,7 +68,7 @@ func (rt *AuditingRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 		if readErr == nil {
 			body = string(bodyBytes)
 		} else {
-			slog.Error("audit: failed to read request body", "method", req.Method, "url", req.URL.String(), "error", readErr)
+			slog.Error("audit: failed to read request body", "method", req.Method, "url", req.URL.String(), "error", readErr) //nolint:gosec // URL is emitted as structured audit context.
 		}
 	}
 

--- a/commons/pkg/auditlogger/roundtripper.go
+++ b/commons/pkg/auditlogger/roundtripper.go
@@ -68,7 +68,11 @@ func (rt *AuditingRoundTripper) RoundTrip(req *http.Request) (*http.Response, er
 		if readErr == nil {
 			body = string(bodyBytes)
 		} else {
-			slog.Error("audit: failed to read request body", "method", req.Method, "url", req.URL.String(), "error", readErr) //nolint:gosec // URL is emitted as structured audit context.
+			//nolint:gosec // URL is emitted as structured audit context.
+			slog.Error("audit: failed to read request body",
+				"method", req.Method,
+				"url", req.URL.String(),
+				"error", readErr)
 		}
 	}
 

--- a/commons/pkg/tracing/tracing.go
+++ b/commons/pkg/tracing/tracing.go
@@ -130,7 +130,8 @@ func InitTracing(serviceName string) error {
 
 	tracer = otel.Tracer(serviceName)
 
-	slog.Info("OpenTelemetry tracing initialized", "endpoint", endpoint) //nolint:gosec // Endpoint is configuration data logged as structured context.
+	//nolint:gosec // Endpoint is configuration data logged as structured context.
+	slog.Info("OpenTelemetry tracing initialized", "endpoint", endpoint)
 
 	return nil
 }

--- a/commons/pkg/tracing/tracing.go
+++ b/commons/pkg/tracing/tracing.go
@@ -130,7 +130,7 @@ func InitTracing(serviceName string) error {
 
 	tracer = otel.Tracer(serviceName)
 
-	slog.Info("OpenTelemetry tracing initialized", "endpoint", endpoint)
+	slog.Info("OpenTelemetry tracing initialized", "endpoint", endpoint) //nolint:gosec // Endpoint is configuration data logged as structured context.
 
 	return nil
 }

--- a/fault-quarantine/pkg/reconciler/reconciler.go
+++ b/fault-quarantine/pkg/reconciler/reconciler.go
@@ -596,7 +596,12 @@ func (r *Reconciler) hasExistingQuarantine(ctx context.Context, nodeName string)
 
 	annotationVal, exists := annotations[common.QuarantineHealthEventAnnotationKey]
 
-	return annotations, exists && annotationVal != ""
+	return annotations, exists && !isEmptyHealthEventAnnotation(annotationVal)
+}
+
+func isEmptyHealthEventAnnotation(annotationVal string) bool {
+	trimmed := strings.TrimSpace(annotationVal)
+	return trimmed == "" || trimmed == "[]"
 }
 
 func (r *Reconciler) sourceDocIDsFromAnnotation(ctx context.Context, nodeName string) []string {

--- a/fault-quarantine/pkg/reconciler/reconciler.go
+++ b/fault-quarantine/pkg/reconciler/reconciler.go
@@ -29,6 +29,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	corev1 "k8s.io/api/core/v1"
 
+	annotationutil "github.com/nvidia/nvsentinel/commons/pkg/annotation"
 	"github.com/nvidia/nvsentinel/commons/pkg/statemanager"
 	"github.com/nvidia/nvsentinel/commons/pkg/tracing"
 	"github.com/nvidia/nvsentinel/data-models/pkg/model"
@@ -600,8 +601,7 @@ func (r *Reconciler) hasExistingQuarantine(ctx context.Context, nodeName string)
 }
 
 func isEmptyHealthEventAnnotation(annotationVal string) bool {
-	trimmed := strings.TrimSpace(annotationVal)
-	return trimmed == "" || trimmed == "[]"
+	return annotationutil.IsEmptyValue(annotationVal)
 }
 
 func (r *Reconciler) sourceDocIDsFromAnnotation(ctx context.Context, nodeName string) []string {

--- a/fault-quarantine/pkg/reconciler/reconciler.go
+++ b/fault-quarantine/pkg/reconciler/reconciler.go
@@ -527,6 +527,10 @@ func (r *Reconciler) handleEvent(
 	annotations, quarantineAnnotationExists := r.hasExistingQuarantine(ctx, event.HealthEvent.NodeName)
 
 	if quarantineAnnotationExists {
+		slog.DebugContext(ctx, "Node already has active quarantine annotation, skipping fresh quarantine",
+			"node", event.HealthEvent.NodeName,
+			"checkName", event.HealthEvent.CheckName)
+
 		return r.handleAlreadyQuarantinedNode(ctx, event.HealthEvent, ruleSetEvals)
 	}
 

--- a/tests/helpers/fault_quarantine.go
+++ b/tests/helpers/fault_quarantine.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	annotationutil "github.com/nvidia/nvsentinel/commons/pkg/annotation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -441,8 +442,7 @@ func checkAnnotationStates(t *testing.T, node *v1.Node, nodeName string, checks 
 }
 
 func isEmptyAnnotationValue(value string) bool {
-	trimmed := strings.TrimSpace(value)
-	return trimmed == "" || trimmed == "[]"
+	return annotationutil.IsEmptyValue(value)
 }
 
 func SetCircuitBreakerState(ctx context.Context, t *testing.T, c *envconf.Config, state, cursorMode string) {

--- a/tests/helpers/fault_quarantine.go
+++ b/tests/helpers/fault_quarantine.go
@@ -40,6 +40,9 @@ const (
 // QuarantineHealthEventAnnotationKey is the annotation key for health events set by fault-quarantine.
 const QuarantineHealthEventAnnotationKey = "quarantineHealthEvent"
 
+// QuarantineHealthEventIsCordonedAnnotationKey records that fault-quarantine cordoned the node.
+const QuarantineHealthEventIsCordonedAnnotationKey = "quarantineHealthEventIsCordoned"
+
 type faultQuarantineConfig struct {
 	LabelPrefix    string               `toml:"label-prefix"`
 	CircuitBreaker circuitBreakerConfig `toml:"circuitBreaker"`
@@ -337,13 +340,13 @@ func checkAnnotation(t *testing.T, nodeName string, check AnnotationCheck, annot
 
 	if check.Pattern == "" {
 		// Just check for annotation existence
-		if check.ShouldExist && annotationValue == "" {
+		if check.ShouldExist && isEmptyAnnotationValue(annotationValue) {
 			t.Logf("waiting for annotation %q on node %s", check.Key, nodeName)
 
 			return false
 		}
 
-		if !check.ShouldExist && annotationValue != "" {
+		if !check.ShouldExist && !isEmptyAnnotationValue(annotationValue) {
 			t.Logf("annotation %q should NOT exist on node %s (current: %s)",
 				check.Key, nodeName, annotationValue)
 
@@ -435,6 +438,11 @@ func checkAnnotationStates(t *testing.T, node *v1.Node, nodeName string, checks 
 	}
 
 	return true
+}
+
+func isEmptyAnnotationValue(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	return trimmed == "" || trimmed == "[]"
 }
 
 func SetCircuitBreakerState(ctx context.Context, t *testing.T, c *envconf.Config, state, cursorMode string) {

--- a/tests/helpers/nic-health-monitor.go
+++ b/tests/helpers/nic-health-monitor.go
@@ -482,7 +482,7 @@ func nicQuarantineMetadataCleared(t *testing.T, node *corev1.Node) bool {
 			return false
 		}
 
-		if value := node.Annotations[QuarantineHealthEventIsCordonedAnnotationKey]; value != "" {
+		if value := node.Annotations[QuarantineHealthEventIsCordonedAnnotationKey]; !isEmptyAnnotationValue(value) {
 			t.Logf("node %s still has quarantine cordon annotation: %s", node.Name, value)
 			return false
 		}

--- a/tests/helpers/nic-health-monitor.go
+++ b/tests/helpers/nic-health-monitor.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nvidia/nvsentinel/commons/pkg/statemanager"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -67,6 +68,7 @@ func SetUpNICHealthMonitor(ctx context.Context, t *testing.T,
 	// platform connector
 	t.Logf("Clearing stale NIC conditions from node %s", testNodeName)
 	clearNICConditions(ctx, t, testNodeName)
+	waitForNICCleanupComplete(ctx, t, client, testNodeName)
 
 	configSnapshot, err := BackupConfigMap(ctx, client, NICHealthMonitorConfigMapName, NVSentinelNamespace)
 	require.NoError(t, err, "failed to backup NIC monitor ConfigMap")
@@ -142,13 +144,15 @@ func TearDownNICHealthMonitor(ctx context.Context, t *testing.T,
 	}
 
 	if state.NodeName != "" {
-		CleanupFakeSysfs(t, ctx, client, NVSentinelNamespace, state.NodeName)
-
-		// Re-inject stub metadata so the pod that starts after the
-		// no-wait args restoration has valid metadata and doesn't
-		// CrashLoopBackOff, blocking subsequent tests.
+		// Re-inject stub metadata and restart the pod after restoring the
+		// production config/args. This ensures the monitor is no longer
+		// reading fake sysfs before that tree is removed below.
 		stubMeta := CreateNICTestMetadata(state.NodeName)
 		InjectMetadata(t, ctx, client, NVSentinelNamespace, state.NodeName, stubMeta)
+
+		restartNICMonitorPodAfterRestore(ctx, t, client, state.NodeName)
+
+		CleanupFakeSysfs(t, ctx, client, NVSentinelNamespace, state.NodeName)
 
 		t.Logf("Clearing stale NIC conditions from node %s", state.NodeName)
 		clearNICConditions(ctx, t, state.NodeName)
@@ -160,6 +164,7 @@ func TearDownNICHealthMonitor(ctx context.Context, t *testing.T,
 				{Key: QuarantineHealthEventAnnotationKey, ShouldExist: false},
 			},
 		})
+		waitForNICCleanupComplete(ctx, t, client, state.NodeName)
 
 		t.Logf("Removing ManagedByNVSentinel label from node %s", state.NodeName)
 
@@ -167,6 +172,14 @@ func TearDownNICHealthMonitor(ctx context.Context, t *testing.T,
 			t.Logf("Warning: failed to remove label: %v", err)
 		}
 	}
+}
+
+func restartNICMonitorPodAfterRestore(ctx context.Context, t *testing.T, client klient.Client, nodeName string) {
+	t.Helper()
+	t.Logf("Restarting NIC monitor pod on node %s after restoring config", nodeName)
+
+	deleteNICMonitorPodOnNode(ctx, t, client, nodeName)
+	WaitForDaemonSetPodRunning(ctx, t, client, NVSentinelNamespace, NICHealthMonitorDaemonSetName, nodeName)
 }
 
 // CreateFakeSysfsTree creates the full fake sysfs tree on the target node.
@@ -401,10 +414,7 @@ func hostPathType(t corev1.HostPathType) *corev1.HostPathType { return &t }
 func clearNICConditions(ctx context.Context, t *testing.T, nodeName string) {
 	t.Helper()
 
-	for _, checkName := range []string{
-		"InfiniBandStateCheck", "EthernetStateCheck",
-		"InfiniBandDegradationCheck", "EthernetDegradationCheck",
-	} {
+	for _, checkName := range nicConditionCheckNames() {
 		event := NewHealthEvent(nodeName).
 			WithAgent("nic-health-monitor").
 			WithCheckName(checkName).
@@ -416,6 +426,105 @@ func clearNICConditions(ctx context.Context, t *testing.T, nodeName string) {
 		event.EntitiesImpacted = []EntityImpacted{}
 		SendHealthEvent(ctx, t, event)
 	}
+}
+
+func nicConditionCheckNames() []string {
+	return []string{
+		"InfiniBandStateCheck",
+		"EthernetStateCheck",
+		"InfiniBandDegradationCheck",
+		"EthernetDegradationCheck",
+	}
+}
+
+func waitForNICCleanupComplete(ctx context.Context, t *testing.T, client klient.Client, nodeName string) {
+	t.Helper()
+	t.Logf("Waiting for NIC cleanup to converge on node %s", nodeName)
+
+	require.Eventually(t, func() bool {
+		node, err := GetNodeByName(ctx, client, nodeName)
+		if err != nil {
+			t.Logf("failed to get node %s: %v", nodeName, err)
+			return false
+		}
+
+		return nicCleanupComplete(t, node)
+	}, EventuallyWaitTimeout, WaitInterval, "NIC cleanup should complete on node %s", nodeName)
+
+	require.Never(t, func() bool {
+		node, err := GetNodeByName(ctx, client, nodeName)
+		if err != nil {
+			t.Logf("failed to get node %s during stability check: %v", nodeName, err)
+			return false
+		}
+
+		return !nicCleanupComplete(t, node)
+	}, NeverWaitTimeout, WaitInterval, "NIC cleanup should remain stable on node %s", nodeName)
+}
+
+func nicCleanupComplete(t *testing.T, node *corev1.Node) bool {
+	t.Helper()
+
+	if node.Spec.Unschedulable {
+		t.Logf("node %s is still cordoned", node.Name)
+		return false
+	}
+
+	return nicQuarantineMetadataCleared(t, node) && nicConditionsHealthy(t, node)
+}
+
+func nicQuarantineMetadataCleared(t *testing.T, node *corev1.Node) bool {
+	t.Helper()
+
+	if node.Annotations != nil {
+		if value := node.Annotations[QuarantineHealthEventAnnotationKey]; quarantineAnnotationHasActiveEvents(value) {
+			t.Logf("node %s still has quarantine annotation: %s", node.Name, value)
+			return false
+		}
+
+		if value := node.Annotations[QuarantineHealthEventIsCordonedAnnotationKey]; value != "" {
+			t.Logf("node %s still has quarantine cordon annotation: %s", node.Name, value)
+			return false
+		}
+	}
+
+	if node.Labels != nil {
+		if value := node.Labels[statemanager.NVSentinelStateLabelKey]; value != "" {
+			t.Logf("node %s still has NVSentinel state label: %s", node.Name, value)
+			return false
+		}
+	}
+
+	return true
+}
+
+func quarantineAnnotationHasActiveEvents(value string) bool {
+	return !isEmptyAnnotationValue(value)
+}
+
+func nicConditionsHealthy(t *testing.T, node *corev1.Node) bool {
+	t.Helper()
+
+	for _, checkName := range nicConditionCheckNames() {
+		if !nicConditionHealthy(t, node, checkName) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func nicConditionHealthy(t *testing.T, node *corev1.Node, checkName string) bool {
+	t.Helper()
+
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeConditionType(checkName) && condition.Status == corev1.ConditionTrue {
+			t.Logf("node %s still has unhealthy NIC condition %s: %s", node.Name, checkName, condition.Message)
+			return false
+		}
+	}
+
+	return true
 }
 
 // deleteNICMonitorPodOnNode finds and deletes the NIC monitor pod on


### PR DESCRIPTION

## Summary


Fixes a production bug in fault-quarantine and hardens NIC E2E test teardown to prevent test contamination that caused the `TestFatalHealthEvent/Node_is_cordoned` flake on ARM64 + PostgreSQL.

## Root Cause Analysis

The flake was caused by **two independent bugs that compound each other**:

### Bug 1: fault-quarantine treats `quarantineHealthEvent: []` as active quarantine

When fault-quarantine processes a healthy event that clears the last entity from a quarantined node, it writes the annotation as an empty JSON array (`[]`) via `removeEventFromAnnotation()` before proceeding to uncordon. If fault-quarantine restarts, hits a conflict, or the next test begins before `performUncordon()` removes the annotation key entirely, the node is left with:

```yaml
quarantineHealthEvent: "[]"
```

Later, when a **new** fatal event arrives for that node, `hasExistingQuarantine()` checks:

```go
return annotations, exists && annotationVal != ""
```

Since `"[]" != ""`, it returns `true` — incorrectly treating the node as already quarantined. The event then follows the `handleAlreadyQuarantinedNode` path, which only appends the event to the annotation **without cordoning the node**. This produces the impossible state observed in CI:

```text
quarantineHealthEvent: [GpuXidError...]
dgxc.nvidia.com/nvsentinel-state: draining
spec.unschedulable: false              ← never cordoned!
quarantineHealthEventIsCordoned: ""    ← cordon was skipped
```

### Bug 2: NIC test teardown deletes fake sysfs while the NIC monitor is still reading it

NIC E2E tests create a fake sysfs tree, point the NIC monitor at it, then during teardown:

1. Restore DaemonSet args (no rollout wait)
2. **Delete fake sysfs** ← monitor pod may still be running with fake sysfs paths
3. Send healthy NIC events
4. Wait for uncordon only

Between steps 1 and 2, the NIC monitor pod that is still running with fake sysfs args detects all fake devices as "disappeared" and emits ~18 fatal NIC events (one per device × InfiniBand + Ethernet). These events trigger fault-quarantine to quarantine the node. The healthy events sent in step 3 then clear the quarantine, but leave `quarantineHealthEvent: []` on the node.

### How they combine to cause the flake

```text
NIC test teardown on nvsentinel-worker
→ fake sysfs deleted while NIC monitor still reads it
→ burst of fatal "device disappeared" events
→ fault-quarantine quarantines the node
→ healthy NIC events clear quarantine
→ quarantineHealthEvent: [] left on node
→ TestFatalHealthEvent starts on same node
→ sends GPU fatal event
→ hasExistingQuarantine("[]") returns true
→ GPU event appended without cordoning
→ test waits for cordon → 600s timeout → FAIL
```

The flake is intermittent because:
- It depends on which worker node the NIC test and smoke test select
- It depends on whether the NIC monitor pod processes the sysfs deletion before being restarted
- PostgreSQL change-stream timing affects how quickly the cleanup settles

### Evidence

- **CI artifacts** showed `nvsentinel-worker` with `nvsentinel-state: draining` but `unschedulable: false` and empty `quarantineHealthEventIsCordoned`
- **fault-quarantine logs** showed `handleUnhealthyEventOnQuarantinedNode` path for the GPU event (should have been fresh quarantine)
- **Local repro** confirmed: forcing both tests onto the same node reproduced the failure deterministically
- **Flake started after PR #1288** which added fault-quarantine rulesets for NIC fatal events — before that, NIC test teardown didn't trigger quarantine at all

### Temporary repro-only changes used during investigation

To remove node-selection randomness and prove the contamination path, I temporarily made two local-only changes (not part of the final PR diff):

1. Forced the NIC monitor helper to select `nvsentinel-worker`.
2. Forced `TestFatalHealthEvent` to also use `nvsentinel-worker` and added a precondition guard that failed if the node still had:
   - `spec.unschedulable=true`
   - `quarantineHealthEvent`
   - `quarantineHealthEventIsCordoned`
   - `dgxc.nvidia.com/nvsentinel-state`

With those temporary changes and without the fix, the smoke test failed immediately when the same node still had active NIC quarantine entries or an empty `quarantineHealthEvent: []` marker left behind by the preceding NIC cleanup. After applying the fix, the forced same-node run completed the full `TestFatalHealthEvent` lifecycle successfully. These repro-only changes were removed before finalizing the PR.

## Fix

### commons/pkg/annotation/prefix.go (shared utility)

Added `annotation.IsEmptyValue()` to centralize empty-annotation semantics in one place, as per the project convention of using `commons/` for shared utilities:

```go
func IsEmptyValue(value string) bool {
    trimmed := strings.TrimSpace(value)
    return trimmed == "" || trimmed == "[]"
}
```

Unit tests added in `commons/pkg/annotation/prefix_test.go`.

### fault-quarantine/pkg/reconciler/reconciler.go (main code fix)

`hasExistingQuarantine()` now uses `annotation.IsEmptyValue()` to determine if a quarantine annotation is present. This ensures new fatal events always go through the full cordon path when there are no active quarantine entities.

### tests/helpers/nic-health-monitor.go (test fix)

Teardown ordering changed to prevent the "device disappeared" burst:

**Before:**
1. Restore args (no wait)
2. Delete fake sysfs ← NIC monitor still running with fake paths!
3. Send healthy events
4. Wait for uncordon only

**After:**
1. Restore args (no wait)
2. Inject stub metadata
3. **Restart NIC monitor pod and wait for it to be Running/Ready** ← now running with real paths
4. Delete fake sysfs ← safe, monitor no longer reading it
5. Send healthy NIC events
6. Wait for full cleanup convergence (uncordon + no annotations + no labels + no unhealthy conditions)
7. Verify cleanup remains stable for 10s

The cordon annotation check now also uses the shared `isEmptyAnnotationValue()` semantics for consistency.

### tests/helpers/fault_quarantine.go (test helper fix)

- Added `QuarantineHealthEventIsCordonedAnnotationKey` constant
- `checkAnnotation()` uses `annotation.IsEmptyValue()` for annotation existence checks
- Local `isEmptyAnnotationValue()` delegates to the shared `commons` helper

## Reproduction

On a PostgreSQL Tilt cluster:

```bash
# Force both tests onto the same real worker
make -C tests test TEST_TAGS="arm64_group" \
  TEST_EXTRA_FLAGS="-timeout 25m -count 1 -failfast -run 'TestNICHealthMonitorConditionMessage|TestFatalHealthEvent'"
```

Without the fix: `TestFatalHealthEvent/Node_is_cordoned` fails because fault-quarantine skips cordon for the GPU event.

With the fix: full lifecycle completes (quarantined → draining → drain-succeeded → remediating → remediation-succeeded → label removed → uncordoned).

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Quarantine annotation handling now treats empty, whitespace-only, and "[]" values as absent, and skips creating fresh quarantine when an active annotation is detected (with a debug log).

* **Tests**
  * Stronger NIC health-monitor synchronization, clearer teardown/setup helpers, and new unit tests for annotation-empty semantics.

* **Chores**
  * Improved audit and tracing log formatting for clearer diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NVSentinel/pull/1309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->