### PR TITLE
fix(ci): frozen-only versioning — remove live docs entry, always register

### DIFF
--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -3,14 +3,18 @@
 
 # Publishes the Fern documentation site on release tag push or manual dispatch.
 #
+# All versions serve frozen content extracted from their git tag — there is no
+# "live docs" entry. The newest version is stamped "Latest · vX.Y.Z" at publish
+# time so readers know which is current; the stamp is transient and not persisted.
+#
 # Manual dispatch accepts an optional `tag` input:
 #   - empty: resolves to the latest GitHub release tag
 #   - explicit (e.g. v1.5.0): publishes that tag
 #
 # On a vX.Y.Z release tag (push or dispatch), the workflow also:
 #   1. Generates fern/versions/vX.Y.Z.yml from the tag's docs/index.yml
-#   2. Adds a version entry to fern/docs.yml
-#   3. Prunes older versions to keep only the 3 most recent (plus Latest)
+#   2. Adds a version entry to fern/docs.yml, sorted by semver descending
+#   3. Prunes older versions to keep only the MAX_VERSIONS most recent
 #   4. Opens a PR to persist registry changes back to main (after publish)
 #
 # Pre-release tags (e.g. v1.6.0-rc1) trigger publish but skip version registration.
@@ -84,23 +88,12 @@ jobs:
           else
             IS_RELEASE=true
           fi
-
-          # Resolve latest release to avoid duplicate registration (Latest already covers it)
-          LATEST=$(gh release view --repo "${GITHUB_REPOSITORY}" --json tagName -q .tagName 2>/dev/null || true)
-          if [ "$IS_RELEASE" = "true" ] && [ "$TAG" = "$LATEST" ]; then
-            SHOULD_REGISTER=false
-            echo "Tag $TAG is the current latest release — will be shown as 'Latest · $TAG', skipping version entry"
-          else
-            SHOULD_REGISTER=$IS_RELEASE
-          fi
-
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "is_release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
-          echo "should_register=$SHOULD_REGISTER" >> "$GITHUB_OUTPUT"
-          echo "Resolved target tag: $TAG (is_release=$IS_RELEASE, should_register=$SHOULD_REGISTER)"
+          echo "Resolved target tag: $TAG (is_release=$IS_RELEASE)"
 
       - name: Register new version from tag
-        if: steps.resolve.outputs.should_register == 'true'
+        if: steps.resolve.outputs.is_release == 'true'
         env:
           TAG_VERSION: ${{ steps.resolve.outputs.tag }}
         run: |
@@ -119,14 +112,14 @@ jobs:
 
           # Add version entry to docs.yml
           export TAG_VERSION
-          EXPR='.products[0].versions |= [.[0]] + [{"display-name": env(TAG_VERSION),'
+          EXPR='.products[0].versions += [{"display-name": env(TAG_VERSION),'
           EXPR+=' "path": "versions/" + env(TAG_VERSION) + ".yml",'
-          EXPR+=' "slug": env(TAG_VERSION), "availability": "stable"}] + .[1:]'
+          EXPR+=' "slug": env(TAG_VERSION), "availability": "stable"}]'
           yq -i "$EXPR" fern/docs.yml
 
-          # Sort versioned entries by semver descending (Latest stays at [0])
-          SORTED_SLUGS=$(yq '.products[0].versions[1:][].slug' fern/docs.yml | sort -rV)
-          yq -i '.products[0].versions = [.products[0].versions[0]]' fern/docs.yml
+          # Sort all version entries by semver descending
+          SORTED_SLUGS=$(yq '.products[0].versions[].slug' fern/docs.yml | sort -rV)
+          yq -i '.products[0].versions = []' fern/docs.yml
           for slug in $SORTED_SLUGS; do
             export slug
             yq -i '.products[0].versions += [{"display-name": env(slug), "path": "versions/" + env(slug) + ".yml", "slug": env(slug), "availability": "stable"}]' fern/docs.yml
@@ -136,21 +129,19 @@ jobs:
           yq '.products[0].versions[].display-name' fern/docs.yml
 
       - name: Prune old versions
-        if: steps.resolve.outputs.should_register == 'true'
+        if: steps.resolve.outputs.is_release == 'true'
         run: |
           set -eo pipefail
-          KEEP=$((MAX_VERSIONS + 1))  # +1 for the Latest entry at index 0
-
-          # Count current versioned entries (including Latest)
           TOTAL=$(yq '.products[0].versions | length' fern/docs.yml)
-          if [ "$TOTAL" -le "$KEEP" ]; then
-            echo "Only $TOTAL version entries — nothing to prune"
+
+          if [ "$TOTAL" -le "$MAX_VERSIONS" ]; then
+            echo "Only $TOTAL versions — nothing to prune (keeping $MAX_VERSIONS)"
             exit 0
           fi
 
           # Remove excess entries from the end (oldest) and their version files
-          PRUNED=$(yq ".products[0].versions[$KEEP:][].slug" fern/docs.yml)
-          yq -i ".products[0].versions |= .[:$KEEP]" fern/docs.yml
+          PRUNED=$(yq ".products[0].versions[$MAX_VERSIONS:][].slug" fern/docs.yml)
+          yq -i ".products[0].versions |= .[:$MAX_VERSIONS]" fern/docs.yml
 
           for slug in $PRUNED; do
             rm -f "fern/versions/${slug}.yml"
@@ -180,17 +171,13 @@ jobs:
             fi
           done
 
-      - name: Stamp version in docs.yml
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Stamp newest version as Latest
         run: |
           cp fern/docs.yml /tmp/docs.yml.preStamp
-          VERSION=$(gh api repos/${{ github.repository }}/releases/latest --jq .tag_name 2>/dev/null || true)
-          if [ -n "$VERSION" ] && [ "$VERSION" != "null" ]; then
-            export VERSION
-            yq -i '(.products[0].versions[] | select(.slug == "latest")).display-name = "Latest · " + env(VERSION)' fern/docs.yml
-          else
-            echo "::warning::Could not resolve latest GitHub release tag; continuing without stamping"
+          NEWEST=$(yq '.products[0].versions[0].display-name' fern/docs.yml)
+          if [ -n "$NEWEST" ] && [ "$NEWEST" != "null" ]; then
+            export NEWEST
+            yq -i '.products[0].versions[0].display-name = "Latest · " + env(NEWEST)' fern/docs.yml
           fi
           echo "--- docs.yml versions after stamp ---"
           yq '.products[0].versions[].display-name' fern/docs.yml
@@ -216,11 +203,11 @@ jobs:
           fi
 
       - name: Restore unstamped docs.yml for persistence
-        if: steps.resolve.outputs.should_register == 'true'
+        if: steps.resolve.outputs.is_release == 'true'
         run: cp /tmp/docs.yml.preStamp fern/docs.yml
 
       - name: Open PR for version registry changes
-        if: steps.resolve.outputs.should_register == 'true'
+        if: steps.resolve.outputs.is_release == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           base: main

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -14,14 +14,12 @@ products:
     slug: /
     path: ../docs/index.yml
     versions:
-      # display-name is stamped by publish-fern-docs.yml at publish time
-      - display-name: "Latest"
-        path: ../docs/index.yml
-        slug: latest
-        availability: stable
+      # The newest entry is stamped "Latest · vX.Y.Z" by publish-fern-docs.yml at publish time.
+      # All versions serve frozen content from their git tag.
       - display-name: v1.6.0
         path: versions/v1.6.0.yml
         slug: v1.6.0
+        availability: stable
       - display-name: v1.5.1
         path: versions/v1.5.1.yml
         slug: v1.5.1
@@ -37,12 +35,10 @@ products:
 redirects:
   - source: "/nvsentinel/index.html"
     destination: "/nvsentinel/"
-  - source: "/nvsentinel/dev/"
-    destination: "/nvsentinel/latest/"
-  - source: "/nvsentinel/dev"
-    destination: "/nvsentinel/latest/"
-  - source: "/nvsentinel/dev/index.html"
-    destination: "/nvsentinel/latest/"
+  - source: "/nvsentinel/latest/:path*"
+    destination: "/nvsentinel/:path*"
+  - source: "/nvsentinel/dev/:path*"
+    destination: "/nvsentinel/:path*"
 # GitHub repository link in navbar
 navbar-links:
   - type: github


### PR DESCRIPTION
## Summary

Align NVSentinel's Fern publish workflow with the canonical frozen-only versioning pattern (matching topograph PR #338).

All versions now serve frozen content from their git tag — there is no "live docs" entry. The newest version is stamped "Latest · vX.Y.Z" transiently at publish time. This eliminates:
- Duplicate dropdown entries (old "Latest" + registered version for the same tag)
- `should_register` / duplicate-avoidance complexity
- Off-by-one in pruning (`KEEP+1`)
- Dependency on GitHub releases API for stamping

Changes:
- Remove `slug: latest` entry from `docs.yml` (no more live docs from main)
- Remove stale `/dev/` → `/latest/` redirects; add wildcard catch-all redirects for old bookmarks
- Sort all version entries by semver descending (`sort -rV`)
- Prune uses `MAX_VERSIONS` directly (no +1 offset)
- Stamp reads newest from `[0]` after sort instead of calling GitHub API
- Simplify back to `is_release` — no `should_register` branching

No impact on the currently published site — changes take effect on the next publish.

## Type of Change
- [x] 🐛 Bug fix
- [x] 🔨 Build/CI

## Component(s) Affected
- [x] Documentation/CI

## Testing
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Documentation versioning configuration updated to explicitly display v1.6.0 as the latest release version.
  * Version registration and pruning logic refined for consistent version history management.
  * Documentation URL redirects modernized with simplified wildcard-based routing patterns for improved consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NVSentinel/pull/1319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->