### PR TITLE
fix: cover cancellation completion marker for fault-remediation

### DIFF
--- a/fault-remediation/pkg/reconciler/reconciler.go
+++ b/fault-remediation/pkg/reconciler/reconciler.go
@@ -424,6 +424,7 @@ func (r *FaultRemediationReconciler) handleCancellationEvent(
 			"node", nodeName,
 			"error", err)
 		tracing.RecordError(span, err)
+
 		return ctrl.Result{}, fmt.Errorf("failed to write completion marker for cancellation event: %w", err)
 	}
 

--- a/fault-remediation/pkg/reconciler/reconciler.go
+++ b/fault-remediation/pkg/reconciler/reconciler.go
@@ -428,7 +428,7 @@ func (r *FaultRemediationReconciler) handleCancellationEvent(
 		return ctrl.Result{}, fmt.Errorf("failed to write completion marker for cancellation event: %w", err)
 	}
 
-	if err := safeMarkProcessed(context.Background(), watcherInstance, eventWithToken.ResumeToken, nodeName); err != nil {
+	if err := safeMarkProcessed(ctx, watcherInstance, eventWithToken.ResumeToken, nodeName); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/fault-remediation/pkg/reconciler/reconciler.go
+++ b/fault-remediation/pkg/reconciler/reconciler.go
@@ -155,8 +155,7 @@ func (r *FaultRemediationReconciler) Reconcile(
 	nodeQuarantined := healthEventWithStatus.HealthEventStatus.NodeQuarantined
 
 	if nodeQuarantined == string(model.UnQuarantined) || nodeQuarantined == string(model.Cancelled) {
-		return r.handleCancellationEvent(ctx, nodeName, model.Status(nodeQuarantined), r.Watcher, event.ResumeToken,
-			r.healthEventStore)
+		return r.handleCancellationEvent(ctx, nodeName, model.Status(nodeQuarantined), r.Watcher, *event, r.healthEventStore)
 	}
 
 	return r.handleRemediationEvent(ctx, &healthEventWithStatus, *event, r.Watcher, r.healthEventStore)
@@ -371,13 +370,15 @@ func (r *FaultRemediationReconciler) performRemediation(ctx context.Context,
 	return crName, nil
 }
 
-// handleCancellationEvent handles node unquarantine and cancellation events by clearing annotations
+// handleCancellationEvent handles node unquarantine and cancellation events by clearing
+// annotations and writing a completion marker so the event is excluded from cold start
+// queries on future restarts.
 func (r *FaultRemediationReconciler) handleCancellationEvent(
 	ctx context.Context,
 	nodeName string,
 	status model.Status,
 	watcherInstance datastore.ChangeStreamWatcher,
-	resumeToken []byte,
+	eventWithToken datastore.EventWithToken,
 	healthEventStore datastore.HealthEventStore,
 ) (ctrl.Result, error) {
 	ctx, span := tracing.StartSpan(ctx, "fault_remediation.cancellation_event")
@@ -418,7 +419,15 @@ func (r *FaultRemediationReconciler) handleCancellationEvent(
 		return ctrl.Result{}, fmt.Errorf("failed to clear remediation state for node: %w", err)
 	}
 
-	if err := safeMarkProcessed(context.Background(), watcherInstance, resumeToken, nodeName); err != nil {
+	if err := r.updateNodeRemediatedStatus(ctx, healthEventStore, eventWithToken, true); err != nil {
+		slog.ErrorContext(ctx, "Failed to write completion marker for cancellation event",
+			"node", nodeName,
+			"error", err)
+		tracing.RecordError(span, err)
+		return ctrl.Result{}, fmt.Errorf("failed to write completion marker for cancellation event: %w", err)
+	}
+
+	if err := safeMarkProcessed(context.Background(), watcherInstance, eventWithToken.ResumeToken, nodeName); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -1128,9 +1137,12 @@ func (r *FaultRemediationReconciler) HandleColdStart(ctx context.Context) {
 		query.Or(
 			// Quarantined + drained but not yet remediated
 			unresolvedRemediationReadyEventsCondition(""),
-			// Cancelled/unquarantined events (need cleanup)
-			query.In("healtheventstatus.nodequarantined",
-				[]interface{}{string(model.UnQuarantined), string(model.Cancelled)}),
+			// Cancelled/unquarantined events that haven't been marked complete
+			query.And(
+				query.In("healtheventstatus.nodequarantined",
+					[]interface{}{string(model.UnQuarantined), string(model.Cancelled)}),
+				query.Eq("healtheventstatus.faultremediated", nil),
+			),
 		),
 	)
 

--- a/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
@@ -2103,6 +2103,241 @@ func TestHandleColdStart_CancellationFlow(t *testing.T) {
 	_ = testDynamic.Resource(gvr).Delete(ctx, crName, metav1.DeleteOptions{})
 }
 
+// TestCancellationEvent_WritesCompletionMarker verifies that handleCancellationEvent writes
+// faultRemediated=true to the health event store, making cold start self-terminating for
+// cancellation events.
+func TestCancellationEvent_WritesCompletionMarker(t *testing.T) {
+	ctx, cancel := context.WithTimeout(testContext, 30*time.Second)
+	defer cancel()
+
+	nodeName := testutils.GenerateTestNodeName("test-cancel-marker")
+	createTestNode(ctx, nodeName, nil, map[string]string{"test": "label"})
+	defer func() {
+		_ = testClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
+	}()
+
+	cleanupNodeAnnotations(ctx, t, nodeName)
+
+	gvr := schema.GroupVersionResource{
+		Group:    "janitor.dgxc.nvidia.com",
+		Version:  "v1alpha1",
+		Resource: "rebootnodes",
+	}
+
+	remediationClient, err := createTestRemediationClient(false, restartRemediationActions)
+	require.NoError(t, err)
+
+	var capturedStatuses []datastore.HealthEventStatus
+	var capturedIDs []string
+	var mu sync.Mutex
+
+	localStore := &MockHealthEventStore{}
+	localStore.UpdateHealthEventStatusFn = func(ctx context.Context, id string, status datastore.HealthEventStatus) error {
+		mu.Lock()
+		capturedIDs = append(capturedIDs, id)
+		capturedStatuses = append(capturedStatuses, status)
+		mu.Unlock()
+		return nil
+	}
+
+	localWatcher := NewMockChangeStreamWatcher()
+	cfg := ReconcilerConfig{
+		RemediationClient: remediationClient,
+		StateManager:      statemanager.NewStateManager(testClient),
+		UpdateMaxRetries:  3,
+		UpdateRetryDelay:  100 * time.Millisecond,
+	}
+	localReconciler := NewFaultRemediationReconciler(nil, localWatcher, localStore, cfg, false)
+
+	// Pre-set the node state to match what fault-quarantine + node-drainer would have done.
+	_, err = cfg.StateManager.UpdateNVSentinelStateNodeLabel(ctx, nodeName,
+		statemanager.QuarantinedLabelValue, false)
+	require.NoError(t, err)
+	_, err = cfg.StateManager.UpdateNVSentinelStateNodeLabel(ctx, nodeName,
+		statemanager.DrainingLabelValue, false)
+	require.NoError(t, err)
+	_, err = cfg.StateManager.UpdateNVSentinelStateNodeLabel(ctx, nodeName,
+		statemanager.DrainSucceededLabelValue, false)
+	require.NoError(t, err)
+
+	// Step 1: Send a quarantine event to establish remediation state
+	t.Log("Step 1: Processing quarantine event to create CR and annotation")
+	eventID := "cancel-marker-event-1"
+	quarantineEvent := createQuarantineEvent(eventID, nodeName, protos.RecommendedAction_RESTART_BM)
+	quarantineEventToken := datastore.EventWithToken{
+		Event:       map[string]interface{}(quarantineEvent),
+		ResumeToken: []byte("cancel-marker-token-1"),
+	}
+	_, err = localReconciler.Reconcile(ctx, &quarantineEventToken)
+	require.NoError(t, err)
+
+	var crName string
+	require.Eventually(t, func() bool {
+		state, _, err := localReconciler.annotationManager.GetRemediationState(ctx, nodeName)
+		if err != nil {
+			return false
+		}
+		if grp, ok := state.EquivalenceGroups["restart"]; ok {
+			crName = grp.MaintenanceCR
+			return crName != ""
+		}
+		return false
+	}, 5*time.Second, 100*time.Millisecond, "CR and annotation should be created")
+
+	mu.Lock()
+	capturedIDs = nil
+	capturedStatuses = nil
+	mu.Unlock()
+
+	// Step 2: Send the cancellation event and capture only the cancellation store updates.
+	t.Log("Step 2: Sending cancellation event and capturing store updates")
+	cancelledEvent := createCancelledEvent(eventID, nodeName, protos.RecommendedAction_RESTART_BM)
+	cancelledEventToken := datastore.EventWithToken{
+		Event:       map[string]interface{}(cancelledEvent),
+		ResumeToken: []byte("cancel-marker-token-2"),
+	}
+	_, err = localReconciler.Reconcile(ctx, &cancelledEventToken)
+	require.NoError(t, err)
+
+	// Step 3: Wait for remediation state to be cleared (proves cancellation was processed)
+	require.Eventually(t, func() bool {
+		node, err := testClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		_, hasAnnotation := node.Annotations[annotation.AnnotationKey]
+		return !hasAnnotation
+	}, 5*time.Second, 100*time.Millisecond, "Remediation annotation should be cleared")
+
+	// Step 4: Verify that UpdateHealthEventStatus was called with FaultRemediated=true
+	t.Log("Step 4: Verifying completion marker was written")
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.NotEmpty(t, capturedStatuses, "UpdateHealthEventStatus should have been called for cancellation")
+
+	var foundCompletionMarker bool
+	for i, status := range capturedStatuses {
+		if capturedIDs[i] == eventID && status.FaultRemediated != nil && *status.FaultRemediated {
+			foundCompletionMarker = true
+			t.Logf("Completion marker written for event ID: %s (FaultRemediated=true)", capturedIDs[i])
+			assert.NotNil(t, status.LastRemediationTimestamp,
+				"LastRemediationTimestamp should be set when FaultRemediated=true")
+			break
+		}
+	}
+	require.True(t, foundCompletionMarker,
+		"handleCancellationEvent must write FaultRemediated=true for the cancelled event")
+
+	_ = testDynamic.Resource(gvr).Delete(ctx, crName, metav1.DeleteOptions{})
+}
+
+// TestColdStartCancellationQueryRequiresCompletionMarker verifies that the cold start
+// cancellation query includes the same completion gate as the remediation query leg.
+// Without this faultremediated==nil predicate, every historical cancellation can replay
+// on every restart.
+func TestColdStartCancellationQueryRequiresCompletionMarker(t *testing.T) {
+	ctx, cancel := context.WithTimeout(testContext, 30*time.Second)
+	defer cancel()
+
+	var capturedQuery map[string]interface{}
+	coldStartCallCount := 0
+
+	localStore := &MockHealthEventStore{}
+	localStore.FindHealthEventsByQueryBatchedFn = func(_ context.Context, builder datastore.QueryBuilder, _ int, fn func([]datastore.HealthEventWithStatus) error) error {
+		coldStartCallCount++
+		capturedQuery = builder.ToMongo()
+		return fn([]datastore.HealthEventWithStatus{})
+	}
+
+	remediationClient, err := createTestRemediationClient(false, restartRemediationActions)
+	require.NoError(t, err)
+	cfg := ReconcilerConfig{
+		RemediationClient: remediationClient,
+		StateManager:      statemanager.NewStateManager(testClient),
+		UpdateMaxRetries:  3,
+		UpdateRetryDelay:  100 * time.Millisecond,
+	}
+	localReconciler := NewFaultRemediationReconciler(nil, NewMockChangeStreamWatcher(), localStore, cfg, false)
+
+	localReconciler.HandleColdStart(ctx)
+
+	assert.Equal(t, 1, coldStartCallCount,
+		"Cold start should query the store exactly once")
+	require.NotNil(t, capturedQuery, "Cold start query should be captured")
+	require.True(t, coldStartCancellationQueryHasCompletionGate(capturedQuery),
+		"Cold start cancellation query must include faultremediated==nil gate")
+}
+
+func coldStartCancellationQueryHasCompletionGate(q map[string]interface{}) bool {
+	orConditions, ok := q["$or"].([]interface{})
+	if !ok {
+		return false
+	}
+
+	for _, rawCondition := range orConditions {
+		condition, ok := rawCondition.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		if isCancellationQueryLeg(condition) && hasFaultRemediatedNilGate(condition) {
+			return true
+		}
+
+		andConditions, ok := condition["$and"].([]interface{})
+		if !ok {
+			continue
+		}
+
+		hasCancellationFilter := false
+		hasCompletionGate := false
+		for _, rawAndCondition := range andConditions {
+			andCondition, ok := rawAndCondition.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			hasCancellationFilter = hasCancellationFilter || isCancellationQueryLeg(andCondition)
+			hasCompletionGate = hasCompletionGate || hasFaultRemediatedNilGate(andCondition)
+		}
+		if hasCancellationFilter && hasCompletionGate {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isCancellationQueryLeg(condition map[string]interface{}) bool {
+	nodeQuarantined, ok := condition["healtheventstatus.nodequarantined"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	values, ok := nodeQuarantined["$in"].([]interface{})
+	if !ok {
+		return false
+	}
+
+	foundUnquarantined := false
+	foundCancelled := false
+	for _, value := range values {
+		switch value {
+		case string(model.UnQuarantined):
+			foundUnquarantined = true
+		case string(model.Cancelled):
+			foundCancelled = true
+		}
+	}
+
+	return foundUnquarantined && foundCancelled
+}
+
+func hasFaultRemediatedNilGate(condition map[string]interface{}) bool {
+	value, ok := condition["healtheventstatus.faultremediated"]
+	return ok && value == nil
+}
+
 // TestCustomAction_E2E tests the full reconciler flow with a custom remediation action.
 // Exercises the complete path: raw MongoDB event → Reconcile → GetEffectiveActionName
 // → template rendering → CR creation.

--- a/tests/fault_management_test.go
+++ b/tests/fault_management_test.go
@@ -19,8 +19,6 @@ package tests
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -30,8 +28,6 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/rest"
-	"sigs.k8s.io/e2e-framework/klient"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
@@ -563,7 +559,7 @@ func TestManualUncordonWithFaultRemediation(t *testing.T) {
 
 		client, err := c.NewClient()
 		require.NoError(t, err)
-		mongoPod = helpers.GetMongoDBPrimaryPodName(ctx, t, client)
+		mongoPod, _ = helpers.TryGetMongoDBPrimaryPodName(ctx, t, client)
 
 		return newCtx
 	})
@@ -650,12 +646,17 @@ func TestManualUncordonWithFaultRemediation(t *testing.T) {
 	})
 
 	feature.Assess("verify FR marks cancelled event remediated", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		if mongoPod == "" {
+			t.Log("Skipping direct faultRemediated MongoDB assertion for non-MongoDB datastore")
+			return ctx
+		}
+
 		client, err := c.NewClient()
 		require.NoError(t, err)
 
 		t.Log("Waiting for FR to write faultRemediated=true on the Cancelled HealthEvent")
 		require.Eventually(t, func() bool {
-			return faultRemediatedMarkerWritten(ctx, t, client.RESTConfig(), client, mongoPod,
+			return helpers.CancelledHealthEventFaultRemediated(ctx, t, client.RESTConfig(), client, mongoPod,
 				testCtx.NodeName, cancellationMarkerMessage)
 		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval,
 			"FR should write faultRemediated=true for the cancelled HealthEvent")
@@ -679,37 +680,4 @@ func TestManualUncordonWithFaultRemediation(t *testing.T) {
 	})
 
 	testEnv.Test(t, feature.Feature())
-}
-
-func faultRemediatedMarkerWritten(
-	ctx context.Context,
-	t *testing.T,
-	restConfig *rest.Config,
-	client klient.Client,
-	mongoPod, nodeName, message string,
-) bool {
-	t.Helper()
-
-	js := fmt.Sprintf(`
-		db = db.getSiblingDB("%s");
-		const doc = db.HealthEvents.findOne({
-			"healthevent.nodename": %q,
-			"healthevent.message": %q,
-			"healtheventstatus.nodequarantined": "Cancelled"
-		});
-		if (doc && doc.healtheventstatus &&
-			doc.healtheventstatus.faultremediated &&
-			doc.healtheventstatus.faultremediated.value === true) {
-			print("FAULT_REMEDIATED_TRUE");
-		} else {
-			print("NOT_READY");
-			if (doc) {
-				printjson(doc.healtheventstatus);
-			}
-		}
-	`, helpers.MongoDBDatabase, nodeName, message)
-
-	stdout, _ := helpers.ExecMongosh(ctx, t, restConfig, client, mongoPod, js)
-
-	return strings.Contains(stdout, "FAULT_REMEDIATED_TRUE")
 }

--- a/tests/fault_management_test.go
+++ b/tests/fault_management_test.go
@@ -19,6 +19,8 @@ package tests
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,6 +30,8 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/e2e-framework/klient"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
@@ -547,13 +551,19 @@ func TestManualUncordonWithFaultRemediation(t *testing.T) {
 		WithLabel("suite", "fault-management-manual-intervention-fr")
 
 	var testCtx *helpers.RemediationTestContext
+	var mongoPod string
 	var podNames []string
 	testNamespace := "immediate-test"
+	const cancellationMarkerMessage = "XID 79 fatal error for FR cancellation marker"
 
 	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		var newCtx context.Context
 		newCtx, testCtx = helpers.SetupFaultRemediationTest(ctx, t, c, testNamespace)
 		newCtx = helpers.ApplyNodeDrainerConfig(newCtx, t, c, "data/nd-all-modes.yaml")
+
+		client, err := c.NewClient()
+		require.NoError(t, err)
+		mongoPod = helpers.GetMongoDBPrimaryPodName(ctx, t, client)
 
 		return newCtx
 	})
@@ -569,7 +579,7 @@ func TestManualUncordonWithFaultRemediation(t *testing.T) {
 		t.Log("Sending fatal health event to trigger quarantine")
 		fatalEvent := helpers.NewHealthEvent(testCtx.NodeName).
 			WithErrorCode("79").
-			WithMessage("XID 79 fatal error").
+			WithMessage(cancellationMarkerMessage).
 			WithRecommendedAction(24)
 		helpers.SendHealthEvent(ctx, t, fatalEvent)
 
@@ -639,6 +649,20 @@ func TestManualUncordonWithFaultRemediation(t *testing.T) {
 		return ctx
 	})
 
+	feature.Assess("verify FR marks cancelled event remediated", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err)
+
+		t.Log("Waiting for FR to write faultRemediated=true on the Cancelled HealthEvent")
+		require.Eventually(t, func() bool {
+			return faultRemediatedMarkerWritten(ctx, t, client.RESTConfig(), client, mongoPod,
+				testCtx.NodeName, cancellationMarkerMessage)
+		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval,
+			"FR should write faultRemediated=true for the cancelled HealthEvent")
+
+		return ctx
+	})
+
 	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		client, err := c.NewClient()
 		require.NoError(t, err)
@@ -655,4 +679,37 @@ func TestManualUncordonWithFaultRemediation(t *testing.T) {
 	})
 
 	testEnv.Test(t, feature.Feature())
+}
+
+func faultRemediatedMarkerWritten(
+	ctx context.Context,
+	t *testing.T,
+	restConfig *rest.Config,
+	client klient.Client,
+	mongoPod, nodeName, message string,
+) bool {
+	t.Helper()
+
+	js := fmt.Sprintf(`
+		db = db.getSiblingDB("%s");
+		const doc = db.HealthEvents.findOne({
+			"healthevent.nodename": %q,
+			"healthevent.message": %q,
+			"healtheventstatus.nodequarantined": "Cancelled"
+		});
+		if (doc && doc.healtheventstatus &&
+			doc.healtheventstatus.faultremediated &&
+			doc.healtheventstatus.faultremediated.value === true) {
+			print("FAULT_REMEDIATED_TRUE");
+		} else {
+			print("NOT_READY");
+			if (doc) {
+				printjson(doc.healtheventstatus);
+			}
+		}
+	`, helpers.MongoDBDatabase, nodeName, message)
+
+	stdout, _ := helpers.ExecMongosh(ctx, t, restConfig, client, mongoPod, js)
+
+	return strings.Contains(stdout, "FAULT_REMEDIATED_TRUE")
 }

--- a/tests/helpers/mongodb.go
+++ b/tests/helpers/mongodb.go
@@ -74,6 +74,21 @@ func GetMongoDBPrimaryPodName(
 ) string {
 	t.Helper()
 
+	podName, found := TryGetMongoDBPrimaryPodName(ctx, t, client)
+	require.True(t, found, "no running MongoDB pod found in namespace %s", NVSentinelNamespace)
+
+	return podName
+}
+
+// TryGetMongoDBPrimaryPodName returns the writable primary MongoDB pod if this
+// test environment is backed by MongoDB. PostgreSQL-backed e2e jobs do not
+// deploy MongoDB, so callers that support both datastores can use the boolean
+// return value to skip MongoDB-specific assertions.
+func TryGetMongoDBPrimaryPodName(
+	ctx context.Context, t *testing.T, client klient.Client,
+) (string, bool) {
+	t.Helper()
+
 	for _, flavor := range []mongoDBFlavor{perconaFlavor, bitnamiFlavor} {
 		pods := &v1.PodList{}
 		err := client.Resources().List(ctx, pods, func(opts *metav1.ListOptions) {
@@ -98,19 +113,19 @@ func GetMongoDBPrimaryPodName(
 		for _, pod := range runningPods {
 			if strings.HasSuffix(pod.Name, "-0") {
 				t.Logf("Found primary MongoDB pod: %s (flavor: %s)", pod.Name, flavor.ContainerName)
-				return pod.Name
+				return pod.Name, true
 			}
 		}
 
 		// Fallback: return any running pod (shouldn't happen with 3-node RS).
 		t.Logf("Found running MongoDB pod (no -0 ordinal): %s (flavor: %s)", runningPods[0].Name, flavor.ContainerName)
 
-		return runningPods[0].Name
+		return runningPods[0].Name, true
 	}
 
-	require.Fail(t, "no running MongoDB pod found in namespace %s", NVSentinelNamespace)
+	t.Logf("No running MongoDB pod found in namespace %s", NVSentinelNamespace)
 
-	return ""
+	return "", false
 }
 
 // detectMongoDBFlavor determines whether the given pod belongs to a Bitnami or
@@ -320,4 +335,39 @@ func GetResumeTokenDoc(
 	stdout, _ := ExecMongosh(ctx, t, restConfig, client, mongoPod, js)
 
 	return strings.TrimSpace(stdout)
+}
+
+// CancelledHealthEventFaultRemediated returns true when the matching cancelled
+// HealthEvent document has the faultRemediated completion marker set to true.
+func CancelledHealthEventFaultRemediated(
+	ctx context.Context,
+	t *testing.T,
+	restConfig *rest.Config,
+	client klient.Client,
+	mongoPod, nodeName, message string,
+) bool {
+	t.Helper()
+
+	js := fmt.Sprintf(`
+		db = db.getSiblingDB("%s");
+		const doc = db.HealthEvents.findOne({
+			"healthevent.nodename": %q,
+			"healthevent.message": %q,
+			"healtheventstatus.nodequarantined": "Cancelled"
+		});
+		if (doc && doc.healtheventstatus &&
+			doc.healtheventstatus.faultremediated &&
+			doc.healtheventstatus.faultremediated.value === true) {
+			print("FAULT_REMEDIATED_TRUE");
+		} else {
+			print("NOT_READY");
+			if (doc) {
+				printjson(doc.healtheventstatus);
+			}
+		}
+	`, MongoDBDatabase, nodeName, message)
+
+	stdout, _ := ExecMongosh(ctx, t, restConfig, client, mongoPod, js)
+
+	return strings.Contains(stdout, "FAULT_REMEDIATED_TRUE")
 }


### PR DESCRIPTION
## Summary

**Bug**: `handleCancellationEvent` clears K8s annotations and advances the resume token, but never writes `faultRemediated` back to MongoDB. The cold-start cancellation query has no `faultremediated == nil` filter. Together these mean every historical cancellation replays on every restart, growing monotonically and eventually causing OOM kills.

**Fix** (cherry-picked from reflectionai/NVSentinel#25, authored by rohansav):
1. `handleCancellationEvent` now calls `updateNodeRemediatedStatus(true)` after clearing annotations, writing the same completion marker the remediation path already writes.
2. The cold-start cancellation query leg adds `faultremediated == nil` so already-processed cancellations are excluded.
3. The call returns an error (rather than just logging) if the marker write fails, preventing the resume token from advancing without a durable terminal state.

## Tests Added

**Package-level envtest** (`fault-remediation/pkg/reconciler/reconciler_e2e_test.go`):
- `TestCancellationEvent_WritesCompletionMarker` — sends a quarantine event followed by a cancellation through a local reconciler, then asserts `UpdateHealthEventStatus` was called with `FaultRemediated=true` and `LastRemediationTimestamp` set for the exact cancelled event ID.
- `TestColdStartCancellationQueryRequiresCompletionMarker` — calls `HandleColdStart`, captures the generated MongoDB query via a mock, and asserts the cancellation leg includes `healtheventstatus.faultremediated == nil` alongside the `UnQuarantined`/`Cancelled` filter.

**Tilt test** (`tests/fault_management_test.go`):
- Extended `TestManualUncordonWithFaultRemediation` with a new assessment step that queries MongoDB directly and asserts the cancelled HealthEvent document has `healtheventstatus.faultremediated.value === true` after FR processes the manual uncordon.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cancellation handling now records completion markers and checkpoints canceled events to avoid replay.
  * Cold-start processing now excludes already-completed cancellations so historical cancellations aren’t reprocessed.

* **Tests**
  * Added e2e-style and integration tests validating cancellation processing, completion markers, and cold-start query behavior.

* **Chores**
  * Test helpers added for MongoDB pod discovery and for asserting a cancelled health event’s remediation marker.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NVSentinel/pull/1335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->