### PR TITLE
fix(fern): add multi-source to enable global theme JS assets

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -6,6 +6,7 @@
 instances:
   - url: nvsentinel.docs.buildwithfern.com/nvsentinel
     custom-domain: docs.nvidia.com/nvsentinel
+    multi-source: true
 
 title: NVIDIA NVSentinel Documentation
 


### PR DESCRIPTION
## Summary

Add `multi-source: true` to the Fern instance config. Without it, the global theme's JS bundle (`theme_asset_5.js` — OneTrust cookie consent SDK) is not loaded; only the CSS portion of the global theme is applied.

Follows topograph PR #340.

## Type of Change
- [x] 🐛 Bug fix

## Component(s) Affected
- [x] Documentation/CI

## Testing
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation instances now support multi-source content integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NVSentinel/pull/1321?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->