### PR TITLE
feat: store maintenance CR references in annotations

### DIFF
--- a/fault-remediation/pkg/annotation/annotation.go
+++ b/fault-remediation/pkg/annotation/annotation.go
@@ -96,6 +96,10 @@ func (m *NodeAnnotationManager) GetRemediationState(
 // UpdateRemediationState updates the node annotation with new remediation state
 func (m *NodeAnnotationManager) UpdateRemediationState(ctx context.Context, nodeName string,
 	group string, crName string, actionName string, resourceRef MaintenanceResourceReference) error {
+	if err := validateMaintenanceResourceReference(resourceRef); err != nil {
+		return fmt.Errorf("invalid maintenance resource reference for node %s group %s: %w", nodeName, group, err)
+	}
+
 	err := retry.RetryOnConflict(conflictBackoff, func() error {
 		// Get current state
 		state, node, err := m.GetRemediationState(ctx, nodeName)
@@ -111,7 +115,7 @@ func (m *NodeAnnotationManager) UpdateRemediationState(ctx context.Context, node
 			ActionName:    actionName,
 			Namespace:     resourceRef.Namespace,
 			Version:       resourceRef.Version,
-			ApiGroup:      resourceRef.ApiGroup,
+			APIGroup:      resourceRef.APIGroup,
 			Kind:          resourceRef.Kind,
 		}
 
@@ -147,11 +151,12 @@ func (m *NodeAnnotationManager) UpdateRemediationState(ctx context.Context, node
 }
 
 // EnsureRemediationStateGVK backfills concrete resource identity for legacy
-// annotation entries using the resourceRefs map, if and only if the GVK is not already set.
+// annotation entries using resourceRefsByAction, if and only if the GVK is not already set.
+// The map must be keyed by ActionName.
 func (m *NodeAnnotationManager) EnsureRemediationStateGVK(
 	ctx context.Context,
 	nodeName string,
-	resourceRefs map[string]MaintenanceResourceReference,
+	resourceRefsByAction map[string]MaintenanceResourceReference,
 ) error {
 	err := retry.RetryOnConflict(conflictBackoff, func() error {
 		state, node, err := m.GetRemediationState(ctx, nodeName)
@@ -163,7 +168,7 @@ func (m *NodeAnnotationManager) EnsureRemediationStateGVK(
 		changed := false
 
 		for group, groupState := range state.EquivalenceGroups {
-			resourceRef, exists := resourceRefs[groupState.ActionName]
+			resourceRef, exists := resourceRefsByAction[groupState.ActionName]
 			if !exists {
 				continue
 			}
@@ -207,14 +212,22 @@ func (m *NodeAnnotationManager) EnsureRemediationStateGVK(
 	return nil
 }
 
+func validateMaintenanceResourceReference(resourceRef MaintenanceResourceReference) error {
+	if resourceRef.APIGroup == "" || resourceRef.Version == "" || resourceRef.Kind == "" {
+		return fmt.Errorf("apiGroup, version, and kind must be non-empty")
+	}
+
+	return nil
+}
+
 func backfillResourceReference(
 	groupState *EquivalenceGroupState,
 	resourceRef MaintenanceResourceReference,
 ) bool {
 	changed := false
 
-	if groupState.ApiGroup == "" && resourceRef.ApiGroup != "" {
-		groupState.ApiGroup = resourceRef.ApiGroup
+	if groupState.APIGroup == "" && resourceRef.APIGroup != "" {
+		groupState.APIGroup = resourceRef.APIGroup
 		changed = true
 	}
 

--- a/fault-remediation/pkg/annotation/annotation.go
+++ b/fault-remediation/pkg/annotation/annotation.go
@@ -95,7 +95,7 @@ func (m *NodeAnnotationManager) GetRemediationState(
 
 // UpdateRemediationState updates the node annotation with new remediation state
 func (m *NodeAnnotationManager) UpdateRemediationState(ctx context.Context, nodeName string,
-	group string, crName string, actionName string) error {
+	group string, crName string, actionName string, resourceRef MaintenanceResourceReference) error {
 	err := retry.RetryOnConflict(conflictBackoff, func() error {
 		// Get current state
 		state, node, err := m.GetRemediationState(ctx, nodeName)
@@ -109,6 +109,10 @@ func (m *NodeAnnotationManager) UpdateRemediationState(ctx context.Context, node
 			MaintenanceCR: crName,
 			CreatedAt:     time.Now().UTC(),
 			ActionName:    actionName,
+			Namespace:     resourceRef.Namespace,
+			Version:       resourceRef.Version,
+			ApiGroup:      resourceRef.ApiGroup,
+			Kind:          resourceRef.Kind,
 		}
 
 		// Marshal to JSON
@@ -140,6 +144,96 @@ func (m *NodeAnnotationManager) UpdateRemediationState(ctx context.Context, node
 	}
 
 	return nil
+}
+
+// EnsureRemediationStateGVK backfills concrete resource identity for legacy
+// annotation entries using the resourceRefs map, if and only if the GVK is not already set.
+func (m *NodeAnnotationManager) EnsureRemediationStateGVK(
+	ctx context.Context,
+	nodeName string,
+	resourceRefs map[string]MaintenanceResourceReference,
+) error {
+	err := retry.RetryOnConflict(conflictBackoff, func() error {
+		state, node, err := m.GetRemediationState(ctx, nodeName)
+		if err != nil {
+			slog.WarnContext(ctx, "Failed to get current remediation state", "node", nodeName, "error", err)
+			return err
+		}
+
+		changed := false
+
+		for group, groupState := range state.EquivalenceGroups {
+			resourceRef, exists := resourceRefs[groupState.ActionName]
+			if !exists {
+				continue
+			}
+
+			updatedGroupState := groupState
+			if backfillResourceReference(&updatedGroupState, resourceRef) {
+				state.EquivalenceGroups[group] = updatedGroupState
+				changed = true
+			}
+		}
+
+		if !changed {
+			return nil
+		}
+
+		stateJSON, err := json.Marshal(state)
+		if err != nil {
+			return err
+		}
+
+		updatedNode := node.DeepCopy()
+		if updatedNode.Annotations == nil {
+			updatedNode.Annotations = map[string]string{}
+		}
+
+		updatedNode.Annotations[AnnotationKey] = string(stateJSON)
+
+		if err = m.client.Update(ctx, updatedNode); err != nil {
+			return err
+		}
+
+		slog.InfoContext(ctx, "Backfilled remediation state annotation GVK for node",
+			"node", nodeName)
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to ensure remediation state GVK for node %s: %w", nodeName, err)
+	}
+
+	return nil
+}
+
+func backfillResourceReference(
+	groupState *EquivalenceGroupState,
+	resourceRef MaintenanceResourceReference,
+) bool {
+	changed := false
+
+	if groupState.ApiGroup == "" && resourceRef.ApiGroup != "" {
+		groupState.ApiGroup = resourceRef.ApiGroup
+		changed = true
+	}
+
+	if groupState.Version == "" && resourceRef.Version != "" {
+		groupState.Version = resourceRef.Version
+		changed = true
+	}
+
+	if groupState.Kind == "" && resourceRef.Kind != "" {
+		groupState.Kind = resourceRef.Kind
+		changed = true
+	}
+
+	if groupState.Namespace == "" && resourceRef.Namespace != "" {
+		groupState.Namespace = resourceRef.Namespace
+		changed = true
+	}
+
+	return changed
 }
 
 // ClearRemediationState removes the remediation state annotation from a node

--- a/fault-remediation/pkg/annotation/annotation_interface.go
+++ b/fault-remediation/pkg/annotation/annotation_interface.go
@@ -29,7 +29,19 @@ const (
 // NodeAnnotationManagerInterface defines the interface for managing node annotations
 type NodeAnnotationManagerInterface interface {
 	GetRemediationState(ctx context.Context, nodeName string) (*RemediationStateAnnotation, *corev1.Node, error)
-	UpdateRemediationState(ctx context.Context, nodeName string, group string, crName string, actionName string) error
+	UpdateRemediationState(
+		ctx context.Context,
+		nodeName string,
+		group string,
+		crName string,
+		actionName string,
+		resourceRef MaintenanceResourceReference,
+	) error
+	EnsureRemediationStateGVK(
+		ctx context.Context,
+		nodeName string,
+		resourceRefs map[string]MaintenanceResourceReference,
+	) error
 	ClearRemediationState(ctx context.Context, nodeName string) error
 	RemoveGroupsFromState(ctx context.Context, nodeName string, groups []string) error
 }
@@ -39,12 +51,27 @@ type RemediationStateAnnotation struct {
 	EquivalenceGroups map[string]EquivalenceGroupState `json:"equivalenceGroups"`
 }
 
+// MaintenanceResourceReference is the concrete object identity needed to find
+// a created maintenance CR without re-deriving its GVK from current config.
+type MaintenanceResourceReference struct {
+	Namespace string
+	Version   string
+	ApiGroup  string
+	Kind      string
+}
+
 // EquivalenceGroupState represents the state of a single equivalence group
 type EquivalenceGroupState struct {
 	MaintenanceCR string    `json:"maintenanceCR"`
 	CreatedAt     time.Time `json:"createdAt"`
 
-	// Action that created the CR (e.g., "RESTART_BM")
-	// Required to look up the corresponding MaintenanceResource from the TomlConfig
+	// Action that created the CR (e.g., "RESTART_BM"). Kept as provenance
+	// and to resolve legacy annotations that predate the concrete resource fields.
 	ActionName string `json:"actionName"`
+
+	// Concrete resource identity for the CR that was created.
+	Namespace string `json:"namespace,omitempty"`
+	Version   string `json:"version,omitempty"`
+	ApiGroup  string `json:"apiGroup,omitempty"`
+	Kind      string `json:"kind,omitempty"`
 }

--- a/fault-remediation/pkg/annotation/annotation_interface.go
+++ b/fault-remediation/pkg/annotation/annotation_interface.go
@@ -37,10 +37,12 @@ type NodeAnnotationManagerInterface interface {
 		actionName string,
 		resourceRef MaintenanceResourceReference,
 	) error
+	// EnsureRemediationStateGVK backfills legacy annotation entries using
+	// resource references keyed by ActionName.
 	EnsureRemediationStateGVK(
 		ctx context.Context,
 		nodeName string,
-		resourceRefs map[string]MaintenanceResourceReference,
+		resourceRefsByAction map[string]MaintenanceResourceReference,
 	) error
 	ClearRemediationState(ctx context.Context, nodeName string) error
 	RemoveGroupsFromState(ctx context.Context, nodeName string, groups []string) error
@@ -56,7 +58,7 @@ type RemediationStateAnnotation struct {
 type MaintenanceResourceReference struct {
 	Namespace string
 	Version   string
-	ApiGroup  string
+	APIGroup  string
 	Kind      string
 }
 
@@ -72,6 +74,6 @@ type EquivalenceGroupState struct {
 	// Concrete resource identity for the CR that was created.
 	Namespace string `json:"namespace,omitempty"`
 	Version   string `json:"version,omitempty"`
-	ApiGroup  string `json:"apiGroup,omitempty"`
+	APIGroup  string `json:"apiGroup,omitempty"`
 	Kind      string `json:"kind,omitempty"`
 }

--- a/fault-remediation/pkg/annotation/annotation_test.go
+++ b/fault-remediation/pkg/annotation/annotation_test.go
@@ -29,6 +29,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+func testMaintenanceResourceReference() MaintenanceResourceReference {
+	return MaintenanceResourceReference{
+		Version:  "v1alpha1",
+		APIGroup: "janitor.dgxc.nvidia.com",
+		Kind:     "RebootNode",
+	}
+}
+
 func TestGetRemediationState(t *testing.T) {
 	ctx := context.Background()
 	nodeName := "test-node"
@@ -144,7 +152,7 @@ func TestUpdateRemediationState(t *testing.T) {
 	resourceRef := MaintenanceResourceReference{
 		Namespace: "dgxc-janitor",
 		Version:   "v1alpha1",
-		ApiGroup:  "janitor.dgxc.nvidia.com",
+		APIGroup:  "janitor.dgxc.nvidia.com",
 		Kind:      "RebootNode",
 	}
 	node := &corev1.Node{
@@ -168,8 +176,61 @@ func TestUpdateRemediationState(t *testing.T) {
 	assert.Equal(t, actionName, state.EquivalenceGroups[group].ActionName)
 	assert.Equal(t, resourceRef.Namespace, state.EquivalenceGroups[group].Namespace)
 	assert.Equal(t, resourceRef.Version, state.EquivalenceGroups[group].Version)
-	assert.Equal(t, resourceRef.ApiGroup, state.EquivalenceGroups[group].ApiGroup)
+	assert.Equal(t, resourceRef.APIGroup, state.EquivalenceGroups[group].APIGroup)
 	assert.Equal(t, resourceRef.Kind, state.EquivalenceGroups[group].Kind)
+}
+
+func TestUpdateRemediationStateRejectsIncompleteReference(t *testing.T) {
+	nodeName := "node"
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        nodeName,
+			Annotations: map[string]string{},
+		},
+	}
+	client := fake.NewClientBuilder().WithObjects(node).Build()
+	annotationManager := NodeAnnotationManager{client: client}
+
+	err := annotationManager.UpdateRemediationState(
+		context.TODO(),
+		nodeName,
+		"test",
+		"reboot",
+		"reboot-action",
+		MaintenanceResourceReference{Version: "v1alpha1", Kind: "RebootNode"},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "apiGroup, version, and kind must be non-empty")
+}
+
+func TestUpdateRemediationStateAllowsClusterScopedReference(t *testing.T) {
+	group := "test"
+	nodeName := "node"
+	resourceRef := MaintenanceResourceReference{
+		Version:  "v1alpha1",
+		APIGroup: "janitor.dgxc.nvidia.com",
+		Kind:     "RebootNode",
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        nodeName,
+			Annotations: map[string]string{},
+		},
+	}
+	client := fake.NewClientBuilder().WithObjects(node).Build()
+	annotationManager := NodeAnnotationManager{client: client}
+
+	err := annotationManager.UpdateRemediationState(context.TODO(), nodeName, group, "reboot", "reboot-action", resourceRef)
+	require.NoError(t, err)
+
+	updatedNode := &corev1.Node{}
+	require.NoError(t, client.Get(context.TODO(), types.NamespacedName{Name: nodeName}, updatedNode))
+	assert.Contains(t, updatedNode.Annotations[AnnotationKey], `"apiGroup":"janitor.dgxc.nvidia.com"`)
+
+	state, _, err := annotationManager.GetRemediationState(context.TODO(), nodeName)
+	require.NoError(t, err)
+	assert.Empty(t, state.EquivalenceGroups[group].Namespace)
+	assert.Equal(t, resourceRef.APIGroup, state.EquivalenceGroups[group].APIGroup)
 }
 
 func TestEnsureRemediationStateGVKBackfillsLegacyState(t *testing.T) {
@@ -195,7 +256,7 @@ func TestEnsureRemediationStateGVKBackfillsLegacyState(t *testing.T) {
 	resourceRef := MaintenanceResourceReference{
 		Namespace: "dgxc-janitor",
 		Version:   "v1alpha1",
-		ApiGroup:  "janitor.dgxc.nvidia.com",
+		APIGroup:  "janitor.dgxc.nvidia.com",
 		Kind:      "RebootNode",
 	}
 	client := fake.NewClientBuilder().WithObjects(node).Build()
@@ -215,7 +276,7 @@ func TestEnsureRemediationStateGVKBackfillsLegacyState(t *testing.T) {
 	assert.Equal(t, createdAt.Unix(), groupState.CreatedAt.Unix())
 	assert.Equal(t, resourceRef.Namespace, groupState.Namespace)
 	assert.Equal(t, resourceRef.Version, groupState.Version)
-	assert.Equal(t, resourceRef.ApiGroup, groupState.ApiGroup)
+	assert.Equal(t, resourceRef.APIGroup, groupState.APIGroup)
 	assert.Equal(t, resourceRef.Kind, groupState.Kind)
 }
 
@@ -248,7 +309,7 @@ func TestEnsureRemediationStateGVKDoesNotOverwriteExistingReference(t *testing.T
 		"RESTART_BM": {
 			Namespace: "new-namespace",
 			Version:   "v2",
-			ApiGroup:  "new.example.com",
+			APIGroup:  "new.example.com",
 			Kind:      "NewKind",
 		},
 	})
@@ -259,7 +320,7 @@ func TestEnsureRemediationStateGVKDoesNotOverwriteExistingReference(t *testing.T
 
 	groupState := state.EquivalenceGroups["restart"]
 	assert.Equal(t, "old-namespace", groupState.Namespace)
-	assert.Equal(t, "old.example.com", groupState.ApiGroup)
+	assert.Equal(t, "old.example.com", groupState.APIGroup)
 	assert.Equal(t, "v1", groupState.Version)
 	assert.Equal(t, "OldKind", groupState.Kind)
 }
@@ -394,10 +455,10 @@ func TestConcurrentUpdateAndRemoveGroupsFromState(t *testing.T) {
 	for i := 0; i < iterations; i++ {
 		// Reset state each iteration
 		err := annotationManager.UpdateRemediationState(context.TODO(), nodeName, "existing-group-1", "old-cr-1",
-			"RESTART_BM", MaintenanceResourceReference{})
+			"RESTART_BM", testMaintenanceResourceReference())
 		require.NoError(t, err)
 		err = annotationManager.UpdateRemediationState(context.TODO(), nodeName, "existing-group-2", "old-cr-2",
-			"COMPONENT_RESET", MaintenanceResourceReference{})
+			"COMPONENT_RESET", testMaintenanceResourceReference())
 		require.NoError(t, err)
 
 		var wg sync.WaitGroup
@@ -411,7 +472,7 @@ func TestConcurrentUpdateAndRemoveGroupsFromState(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			_ = annotationManager.UpdateRemediationState(context.TODO(), nodeName, "new-group", "new-cr",
-				"COMPONENT_RESET", MaintenanceResourceReference{})
+				"COMPONENT_RESET", testMaintenanceResourceReference())
 		}()
 
 		wg.Wait()

--- a/fault-remediation/pkg/annotation/annotation_test.go
+++ b/fault-remediation/pkg/annotation/annotation_test.go
@@ -18,14 +18,15 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
-	"time"
 )
 
 func TestGetRemediationState(t *testing.T) {
@@ -140,6 +141,12 @@ func TestUpdateRemediationState(t *testing.T) {
 	crName := "reboot"
 	nodeName := "node"
 	actionName := "reboot-action"
+	resourceRef := MaintenanceResourceReference{
+		Namespace: "dgxc-janitor",
+		Version:   "v1alpha1",
+		ApiGroup:  "janitor.dgxc.nvidia.com",
+		Kind:      "RebootNode",
+	}
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        nodeName,
@@ -150,7 +157,7 @@ func TestUpdateRemediationState(t *testing.T) {
 	annotationManager := NodeAnnotationManager{
 		client: client,
 	}
-	err := annotationManager.UpdateRemediationState(context.TODO(), nodeName, group, crName, actionName)
+	err := annotationManager.UpdateRemediationState(context.TODO(), nodeName, group, crName, actionName, resourceRef)
 	assert.NoError(t, err)
 
 	state, _, err := annotationManager.GetRemediationState(context.TODO(), nodeName)
@@ -159,6 +166,102 @@ func TestUpdateRemediationState(t *testing.T) {
 	assert.Contains(t, state.EquivalenceGroups, group)
 	assert.Equal(t, crName, state.EquivalenceGroups[group].MaintenanceCR)
 	assert.Equal(t, actionName, state.EquivalenceGroups[group].ActionName)
+	assert.Equal(t, resourceRef.Namespace, state.EquivalenceGroups[group].Namespace)
+	assert.Equal(t, resourceRef.Version, state.EquivalenceGroups[group].Version)
+	assert.Equal(t, resourceRef.ApiGroup, state.EquivalenceGroups[group].ApiGroup)
+	assert.Equal(t, resourceRef.Kind, state.EquivalenceGroups[group].Kind)
+}
+
+func TestEnsureRemediationStateGVKBackfillsLegacyState(t *testing.T) {
+	nodeName := "node"
+	createdAt := time.Now().Add(-time.Hour).UTC()
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+			Annotations: map[string]string{
+				AnnotationKey: fmt.Sprintf(`{
+				  "equivalenceGroups": {
+					"restart": {
+					  "maintenanceCR": "reboot-cr",
+					  "createdAt": "%s",
+					  "actionName": "RESTART_BM"
+					}
+				  }
+				}`, createdAt.Format(time.RFC3339Nano)),
+			},
+		},
+	}
+
+	resourceRef := MaintenanceResourceReference{
+		Namespace: "dgxc-janitor",
+		Version:   "v1alpha1",
+		ApiGroup:  "janitor.dgxc.nvidia.com",
+		Kind:      "RebootNode",
+	}
+	client := fake.NewClientBuilder().WithObjects(node).Build()
+	annotationManager := NodeAnnotationManager{client: client}
+
+	err := annotationManager.EnsureRemediationStateGVK(context.TODO(), nodeName, map[string]MaintenanceResourceReference{
+		"RESTART_BM": resourceRef,
+	})
+	require.NoError(t, err)
+
+	state, _, err := annotationManager.GetRemediationState(context.TODO(), nodeName)
+	require.NoError(t, err)
+
+	groupState := state.EquivalenceGroups["restart"]
+	assert.Equal(t, "reboot-cr", groupState.MaintenanceCR)
+	assert.Equal(t, "RESTART_BM", groupState.ActionName)
+	assert.Equal(t, createdAt.Unix(), groupState.CreatedAt.Unix())
+	assert.Equal(t, resourceRef.Namespace, groupState.Namespace)
+	assert.Equal(t, resourceRef.Version, groupState.Version)
+	assert.Equal(t, resourceRef.ApiGroup, groupState.ApiGroup)
+	assert.Equal(t, resourceRef.Kind, groupState.Kind)
+}
+
+func TestEnsureRemediationStateGVKDoesNotOverwriteExistingReference(t *testing.T) {
+	nodeName := "node"
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+			Annotations: map[string]string{
+				AnnotationKey: `{
+				  "equivalenceGroups": {
+					"restart": {
+					  "maintenanceCR": "reboot-cr",
+					  "actionName": "RESTART_BM",
+					  "namespace": "old-namespace",
+					  "apiGroup": "old.example.com",
+					  "version": "v1",
+					  "kind": "OldKind"
+					}
+				  }
+				}`,
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().WithObjects(node).Build()
+	annotationManager := NodeAnnotationManager{client: client}
+
+	err := annotationManager.EnsureRemediationStateGVK(context.TODO(), nodeName, map[string]MaintenanceResourceReference{
+		"RESTART_BM": {
+			Namespace: "new-namespace",
+			Version:   "v2",
+			ApiGroup:  "new.example.com",
+			Kind:      "NewKind",
+		},
+	})
+	require.NoError(t, err)
+
+	state, _, err := annotationManager.GetRemediationState(context.TODO(), nodeName)
+	require.NoError(t, err)
+
+	groupState := state.EquivalenceGroups["restart"]
+	assert.Equal(t, "old-namespace", groupState.Namespace)
+	assert.Equal(t, "old.example.com", groupState.ApiGroup)
+	assert.Equal(t, "v1", groupState.Version)
+	assert.Equal(t, "OldKind", groupState.Kind)
 }
 
 func TestClearRemediationState(t *testing.T) {
@@ -290,9 +393,11 @@ func TestConcurrentUpdateAndRemoveGroupsFromState(t *testing.T) {
 	const iterations = 100
 	for i := 0; i < iterations; i++ {
 		// Reset state each iteration
-		err := annotationManager.UpdateRemediationState(context.TODO(), nodeName, "existing-group-1", "old-cr-1", "RESTART_BM")
+		err := annotationManager.UpdateRemediationState(context.TODO(), nodeName, "existing-group-1", "old-cr-1",
+			"RESTART_BM", MaintenanceResourceReference{})
 		require.NoError(t, err)
-		err = annotationManager.UpdateRemediationState(context.TODO(), nodeName, "existing-group-2", "old-cr-2", "COMPONENT_RESET")
+		err = annotationManager.UpdateRemediationState(context.TODO(), nodeName, "existing-group-2", "old-cr-2",
+			"COMPONENT_RESET", MaintenanceResourceReference{})
 		require.NoError(t, err)
 
 		var wg sync.WaitGroup
@@ -305,7 +410,8 @@ func TestConcurrentUpdateAndRemoveGroupsFromState(t *testing.T) {
 
 		go func() {
 			defer wg.Done()
-			_ = annotationManager.UpdateRemediationState(context.TODO(), nodeName, "new-group", "new-cr", "COMPONENT_RESET")
+			_ = annotationManager.UpdateRemediationState(context.TODO(), nodeName, "new-group", "new-cr",
+				"COMPONENT_RESET", MaintenanceResourceReference{})
 		}()
 
 		wg.Wait()

--- a/fault-remediation/pkg/common/equivalence_groups.go
+++ b/fault-remediation/pkg/common/equivalence_groups.go
@@ -105,35 +105,51 @@ This function will filter the RemediationStateAnnotation to only include the Equ
 event. Specifically, we will only return the EquivalenceGroupState on the annotation for groups which match the
 EffectiveEquivalenceGroup or any SupersedingEquivalenceGroups for the given HealthEvent. For example, if the current
 HealthEvent has EffectiveEquivalenceGroup=reset-GPU-123 and SupersedingEquivalenceGroups=["restart"] and then
-RemediationStateAnnotation state annotation on the node is
+RemediationStateAnnotation state annotation on the node is (namespace omitted because these example CRs are
+cluster-scoped)
 
 	"restart": {
 	  "maintenanceCR": "maintenance-123",
-	  "createdAt": "2025-11-13T17:18:32.163469826Z"
-	  "actionName", "RESTART_VM",
+	  "createdAt": "2025-11-13T17:18:32.163469826Z",
+	  "actionName": "RESTART_VM",
+	  "apiGroup": "janitor.dgxc.nvidia.com",
+	  "version": "v1alpha1",
+	  "kind": "RebootNode",
 	},
 	"reset-GPU-123": {
 	  "maintenanceCR": "maintenance-456",
-	  "createdAt": "2025-11-13T17:18:32.163469826Z"
-	  "actionName", "COMPONENT_RESET",
+	  "createdAt": "2025-11-13T17:18:32.163469826Z",
+	  "actionName": "COMPONENT_RESET",
+	  "apiGroup": "janitor.dgxc.nvidia.com",
+	  "version": "v1alpha1",
+	  "kind": "GPUReset",
 	},
 	"reset-GPU-456": {
 	  "maintenanceCR": "maintenance-789",
-	  "createdAt": "2025-11-13T17:18:32.163469826Z"
-	  "actionName", "COMPONENT_RESET",
+	  "createdAt": "2025-11-13T17:18:32.163469826Z",
+	  "actionName": "COMPONENT_RESET",
+	  "apiGroup": "janitor.dgxc.nvidia.com",
+	  "version": "v1alpha1",
+	  "kind": "GPUReset",
 	}
 
 We will return the following EquivalenceGroupStates which match our current event:
 
 	"restart": {
 	  "maintenanceCR": "maintenance-123",
-	  "createdAt": "2025-11-13T17:18:32.163469826Z"
-	  "actionName", "RESTART_VM",
+	  "createdAt": "2025-11-13T17:18:32.163469826Z",
+	  "actionName": "RESTART_VM",
+	  "apiGroup": "janitor.dgxc.nvidia.com",
+	  "version": "v1alpha1",
+	  "kind": "RebootNode",
 	},
 	"reset-GPU-123": {
 	  "maintenanceCR": "maintenance-456",
-	  "createdAt": "2025-11-13T17:18:32.163469826Z"
-	  "actionName", "COMPONENT_RESET",
+	  "createdAt": "2025-11-13T17:18:32.163469826Z",
+	  "actionName": "COMPONENT_RESET",
+	  "apiGroup": "janitor.dgxc.nvidia.com",
+	  "version": "v1alpha1",
+	  "kind": "GPUReset",
 	}
 
 We will validate that both maintenance-123 and maintenance-456 are not in-progress prior to creating a new maintenance

--- a/fault-remediation/pkg/crstatus/checker.go
+++ b/fault-remediation/pkg/crstatus/checker.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"log/slog"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -49,6 +50,7 @@ func NewCRStatusChecker(
 	}
 }
 
+// GetCRStateForReference fetches the stored maintenance CR reference and returns its current remediation state.
 func (c *CRStatusChecker) GetCRStateForReference(
 	ctx context.Context,
 	crName string,
@@ -61,7 +63,7 @@ func (c *CRStatusChecker) GetCRStateForReference(
 	}
 
 	gvk := schema.GroupVersionKind{
-		Group:   resourceRef.ApiGroup,
+		Group:   resourceRef.APIGroup,
 		Version: resourceRef.Version,
 		Kind:    resourceRef.Kind,
 	}
@@ -76,8 +78,14 @@ func (c *CRStatusChecker) GetCRStateForReference(
 	key := client.ObjectKey{Name: crName, Namespace: resourceRef.Namespace}
 
 	if err := c.client.Get(ctx, key, obj); err != nil {
-		slog.WarnContext(ctx, "Failed to get CR, allowing create", "crName", crName, "gvk", gvk.String(), "error", err)
-		return CRStateNotFound
+		if apierrors.IsNotFound(err) {
+			slog.InfoContext(ctx, "Stored CR was not found", "crName", crName, "gvk", gvk.String())
+			return CRStateNotFound
+		}
+
+		slog.ErrorContext(ctx, "Failed to get CR, keeping create blocked",
+			"crName", crName, "gvk", gvk.String(), "error", err)
+		return CRStateInProgress
 	}
 
 	return c.checkConditionType(obj, completeConditionType)

--- a/fault-remediation/pkg/crstatus/checker.go
+++ b/fault-remediation/pkg/crstatus/checker.go
@@ -23,13 +23,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/nvidia/nvsentinel/fault-remediation/pkg/annotation"
-	"github.com/nvidia/nvsentinel/fault-remediation/pkg/config"
 )
 
 type CRStatusChecker struct {
-	client             client.Client
-	remediationActions map[string]config.MaintenanceResource
-	dryRun             bool
+	client client.Client
+	dryRun bool
 }
 
 type CRState string
@@ -43,37 +41,12 @@ const (
 
 func NewCRStatusChecker(
 	client client.Client,
-	remediationActions map[string]config.MaintenanceResource,
 	dryRun bool,
 ) *CRStatusChecker {
 	return &CRStatusChecker{
-		client:             client,
-		remediationActions: remediationActions,
-		dryRun:             dryRun,
+		client: client,
+		dryRun: dryRun,
 	}
-}
-
-// ShouldSkipCRCreation returns true if an existing CR should suppress creation of a new CR.
-func (c *CRStatusChecker) ShouldSkipCRCreation(ctx context.Context, actionName string, crName string) bool {
-	state := c.GetCRState(ctx, actionName, crName)
-	return state == CRStateInProgress || state == CRStateSucceeded
-}
-
-func (c *CRStatusChecker) GetCRState(ctx context.Context, actionName string, crName string) CRState {
-	resource, exists := c.remediationActions[actionName]
-	if !exists {
-		slog.ErrorContext(ctx, "No remediation configuration found for action", "action", actionName)
-		return CRStateNotFound
-	}
-
-	resourceRef := annotation.MaintenanceResourceReference{
-		Namespace: resource.Namespace,
-		Version:   resource.Version,
-		ApiGroup:  resource.ApiGroup,
-		Kind:      resource.Kind,
-	}
-
-	return c.GetCRStateForReference(ctx, crName, resourceRef, resource.CompleteConditionType)
 }
 
 func (c *CRStatusChecker) GetCRStateForReference(
@@ -108,10 +81,6 @@ func (c *CRStatusChecker) GetCRStateForReference(
 	}
 
 	return c.checkConditionType(obj, completeConditionType)
-}
-
-func (c *CRStatusChecker) checkCondition(obj *unstructured.Unstructured, resource config.MaintenanceResource) CRState {
-	return c.checkConditionType(obj, resource.CompleteConditionType)
 }
 
 func (c *CRStatusChecker) checkConditionType(obj *unstructured.Unstructured, completeConditionType string) CRState {

--- a/fault-remediation/pkg/crstatus/checker.go
+++ b/fault-remediation/pkg/crstatus/checker.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/nvidia/nvsentinel/fault-remediation/pkg/annotation"
 	"github.com/nvidia/nvsentinel/fault-remediation/pkg/config"
 )
 
@@ -65,31 +66,55 @@ func (c *CRStatusChecker) GetCRState(ctx context.Context, actionName string, crN
 		return CRStateNotFound
 	}
 
+	resourceRef := annotation.MaintenanceResourceReference{
+		Namespace: resource.Namespace,
+		Version:   resource.Version,
+		ApiGroup:  resource.ApiGroup,
+		Kind:      resource.Kind,
+	}
+
+	return c.GetCRStateForReference(ctx, crName, resourceRef, resource.CompleteConditionType)
+}
+
+func (c *CRStatusChecker) GetCRStateForReference(
+	ctx context.Context,
+	crName string,
+	resourceRef annotation.MaintenanceResourceReference,
+	completeConditionType string,
+) CRState {
 	if c.dryRun {
-		slog.InfoContext(ctx, "DRY-RUN: CR doesn't exist (dry-run mode)", "crName", crName, "action", actionName)
+		slog.InfoContext(ctx, "DRY-RUN: CR doesn't exist (dry-run mode)", "crName", crName)
 		return CRStateNotFound
 	}
 
 	gvk := schema.GroupVersionKind{
-		Group:   resource.ApiGroup,
-		Version: resource.Version,
-		Kind:    resource.Kind,
+		Group:   resourceRef.ApiGroup,
+		Version: resourceRef.Version,
+		Kind:    resourceRef.Kind,
+	}
+	if gvk.Group == "" || gvk.Version == "" || gvk.Kind == "" {
+		slog.WarnContext(ctx, "Stored CR reference is missing GVK, allowing create", "crName", crName)
+		return CRStateNotFound
 	}
 
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(gvk)
 
-	key := client.ObjectKey{Name: crName, Namespace: resource.Namespace}
+	key := client.ObjectKey{Name: crName, Namespace: resourceRef.Namespace}
 
 	if err := c.client.Get(ctx, key, obj); err != nil {
 		slog.WarnContext(ctx, "Failed to get CR, allowing create", "crName", crName, "gvk", gvk.String(), "error", err)
 		return CRStateNotFound
 	}
 
-	return c.checkCondition(obj, resource)
+	return c.checkConditionType(obj, completeConditionType)
 }
 
 func (c *CRStatusChecker) checkCondition(obj *unstructured.Unstructured, resource config.MaintenanceResource) CRState {
+	return c.checkConditionType(obj, resource.CompleteConditionType)
+}
+
+func (c *CRStatusChecker) checkConditionType(obj *unstructured.Unstructured, completeConditionType string) CRState {
 	status, found, err := unstructured.NestedMap(obj.Object, "status")
 	if err != nil || !found {
 		return CRStateInProgress
@@ -100,7 +125,7 @@ func (c *CRStatusChecker) checkCondition(obj *unstructured.Unstructured, resourc
 		return CRStateInProgress
 	}
 
-	conditionStatus := c.findConditionStatus(conditions, resource.CompleteConditionType)
+	conditionStatus := c.findConditionStatus(conditions, completeConditionType)
 
 	switch conditionStatus {
 	case "True":

--- a/fault-remediation/pkg/crstatus/checker.go
+++ b/fault-remediation/pkg/crstatus/checker.go
@@ -85,6 +85,7 @@ func (c *CRStatusChecker) GetCRStateForReference(
 
 		slog.ErrorContext(ctx, "Failed to get CR, keeping create blocked",
 			"crName", crName, "gvk", gvk.String(), "error", err)
+
 		return CRStateInProgress
 	}
 

--- a/fault-remediation/pkg/crstatus/crstatus_interface.go
+++ b/fault-remediation/pkg/crstatus/crstatus_interface.go
@@ -23,7 +23,5 @@ import (
 )
 
 type CRStatusCheckerInterface interface {
-	ShouldSkipCRCreation(context.Context, string, string) bool
-	GetCRState(context.Context, string, string) CRState
 	GetCRStateForReference(context.Context, string, annotation.MaintenanceResourceReference, string) CRState
 }

--- a/fault-remediation/pkg/crstatus/crstatus_interface.go
+++ b/fault-remediation/pkg/crstatus/crstatus_interface.go
@@ -18,9 +18,12 @@ package crstatus
 
 import (
 	"context"
+
+	"github.com/nvidia/nvsentinel/fault-remediation/pkg/annotation"
 )
 
 type CRStatusCheckerInterface interface {
 	ShouldSkipCRCreation(context.Context, string, string) bool
 	GetCRState(context.Context, string, string) CRState
+	GetCRStateForReference(context.Context, string, annotation.MaintenanceResourceReference, string) CRState
 }

--- a/fault-remediation/pkg/crstatus/crstatus_test.go
+++ b/fault-remediation/pkg/crstatus/crstatus_test.go
@@ -16,11 +16,14 @@ package crstatus
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/nvidia/nvsentinel/fault-remediation/pkg/annotation"
 )
@@ -142,11 +145,35 @@ func TestGetCRStateForReferenceUsesStoredReference(t *testing.T) {
 	checker := NewCRStatusChecker(fakeClient, false)
 
 	state := checker.GetCRStateForReference(context.Background(), "stored-cr", annotation.MaintenanceResourceReference{
-		ApiGroup:  "stored.example.com",
+		APIGroup:  "stored.example.com",
 		Version:   "v9",
 		Kind:      "StoredMaintenance",
 		Namespace: "stored-namespace",
 	}, "NodeReady")
 
 	assert.Equal(t, CRStateSucceeded, state)
+}
+
+func TestGetCRStateForReferenceBlocksOnGetError(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+		Get: func(
+			_ context.Context,
+			_ client.WithWatch,
+			_ client.ObjectKey,
+			_ client.Object,
+			_ ...client.GetOption,
+		) error {
+			return fmt.Errorf("api server unavailable")
+		},
+	}).Build()
+	checker := NewCRStatusChecker(fakeClient, false)
+
+	state := checker.GetCRStateForReference(context.Background(), "stored-cr", annotation.MaintenanceResourceReference{
+		APIGroup:  "stored.example.com",
+		Version:   "v9",
+		Kind:      "StoredMaintenance",
+		Namespace: "stored-namespace",
+	}, "NodeReady")
+
+	assert.Equal(t, CRStateInProgress, state)
 }

--- a/fault-remediation/pkg/crstatus/crstatus_test.go
+++ b/fault-remediation/pkg/crstatus/crstatus_test.go
@@ -15,11 +15,14 @@
 package crstatus
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/nvidia/nvsentinel/fault-remediation/pkg/annotation"
 	"github.com/nvidia/nvsentinel/fault-remediation/pkg/config"
 )
 
@@ -119,4 +122,45 @@ func TestCheckCondition(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestGetCRStateForReferenceUsesStoredReference(t *testing.T) {
+	storedCR := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "stored.example.com/v9",
+			"kind":       "StoredMaintenance",
+			"metadata": map[string]any{
+				"name":      "stored-cr",
+				"namespace": "stored-namespace",
+			},
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{
+						"type":   "NodeReady",
+						"status": "True",
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithObjects(storedCR).Build()
+	checker := NewCRStatusChecker(fakeClient, map[string]config.MaintenanceResource{
+		"RESTART_BM": {
+			ApiGroup:              "config.example.com",
+			Version:               "v1",
+			Kind:                  "ConfigMaintenance",
+			Namespace:             "config-namespace",
+			CompleteConditionType: "NodeReady",
+		},
+	}, false)
+
+	state := checker.GetCRStateForReference(context.Background(), "stored-cr", annotation.MaintenanceResourceReference{
+		ApiGroup:  "stored.example.com",
+		Version:   "v9",
+		Kind:      "StoredMaintenance",
+		Namespace: "stored-namespace",
+	}, "NodeReady")
+
+	assert.Equal(t, CRStateSucceeded, state)
 }

--- a/fault-remediation/pkg/crstatus/crstatus_test.go
+++ b/fault-remediation/pkg/crstatus/crstatus_test.go
@@ -23,18 +23,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/nvidia/nvsentinel/fault-remediation/pkg/annotation"
-	"github.com/nvidia/nvsentinel/fault-remediation/pkg/config"
 )
 
 func TestCheckCondition(t *testing.T) {
-	testResource := config.MaintenanceResource{
-		CompleteConditionType: "Completed",
-	}
-	cfg := map[string]config.MaintenanceResource{
-		"test": testResource,
-	}
+	completeConditionType := "Completed"
 
-	checker := NewCRStatusChecker(nil, cfg, false)
+	checker := NewCRStatusChecker(nil, false)
 
 	tests := []struct {
 		name     string
@@ -118,7 +112,7 @@ func TestCheckCondition(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := checker.checkCondition(tt.cr, testResource)
+			result := checker.checkConditionType(tt.cr, completeConditionType)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -145,15 +139,7 @@ func TestGetCRStateForReferenceUsesStoredReference(t *testing.T) {
 	}
 
 	fakeClient := fake.NewClientBuilder().WithObjects(storedCR).Build()
-	checker := NewCRStatusChecker(fakeClient, map[string]config.MaintenanceResource{
-		"RESTART_BM": {
-			ApiGroup:              "config.example.com",
-			Version:               "v1",
-			Kind:                  "ConfigMaintenance",
-			Namespace:             "config-namespace",
-			CompleteConditionType: "NodeReady",
-		},
-	}, false)
+	checker := NewCRStatusChecker(fakeClient, false)
 
 	state := checker.GetCRStateForReference(context.Background(), "stored-cr", annotation.MaintenanceResourceReference{
 		ApiGroup:  "stored.example.com",

--- a/fault-remediation/pkg/reconciler/reconciler.go
+++ b/fault-remediation/pkg/reconciler/reconciler.go
@@ -1001,7 +1001,24 @@ func (r *FaultRemediationReconciler) evaluateExistingCR(
 	nodeName string,
 ) existingCRDecision {
 	crName := groupState.state.MaintenanceCR
-	crState := statusChecker.GetCRState(ctx, groupState.state.ActionName, crName)
+
+	resourceRef, ok := resourceReferenceFromState(groupState.state)
+	if !ok {
+		slog.WarnContext(ctx, "Stored remediation state is missing CR GVK, allowing retry",
+			"node", nodeName, "crName", crName, "group", groupState.name)
+
+		return existingCRDecision{shouldCreate: true, removeGroup: true}
+	}
+
+	completeConditionType, ok := r.completeConditionTypeForStoredState(groupState.state)
+	if !ok {
+		slog.WarnContext(ctx, "Stored remediation state has no completion condition config, allowing retry",
+			"node", nodeName, "crName", crName, "group", groupState.name, "action", groupState.state.ActionName)
+
+		return existingCRDecision{shouldCreate: true, removeGroup: true}
+	}
+
+	crState := statusChecker.GetCRStateForReference(ctx, crName, resourceRef, completeConditionType)
 
 	switch crState {
 	case crstatus.CRStateInProgress:
@@ -1019,6 +1036,42 @@ func (r *FaultRemediationReconciler) evaluateExistingCR(
 
 		return existingCRDecision{shouldCreate: true, removeGroup: true}
 	}
+}
+
+func resourceReferenceFromState(
+	groupState annotation.EquivalenceGroupState,
+) (annotation.MaintenanceResourceReference, bool) {
+	resourceRef := annotation.MaintenanceResourceReference{
+		Namespace: groupState.Namespace,
+		Version:   groupState.Version,
+		ApiGroup:  groupState.ApiGroup,
+		Kind:      groupState.Kind,
+	}
+	if resourceRef.ApiGroup == "" || resourceRef.Version == "" || resourceRef.Kind == "" {
+		return annotation.MaintenanceResourceReference{}, false
+	}
+
+	return resourceRef, true
+}
+
+func (r *FaultRemediationReconciler) completeConditionTypeForStoredState(
+	groupState annotation.EquivalenceGroupState,
+) (string, bool) {
+	if r.Config.RemediationClient == nil {
+		return "", false
+	}
+
+	remediationConfig := r.Config.RemediationClient.GetConfig()
+	if remediationConfig == nil {
+		return "", false
+	}
+
+	resource, exists := remediationConfig.RemediationActions[groupState.ActionName]
+	if !exists {
+		return "", false
+	}
+
+	return resource.CompleteConditionType, true
 }
 
 func (r *FaultRemediationReconciler) evaluateSucceededCR(

--- a/fault-remediation/pkg/reconciler/reconciler.go
+++ b/fault-remediation/pkg/reconciler/reconciler.go
@@ -527,28 +527,28 @@ func (r *FaultRemediationReconciler) ensureRemediationStateGVK(ctx context.Conte
 		return nil
 	}
 
-	resourceRefs := maintenanceResourceReferences(remediationConfig.RemediationActions)
-	if len(resourceRefs) == 0 {
+	resourceRefsByAction := maintenanceResourceReferences(remediationConfig.RemediationActions)
+	if len(resourceRefsByAction) == 0 {
 		return nil
 	}
 
-	return r.annotationManager.EnsureRemediationStateGVK(ctx, nodeName, resourceRefs)
+	return r.annotationManager.EnsureRemediationStateGVK(ctx, nodeName, resourceRefsByAction)
 }
 
 func maintenanceResourceReferences(
 	remediationActions map[string]config.MaintenanceResource,
 ) map[string]annotation.MaintenanceResourceReference {
-	resourceRefs := make(map[string]annotation.MaintenanceResourceReference, len(remediationActions))
+	resourceRefsByAction := make(map[string]annotation.MaintenanceResourceReference, len(remediationActions))
 	for actionName, resource := range remediationActions {
-		resourceRefs[actionName] = annotation.MaintenanceResourceReference{
+		resourceRefsByAction[actionName] = annotation.MaintenanceResourceReference{
 			Namespace: resource.Namespace,
 			Version:   resource.Version,
-			ApiGroup:  resource.ApiGroup,
+			APIGroup:  resource.ApiGroup,
 			Kind:      resource.Kind,
 		}
 	}
 
-	return resourceRefs
+	return resourceRefsByAction
 }
 
 // trySkipEvent returns (result, err, true) when the event should be skipped; otherwise (zero, nil, false).
@@ -1044,10 +1044,10 @@ func resourceReferenceFromState(
 	resourceRef := annotation.MaintenanceResourceReference{
 		Namespace: groupState.Namespace,
 		Version:   groupState.Version,
-		ApiGroup:  groupState.ApiGroup,
+		APIGroup:  groupState.APIGroup,
 		Kind:      groupState.Kind,
 	}
-	if resourceRef.ApiGroup == "" || resourceRef.Version == "" || resourceRef.Kind == "" {
+	if resourceRef.APIGroup == "" || resourceRef.Version == "" || resourceRef.Kind == "" {
 		return annotation.MaintenanceResourceReference{}, false
 	}
 
@@ -1068,6 +1068,9 @@ func (r *FaultRemediationReconciler) completeConditionTypeForStoredState(
 
 	resource, exists := remediationConfig.RemediationActions[groupState.ActionName]
 	if !exists {
+		return "", false
+	}
+	if strings.TrimSpace(resource.CompleteConditionType) == "" {
 		return "", false
 	}
 

--- a/fault-remediation/pkg/reconciler/reconciler.go
+++ b/fault-remediation/pkg/reconciler/reconciler.go
@@ -41,6 +41,7 @@ import (
 	"github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	"github.com/nvidia/nvsentinel/fault-remediation/pkg/annotation"
 	"github.com/nvidia/nvsentinel/fault-remediation/pkg/common"
+	"github.com/nvidia/nvsentinel/fault-remediation/pkg/config"
 	"github.com/nvidia/nvsentinel/fault-remediation/pkg/crstatus"
 	"github.com/nvidia/nvsentinel/fault-remediation/pkg/events"
 	"github.com/nvidia/nvsentinel/fault-remediation/pkg/metrics"
@@ -468,6 +469,19 @@ func (r *FaultRemediationReconciler) handleRemediationEvent(
 		return res, err
 	}
 
+	if err := r.ensureRemediationStateGVK(ctx, nodeName); err != nil {
+		metrics.ProcessingErrors.WithLabelValues("annotation_gvk_update_error", nodeName).Inc()
+		slog.ErrorContext(ctx, "Error ensuring remediation state GVK annotation", "node", nodeName, "error", err)
+
+		span.SetAttributes(
+			attribute.String("fault_remediation.error.type", "annotation_gvk_update_error"),
+			attribute.String("fault_remediation.error.message", err.Error()),
+		)
+		tracing.RecordError(span, err)
+
+		return ctrl.Result{}, fmt.Errorf("error ensuring remediation state GVK annotation: %w", err)
+	}
+
 	shouldCreateCR, existingCR, existingCRRemediated, err := r.checkExistingCRStatus(ctx, healthEvent,
 		healthEventWithStatus.CreatedAt, groupConfig)
 	if err != nil {
@@ -501,6 +515,40 @@ func (r *FaultRemediationReconciler) handleRemediationEvent(
 	metrics.EventsProcessed.WithLabelValues(metrics.CRStatusCreated, nodeName).Inc()
 
 	return r.markProcessedOrError(ctx, watcherInstance, eventWithToken, nodeName)
+}
+
+func (r *FaultRemediationReconciler) ensureRemediationStateGVK(ctx context.Context, nodeName string) error {
+	if r.annotationManager == nil || r.Config.RemediationClient == nil {
+		return nil
+	}
+
+	remediationConfig := r.Config.RemediationClient.GetConfig()
+	if remediationConfig == nil || len(remediationConfig.RemediationActions) == 0 {
+		return nil
+	}
+
+	resourceRefs := maintenanceResourceReferences(remediationConfig.RemediationActions)
+	if len(resourceRefs) == 0 {
+		return nil
+	}
+
+	return r.annotationManager.EnsureRemediationStateGVK(ctx, nodeName, resourceRefs)
+}
+
+func maintenanceResourceReferences(
+	remediationActions map[string]config.MaintenanceResource,
+) map[string]annotation.MaintenanceResourceReference {
+	resourceRefs := make(map[string]annotation.MaintenanceResourceReference, len(remediationActions))
+	for actionName, resource := range remediationActions {
+		resourceRefs[actionName] = annotation.MaintenanceResourceReference{
+			Namespace: resource.Namespace,
+			Version:   resource.Version,
+			ApiGroup:  resource.ApiGroup,
+			Kind:      resource.Kind,
+		}
+	}
+
+	return resourceRefs
 }
 
 // trySkipEvent returns (result, err, true) when the event should be skipped; otherwise (zero, nil, false).

--- a/fault-remediation/pkg/reconciler/reconciler.go
+++ b/fault-remediation/pkg/reconciler/reconciler.go
@@ -1070,6 +1070,7 @@ func (r *FaultRemediationReconciler) completeConditionTypeForStoredState(
 	if !exists {
 		return "", false
 	}
+
 	if strings.TrimSpace(resource.CompleteConditionType) == "" {
 		return "", false
 	}

--- a/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
@@ -29,7 +29,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -440,6 +442,11 @@ func TestCRBasedDeduplication_Integration(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, state.EquivalenceGroups, "restart")
 		assert.NotEmpty(t, state.EquivalenceGroups["restart"].MaintenanceCR)
+		assert.Equal(t, protos.RecommendedAction_RESTART_BM.String(), state.EquivalenceGroups["restart"].ActionName)
+		assert.Equal(t, "janitor.dgxc.nvidia.com", state.EquivalenceGroups["restart"].ApiGroup)
+		assert.Equal(t, "v1alpha1", state.EquivalenceGroups["restart"].Version)
+		assert.Equal(t, "RebootNode", state.EquivalenceGroups["restart"].Kind)
+		assert.Empty(t, state.EquivalenceGroups["restart"].Namespace)
 		assert.WithinDuration(t, time.Now(), state.EquivalenceGroups["restart"].CreatedAt, 5*time.Second)
 
 		// Verify CR was actually created
@@ -1129,6 +1136,120 @@ func TestEventSequenceWithSupersedingGroup(t *testing.T) {
 	_ = testDynamic.Resource(rebootNodeGVR).Delete(ctx, crName1, metav1.DeleteOptions{})
 	_ = testDynamic.Resource(gpuResetGVR).Delete(ctx, crName2, metav1.DeleteOptions{})
 	_ = testDynamic.Resource(gpuResetGVR).Delete(ctx, crName3, metav1.DeleteOptions{})
+}
+
+func TestExistingCRStatusUsesStoredGVKAnnotation_E2E(t *testing.T) {
+	ctx := testContext
+
+	nodeName := "test-node-stored-gvk-e2e"
+	createTestNode(ctx, nodeName, nil, map[string]string{"test": "label"})
+	defer func() {
+		_ = testClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
+	}()
+
+	rebootNodeGVR := schema.GroupVersionResource{
+		Group:    "janitor.dgxc.nvidia.com",
+		Version:  "v1alpha1",
+		Resource: "rebootnodes",
+	}
+	gpuResetGVR := schema.GroupVersionResource{
+		Group:    "janitor.dgxc.nvidia.com",
+		Version:  "v1alpha1",
+		Resource: "gpuresets",
+	}
+	existingCRName := "maintenance-" + nodeName + "-existing"
+
+	existingRebootNode := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "janitor.dgxc.nvidia.com/v1alpha1",
+		"kind":       "RebootNode",
+		"metadata": map[string]interface{}{
+			"name": existingCRName,
+		},
+		"spec": map[string]interface{}{
+			"nodeName": nodeName,
+			"force":    false,
+		},
+	}}
+	_, err := testDynamic.Resource(rebootNodeGVR).Create(ctx, existingRebootNode, metav1.CreateOptions{})
+	require.NoError(t, err)
+	defer func() {
+		_ = testDynamic.Resource(rebootNodeGVR).Delete(ctx, existingCRName, metav1.DeleteOptions{})
+		_ = testDynamic.Resource(gpuResetGVR).Delete(ctx, "maintenance-"+nodeName+"-event-uses-stored-gvk",
+			metav1.DeleteOptions{})
+	}()
+
+	driftedRemediationActions := map[string]config.MaintenanceResource{
+		protos.RecommendedAction_RESTART_BM.String(): {
+			ApiGroup:              "janitor.dgxc.nvidia.com",
+			Version:               "v1alpha1",
+			Kind:                  "GPUReset",
+			TemplateFileName:      "gpureset-template.yaml",
+			CompleteConditionType: "NodeReady",
+			EquivalenceGroup:      "restart",
+		},
+	}
+	remediationClient, err := createTestRemediationClient(false, driftedRemediationActions)
+	require.NoError(t, err)
+
+	cfg := ReconcilerConfig{
+		RemediationClient: remediationClient,
+		StateManager:      statemanager.NewStateManager(testClient),
+		UpdateMaxRetries:  3,
+		UpdateRetryDelay:  100 * time.Millisecond,
+	}
+	r := &FaultRemediationReconciler{
+		Config:            cfg,
+		annotationManager: cfg.RemediationClient.GetAnnotationManager(),
+	}
+
+	err = r.annotationManager.UpdateRemediationState(
+		ctx,
+		nodeName,
+		"restart",
+		existingCRName,
+		protos.RecommendedAction_RESTART_BM.String(),
+		annotation.MaintenanceResourceReference{
+			ApiGroup: "janitor.dgxc.nvidia.com",
+			Version:  "v1alpha1",
+			Kind:     "RebootNode",
+		},
+	)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		state, _, err := r.annotationManager.GetRemediationState(ctx, nodeName)
+		if err != nil {
+			return false
+		}
+
+		groupState, ok := state.EquivalenceGroups["restart"]
+		return ok && groupState.MaintenanceCR == existingCRName && groupState.Kind == "RebootNode"
+	}, 5*time.Second, 100*time.Millisecond, "stored RebootNode reference should be visible before handling event")
+
+	healthEventDoc := &events.HealthEventDoc{
+		ID: "event-uses-stored-gvk",
+		HealthEventWithStatus: model.HealthEventWithStatus{
+			CreatedAt: time.Now(),
+			HealthEvent: &protos.HealthEvent{
+				NodeName:          nodeName,
+				RecommendedAction: protos.RecommendedAction_RESTART_BM,
+			},
+			HealthEventStatus: &protos.HealthEventStatus{},
+		},
+	}
+
+	_, err = r.handleRemediationEvent(ctx, healthEventDoc, datastore.EventWithToken{}, nil, &MockHealthEventStore{})
+	require.NoError(t, err)
+
+	state, _, err := r.annotationManager.GetRemediationState(ctx, nodeName)
+	require.NoError(t, err)
+	require.Contains(t, state.EquivalenceGroups, "restart")
+	assert.Equal(t, existingCRName, state.EquivalenceGroups["restart"].MaintenanceCR)
+	assert.Equal(t, "RebootNode", state.EquivalenceGroups["restart"].Kind)
+
+	_, err = testDynamic.Resource(gpuResetGVR).Get(ctx, "maintenance-"+nodeName+"-event-uses-stored-gvk",
+		metav1.GetOptions{})
+	assert.True(t, apierrors.IsNotFound(err),
+		"current config points at GPUReset, but stored RebootNode reference should suppress creation")
 }
 
 // TestFullReconcilerWithMockedMongoDB tests the entire reconciler flow

--- a/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
@@ -443,7 +443,7 @@ func TestCRBasedDeduplication_Integration(t *testing.T) {
 		assert.Contains(t, state.EquivalenceGroups, "restart")
 		assert.NotEmpty(t, state.EquivalenceGroups["restart"].MaintenanceCR)
 		assert.Equal(t, protos.RecommendedAction_RESTART_BM.String(), state.EquivalenceGroups["restart"].ActionName)
-		assert.Equal(t, "janitor.dgxc.nvidia.com", state.EquivalenceGroups["restart"].ApiGroup)
+		assert.Equal(t, "janitor.dgxc.nvidia.com", state.EquivalenceGroups["restart"].APIGroup)
 		assert.Equal(t, "v1alpha1", state.EquivalenceGroups["restart"].Version)
 		assert.Equal(t, "RebootNode", state.EquivalenceGroups["restart"].Kind)
 		assert.Empty(t, state.EquivalenceGroups["restart"].Namespace)
@@ -1209,7 +1209,7 @@ func TestExistingCRStatusUsesStoredGVKAnnotation_E2E(t *testing.T) {
 		existingCRName,
 		protos.RecommendedAction_RESTART_BM.String(),
 		annotation.MaintenanceResourceReference{
-			ApiGroup: "janitor.dgxc.nvidia.com",
+			APIGroup: "janitor.dgxc.nvidia.com",
 			Version:  "v1alpha1",
 			Kind:     "RebootNode",
 		},

--- a/fault-remediation/pkg/reconciler/reconciler_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_test.go
@@ -64,17 +64,22 @@ func (m *MockK8sClient) GetStatusChecker() crstatus.CRStatusCheckerInterface {
 }
 
 type mockStatusChecker struct {
-	shouldSkip []bool
-	states     []crstatus.CRState
-	stateByCR  map[string]crstatus.CRState
-	callCount  int
+	getCRStateFn func(context.Context, string, string) crstatus.CRState
+	shouldSkip   []bool
+	states       []crstatus.CRState
+	stateByCR    map[string]crstatus.CRState
+	callCount    int
 }
 
 func (statusChecker *mockStatusChecker) ShouldSkipCRCreation(context.Context, string, string) bool {
 	return statusChecker.GetCRState(context.Background(), "", "") != crstatus.CRStateFailed
 }
 
-func (statusChecker *mockStatusChecker) GetCRState(_ context.Context, _ string, crName string) crstatus.CRState {
+func (statusChecker *mockStatusChecker) GetCRState(ctx context.Context, actionName string, crName string) crstatus.CRState {
+	if statusChecker.getCRStateFn != nil {
+		return statusChecker.getCRStateFn(ctx, actionName, crName)
+	}
+
 	if statusChecker.stateByCR != nil {
 		return statusChecker.stateByCR[crName]
 	}
@@ -104,9 +109,15 @@ func (m *MockK8sClient) GetConfig() *config.TomlConfig {
 		RemediationActions: map[string]config.MaintenanceResource{
 			protos.RecommendedAction_RESTART_BM.String(): {
 				EquivalenceGroup: "restart",
+				ApiGroup:         "janitor.dgxc.nvidia.com",
+				Version:          "v1alpha1",
+				Kind:             "RebootNode",
 			},
 			protos.RecommendedAction_COMPONENT_RESET.String(): {
 				EquivalenceGroup: "restart",
+				ApiGroup:         "janitor.dgxc.nvidia.com",
+				Version:          "v1alpha1",
+				Kind:             "RebootNode",
 			},
 		},
 	}
@@ -150,6 +161,8 @@ type MockNodeAnnotationManager struct {
 	existingCRs       map[string]string
 	existingCRCreated time.Time
 	createdByGroup    map[string]time.Time
+	actionByGroup     map[string]string
+	ensureGVKFn       func(ctx context.Context, nodeName string, resourceRefs map[string]annotation.MaintenanceResourceReference) error
 }
 
 func (m *MockNodeAnnotationManager) GetRemediationState(ctx context.Context, nodeName string) (*annotation.RemediationStateAnnotation, *corev1.Node, error) {
@@ -174,13 +187,26 @@ func (m *MockNodeAnnotationManager) GetRemediationState(ctx context.Context, nod
 		annotationState.EquivalenceGroups[groupName] = annotation.EquivalenceGroupState{
 			MaintenanceCR: crName,
 			CreatedAt:     groupCreatedAt,
+			ActionName:    m.actionByGroup[groupName],
 		}
 	}
 	return annotationState, nil, nil
 }
 
 func (m *MockNodeAnnotationManager) UpdateRemediationState(ctx context.Context, nodeName string,
-	group string, crName string, actionName string) error {
+	group string, crName string, actionName string, resourceRef annotation.MaintenanceResourceReference) error {
+	return nil
+}
+
+func (m *MockNodeAnnotationManager) EnsureRemediationStateGVK(
+	ctx context.Context,
+	nodeName string,
+	resourceRefs map[string]annotation.MaintenanceResourceReference,
+) error {
+	if m.ensureGVKFn != nil {
+		return m.ensureGVKFn(ctx, nodeName, resourceRefs)
+	}
+
 	return nil
 }
 
@@ -959,6 +985,68 @@ func TestUpdateNodeRemediatedStatus(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandleRemediationEventEnsuresGVKBeforeStatusCheck(t *testing.T) {
+	ctx := context.Background()
+	nodeName := "test-node"
+	ensureCalled := false
+	statusChecked := false
+
+	mockAnnotationManager := &MockNodeAnnotationManager{
+		existingCRs: map[string]string{
+			"restart": "existing-cr",
+		},
+		actionByGroup: map[string]string{
+			"restart": protos.RecommendedAction_RESTART_BM.String(),
+		},
+		ensureGVKFn: func(
+			_ context.Context,
+			gotNodeName string,
+			resourceRefs map[string]annotation.MaintenanceResourceReference,
+		) error {
+			ensureCalled = true
+			assert.Equal(t, nodeName, gotNodeName)
+			assert.Equal(t, "RebootNode", resourceRefs[protos.RecommendedAction_RESTART_BM.String()].Kind)
+
+			return nil
+		},
+	}
+
+	mockK8sClient := &MockK8sClient{
+		annotationManagerOverride: mockAnnotationManager,
+		mockStatusChecker: &mockStatusChecker{
+			getCRStateFn: func(_ context.Context, actionName string, crName string) crstatus.CRState {
+				statusChecked = true
+				assert.True(t, ensureCalled, "GVK annotation should be ensured before CR status checks")
+				assert.Equal(t, protos.RecommendedAction_RESTART_BM.String(), actionName)
+				assert.Equal(t, "existing-cr", crName)
+
+				return crstatus.CRStateInProgress
+			},
+		},
+	}
+	cfg := ReconcilerConfig{
+		RemediationClient: mockK8sClient,
+	}
+	r := NewFaultRemediationReconciler(nil, nil, nil, cfg, false)
+
+	healthEventDoc := &events.HealthEventDoc{
+		ID: "event-1",
+		HealthEventWithStatus: model.HealthEventWithStatus{
+			CreatedAt: time.Now(),
+			HealthEvent: &protos.HealthEvent{
+				NodeName:          nodeName,
+				RecommendedAction: protos.RecommendedAction_RESTART_BM,
+			},
+			HealthEventStatus: &protos.HealthEventStatus{},
+		},
+	}
+
+	_, err := r.handleRemediationEvent(ctx, healthEventDoc, datastore.EventWithToken{}, nil, nil)
+	assert.NoError(t, err)
+	assert.True(t, ensureCalled)
+	assert.True(t, statusChecked)
 }
 
 func TestCRBasedDeduplication(t *testing.T) {

--- a/fault-remediation/pkg/reconciler/reconciler_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_test.go
@@ -174,7 +174,7 @@ type MockNodeAnnotationManager struct {
 	existingCRCreated time.Time
 	createdByGroup    map[string]time.Time
 	actionByGroup     map[string]string
-	ensureGVKFn       func(ctx context.Context, nodeName string, resourceRefs map[string]annotation.MaintenanceResourceReference) error
+	ensureGVKFn       func(ctx context.Context, nodeName string, resourceRefsByAction map[string]annotation.MaintenanceResourceReference) error
 }
 
 func (m *MockNodeAnnotationManager) GetRemediationState(ctx context.Context, nodeName string) (*annotation.RemediationStateAnnotation, *corev1.Node, error) {
@@ -204,7 +204,7 @@ func (m *MockNodeAnnotationManager) GetRemediationState(ctx context.Context, nod
 			MaintenanceCR: crName,
 			CreatedAt:     groupCreatedAt,
 			ActionName:    actionName,
-			ApiGroup:      "janitor.dgxc.nvidia.com",
+			APIGroup:      "janitor.dgxc.nvidia.com",
 			Version:       "v1alpha1",
 			Kind:          "RebootNode",
 		}
@@ -220,10 +220,10 @@ func (m *MockNodeAnnotationManager) UpdateRemediationState(ctx context.Context, 
 func (m *MockNodeAnnotationManager) EnsureRemediationStateGVK(
 	ctx context.Context,
 	nodeName string,
-	resourceRefs map[string]annotation.MaintenanceResourceReference,
+	resourceRefsByAction map[string]annotation.MaintenanceResourceReference,
 ) error {
 	if m.ensureGVKFn != nil {
-		return m.ensureGVKFn(ctx, nodeName, resourceRefs)
+		return m.ensureGVKFn(ctx, nodeName, resourceRefsByAction)
 	}
 
 	return nil
@@ -1022,11 +1022,11 @@ func TestHandleRemediationEventEnsuresGVKBeforeStatusCheck(t *testing.T) {
 		ensureGVKFn: func(
 			_ context.Context,
 			gotNodeName string,
-			resourceRefs map[string]annotation.MaintenanceResourceReference,
+			resourceRefsByAction map[string]annotation.MaintenanceResourceReference,
 		) error {
 			ensureCalled = true
 			assert.Equal(t, nodeName, gotNodeName)
-			assert.Equal(t, "RebootNode", resourceRefs[protos.RecommendedAction_RESTART_BM.String()].Kind)
+			assert.Equal(t, "RebootNode", resourceRefsByAction[protos.RecommendedAction_RESTART_BM.String()].Kind)
 
 			return nil
 		},
@@ -1040,7 +1040,7 @@ func TestHandleRemediationEventEnsuresGVKBeforeStatusCheck(t *testing.T) {
 				statusChecked = true
 				assert.True(t, ensureCalled, "GVK annotation should be ensured before CR status checks")
 				assert.Equal(t, "existing-cr", crName)
-				assert.Equal(t, "janitor.dgxc.nvidia.com", resourceRef.ApiGroup)
+				assert.Equal(t, "janitor.dgxc.nvidia.com", resourceRef.APIGroup)
 				assert.Equal(t, "v1alpha1", resourceRef.Version)
 				assert.Equal(t, "RebootNode", resourceRef.Kind)
 				assert.Equal(t, "NodeReady", completeConditionType)
@@ -1078,7 +1078,7 @@ func TestEvaluateExistingCRUsesStoredReference(t *testing.T) {
 		getCRStateForReferenceFn: func(_ context.Context, crName string,
 			resourceRef annotation.MaintenanceResourceReference, completeConditionType string) crstatus.CRState {
 			assert.Equal(t, "stored-cr", crName)
-			assert.Equal(t, "stored.example.com", resourceRef.ApiGroup)
+			assert.Equal(t, "stored.example.com", resourceRef.APIGroup)
 			assert.Equal(t, "v9", resourceRef.Version)
 			assert.Equal(t, "StoredMaintenance", resourceRef.Kind)
 			assert.Equal(t, "stored-namespace", resourceRef.Namespace)
@@ -1108,7 +1108,7 @@ func TestEvaluateExistingCRUsesStoredReference(t *testing.T) {
 		state: annotation.EquivalenceGroupState{
 			MaintenanceCR: "stored-cr",
 			ActionName:    protos.RecommendedAction_RESTART_BM.String(),
-			ApiGroup:      "stored.example.com",
+			APIGroup:      "stored.example.com",
 			Version:       "v9",
 			Kind:          "StoredMaintenance",
 			Namespace:     "stored-namespace",
@@ -1117,6 +1117,26 @@ func TestEvaluateExistingCRUsesStoredReference(t *testing.T) {
 
 	assert.False(t, decision.shouldCreate)
 	assert.Equal(t, "stored-cr", decision.crName)
+}
+
+func TestCompleteConditionTypeForStoredStateRejectsEmptyConfig(t *testing.T) {
+	mockK8sClient := &MockK8sClient{
+		configOverride: &config.TomlConfig{
+			RemediationActions: map[string]config.MaintenanceResource{
+				protos.RecommendedAction_RESTART_BM.String(): {
+					CompleteConditionType: " ",
+				},
+			},
+		},
+	}
+	r := NewFaultRemediationReconciler(nil, nil, nil, ReconcilerConfig{RemediationClient: mockK8sClient}, false)
+
+	completeConditionType, ok := r.completeConditionTypeForStoredState(annotation.EquivalenceGroupState{
+		ActionName: protos.RecommendedAction_RESTART_BM.String(),
+	})
+
+	assert.False(t, ok)
+	assert.Empty(t, completeConditionType)
 }
 
 func TestCRBasedDeduplication(t *testing.T) {

--- a/fault-remediation/pkg/reconciler/reconciler_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_test.go
@@ -65,24 +65,11 @@ func (m *MockK8sClient) GetStatusChecker() crstatus.CRStatusCheckerInterface {
 }
 
 type mockStatusChecker struct {
-	getCRStateFn             func(context.Context, string, string) crstatus.CRState
 	getCRStateForReferenceFn func(context.Context, string, annotation.MaintenanceResourceReference, string) crstatus.CRState
 	shouldSkip               []bool
 	states                   []crstatus.CRState
 	stateByCR                map[string]crstatus.CRState
 	callCount                int
-}
-
-func (statusChecker *mockStatusChecker) ShouldSkipCRCreation(context.Context, string, string) bool {
-	return statusChecker.GetCRState(context.Background(), "", "") != crstatus.CRStateFailed
-}
-
-func (statusChecker *mockStatusChecker) GetCRState(ctx context.Context, actionName string, crName string) crstatus.CRState {
-	if statusChecker.getCRStateFn != nil {
-		return statusChecker.getCRStateFn(ctx, actionName, crName)
-	}
-
-	return statusChecker.nextState(crName)
 }
 
 func (statusChecker *mockStatusChecker) GetCRStateForReference(

--- a/fault-remediation/pkg/reconciler/reconciler_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_test.go
@@ -45,6 +45,7 @@ type MockK8sClient struct {
 	runLogCollectorJobFn      func(ctx context.Context, nodeName string) (ctrl.Result, error)
 	annotationManagerOverride annotation.NodeAnnotationManagerInterface
 	mockStatusChecker         *mockStatusChecker
+	configOverride            *config.TomlConfig
 }
 
 func (m *MockK8sClient) CreateMaintenanceResource(ctx context.Context, healthEventData *events.HealthEventData, groupConfig *common.EquivalenceGroupConfig) (string, error) {
@@ -64,11 +65,12 @@ func (m *MockK8sClient) GetStatusChecker() crstatus.CRStatusCheckerInterface {
 }
 
 type mockStatusChecker struct {
-	getCRStateFn func(context.Context, string, string) crstatus.CRState
-	shouldSkip   []bool
-	states       []crstatus.CRState
-	stateByCR    map[string]crstatus.CRState
-	callCount    int
+	getCRStateFn             func(context.Context, string, string) crstatus.CRState
+	getCRStateForReferenceFn func(context.Context, string, annotation.MaintenanceResourceReference, string) crstatus.CRState
+	shouldSkip               []bool
+	states                   []crstatus.CRState
+	stateByCR                map[string]crstatus.CRState
+	callCount                int
 }
 
 func (statusChecker *mockStatusChecker) ShouldSkipCRCreation(context.Context, string, string) bool {
@@ -80,6 +82,23 @@ func (statusChecker *mockStatusChecker) GetCRState(ctx context.Context, actionNa
 		return statusChecker.getCRStateFn(ctx, actionName, crName)
 	}
 
+	return statusChecker.nextState(crName)
+}
+
+func (statusChecker *mockStatusChecker) GetCRStateForReference(
+	ctx context.Context,
+	crName string,
+	resourceRef annotation.MaintenanceResourceReference,
+	completeConditionType string,
+) crstatus.CRState {
+	if statusChecker.getCRStateForReferenceFn != nil {
+		return statusChecker.getCRStateForReferenceFn(ctx, crName, resourceRef, completeConditionType)
+	}
+
+	return statusChecker.nextState(crName)
+}
+
+func (statusChecker *mockStatusChecker) nextState(crName string) crstatus.CRState {
 	if statusChecker.stateByCR != nil {
 		return statusChecker.stateByCR[crName]
 	}
@@ -105,19 +124,25 @@ func (statusChecker *mockStatusChecker) GetCRState(ctx context.Context, actionNa
 }
 
 func (m *MockK8sClient) GetConfig() *config.TomlConfig {
+	if m.configOverride != nil {
+		return m.configOverride
+	}
+
 	return &config.TomlConfig{
 		RemediationActions: map[string]config.MaintenanceResource{
 			protos.RecommendedAction_RESTART_BM.String(): {
-				EquivalenceGroup: "restart",
-				ApiGroup:         "janitor.dgxc.nvidia.com",
-				Version:          "v1alpha1",
-				Kind:             "RebootNode",
+				EquivalenceGroup:      "restart",
+				ApiGroup:              "janitor.dgxc.nvidia.com",
+				Version:               "v1alpha1",
+				Kind:                  "RebootNode",
+				CompleteConditionType: "NodeReady",
 			},
 			protos.RecommendedAction_COMPONENT_RESET.String(): {
-				EquivalenceGroup: "restart",
-				ApiGroup:         "janitor.dgxc.nvidia.com",
-				Version:          "v1alpha1",
-				Kind:             "RebootNode",
+				EquivalenceGroup:      "restart",
+				ApiGroup:              "janitor.dgxc.nvidia.com",
+				Version:               "v1alpha1",
+				Kind:                  "RebootNode",
+				CompleteConditionType: "NodeReady",
 			},
 		},
 	}
@@ -184,10 +209,17 @@ func (m *MockNodeAnnotationManager) GetRemediationState(ctx context.Context, nod
 		if createdAtForGroup, ok := m.createdByGroup[groupName]; ok {
 			groupCreatedAt = createdAtForGroup
 		}
+		actionName := m.actionByGroup[groupName]
+		if actionName == "" {
+			actionName = protos.RecommendedAction_RESTART_BM.String()
+		}
 		annotationState.EquivalenceGroups[groupName] = annotation.EquivalenceGroupState{
 			MaintenanceCR: crName,
 			CreatedAt:     groupCreatedAt,
-			ActionName:    m.actionByGroup[groupName],
+			ActionName:    actionName,
+			ApiGroup:      "janitor.dgxc.nvidia.com",
+			Version:       "v1alpha1",
+			Kind:          "RebootNode",
 		}
 	}
 	return annotationState, nil, nil
@@ -1016,11 +1048,15 @@ func TestHandleRemediationEventEnsuresGVKBeforeStatusCheck(t *testing.T) {
 	mockK8sClient := &MockK8sClient{
 		annotationManagerOverride: mockAnnotationManager,
 		mockStatusChecker: &mockStatusChecker{
-			getCRStateFn: func(_ context.Context, actionName string, crName string) crstatus.CRState {
+			getCRStateForReferenceFn: func(_ context.Context, crName string,
+				resourceRef annotation.MaintenanceResourceReference, completeConditionType string) crstatus.CRState {
 				statusChecked = true
 				assert.True(t, ensureCalled, "GVK annotation should be ensured before CR status checks")
-				assert.Equal(t, protos.RecommendedAction_RESTART_BM.String(), actionName)
 				assert.Equal(t, "existing-cr", crName)
+				assert.Equal(t, "janitor.dgxc.nvidia.com", resourceRef.ApiGroup)
+				assert.Equal(t, "v1alpha1", resourceRef.Version)
+				assert.Equal(t, "RebootNode", resourceRef.Kind)
+				assert.Equal(t, "NodeReady", completeConditionType)
 
 				return crstatus.CRStateInProgress
 			},
@@ -1047,6 +1083,53 @@ func TestHandleRemediationEventEnsuresGVKBeforeStatusCheck(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, ensureCalled)
 	assert.True(t, statusChecked)
+}
+
+func TestEvaluateExistingCRUsesStoredReference(t *testing.T) {
+	ctx := context.Background()
+	statusChecker := &mockStatusChecker{
+		getCRStateForReferenceFn: func(_ context.Context, crName string,
+			resourceRef annotation.MaintenanceResourceReference, completeConditionType string) crstatus.CRState {
+			assert.Equal(t, "stored-cr", crName)
+			assert.Equal(t, "stored.example.com", resourceRef.ApiGroup)
+			assert.Equal(t, "v9", resourceRef.Version)
+			assert.Equal(t, "StoredMaintenance", resourceRef.Kind)
+			assert.Equal(t, "stored-namespace", resourceRef.Namespace)
+			assert.Equal(t, "NodeReady", completeConditionType)
+
+			return crstatus.CRStateInProgress
+		},
+	}
+	mockK8sClient := &MockK8sClient{
+		mockStatusChecker: statusChecker,
+		configOverride: &config.TomlConfig{
+			RemediationActions: map[string]config.MaintenanceResource{
+				protos.RecommendedAction_RESTART_BM.String(): {
+					ApiGroup:              "config.example.com",
+					Version:               "v1",
+					Kind:                  "ConfigMaintenance",
+					Namespace:             "config-namespace",
+					CompleteConditionType: "NodeReady",
+				},
+			},
+		},
+	}
+	r := NewFaultRemediationReconciler(nil, nil, nil, ReconcilerConfig{RemediationClient: mockK8sClient}, false)
+
+	decision := r.evaluateExistingCR(ctx, statusChecker, namedEquivalenceGroupState{
+		name: "restart",
+		state: annotation.EquivalenceGroupState{
+			MaintenanceCR: "stored-cr",
+			ActionName:    protos.RecommendedAction_RESTART_BM.String(),
+			ApiGroup:      "stored.example.com",
+			Version:       "v9",
+			Kind:          "StoredMaintenance",
+			Namespace:     "stored-namespace",
+		},
+	}, time.Now(), "test-node")
+
+	assert.False(t, decision.shouldCreate)
+	assert.Equal(t, "stored-cr", decision.crName)
 }
 
 func TestCRBasedDeduplication(t *testing.T) {

--- a/fault-remediation/pkg/remediation/remediation.go
+++ b/fault-remediation/pkg/remediation/remediation.go
@@ -220,7 +220,8 @@ func (c *FaultRemediationClient) CreateMaintenanceResource(ctx context.Context, 
 	templateData := templateDataFromEvent(healthEvent, healthEventID, traceID, tracing.SpanIDFromSpan(span),
 		recommendedActionName, groupConfig.ImpactedEntityScopeValue, maintenanceResource)
 
-	actualCRName, err := c.createMaintenanceCR(ctx, selectedTemplate, templateData, actionKey, node, healthEventData)
+	actualCRName, resourceRef, err := c.createMaintenanceCR(ctx, selectedTemplate, templateData, actionKey, node,
+		healthEventData)
 	if err != nil {
 		tracing.RecordError(span, err)
 		span.SetAttributes(
@@ -232,7 +233,7 @@ func (c *FaultRemediationClient) CreateMaintenanceResource(ctx context.Context, 
 	}
 
 	if err := c.updateRemediationAnnotationIfNeeded(ctx, healthEvent.NodeName, groupConfig.EffectiveEquivalenceGroup,
-		actualCRName, recommendedActionName); err != nil {
+		actualCRName, recommendedActionName, resourceRef); err != nil {
 		tracing.RecordError(span, err)
 		span.SetAttributes(
 			attribute.String("fault_remediation.error.type", "update_remediation_annotation_error"),
@@ -273,7 +274,7 @@ func templateDataFromEvent(healthEvent *protos.HealthEvent, healthEventID, trace
 // createMaintenanceCR renders the template, sets owner ref, and creates the maintenance CR.
 func (c *FaultRemediationClient) createMaintenanceCR(ctx context.Context, selectedTemplate *template.Template,
 	templateData TemplateData, actionKey string, node *corev1.Node, healthEventData *events.HealthEventData,
-) (string, error) {
+) (string, annotation.MaintenanceResourceReference, error) {
 	ctx, span := tracing.StartSpan(ctx, "fault_remediation.create_maintenance_cr")
 	defer span.End()
 
@@ -291,7 +292,20 @@ func (c *FaultRemediationClient) createMaintenanceCR(ctx context.Context, select
 		)
 		slog.ErrorContext(ctx, "Failed to render maintenance template", "template", actionKey, "error", err)
 
-		return "", fmt.Errorf("error rendering maintenance template: %w", err)
+		return "", annotation.MaintenanceResourceReference{}, fmt.Errorf("error rendering maintenance template: %w", err)
+	}
+
+	resourceRef, err := maintenanceResourceReferenceFromObject(maintenance)
+	if err != nil {
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("fault_remediation.error.type", "rendered_maintenance_reference_error"),
+			attribute.String("fault_remediation.error.message", err.Error()),
+		)
+		slog.ErrorContext(ctx, "Rendered maintenance template is missing resource identity",
+			"template", actionKey, "error", err)
+
+		return "", annotation.MaintenanceResourceReference{}, err
 	}
 
 	slog.DebugContext(ctx, "Generated YAML from template", "template", actionKey, "yaml", yamlStr)
@@ -309,7 +323,7 @@ func (c *FaultRemediationClient) createMaintenanceCR(ctx context.Context, select
 			slog.InfoContext(ctx, "Maintenance CR already exists for node, treating as success",
 				"CR", maintenance.GetName(), "node", healthEventData.HealthEvent.NodeName)
 
-			return maintenance.GetName(), nil
+			return maintenance.GetName(), resourceRef, nil
 		}
 
 		tracing.RecordError(span, err)
@@ -318,7 +332,7 @@ func (c *FaultRemediationClient) createMaintenanceCR(ctx context.Context, select
 			attribute.String("fault_remediation.error.message", err.Error()),
 		)
 
-		return "", fmt.Errorf("failed to create maintenance CR: %w", err)
+		return "", annotation.MaintenanceResourceReference{}, fmt.Errorf("failed to create maintenance CR: %w", err)
 	} else if healthEventData.HealthEventStatus != nil && healthEventData.HealthEventStatus.DrainFinishTimestamp != nil {
 		duration := time.Since(healthEventData.HealthEventStatus.DrainFinishTimestamp.AsTime()).Seconds()
 		if duration > 0 {
@@ -332,13 +346,33 @@ func (c *FaultRemediationClient) createMaintenanceCR(ctx context.Context, select
 	slog.InfoContext(ctx, "Created Maintenance CR successfully",
 		"crName", maintenance.GetName(), "node", healthEventData.HealthEvent.NodeName, "template", actionKey)
 
-	return maintenance.GetName(), nil
+	return maintenance.GetName(), resourceRef, nil
+}
+
+func maintenanceResourceReferenceFromObject(
+	maintenance *unstructured.Unstructured,
+) (annotation.MaintenanceResourceReference, error) {
+	gvk := maintenance.GroupVersionKind()
+	resourceRef := annotation.MaintenanceResourceReference{
+		Namespace: maintenance.GetNamespace(),
+		Version:   gvk.Version,
+		ApiGroup:  gvk.Group,
+		Kind:      gvk.Kind,
+	}
+	if resourceRef.ApiGroup == "" || resourceRef.Version == "" || resourceRef.Kind == "" {
+		return annotation.MaintenanceResourceReference{}, fmt.Errorf(
+			"rendered maintenance CR must set apiVersion group, version, and kind",
+		)
+	}
+
+	return resourceRef, nil
 }
 
 // updateRemediationAnnotationIfNeeded updates node remediation state when equivalence group
 // and annotation manager are set.
 func (c *FaultRemediationClient) updateRemediationAnnotationIfNeeded(ctx context.Context, nodeName string,
 	effectiveEquivalenceGroup string, actualCRName, recommendedActionName string,
+	resourceRef annotation.MaintenanceResourceReference,
 ) error {
 	if effectiveEquivalenceGroup == "" || c.annotationManager == nil {
 		return nil
@@ -354,7 +388,7 @@ func (c *FaultRemediationClient) updateRemediationAnnotationIfNeeded(ctx context
 	)
 
 	err := c.annotationManager.UpdateRemediationState(ctx, nodeName, effectiveEquivalenceGroup,
-		actualCRName, recommendedActionName)
+		actualCRName, recommendedActionName, resourceRef)
 	if err != nil {
 		slog.WarnContext(ctx, "Failed to update node annotation", "node", nodeName, "error", err)
 		tracing.RecordError(span, err)

--- a/fault-remediation/pkg/remediation/remediation.go
+++ b/fault-remediation/pkg/remediation/remediation.go
@@ -352,6 +352,7 @@ func maintenanceResourceReferenceFromObject(
 	maintenance *unstructured.Unstructured,
 ) (annotation.MaintenanceResourceReference, error) {
 	gvk := maintenance.GroupVersionKind()
+
 	resourceRef := annotation.MaintenanceResourceReference{
 		Namespace: maintenance.GetNamespace(),
 		Version:   gvk.Version,

--- a/fault-remediation/pkg/remediation/remediation.go
+++ b/fault-remediation/pkg/remediation/remediation.go
@@ -127,7 +127,6 @@ func NewRemediationClient(
 
 	ctrlRuntimeRemediationClient.statusChecker = crstatus.NewCRStatusChecker(
 		client,
-		remediationConfig.RemediationActions,
 		dryRun,
 	)
 

--- a/fault-remediation/pkg/remediation/remediation.go
+++ b/fault-remediation/pkg/remediation/remediation.go
@@ -355,10 +355,10 @@ func maintenanceResourceReferenceFromObject(
 	resourceRef := annotation.MaintenanceResourceReference{
 		Namespace: maintenance.GetNamespace(),
 		Version:   gvk.Version,
-		ApiGroup:  gvk.Group,
+		APIGroup:  gvk.Group,
 		Kind:      gvk.Kind,
 	}
-	if resourceRef.ApiGroup == "" || resourceRef.Version == "" || resourceRef.Kind == "" {
+	if resourceRef.APIGroup == "" || resourceRef.Version == "" || resourceRef.Kind == "" {
 		return annotation.MaintenanceResourceReference{}, fmt.Errorf(
 			"rendered maintenance CR must set apiVersion group, version, and kind",
 		)

--- a/fault-remediation/pkg/remediation/remediation_test.go
+++ b/fault-remediation/pkg/remediation/remediation_test.go
@@ -433,7 +433,7 @@ spec:
 	groupState := state.EquivalenceGroups["restart"]
 	assert.Equal(t, crName, groupState.MaintenanceCR)
 	assert.Equal(t, "rendered-namespace", groupState.Namespace)
-	assert.Equal(t, "rendered.example.com", groupState.ApiGroup)
+	assert.Equal(t, "rendered.example.com", groupState.APIGroup)
 	assert.Equal(t, "v2", groupState.Version)
 	assert.Equal(t, "RenderedMaintenance", groupState.Kind)
 }

--- a/fault-remediation/pkg/remediation/remediation_test.go
+++ b/fault-remediation/pkg/remediation/remediation_test.go
@@ -361,6 +361,83 @@ spec:
 	}
 }
 
+func TestCreateMaintenanceResourceStoresRenderedObjectReference(t *testing.T) {
+	tempDir := t.TempDir()
+	templateContent := `apiVersion: rendered.example.com/v2
+kind: RenderedMaintenance
+metadata:
+  name: maintenance-{{.NodeName}}-{{.HealthEventID}}
+  namespace: rendered-namespace
+spec:
+  nodeName: {{.NodeName}}`
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "rendered-template.yaml"), []byte(templateContent), 0644))
+
+	nodeName := "test-node-rendered-reference"
+	fakeClient := fake.NewClientBuilder().
+		WithObjects(&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName,
+			},
+		}).
+		Build()
+
+	remediationConfig := config.TomlConfig{
+		Template: config.Template{
+			MountPath: tempDir,
+		},
+		RemediationActions: map[string]config.MaintenanceResource{
+			protos.RecommendedAction_RESTART_BM.String(): {
+				Namespace:             "configured-namespace",
+				Version:               "v1",
+				ApiGroup:              "configured.example.com",
+				Kind:                  "ConfiguredMaintenance",
+				CompleteConditionType: "Complete",
+				TemplateFileName:      "rendered-template.yaml",
+				EquivalenceGroup:      "restart",
+			},
+		},
+	}
+	remediationClient, err := NewRemediationClient(fakeClient, false, remediationConfig)
+	require.NoError(t, err)
+
+	healthEventData := &events.HealthEventData{
+		ID: "event-rendered-reference",
+		HealthEventWithStatus: model.HealthEventWithStatus{
+			HealthEvent: &protos.HealthEvent{
+				NodeName:          nodeName,
+				RecommendedAction: protos.RecommendedAction_RESTART_BM,
+			},
+		},
+	}
+	groupConfig, err := common.GetGroupConfigForEvent(remediationConfig.RemediationActions,
+		healthEventData.HealthEvent)
+	require.NoError(t, err)
+
+	crName, err := remediationClient.CreateMaintenanceResource(context.Background(), healthEventData, groupConfig)
+	require.NoError(t, err)
+
+	renderedObject := &unstructured.Unstructured{}
+	renderedObject.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "rendered.example.com",
+		Version: "v2",
+		Kind:    "RenderedMaintenance",
+	})
+	require.NoError(t, fakeClient.Get(context.Background(), types.NamespacedName{
+		Name:      crName,
+		Namespace: "rendered-namespace",
+	}, renderedObject))
+
+	state, _, err := remediationClient.GetAnnotationManager().GetRemediationState(context.Background(), nodeName)
+	require.NoError(t, err)
+
+	groupState := state.EquivalenceGroups["restart"]
+	assert.Equal(t, crName, groupState.MaintenanceCR)
+	assert.Equal(t, "rendered-namespace", groupState.Namespace)
+	assert.Equal(t, "rendered.example.com", groupState.ApiGroup)
+	assert.Equal(t, "v2", groupState.Version)
+	assert.Equal(t, "RenderedMaintenance", groupState.Kind)
+}
+
 func TestRunLogCollectorJob(t *testing.T) {
 	eventId := "12345"
 	jobNamespace := "test"


### PR DESCRIPTION
Signed-off-by: Alex Jun [aljun@nvidia.com](mailto:aljun@nvidia.com)

## Summary

This PR makes remediation annotations store the concrete Kubernetes identity of the maintenance CR that was created: CR name, API group, version, kind, namespace, and action name. Duplicate detection and status checks now fetch that stored object directly instead of reconstructing its GVK/namespace from the current `remediationActions` config. 

Legacy annotation entries missing those fields are backfilled from the existing shared action config before status checks. 

This prepares for an upcoming feature - adding component-based mappings for created CR's. Adding a more reliable source of truth for the created CR avoids needlessly ugly reverse-matching based on actionName

https://github.com/NVIDIA/NVSentinel/pull/1124

```

// ResolveStoredMaintenanceResource resolves the maintenance resource for a
// remediation entry previously stored in the node annotation.
//
// Older remediation annotations may not have ComponentClass populated.
// When componentClass is unpopulated, we will resolve the action when it is still unambiguous in the current config.
// If ambiguous, it will be treated as stale.
func (c *TomlConfig) ResolveStoredMaintenanceResource(componentClass, actionName string) (MaintenanceResource, bool) {
	if componentClass != "" {
		if componentActions, exists := c.ComponentRemediationActions[componentClass]; exists {
			if resource, ok := componentActions[actionName]; ok {
				return resource, true
			}
		}

		if resource, exists := c.RemediationActions[actionName]; exists {
			return resource, true
		}

		return MaintenanceResource{}, false
	}

	for _, componentActions := range c.ComponentRemediationActions {
		if _, ok := componentActions[actionName]; ok {
			return MaintenanceResource{}, false
		}
	}

	if resource, exists := c.RemediationActions[actionName]; exists {
		return resource, true
	}

	return MaintenanceResource{}, false
}
```


`completeConditionType` remains intentionally config-driven, so changing that config changes how future status checks interpret the same stored CR. 


## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Remediation state now records full resource identity (namespace, API group, version, kind) and status evaluation uses those stored references.

* **New Behavior**
  * Reconciler enforces and backfills missing resource identity on remediation state when possible.
  * Reference validation added (API group, version, kind required; namespace may be empty for cluster-scoped).

* **Tests**
  * Expanded unit and e2e coverage for GVK storage, backfill, validation, and reference-based CR status checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NVSentinel/pull/1327?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->