### PR TITLE
chore: run make dependencies-sync + go-mod-tidy-all for dependabot MRs

### DIFF
--- a/.github/workflows/dependabot-gomod-fixup.yml
+++ b/.github/workflows/dependabot-gomod-fixup.yml
@@ -23,15 +23,9 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - main
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: "Existing Dependabot PR number to fix up"
-        required: true
-        type: number
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:
@@ -42,43 +36,15 @@ jobs:
     name: Sync Go module files
     if: >
       github.repository == 'xrfxlp/nvsentinel' &&
-      (github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch')
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'dependabot/go_modules/')
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: read
     timeout-minutes: 30
     steps:
-      - name: Resolve Dependabot PR
-        id: pr
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
-        with:
-          script: |
-            const prNumber = context.payload.pull_request?.number ?? Number(context.payload.inputs?.pr_number);
-            if (!Number.isInteger(prNumber) || prNumber <= 0) {
-              core.setFailed(`Invalid PR number: ${context.payload.inputs?.pr_number}`);
-              return;
-            }
-
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-            });
-
-            if (pr.user.login !== 'dependabot[bot]') {
-              core.setFailed(`PR #${pr.number} was opened by ${pr.user.login}, not dependabot[bot].`);
-            }
-            if (pr.head.repo.full_name.toLowerCase() !== `${context.repo.owner}/${context.repo.repo}`.toLowerCase()) {
-              core.setFailed(`PR #${pr.number} is not from this repository: ${pr.head.repo.full_name}`);
-            }
-            if (!pr.head.ref.startsWith('dependabot/go_modules/')) {
-              core.setFailed(`PR #${pr.number} branch is not a Dependabot Go module branch: ${pr.head.ref}`);
-            }
-
-            core.setOutput('number', String(pr.number));
-            core.setOutput('head_ref', pr.head.ref);
-
       - name: Guard dependency-only PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
@@ -86,7 +52,7 @@ jobs:
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: Number('${{ steps.pr.outputs.number }}'),
+              pull_number: context.payload.pull_request.number,
               per_page: 100,
             });
 
@@ -101,7 +67,7 @@ jobs:
       - name: Checkout Dependabot branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          ref: ${{ steps.pr.outputs.head_ref }}
+          ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read Go version

--- a/.github/workflows/dependabot-gomod-fixup.yml
+++ b/.github/workflows/dependabot-gomod-fixup.yml
@@ -43,7 +43,7 @@ jobs:
     if: >
       github.repository == 'xrfxlp/nvsentinel' &&
       (github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch')
-    runs-on: linux-amd64-cpu16
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: read

--- a/.github/workflows/dependabot-gomod-fixup.yml
+++ b/.github/workflows/dependabot-gomod-fixup.yml
@@ -35,11 +35,11 @@ jobs:
   gomod-fixup:
     name: Sync Go module files
     if: >
-      github.repository == 'nvidia/nvsentinel' &&
+      github.repository == 'xrfxlp/nvsentinel' &&
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       startsWith(github.event.pull_request.head.ref, 'dependabot/go_modules/')
-    runs-on: linux-amd64-cpu8
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: read
@@ -75,6 +75,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Read Go version
         if: steps.dependency-only.outputs.skip != 'true'
@@ -126,6 +127,9 @@ jobs:
 
       - name: Commit Go module fixups
         if: steps.dependency-only.outputs.skip != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           if [ -z "$(git status --porcelain --untracked-files=no)" ]; then
             echo "No Go module fixup changes needed."
@@ -137,4 +141,4 @@ jobs:
 
           git add -- ':(glob)**/go.mod' ':(glob)**/go.sum'
           git commit -m "chore: tidy Dependabot Go module updates"
-          git push
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${HEAD_REF}"

--- a/.github/workflows/dependabot-gomod-fixup.yml
+++ b/.github/workflows/dependabot-gomod-fixup.yml
@@ -36,7 +36,7 @@ jobs:
     name: Sync Go module files
     if: >
       github.repository == 'xrfxlp/nvsentinel' &&
-      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       startsWith(github.event.pull_request.head.ref, 'dependabot/go_modules/')
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot-gomod-fixup.yml
+++ b/.github/workflows/dependabot-gomod-fixup.yml
@@ -1,0 +1,129 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Purpose: normalize Dependabot Go module updates so CI can merge clean dependency-only PRs.
+# Contract: only runs for same-repository Dependabot gomod PRs, refuses non-go.mod/go.sum
+# changes, and only commits generated Go module cleanup.
+
+name: Dependabot Go Mod Fixup
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  gomod-fixup:
+    name: Sync Go module files
+    if: >
+      github.repository == 'nvidia/nvsentinel' &&
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'dependabot/go_modules/')
+    runs-on: linux-amd64-cpu16
+    permissions:
+      contents: write
+      pull-requests: read
+    timeout-minutes: 30
+    steps:
+      - name: Guard dependency-only PR
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+
+            const disallowed = files
+              .map((file) => file.filename)
+              .filter((name) => !/(^|\/)go\.(mod|sum)$/.test(name));
+
+            if (disallowed.length > 0) {
+              core.setFailed(`Refusing gomod fixup because this PR changes non-module files: ${disallowed.join(', ')}`);
+            }
+
+      - name: Checkout Dependabot branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read Go version
+        id: go-version
+        run: |
+          GO_VERSION=$(awk -F"'" '/^[[:space:]]*go:/ { print $2; exit }' .versions.yaml)
+          echo "version=${GO_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
+        with:
+          go-version: ${{ steps.go-version.outputs.version }}
+          cache: true
+          cache-dependency-path: |
+            **/go.sum
+            **/go.mod
+
+      - name: Sync and tidy Go modules
+        run: |
+          make dependencies-sync
+
+          for attempt in 1 2 3; do
+            make go-mod-tidy-all
+            if make gomod-lint; then
+              exit 0
+            fi
+            echo "go.mod validation still needed cleanup after attempt ${attempt}; retrying"
+          done
+
+          make gomod-lint
+
+      - name: Guard generated changes
+        run: |
+          changed=$(git status --porcelain --untracked-files=no)
+          if [ -z "$changed" ]; then
+            echo "No Go module fixup changes needed."
+            exit 0
+          fi
+
+          bad=$(git diff --name-only | grep -Ev '(^|/)go\.(mod|sum)$' || true)
+          if [ -n "$bad" ]; then
+            echo "::error::Refusing to commit non-module changes:"
+            echo "$bad"
+            exit 1
+          fi
+
+      - name: Commit Go module fixups
+        run: |
+          if [ -z "$(git status --porcelain --untracked-files=no)" ]; then
+            echo "No Go module fixup changes needed."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add -- ':(glob)**/go.mod' ':(glob)**/go.sum'
+          git commit -m "chore: tidy Dependabot Go module updates"
+          git push

--- a/.github/workflows/dependabot-gomod-fixup.yml
+++ b/.github/workflows/dependabot-gomod-fixup.yml
@@ -46,6 +46,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Guard dependency-only PR
+        id: dependency-only
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
@@ -61,22 +62,29 @@ jobs:
               .filter((name) => !/(^|\/)go\.(mod|sum)$/.test(name));
 
             if (disallowed.length > 0) {
-              core.setFailed(`Refusing gomod fixup because this PR changes non-module files: ${disallowed.join(', ')}`);
+              core.notice(`Skipping gomod fixup because this PR changes non-module files: ${disallowed.join(', ')}`);
+              core.setOutput('skip', 'true');
+              return;
             }
 
+            core.setOutput('skip', 'false');
+
       - name: Checkout Dependabot branch
+        if: steps.dependency-only.outputs.skip != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read Go version
+        if: steps.dependency-only.outputs.skip != 'true'
         id: go-version
         run: |
           GO_VERSION=$(awk -F"'" '/^[[:space:]]*go:/ { print $2; exit }' .versions.yaml)
           echo "version=${GO_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Go
+        if: steps.dependency-only.outputs.skip != 'true'
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
         with:
           go-version: ${{ steps.go-version.outputs.version }}
@@ -86,6 +94,7 @@ jobs:
             **/go.mod
 
       - name: Sync and tidy Go modules
+        if: steps.dependency-only.outputs.skip != 'true'
         run: |
           make dependencies-sync
 
@@ -100,6 +109,7 @@ jobs:
           make gomod-lint
 
       - name: Guard generated changes
+        if: steps.dependency-only.outputs.skip != 'true'
         run: |
           changed=$(git status --porcelain --untracked-files=no)
           if [ -z "$changed" ]; then
@@ -115,6 +125,7 @@ jobs:
           fi
 
       - name: Commit Go module fixups
+        if: steps.dependency-only.outputs.skip != 'true'
         run: |
           if [ -z "$(git status --porcelain --untracked-files=no)" ]; then
             echo "No Go module fixup changes needed."

--- a/.github/workflows/dependabot-gomod-fixup.yml
+++ b/.github/workflows/dependabot-gomod-fixup.yml
@@ -23,9 +23,15 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Existing Dependabot PR number to fix up"
+        required: true
+        type: number
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
   cancel-in-progress: true
 
 permissions:
@@ -36,15 +42,43 @@ jobs:
     name: Sync Go module files
     if: >
       github.repository == 'xrfxlp/nvsentinel' &&
-      github.actor == 'dependabot[bot]' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      startsWith(github.event.pull_request.head.ref, 'dependabot/go_modules/')
+      (github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch')
     runs-on: linux-amd64-cpu16
     permissions:
       contents: write
       pull-requests: read
     timeout-minutes: 30
     steps:
+      - name: Resolve Dependabot PR
+        id: pr
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const prNumber = context.payload.pull_request?.number ?? Number(context.payload.inputs?.pr_number);
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.setFailed(`Invalid PR number: ${context.payload.inputs?.pr_number}`);
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            if (pr.user.login !== 'dependabot[bot]') {
+              core.setFailed(`PR #${pr.number} was opened by ${pr.user.login}, not dependabot[bot].`);
+            }
+            if (pr.head.repo.full_name.toLowerCase() !== `${context.repo.owner}/${context.repo.repo}`.toLowerCase()) {
+              core.setFailed(`PR #${pr.number} is not from this repository: ${pr.head.repo.full_name}`);
+            }
+            if (!pr.head.ref.startsWith('dependabot/go_modules/')) {
+              core.setFailed(`PR #${pr.number} branch is not a Dependabot Go module branch: ${pr.head.ref}`);
+            }
+
+            core.setOutput('number', String(pr.number));
+            core.setOutput('head_ref', pr.head.ref);
+
       - name: Guard dependency-only PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
@@ -52,7 +86,7 @@ jobs:
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
+              pull_number: Number('${{ steps.pr.outputs.number }}'),
               per_page: 100,
             });
 
@@ -67,7 +101,7 @@ jobs:
       - name: Checkout Dependabot branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ steps.pr.outputs.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read Go version

--- a/.github/workflows/dependabot-gomod-fixup.yml
+++ b/.github/workflows/dependabot-gomod-fixup.yml
@@ -35,11 +35,11 @@ jobs:
   gomod-fixup:
     name: Sync Go module files
     if: >
-      github.repository == 'xrfxlp/nvsentinel' &&
+      github.repository == 'nvidia/nvsentinel' &&
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       startsWith(github.event.pull_request.head.ref, 'dependabot/go_modules/')
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu8
     permissions:
       contents: write
       pull-requests: read

--- a/.github/workflows/dependabot-gomod-fixup.yml
+++ b/.github/workflows/dependabot-gomod-fixup.yml
@@ -35,7 +35,7 @@ jobs:
   gomod-fixup:
     name: Sync Go module files
     if: >
-      github.repository == 'nvidia/nvsentinel' &&
+      github.repository == 'xrfxlp/nvsentinel' &&
       github.actor == 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       startsWith(github.event.pull_request.head.ref, 'dependabot/go_modules/')


### PR DESCRIPTION
## Summary

This PR adds a workflow to run the following:
```
          make dependencies-sync

          for attempt in 1 2 3; do
            make go-mod-tidy-all
            if make gomod-lint; then
              exit 0
            fi
            echo "go.mod validation still needed cleanup after attempt ${attempt}; retrying"
          done

          make gomod-lint
```

in all the PRs opened by dependabot consisting only for `go.mod` or `go.sum` changes.


[Here](https://github.com/XRFXLP/NVSentinel/pull/63/changes/94fd1d3a242651c76610b4a44e8d18931268564f) is an example of such commit added by github-action[bot] through which this PR was tested. 

If an MR is created by dependabot and contains files other than go.mod/go.sum then this workflow will be skipped and pipeline will show as Passed, [here](https://github.com/XRFXLP/NVSentinel/actions/runs/26152306271/job/76922586239?pr=49) is an example.

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to validate and process Go dependency update PRs: runs on main PR events, prevents overlapping runs, restricts permitted edits to dependency manifest files only, syncs and tidies Go modules with retry attempts and linting, verifies only allowed files were changed, and commits and pushes tidy fixups back to the PR branch when needed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NVSentinel/pull/1317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->