### PR TITLE
fix(ci): skip version registration for latest release and sort by semver

### DIFF
--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -84,12 +84,23 @@ jobs:
           else
             IS_RELEASE=true
           fi
+
+          # Resolve latest release to avoid duplicate registration (Latest already covers it)
+          LATEST=$(gh release view --repo "${GITHUB_REPOSITORY}" --json tagName -q .tagName 2>/dev/null || true)
+          if [ "$IS_RELEASE" = "true" ] && [ "$TAG" = "$LATEST" ]; then
+            SHOULD_REGISTER=false
+            echo "Tag $TAG is the current latest release — will be shown as 'Latest · $TAG', skipping version entry"
+          else
+            SHOULD_REGISTER=$IS_RELEASE
+          fi
+
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "is_release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
-          echo "Resolved target tag: $TAG (is_release=$IS_RELEASE)"
+          echo "should_register=$SHOULD_REGISTER" >> "$GITHUB_OUTPUT"
+          echo "Resolved target tag: $TAG (is_release=$IS_RELEASE, should_register=$SHOULD_REGISTER)"
 
       - name: Register new version from tag
-        if: steps.resolve.outputs.is_release == 'true'
+        if: steps.resolve.outputs.should_register == 'true'
         env:
           TAG_VERSION: ${{ steps.resolve.outputs.tag }}
         run: |
@@ -106,18 +117,26 @@ jobs:
           git archive "${TAG_VERSION}" -- docs/index.yml | tar -xO docs/index.yml | \
             sed "s|path: |path: ${TAG_VERSION}-content/|g" > "fern/versions/${TAG_VERSION}.yml"
 
-          # Add version entry to docs.yml (insert after Latest, before older versions)
+          # Add version entry to docs.yml
           export TAG_VERSION
           EXPR='.products[0].versions |= [.[0]] + [{"display-name": env(TAG_VERSION),'
           EXPR+=' "path": "versions/" + env(TAG_VERSION) + ".yml",'
           EXPR+=' "slug": env(TAG_VERSION), "availability": "stable"}] + .[1:]'
           yq -i "$EXPR" fern/docs.yml
 
-          echo "--- docs.yml versions after insert ---"
+          # Sort versioned entries by semver descending (Latest stays at [0])
+          SORTED_SLUGS=$(yq '.products[0].versions[1:][].slug' fern/docs.yml | sort -rV)
+          yq -i '.products[0].versions = [.products[0].versions[0]]' fern/docs.yml
+          for slug in $SORTED_SLUGS; do
+            export slug
+            yq -i '.products[0].versions += [{"display-name": env(slug), "path": "versions/" + env(slug) + ".yml", "slug": env(slug), "availability": "stable"}]' fern/docs.yml
+          done
+
+          echo "--- docs.yml versions after insert + sort ---"
           yq '.products[0].versions[].display-name' fern/docs.yml
 
       - name: Prune old versions
-        if: steps.resolve.outputs.is_release == 'true'
+        if: steps.resolve.outputs.should_register == 'true'
         run: |
           set -eo pipefail
           KEEP=$((MAX_VERSIONS + 1))  # +1 for the Latest entry at index 0
@@ -197,11 +216,11 @@ jobs:
           fi
 
       - name: Restore unstamped docs.yml for persistence
-        if: steps.resolve.outputs.is_release == 'true'
+        if: steps.resolve.outputs.should_register == 'true'
         run: cp /tmp/docs.yml.preStamp fern/docs.yml
 
       - name: Open PR for version registry changes
-        if: steps.resolve.outputs.is_release == 'true'
+        if: steps.resolve.outputs.should_register == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           base: main


### PR DESCRIPTION
## Summary

Two fixes to the publish workflow version registration:

- **Skip registration when tag = latest release** — the "Latest · vX.Y.Z" stamp already covers it, so a separate version entry would create a duplicate in the dropdown
- **Sort by semver descending** — uses `sort -rV` after insertion so backport patches (e.g. v1.5.1 after v1.6.0) don't end up above newer releases

## Type of Change
- [x] 🐛 Bug fix
- [x] 🔨 Build/CI

## Component(s) Affected
- [x] Documentation/CI

## Testing
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced documentation publishing workflow to better manage version registration and improve version ordering when handling release tags.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NVSentinel/pull/1315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->