### PR TITLE
fix: preflight-dcgm-diag error handling and dcgm version

### DIFF
--- a/preflight-checks/dcgm-diag/Dockerfile
+++ b/preflight-checks/dcgm-diag/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DCGM_VERSION="4.4.2-1-ubuntu22.04"
+ARG DCGM_VERSION="4.5.2-1-ubuntu22.04"
 ARG VERSION="0.1.0"
 ARG GIT_COMMIT="none"
 ARG BUILD_DATE=$(date -u +%FT%TZ)

--- a/preflight-checks/dcgm-diag/Makefile
+++ b/preflight-checks/dcgm-diag/Makefile
@@ -22,7 +22,7 @@ include ../../make/common.mk
 include ../../make/python.mk
 include ../../make/docker.mk
 
-DCGM_VERSION ?= 4.2.3-1-ubuntu22.04
+DCGM_VERSION ?= 4.5.2-1-ubuntu22.04
 IMAGE_NAME := preflight-dcgm-diag
 
 .PHONY: all

--- a/preflight-checks/dcgm-diag/dcgm_diag/__main__.py
+++ b/preflight-checks/dcgm-diag/dcgm_diag/__main__.py
@@ -19,6 +19,7 @@ from importlib.metadata import version, PackageNotFoundError
 
 from .config import Config
 from .diag import DCGMDiagnostic
+from .errors import resolve_recommended_action
 from .health import HealthReporter
 from .logger import setup_logging
 from .protos import health_event_pb2 as pb
@@ -106,13 +107,20 @@ def _run_diagnostic(cfg: Config, reporter: HealthReporter, diag: DCGMDiagnostic)
     )
 
     # Send one event per test result with specific test name
-    any_fatal = False
+    has_fatal_failure = False
     for r in results:
         if r.status not in ("pass", "warn", "fail"):
             continue
 
         is_pass = r.status == "pass"
-        is_fatal = r.status == "fail"
+        error_code = r.error_code if not is_pass else 0
+        recommended_action = resolve_recommended_action(is_pass, error_code)
+
+        # A failure is fatal only when it has an actionable remediation; failures with
+        # recommended action NONE (e.g. DCGM_FR_XID_ERROR) are reported but do not block.
+        is_fatal = r.status == "fail" and recommended_action != pb.RecommendedAction.NONE
+        has_fatal_failure = has_fatal_failure or is_fatal
+
         message = "Test passed" if is_pass else r.error_message
 
         log.log(
@@ -121,17 +129,14 @@ def _run_diagnostic(cfg: Config, reporter: HealthReporter, diag: DCGMDiagnostic)
             extra={"gpu": r.gpu_uuid, "test": r.test_name, "error_code": r.error_code, "detail": message},
         )
         try:
-            # send_event may downgrade fatality when the error is not actionable
-            # (recommended action NONE), so trust its return value for the exit code.
-            event_fatal = reporter.send_event(
+            reporter.send_event(
                 gpu_uuid=r.gpu_uuid,
                 is_healthy=is_pass,
                 is_fatal=is_fatal,
                 message=message,
-                error_code=r.error_code if not is_pass else 0,
+                error_code=error_code,
                 test_name=r.test_name,
             )
-            any_fatal = any_fatal or event_fatal
         except Exception as send_err:  # noqa: BLE001
             log.error(
                 "Failed to send health event",
@@ -143,10 +148,8 @@ def _run_diagnostic(cfg: Config, reporter: HealthReporter, diag: DCGMDiagnostic)
                     "is_fatal": is_fatal,
                 },
             )
-            # Could not confirm the event; conservatively block on a failed test.
-            any_fatal = any_fatal or is_fatal
 
-    if any_fatal:
+    if has_fatal_failure:
         log.error("DCGM diagnostic check failed")
         return 1
 

--- a/preflight-checks/dcgm-diag/dcgm_diag/__main__.py
+++ b/preflight-checks/dcgm-diag/dcgm_diag/__main__.py
@@ -106,6 +106,7 @@ def _run_diagnostic(cfg: Config, reporter: HealthReporter, diag: DCGMDiagnostic)
     )
 
     # Send one event per test result with specific test name
+    any_fatal = False
     for r in results:
         if r.status not in ("pass", "warn", "fail"):
             continue
@@ -120,7 +121,9 @@ def _run_diagnostic(cfg: Config, reporter: HealthReporter, diag: DCGMDiagnostic)
             extra={"gpu": r.gpu_uuid, "test": r.test_name, "error_code": r.error_code, "detail": message},
         )
         try:
-            reporter.send_event(
+            # send_event may downgrade fatality when the error is not actionable
+            # (recommended action NONE), so trust its return value for the exit code.
+            event_fatal = reporter.send_event(
                 gpu_uuid=r.gpu_uuid,
                 is_healthy=is_pass,
                 is_fatal=is_fatal,
@@ -128,6 +131,7 @@ def _run_diagnostic(cfg: Config, reporter: HealthReporter, diag: DCGMDiagnostic)
                 error_code=r.error_code if not is_pass else 0,
                 test_name=r.test_name,
             )
+            any_fatal = any_fatal or event_fatal
         except Exception as send_err:  # noqa: BLE001
             log.error(
                 "Failed to send health event",
@@ -139,10 +143,15 @@ def _run_diagnostic(cfg: Config, reporter: HealthReporter, diag: DCGMDiagnostic)
                     "is_fatal": is_fatal,
                 },
             )
+            # Could not confirm the event; conservatively block on a failed test.
+            any_fatal = any_fatal or is_fatal
 
-    if failures:
+    if any_fatal:
         log.error("DCGM diagnostic check failed")
         return 1
+
+    if failures:
+        log.warning("DCGM diagnostic reported non-fatal failures (no actionable remediation)")
 
     log.info("DCGM diagnostic check passed")
     return 0

--- a/preflight-checks/dcgm-diag/dcgm_diag/errors.py
+++ b/preflight-checks/dcgm-diag/dcgm_diag/errors.py
@@ -66,3 +66,17 @@ def get_recommended_action(error_code: int) -> int:
     if name:
         return _load_name_to_action().get(name, pb.RecommendedAction.CONTACT_SUPPORT)
     return pb.RecommendedAction.CONTACT_SUPPORT
+
+
+def resolve_recommended_action(is_healthy: bool, error_code: int) -> int:
+    """Resolve the recommended action for a diagnostic result.
+
+    Healthy results need no action. Failures with a known DCGM error code use the CSV
+    mapping (which may itself be NONE, e.g. DCGM_FR_XID_ERROR); failures without a
+    specific code fall back to CONTACT_SUPPORT.
+    """
+    if is_healthy:
+        return pb.RecommendedAction.NONE
+    if error_code:
+        return get_recommended_action(error_code)
+    return pb.RecommendedAction.CONTACT_SUPPORT

--- a/preflight-checks/dcgm-diag/dcgm_diag/health.py
+++ b/preflight-checks/dcgm-diag/dcgm_diag/health.py
@@ -18,7 +18,7 @@ from time import sleep
 import grpc
 from google.protobuf.timestamp_pb2 import Timestamp
 
-from .errors import get_error_name, get_recommended_action
+from .errors import get_error_name, resolve_recommended_action
 from .protos import health_event_pb2 as pb
 from .protos import health_event_pb2_grpc as pb_grpc
 
@@ -53,26 +53,14 @@ class HealthReporter:
         message: str,
         error_code: int = 0,
         test_name: str = "",
-    ) -> bool:
+    ) -> None:
         """Send a single health event for one GPU.
 
-        Returns the effective fatality of the emitted event. The requested ``is_fatal``
-        may be downgraded to ``False`` when the error has no actionable remediation
-        (recommended action ``NONE``), so callers can rely on the return value to decide
-        whether the overall check should be treated as a failure.
+        ``is_fatal`` is emitted as given; the caller is responsible for deciding
+        fatality. The recommended action shown in the event is resolved from the
+        result so it stays consistent with that decision.
         """
-        if is_healthy:
-            recommended_action = pb.RecommendedAction.NONE
-        elif error_code:
-            recommended_action = get_recommended_action(error_code)
-        else:
-            recommended_action = pb.RecommendedAction.CONTACT_SUPPORT
-
-        # A failure with no recommended remediation action is not actionable, so it must
-        # not be reported as fatal. DCGM diag surfaces XID errors via DCGM_FR_XID_ERROR,
-        # which maps to NONE; those events are informational and should not block the node.
-        if recommended_action == pb.RecommendedAction.NONE:
-            is_fatal = False
+        recommended_action = resolve_recommended_action(is_healthy, error_code)
 
         # checkName: "DcgmDiagnostic" or "DcgmDiagnosticMemory" if test_name specified
         check_name = (
@@ -100,8 +88,6 @@ class HealthReporter:
 
         if not self._send_with_retries(health_events):
             raise RuntimeError(f"Failed to send health event after {MAX_RETRIES} retries")
-
-        return is_fatal
 
     @staticmethod
     def _to_camel_case(text: str) -> str:

--- a/preflight-checks/dcgm-diag/dcgm_diag/health.py
+++ b/preflight-checks/dcgm-diag/dcgm_diag/health.py
@@ -53,14 +53,26 @@ class HealthReporter:
         message: str,
         error_code: int = 0,
         test_name: str = "",
-    ) -> None:
-        """Send a single health event for one GPU."""
+    ) -> bool:
+        """Send a single health event for one GPU.
+
+        Returns the effective fatality of the emitted event. The requested ``is_fatal``
+        may be downgraded to ``False`` when the error has no actionable remediation
+        (recommended action ``NONE``), so callers can rely on the return value to decide
+        whether the overall check should be treated as a failure.
+        """
         if is_healthy:
             recommended_action = pb.RecommendedAction.NONE
         elif error_code:
             recommended_action = get_recommended_action(error_code)
         else:
             recommended_action = pb.RecommendedAction.CONTACT_SUPPORT
+
+        # A failure with no recommended remediation action is not actionable, so it must
+        # not be reported as fatal. DCGM diag surfaces XID errors via DCGM_FR_XID_ERROR,
+        # which maps to NONE; those events are informational and should not block the node.
+        if recommended_action == pb.RecommendedAction.NONE:
+            is_fatal = False
 
         # checkName: "DcgmDiagnostic" or "DcgmDiagnosticMemory" if test_name specified
         check_name = (
@@ -88,6 +100,8 @@ class HealthReporter:
 
         if not self._send_with_retries(health_events):
             raise RuntimeError(f"Failed to send health event after {MAX_RETRIES} retries")
+
+        return is_fatal
 
     @staticmethod
     def _to_camel_case(text: str) -> str:

--- a/preflight-checks/dcgm-diag/dcgm_diag/tests/test_errors.py
+++ b/preflight-checks/dcgm-diag/dcgm_diag/tests/test_errors.py
@@ -12,10 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dcgm_diag.errors import get_recommended_action
+from unittest.mock import patch
+
+from dcgm_diag.errors import get_recommended_action, resolve_recommended_action
 from dcgm_diag.protos import health_event_pb2 as pb
 
 
 class TestGetRecommendedAction:
     def test_unknown_code_returns_contact_support(self) -> None:
         assert get_recommended_action(99999) == pb.RecommendedAction.CONTACT_SUPPORT
+
+
+class TestResolveRecommendedAction:
+    def test_healthy_returns_none(self) -> None:
+        assert resolve_recommended_action(is_healthy=True, error_code=0) == pb.RecommendedAction.NONE
+
+    def test_failure_without_code_returns_contact_support(self) -> None:
+        assert resolve_recommended_action(is_healthy=False, error_code=0) == pb.RecommendedAction.CONTACT_SUPPORT
+
+    @patch("dcgm_diag.errors.get_recommended_action", return_value=pb.RecommendedAction.NONE)
+    def test_non_actionable_code_returns_none(self, _mock: object) -> None:
+        # e.g. DCGM_FR_XID_ERROR maps to NONE in the CSV
+        assert resolve_recommended_action(is_healthy=False, error_code=1234) == pb.RecommendedAction.NONE
+
+    @patch("dcgm_diag.errors.get_recommended_action", return_value=pb.RecommendedAction.RESTART_VM)
+    def test_actionable_code_returns_action(self, _mock: object) -> None:
+        assert resolve_recommended_action(is_healthy=False, error_code=1234) == pb.RecommendedAction.RESTART_VM

--- a/preflight-checks/dcgm-diag/dcgm_diag/tests/test_health.py
+++ b/preflight-checks/dcgm-diag/dcgm_diag/tests/test_health.py
@@ -97,3 +97,53 @@ class TestSendEvent:
     def test_raises_on_failure(self, mock_send: MagicMock, reporter: HealthReporter) -> None:
         with pytest.raises(RuntimeError, match="Failed to send health event"):
             reporter.send_event(gpu_uuid="GPU-0", is_healthy=False, is_fatal=True, message="Error")
+
+    @patch.object(HealthReporter, "_send_with_retries", return_value=True)
+    @patch("dcgm_diag.health.get_recommended_action", return_value=pb.RecommendedAction.NONE)
+    @patch("dcgm_diag.health.get_error_name", return_value="DCGM_FR_XID_ERROR")
+    def test_non_actionable_failure_is_not_fatal(
+        self,
+        mock_name: MagicMock,
+        mock_action: MagicMock,
+        mock_send: MagicMock,
+        reporter: HealthReporter,
+    ) -> None:
+        """A failure whose recommended action is NONE (e.g. XID errors) must not be fatal."""
+        effective_fatal = reporter.send_event(
+            gpu_uuid="GPU-0",
+            is_healthy=False,
+            is_fatal=True,
+            message="XID 13 detected",
+            error_code=1234,
+        )
+
+        assert effective_fatal is False
+        events = mock_send.call_args.args[0]
+        event = events.events[0]
+        assert event.isFatal is False
+        assert event.recommendedAction == pb.RecommendedAction.NONE
+
+    @patch.object(HealthReporter, "_send_with_retries", return_value=True)
+    @patch("dcgm_diag.health.get_recommended_action", return_value=pb.RecommendedAction.RESTART_VM)
+    @patch("dcgm_diag.health.get_error_name", return_value="DCGM_FR_NVLINK_DOWN")
+    def test_actionable_failure_stays_fatal(
+        self,
+        mock_name: MagicMock,
+        mock_action: MagicMock,
+        mock_send: MagicMock,
+        reporter: HealthReporter,
+    ) -> None:
+        """A failure with an actionable recommended action keeps its fatal flag."""
+        effective_fatal = reporter.send_event(
+            gpu_uuid="GPU-0",
+            is_healthy=False,
+            is_fatal=True,
+            message="NVLink down",
+            error_code=4321,
+        )
+
+        assert effective_fatal is True
+        events = mock_send.call_args.args[0]
+        event = events.events[0]
+        assert event.isFatal is True
+        assert event.recommendedAction == pb.RecommendedAction.RESTART_VM

--- a/preflight-checks/dcgm-diag/dcgm_diag/tests/test_health.py
+++ b/preflight-checks/dcgm-diag/dcgm_diag/tests/test_health.py
@@ -99,51 +99,26 @@ class TestSendEvent:
             reporter.send_event(gpu_uuid="GPU-0", is_healthy=False, is_fatal=True, message="Error")
 
     @patch.object(HealthReporter, "_send_with_retries", return_value=True)
-    @patch("dcgm_diag.health.get_recommended_action", return_value=pb.RecommendedAction.NONE)
+    @patch("dcgm_diag.health.resolve_recommended_action", return_value=pb.RecommendedAction.NONE)
     @patch("dcgm_diag.health.get_error_name", return_value="DCGM_FR_XID_ERROR")
-    def test_non_actionable_failure_is_not_fatal(
+    def test_emits_event_faithfully(
         self,
         mock_name: MagicMock,
         mock_action: MagicMock,
         mock_send: MagicMock,
         reporter: HealthReporter,
     ) -> None:
-        """A failure whose recommended action is NONE (e.g. XID errors) must not be fatal."""
-        effective_fatal = reporter.send_event(
+        """send_event emits the given fatality and the resolved recommended action."""
+        reporter.send_event(
             gpu_uuid="GPU-0",
             is_healthy=False,
-            is_fatal=True,
+            is_fatal=False,
             message="XID 13 detected",
             error_code=1234,
         )
 
-        assert effective_fatal is False
         events = mock_send.call_args.args[0]
         event = events.events[0]
         assert event.isFatal is False
         assert event.recommendedAction == pb.RecommendedAction.NONE
-
-    @patch.object(HealthReporter, "_send_with_retries", return_value=True)
-    @patch("dcgm_diag.health.get_recommended_action", return_value=pb.RecommendedAction.RESTART_VM)
-    @patch("dcgm_diag.health.get_error_name", return_value="DCGM_FR_NVLINK_DOWN")
-    def test_actionable_failure_stays_fatal(
-        self,
-        mock_name: MagicMock,
-        mock_action: MagicMock,
-        mock_send: MagicMock,
-        reporter: HealthReporter,
-    ) -> None:
-        """A failure with an actionable recommended action keeps its fatal flag."""
-        effective_fatal = reporter.send_event(
-            gpu_uuid="GPU-0",
-            is_healthy=False,
-            is_fatal=True,
-            message="NVLink down",
-            error_code=4321,
-        )
-
-        assert effective_fatal is True
-        events = mock_send.call_args.args[0]
-        event = events.events[0]
-        assert event.isFatal is True
-        assert event.recommendedAction == pb.RecommendedAction.RESTART_VM
+        assert list(event.errorCode) == ["DCGM_FR_XID_ERROR"]


### PR DESCRIPTION
## Summary

1. Update the DCGM version to 4.5.2 to be consistent with gpu-health-monitor
2. DCGM diag failure with no recommended action should be non-fatal


## Testing

For testing, I modified the configmap to inject the current image (for original issue repro) followed by pre-merge image to verify the fix and in another terminal injected XID 45 while `dcgmi diag -r 2` was still running.

before the change:
```
preflight-dcgm-diag {"event": "Test fail", "level": "error", "gpu": "GPU-5c7ff395-70ef-ea76-026b-d819af2fe543", "test": "pcie", "error_code": 101, "detail": "Detected XID 45 for GPU 0 Please consult the documentation for details of this XID.", "timestamp": "2026-06-04T06:08:10.021979Z", "module": "preflight-dcgm-diag", "version": "dev"}
preflight-dcgm-diag {"event": "Loaded 121 DCGM error mappings from /etc/dcgm/dcgmerrorsmapping.csv", "level": "info", "timestamp": "2026-06-04T06:08:10.025393Z", "module": "preflight-dcgm-diag", "version": "dev"}
preflight-dcgm-diag {"event": "Sending health event", "level": "info", "gpu": "GPU-5c7ff395-70ef-ea76-026b-d819af2fe543", "check_name": "DcgmDiagnosticPcie", "is_healthy": false, "is_fatal": true, "error_code": "DCGM_FR_XID_ERROR", "recommended_action": "NONE", "event_message": "Detected XID 45 for GPU 0 Please consult the documentation for details of this XID.", "timestamp": "2026-06-04T06:08:10.025595Z", "module": "preflight-dcgm-diag", "version": "dev"}
preflight-dcgm-diag {"event": "Health event sent successfully", "level": "info", "timestamp": "2026-06-04T06:08:10.028188Z", "module": "preflight-dcgm-diag", "version": "dev"}
```

The point to note here is `"is_fatal": true` along with init container crash:
```
gpu-workload-4gpu-1            ●            0/1             Init:Error
```

After this change:
```
preflight-dcgm-diag {"event": "Test fail", "level": "warning", "gpu": "GPU-d364c728-8a0f-dfe3-6d47-f8aeb5cf7601", "test": "memory", "error_code": 101, "detail": "Detected XID 45 for GPU 0 Please consult the documentation for details of this XID.", "timestamp": "2026-06-04T06:23:18.260390Z", "module": "preflight-dcgm-diag", "version": "dev"}
preflight-dcgm-diag {"event": "Loaded 121 DCGM error mappings from /etc/dcgm/dcgmerrorsmapping.csv", "level": "info", "timestamp": "2026-06-04T06:23:18.261075Z", "module": "preflight-dcgm-diag", "version": "dev"}
preflight-dcgm-diag {"event": "Sending health event", "level": "info", "gpu": "GPU-d364c728-8a0f-dfe3-6d47-f8aeb5cf7601", "check_name": "DcgmDiagnosticMemory", "is_healthy": false, "is_fatal": false, "error_code": "DCGM_FR_XID_ERROR", "recommended_action": "NONE", "event_message": "Detected XID 45 for GPU 0 Please consult the documentation for details of this XID.", "timestamp": "2026-06-04T06:23:18.261270Z", "module": "preflight-dcgm-diag", "version": "dev"}
```

And pod proceeded with next init container:
```
gpu-workload-4gpu-1            ●            0/1             Init:1/2
```


## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [x] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated NVIDIA DCGM diagnostic tool to version 4.5.2

* **Bug Fixes**
  * Improved diagnostic reporting to distinguish actionable vs non-actionable issues
  * Adjusted exit/status behavior so only actionable (fatal) failures cause a blocking exit

* **Tests**
  * Added unit tests covering recommended-action resolution and reporter event emission
<!-- end of auto-generated comment: release notes by coderabbit.ai -->