### PR TITLE
fix: clean up main branch container images

### DIFF
--- a/.github/workflows/cleanup-untagged-images.yml
+++ b/.github/workflows/cleanup-untagged-images.yml
@@ -114,7 +114,7 @@ jobs:
           timestamp-to-use: updated_at
 
       - name: Delete old main branch images for ${{ matrix.package }}
-        uses: dataaxiom/ghcr-cleanup-action@v1.2.1
+        uses: dataaxiom/ghcr-cleanup-action@f092b48ba3b604b2a83690dc4b2bbb3392e1045f  # v1.2.1
         with:
           owner: NVIDIA
           package: ${{ matrix.package }}

--- a/.github/workflows/cleanup-untagged-images.yml
+++ b/.github/workflows/cleanup-untagged-images.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Cleanup Untagged Container Images
+name: Cleanup Container Images
 
 on:
   # Run daily at midnight UTC
@@ -30,9 +30,9 @@ on:
           - 'true'
           - 'false'
       cut_off:
-        description: 'Delete images older than this (e.g., 1h, 1d, 7d, 30d)'
+        description: 'Delete images older than this (e.g., 1h, 1d, 7d, 30 days)'
         required: true
-        default: '30d'
+        default: '30 days'
         type: string
 
 concurrency:
@@ -44,8 +44,8 @@ permissions:
   contents: read
 
 jobs:
-  cleanup-untagged-images:
-    name: Cleanup Untagged Images
+  cleanup-container-images:
+    name: Cleanup Container Images
     runs-on: linux-amd64-cpu32
     if: github.repository == 'NVIDIA/NVSentinel'
     timeout-minutes: 30
@@ -56,8 +56,10 @@ jobs:
         package:
           - nvsentinel
           - nvsentinel/platform-connectors
+          - nvsentinel/plugins-slinky-drainer
           - nvsentinel-platform-connectors
           - nvsentinel/gpu-health-monitor
+          - nvsentinel/gpu-reset
           - nvsentinel/syslog-health-monitor
           - nvsentinel/csp-health-monitor
           - nvsentinel-gpu-health-monitor
@@ -79,6 +81,7 @@ jobs:
           - nvsentinel/log-collector
           - nvsentinel/file-server-cleanup
           - nvsentinel/janitor
+          - nvsentinel/janitor-provider
           - nvsentinel/health-events-analyzer
           - nvsentinel/maintenance-notifier
           - nvsentinel/event-exporter
@@ -92,6 +95,7 @@ jobs:
           - nvsentinel/preflight-dcgm-diag
           - nvsentinel/nic-health-monitor
           - nvsentinel/preflight-nccl-allreduce
+          - nvsentinel/preflight-nccl-loopback
 
     steps:
       - name: Delete untagged images for ${{ matrix.package }}
@@ -100,12 +104,23 @@ jobs:
           account: NVIDIA
           token: ${{ secrets.GITHUB_TOKEN }}
           image-names: ${{ matrix.package }}
-          cut-off: ${{ github.event.inputs.cut_off || '30d' }}
+          cut-off: ${{ github.event.inputs.cut_off || '30 days' }}
           # Keep at least 5 most recent untagged versions as safety buffer
           keep-n-most-recent: 5
-          dry-run: ${{ github.event.inputs.dry_run || 'true' }}
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'false' }}
           # Only target untagged images - preserve all tagged releases
           tag-selection: untagged
           # Use updated_at timestamp for age calculation
           timestamp-to-use: updated_at
+
+      - name: Delete old main branch images for ${{ matrix.package }}
+        uses: dataaxiom/ghcr-cleanup-action@v1.2.1
+        with:
+          owner: NVIDIA
+          package: ${{ matrix.package }}
+          delete-tags: main-*
+          older-than: ${{ github.event.inputs.cut_off || '30 days' }}
+          keep-n-tagged: 10
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'false' }}
+          validate: true
 

--- a/.github/workflows/cleanup-untagged-images.yml
+++ b/.github/workflows/cleanup-untagged-images.yml
@@ -99,7 +99,7 @@ jobs:
 
     steps:
       - name: Delete untagged images for ${{ matrix.package }}
-        uses: snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb  # v3.0.1
+        uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53 # v3.1.0
         with:
           account: NVIDIA
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cleanup-untagged-images.yml
+++ b/.github/workflows/cleanup-untagged-images.yml
@@ -30,7 +30,7 @@ on:
           - 'true'
           - 'false'
       cut_off:
-        description: 'Delete images older than this (e.g., 1h, 1d, 7d, 30 days)'
+        description: 'Delete images older than this (e.g., 1 day, 7 days, 30 days)'
         required: true
         default: '30 days'
         type: string


### PR DESCRIPTION
Closes #171.

## Summary

This completes the cleanup work started in #598.

The existing workflow only removes untagged GHCR images. Images published from `main` are tagged as `main-<shortsha>`, so they were not covered by the untagged cleanup policy.

## Changes

- keep the existing untagged image cleanup
- add cleanup for old `main-*` tagged images
- keep the latest 10 matching main images
- preserve release tags by only matching `main-*`
- keep manual runs dry-run safe by default
- allow scheduled runs to perform real cleanup
- add currently published packages missing from the cleanup matrix

## Validation

```bash
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cleanup-untagged-images.yml"); puts "valid yaml"'
grep -nE 'delete-tags: main-\*|keep-n-tagged: 10|older-than:|validate: true' .github/workflows/cleanup-untagged-images.yml
grep -c "dry-run: \${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'false' }}" .github/workflows/cleanup-untagged-images.yml
git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed and clarified the container image cleanup workflow and its manual-run inputs.
  * Reformatted cutoff input to a human-readable "30 days" and standardized retention defaults.
  * Expanded the list of image packages covered and improved ordering.
  * Adjusted behavior for dry-run between scheduled and manual runs.
  * Added automated removal of older build tags, preserving the 10 most recent and enabling validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->