### PR TITLE
chore: attempt to fix CVEs again

### DIFF
--- a/.versions.yaml
+++ b/.versions.yaml
@@ -31,7 +31,7 @@
 
 # Language Versions
 languages:
-  go: '1.26.2'
+  go: '1.26.3'
   python: '3.13'
 
 # Build & Package Management

--- a/api/go.mod
+++ b/api/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/api
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	google.golang.org/grpc v1.81.1

--- a/commons/go.mod
+++ b/commons/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/commons
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/data-models/go.mod
+++ b/data-models/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/data-models
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	google.golang.org/grpc v1.81.1

--- a/demos/local-custom-remediation-demo/memory-pressure-monitor/Dockerfile
+++ b/demos/local-custom-remediation-demo/memory-pressure-monitor/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM public.ecr.aws/docker/library/golang:1.26.2-trixie AS builder
+FROM public.ecr.aws/docker/library/golang:1.26.3-trixie AS builder
 
 WORKDIR /go/src/nvsentinel
 

--- a/demos/local-custom-remediation-demo/memory-pressure-monitor/go.mod
+++ b/demos/local-custom-remediation-demo/memory-pressure-monitor/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/demos/local-custom-remediation-demo/memory-p
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/nvidia/nvsentinel/data-models v0.0.0

--- a/demos/local-custom-remediation-demo/memory-reclaim-controller/Dockerfile
+++ b/demos/local-custom-remediation-demo/memory-reclaim-controller/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM public.ecr.aws/docker/library/golang:1.26.2-trixie AS builder
+FROM public.ecr.aws/docker/library/golang:1.26.3-trixie AS builder
 
 WORKDIR /go/src/app
 

--- a/demos/local-custom-remediation-demo/memory-reclaim-controller/go.mod
+++ b/demos/local-custom-remediation-demo/memory-reclaim-controller/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/demos/local-custom-remediation-demo/memory-r
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	k8s.io/api v0.36.1

--- a/event-exporter/go.mod
+++ b/event-exporter/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/event-exporter
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/google/uuid v1.6.0

--- a/fault-quarantine/go.mod
+++ b/fault-quarantine/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/fault-quarantine
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/google/cel-go v0.28.1

--- a/fault-remediation/go.mod
+++ b/fault-remediation/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/fault-remediation
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/health-events-analyzer/go.mod
+++ b/health-events-analyzer/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/health-events-analyzer
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/hashicorp/go-multierror v1.1.1

--- a/health-monitors/csp-health-monitor/go.mod
+++ b/health-monitors/csp-health-monitor/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/health-monitors/csp-health-monitor
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	cloud.google.com/go/compute v1.64.0

--- a/health-monitors/kubernetes-object-monitor/go.mod
+++ b/health-monitors/kubernetes-object-monitor/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/health-monitors/kubernetes-object-monitor
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/health-monitors/nic-health-monitor/go.mod
+++ b/health-monitors/nic-health-monitor/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/health-monitors/nic-health-monitor
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/nvidia/nvsentinel/commons v0.0.0

--- a/health-monitors/slurm-drain-monitor/go.mod
+++ b/health-monitors/slurm-drain-monitor/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/health-monitors/slurm-drain-monitor
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/health-monitors/syslog-health-monitor/Dockerfile
+++ b/health-monitors/syslog-health-monitor/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM public.ecr.aws/docker/library/golang:1.26.2-trixie AS builder
+FROM public.ecr.aws/docker/library/golang:1.26.3-trixie AS builder
 
 ARG BUILD_TAGS="systemd"
 ARG VERSION="dev"

--- a/health-monitors/syslog-health-monitor/go.mod
+++ b/health-monitors/syslog-health-monitor/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/health-monitors/syslog-health-monitor
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/coreos/go-systemd/v22 v22.7.0

--- a/janitor-provider/go.mod
+++ b/janitor-provider/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/janitor-provider
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	cloud.google.com/go/compute v1.64.0

--- a/janitor/go.mod
+++ b/janitor/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/janitor
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/labeler/go.mod
+++ b/labeler/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/labeler
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/nvidia/nvsentinel/commons v0.0.0

--- a/metadata-collector/Dockerfile
+++ b/metadata-collector/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM public.ecr.aws/docker/library/golang:1.26.2-trixie AS builder
+FROM public.ecr.aws/docker/library/golang:1.26.3-trixie AS builder
 
 ARG VERSION="dev"
 ARG GIT_COMMIT="none"

--- a/metadata-collector/go.mod
+++ b/metadata-collector/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/metadata-collector
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/NVIDIA/go-nvml v0.13.0-1

--- a/node-drainer/go.mod
+++ b/node-drainer/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/node-drainer
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/platform-connectors/go.mod
+++ b/platform-connectors/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/platform-connectors
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/golang/protobuf v1.5.4

--- a/plugins/mock-slurm-operator/go.mod
+++ b/plugins/mock-slurm-operator/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/plugins/mock-slurm-operator
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	k8s.io/api v0.36.1

--- a/plugins/slinky-drainer/go.mod
+++ b/plugins/slinky-drainer/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/plugins/slinky-drainer
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/preflight-checks/nccl-loopback/Dockerfile
+++ b/preflight-checks/nccl-loopback/Dockerfile
@@ -21,7 +21,7 @@ ARG NCCL_TESTS_VERSION=v2.13.11
 # =============================================================================
 # Build stage: Compile Go binary
 # =============================================================================
-FROM public.ecr.aws/docker/library/golang:1.26.2-trixie AS go-builder
+FROM public.ecr.aws/docker/library/golang:1.26.3-trixie AS go-builder
 
 ARG VERSION="dev"
 ARG GIT_COMMIT="none"

--- a/preflight-checks/nccl-loopback/go.mod
+++ b/preflight-checks/nccl-loopback/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/preflight-checks/nccl-loopback
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/nvidia/nvsentinel/commons v0.0.0

--- a/preflight/go.mod
+++ b/preflight/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/preflight
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/store-client/go.mod
+++ b/store-client/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/store-client
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -2,7 +2,7 @@ module tests
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/tests/scale-tests/cmd/fqm-scale-test/go.mod
+++ b/tests/scale-tests/cmd/fqm-scale-test/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/tests/scale-tests/cmd/fqm-scale-test
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	k8s.io/api v0.36.1

--- a/tests/scale-tests/event-generator/go.mod
+++ b/tests/scale-tests/event-generator/go.mod
@@ -2,7 +2,7 @@ module github.com/nvidia/nvsentinel/tests/scale-tests/event-generator
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/nvidia/nvsentinel/data-models v0.0.0

--- a/tilt/csp-api-mock/Dockerfile
+++ b/tilt/csp-api-mock/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM public.ecr.aws/docker/library/golang:1.26.2-trixie AS builder
+FROM public.ecr.aws/docker/library/golang:1.26.3-trixie AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/tilt/csp-api-mock/go.mod
+++ b/tilt/csp-api-mock/go.mod
@@ -16,7 +16,7 @@ module csp-api-mock
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	cloud.google.com/go/logging v1.18.0

--- a/tilt/event-exporter-mock/Dockerfile
+++ b/tilt/event-exporter-mock/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM public.ecr.aws/docker/library/golang:1.26.2-alpine AS builder
+FROM public.ecr.aws/docker/library/golang:1.26.3-alpine AS builder
 WORKDIR /app
 COPY go.mod ./
 COPY main.go ./

--- a/tilt/event-exporter-mock/go.mod
+++ b/tilt/event-exporter-mock/go.mod
@@ -2,4 +2,4 @@ module github.com/nvidia/nvsentinel/tilt/event-exporter-mock
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3

--- a/tilt/simple-health-client/Dockerfile
+++ b/tilt/simple-health-client/Dockerfile
@@ -17,7 +17,7 @@
 ARG TAG=v3.1.13
 ARG IMG=nvcr.io/nvidia/distroless/go
 
-FROM public.ecr.aws/docker/library/golang:1.26.2-trixie AS builder
+FROM public.ecr.aws/docker/library/golang:1.26.3-trixie AS builder
 
 # TODO: remove when pushing to GitHub
 ENV CGO_ENABLED=0

--- a/tilt/simple-health-client/go.mod
+++ b/tilt/simple-health-client/go.mod
@@ -2,7 +2,7 @@ module simple-health-client
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/nvidia/nvsentinel/data-models v0.0.0


### PR DESCRIPTION
## Summary

Go version 1.26.2 -> 1.26.3 upgrade fixes:

1. [CVE-2026-39820](https://nvd.nist.gov/vuln/detail/cve-2026-39820)
2. [CVE-2026-42499](https://nvd.nist.gov/vuln/detail/CVE-2026-42499)
3. [CVE-2026-42501](https://nvd.nist.gov/vuln/detail/CVE-2026-42501)
4. [CVE-2026-33814](https://nvd.nist.gov/vuln/detail/CVE-2026-33814)
5. [CVE-2026-39836](https://nvd.nist.gov/vuln/detail/CVE-2026-39836)
6. [CVE-2026-33811](https://nvd.nist.gov/vuln/detail/CVE-2026-33811)

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review
