### PR TITLE
fix: use T prefix to determine automated breakfix instead of J

### DIFF
--- a/demos/local-slinky-drain-demo/README.md
+++ b/demos/local-slinky-drain-demo/README.md
@@ -140,7 +140,7 @@ Deletes the KIND cluster and cleans up local Docker images.
    - Annotates nodes with cordon reason (skips if already set by another controller)
    - Waits for scheduler signals (pod conditions)
    - Deletes pods after confirmation
-   - Removes annotation if it was set by slinky-drainer (identified by `[J] [NVSentinel]` prefix)
+   - Removes annotation if it was set by slinky-drainer (identified by `[T] [NVSentinel]` prefix)
    - Updates CR status
 
 2. **Mock Slurm Operator** (`plugins/mock-slurm-operator/`)

--- a/plugins/slinky-drainer/pkg/controller/drainrequest_controller.go
+++ b/plugins/slinky-drainer/pkg/controller/drainrequest_controller.go
@@ -42,7 +42,7 @@ const (
 	drainCompleteConditionType       = "DrainComplete"
 	slurmNodeStateDrainConditionType = "SlurmNodeStateDrain"
 	annotationKey                    = "nodeset.slinky.slurm.net/node-cordon-reason"
-	annotationPrefix                 = "[J] [NVSentinel]"
+	annotationPrefix                 = "[T] [NVSentinel]"
 	nvsentinelStateLabelKey          = "dgxc.nvidia.com/nvsentinel-state"
 	drainRequestFinalizer            = "nvsentinel.nvidia.com/slinky-drainer"
 

--- a/plugins/slinky-drainer/pkg/controller/drainrequest_controller_test.go
+++ b/plugins/slinky-drainer/pkg/controller/drainrequest_controller_test.go
@@ -47,7 +47,6 @@ type testEnvContext struct {
 	ctx    context.Context
 }
 
-
 func TestReconcile_FullDrainCycle(t *testing.T) {
 	tc := setupTestEnv(t, "drain-full-cycle")
 
@@ -65,7 +64,7 @@ func TestReconcile_FullDrainCycle(t *testing.T) {
 		Reason:           "GPU has fallen off the bus",
 	})
 
-	assertNodeAnnotation(t, tc, node.Name, "[J] [NVSentinel] 79 GPU:0 - GPU has fallen off the bus")
+	assertNodeAnnotation(t, tc, node.Name, "[T] [NVSentinel] 79 GPU:0 - GPU has fallen off the bus")
 
 	// Simulate DRAINING state: Slurm accepted drain but jobs still running.
 	markPodDraining(t, tc, pod.Name, pod.Namespace)
@@ -80,7 +79,7 @@ func TestReconcile_FullDrainCycle(t *testing.T) {
 	waitForPodDeletion(t, tc, pod.Name, pod.Namespace)
 
 	// Annotation stays while node is still in draining state.
-	assertNodeAnnotation(t, tc, node.Name, "[J] [NVSentinel] 79 GPU:0 - GPU has fallen off the bus")
+	assertNodeAnnotation(t, tc, node.Name, "[T] [NVSentinel] 79 GPU:0 - GPU has fallen off the bus")
 
 	// Simulate remediation success by removing the label (as statemanager would).
 	removeNodeLabel(t, tc, node.Name, nvsentinelStateLabelKey)
@@ -118,7 +117,7 @@ func TestReconcile_DrainingPodNotDeleted(t *testing.T) {
 		Reason:    "GPU has fallen off the bus",
 	})
 
-	assertNodeAnnotation(t, tc, node.Name, "[J] [NVSentinel] 79 - GPU has fallen off the bus")
+	assertNodeAnnotation(t, tc, node.Name, "[T] [NVSentinel] 79 - GPU has fallen off the bus")
 
 	// Set pod to DRAINING: Drain flag set but node is still busy (Allocated).
 	markPodDraining(t, tc, pod.Name, pod.Namespace)


### PR DESCRIPTION
## Summary

Update to make to use T prefix to denote automated breakfix

## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [ ] Documentation updated (if needed)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the node annotation prefix used by the Slinky Drainer plugin to "[T] [NVSentinel]".

* **Documentation**
  * Updated demo documentation to reflect the correct annotation prefix format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NVSentinel/pull/1318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->