### PR TITLE
feat(chart): add setupJob.enabled gate for when using an external mongodb setup job

### DIFF
--- a/distros/kubernetes/nvsentinel/templates/job-external-mongodb-setup.yaml
+++ b/distros/kubernetes/nvsentinel/templates/job-external-mongodb-setup.yaml
@@ -24,9 +24,8 @@ inside the mongodb-store subchart instead.
 {{- $useExternalMongodb := and .Values.global.datastore
                                (eq .Values.global.datastore.provider "mongodb")
                                (not .Values.global.mongodbStore.enabled) }}
-{{- if $useExternalMongodb }}
-
 {{- $setupJob := ((.Values.global.datastore).setupJob) | default dict }}
+{{- if and $useExternalMongodb (ne ($setupJob.enabled | toString) "false") }}
 {{- $image := ($setupJob.image) | default dict }}
 {{- $imageRepo := $image.repository | default "ghcr.io/rtsp/docker-mongosh" }}
 {{- $imageTag := $image.tag | default "2.5.2" }}

--- a/distros/kubernetes/nvsentinel/values.yaml
+++ b/distros/kubernetes/nvsentinel/values.yaml
@@ -87,6 +87,7 @@ global:
   #   # The setup job creates required collections and indexes in the external MongoDB.
   #   # It runs once on install/upgrade when using an external DB.
   #   setupJob:
+  #     enabled: true  # Set to false to skip the setup job entirely
   #     image:
   #       repository: ghcr.io/rtsp/docker-mongosh
   #       tag: "2.5.2"


### PR DESCRIPTION
## Summary

The post-install/post-upgrade hook job that provisions collections, indexes, and x509 users on external mongo cannot be disabled independently of the external mongo configuration. Deployments that provision their database externally have no way to skip the hook, which can cause install failures (for example, when the job's auth requirements don't match the tenant identity). 

This PR gates the `job behind global.datastore.setupJob.enabled` (default: `true`) so consumers can opt out without changing their datastore provider config.

## Type of Change
- [ ] 🐛 Bug fix
- [ X ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ X ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ X ] Tests pass locally
- [ X ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ X ]  Self-review completed
- [ X ] Documentation updated (if needed)
- [ X ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted Kubernetes templates so the external MongoDB setup job is evaluated consistently during deployment checks.
  * Added a commented default setting in the values to document the setup job's enabled state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NVSentinel/pull/1311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->