### PR TITLE
feat: add out-of-cluster platform-connector deployment mode

### DIFF
--- a/docs/configuration/platform-connectors.md
+++ b/docs/configuration/platform-connectors.md
@@ -209,3 +209,24 @@ platformConnector:
     qps: 10.0
     burst: 20
 ```
+
+## Kubernetes Authentication
+
+Platform Connectors uses in-cluster Kubernetes authentication by default. In that mode it authenticates with the pod ServiceAccount and no extra flags are required.
+
+For host-managed deployments, pass a kubeconfig file explicitly:
+
+```bash
+platform-connectors \
+  --socket=/var/run/nvsentinel.sock \
+  --config=/etc/config/config.json \
+  --kubeconfig=/var/lib/kubelet/kubeconfig
+```
+
+When `--kubeconfig` is set:
+- The Kubernetes connector uses that kubeconfig instead of `InClusterConfig()`
+- `MetadataAugmentor` uses the same kubeconfig for node metadata lookups
+
+When `--kubeconfig` is unset, existing in-cluster behavior is unchanged.
+
+The bundled Helm chart continues to rely on in-cluster authentication and does not need to set this flag.

--- a/docs/platform-connectors.md
+++ b/docs/platform-connectors.md
@@ -20,7 +20,7 @@ Without Platform Connectors, health monitors would need to directly integrate wi
 
 ## How It Works
 
-Platform Connectors runs as a deployment in the cluster:
+Platform Connectors typically runs as a deployment in the cluster:
 
 1. Exposes gRPC service for health monitors to send events
 2. Receives health events via gRPC (`HealthEventOccurredV1` API)
@@ -82,6 +82,20 @@ platformConnector:
 - **Kubernetes API Rate Limits**: Configure QPS and burst for Kubernetes API calls
 
 For complete configuration reference, see [Platform Connectors Configuration](configuration/platform-connectors.md).
+
+### Kubernetes Authentication Modes
+
+Platform Connectors supports two Kubernetes authentication modes:
+
+- **In-cluster (default)**: Uses the pod ServiceAccount via `InClusterConfig()`
+- **Out-of-cluster**: Uses an explicit kubeconfig file via `--kubeconfig=/path/to/kubeconfig`
+
+The `--kubeconfig` flag is intended for host-managed deployments, such as running `platform-connectors` under `systemd` alongside the other runtime components. When set, both the Kubernetes connector and `MetadataAugmentor` use that kubeconfig.
+
+Example host-managed invocation:
+```bash
+platform-connectors --socket=/var/run/nvsentinel.sock --config=/etc/config/config.json --kubeconfig=/var/lib/kubelet/kubeconfig
+```
 
 ## What It Does
 

--- a/platform-connectors/main.go
+++ b/platform-connectors/main.go
@@ -108,6 +108,7 @@ func initializeK8sConnector(
 	ctx context.Context,
 	config map[string]interface{},
 	stopCh chan struct{},
+	kubeconfigPath string,
 ) (*ringbuffer.RingBuffer, error) {
 	k8sRingBuffer := ringbuffer.NewRingBuffer("kubernetes", ctx)
 	server.InitializeAndAttachRingBufferForConnectors(k8sRingBuffer)
@@ -141,8 +142,9 @@ func initializeK8sConnector(
 		CompactedHealthEventMsgLen:    compactedEventMsgLen,
 	}
 
-	k8sConnector, _, err := kubernetes.InitializeK8sConnector(ctx, k8sRingBuffer, qps, int(burst),
-		stopCh, k8sConnectorCfg)
+	k8sConnector, _, err := kubernetes.InitializeK8sConnector(
+		ctx, k8sRingBuffer, qps, int(burst), stopCh, k8sConnectorCfg, kubeconfigPath,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize K8sConnector: %w", err)
 	}
@@ -177,7 +179,7 @@ func initializeDatabaseStoreConnector(
 	return storeConnector, nil
 }
 
-func initializePipeline(ctx context.Context, config map[string]any) (*pipeline.Pipeline, error) {
+func initializePipeline(ctx context.Context, config map[string]any, opts pipeline.Options) (*pipeline.Pipeline, error) {
 	pipelineCfg, ok := config["pipeline"].([]any)
 	if !ok || len(pipelineCfg) == 0 {
 		slog.ErrorContext(ctx, "No pipeline configuration found, events will not be transformed")
@@ -214,7 +216,7 @@ func initializePipeline(ctx context.Context, config map[string]any) (*pipeline.P
 		})
 	}
 
-	return pipeline.NewFromConfigs(ctx, transformerConfigs)
+	return pipeline.NewFromConfigs(ctx, transformerConfigs, opts)
 }
 
 func startGRPCServer(
@@ -301,6 +303,7 @@ func initializeConnectors(
 	config map[string]interface{},
 	stopCh chan struct{},
 	databaseClientCertMountPath string,
+	kubeconfigPath string,
 ) (*ringbuffer.RingBuffer, *store.DatabaseStoreConnector, *grpcsink.GRPCSinkConnector, error) {
 	var (
 		k8sRingBuffer     *ringbuffer.RingBuffer
@@ -310,7 +313,7 @@ func initializeConnectors(
 	)
 
 	if config["enableK8sPlatformConnector"] == True {
-		k8sRingBuffer, err = initializeK8sConnector(ctx, config, stopCh)
+		k8sRingBuffer, err = initializeK8sConnector(ctx, config, stopCh, kubeconfigPath)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to initialize K8s connector: %w", err)
 		}
@@ -383,12 +386,14 @@ type platformConnectorConfig struct {
 	configFilePath              string
 	metricsPort                 int
 	databaseClientCertMountPath string
+	kubeconfigPath              string
 }
 
 func parseFlags() (*platformConnectorConfig, error) {
 	socket := flag.String("socket", "", "unix socket path")
 	configFilePath := flag.String("config", "/etc/config/config.json", "path to the config file")
 	metricsPort := flag.String("metrics-port", "2112", "port to expose Prometheus metrics on")
+	kubeconfigPath := flag.String("kubeconfig", "", "path to a kubeconfig file for out-of-cluster Kubernetes auth")
 
 	// Register database certificate flags using common package
 	certConfig := flags.RegisterDatabaseCertFlags()
@@ -409,6 +414,7 @@ func parseFlags() (*platformConnectorConfig, error) {
 		configFilePath:              *configFilePath,
 		metricsPort:                 portInt,
 		databaseClientCertMountPath: certConfig.ResolveCertPath(),
+		kubeconfigPath:              *kubeconfigPath,
 	}, nil
 }
 
@@ -470,18 +476,26 @@ func run() error {
 
 	defer cancel()
 
+	if cfg.kubeconfigPath == "" {
+		slog.InfoContext(ctx, "Using in-cluster Kubernetes authentication")
+	} else {
+		slog.InfoContext(ctx, "Using explicit kubeconfig for Kubernetes authentication", "path", cfg.kubeconfigPath)
+	}
+
 	config, err := loadConfig(cfg.configFilePath)
 	if err != nil {
 		return err
 	}
 
 	k8sRingBuffer, storeConnector, grpcSinkConnector, err := initializeConnectors(ctx,
-		config, stopCh, cfg.databaseClientCertMountPath)
+		config, stopCh, cfg.databaseClientCertMountPath, cfg.kubeconfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to initialize connectors: %w", err)
 	}
 
-	pipeline, err := initializePipeline(ctx, config)
+	pipeline, err := initializePipeline(ctx, config, pipeline.Options{
+		KubeconfigPath: cfg.kubeconfigPath,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to initialize pipeline: %w", err)
 	}

--- a/platform-connectors/main_test.go
+++ b/platform-connectors/main_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func setTestArgs(t *testing.T, args ...string) {
+	t.Helper()
+
+	originalArgs := os.Args
+	originalFlags := flag.CommandLine
+
+	flag.CommandLine = flag.NewFlagSet(args[0], flag.ContinueOnError)
+	flag.CommandLine.SetOutput(io.Discard)
+	os.Args = args
+
+	t.Cleanup(func() {
+		os.Args = originalArgs
+		flag.CommandLine = originalFlags
+	})
+}
+
+func TestParseFlags_DefaultsToInClusterAuth(t *testing.T) {
+	setTestArgs(t, "platform-connectors", "--socket=/tmp/nvsentinel.sock")
+
+	cfg, err := parseFlags()
+	require.NoError(t, err)
+	require.Equal(t, "/tmp/nvsentinel.sock", cfg.socket)
+	require.Equal(t, "/etc/config/config.json", cfg.configFilePath)
+	require.Equal(t, 2112, cfg.metricsPort)
+	require.Empty(t, cfg.kubeconfigPath)
+}
+
+func TestParseFlags_AcceptsExplicitKubeconfig(t *testing.T) {
+	setTestArgs(
+		t,
+		"platform-connectors",
+		"--socket=/tmp/nvsentinel.sock",
+		"--config=/tmp/config.json",
+		"--metrics-port=3112",
+		"--kubeconfig=/var/lib/kubelet/kubeconfig",
+		"--tls-enabled=false",
+	)
+
+	cfg, err := parseFlags()
+	require.NoError(t, err)
+	require.Equal(t, "/tmp/nvsentinel.sock", cfg.socket)
+	require.Equal(t, "/tmp/config.json", cfg.configFilePath)
+	require.Equal(t, 3112, cfg.metricsPort)
+	require.Equal(t, "/var/lib/kubelet/kubeconfig", cfg.kubeconfigPath)
+	require.Empty(t, cfg.databaseClientCertMountPath)
+}

--- a/platform-connectors/pkg/connectors/kubernetes/k8s_connector.go
+++ b/platform-connectors/pkg/connectors/kubernetes/k8s_connector.go
@@ -22,10 +22,10 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 
 	"github.com/nvidia/nvsentinel/commons/pkg/auditlogger"
 	"github.com/nvidia/nvsentinel/commons/pkg/tracing"
+	"github.com/nvidia/nvsentinel/platform-connectors/pkg/kubeconfig"
 	"github.com/nvidia/nvsentinel/platform-connectors/pkg/ringbuffer"
 )
 
@@ -67,6 +67,7 @@ func NewK8sConnector(
 
 func InitializeK8sConnector(ctx context.Context, ringbuffer *ringbuffer.RingBuffer,
 	qps float32, burst int, stopCh <-chan struct{}, cfg K8sConnectorConfig,
+	kubeconfigPath string,
 ) (*K8sConnector, kubernetes.Interface, error) {
 	if cfg.MaxNodeConditionMessageLength <= 0 {
 		return nil, nil, fmt.Errorf("maxNodeConditionMessageLength must be greater than 0, got %d",
@@ -78,10 +79,9 @@ func InitializeK8sConnector(ctx context.Context, ringbuffer *ringbuffer.RingBuff
 			cfg.CompactedHealthEventMsgLen)
 	}
 
-	// Create the in-cluster config
-	config, err := rest.InClusterConfig()
+	config, err := kubeconfig.Load(kubeconfigPath)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error creating in-cluster config: %w", err)
+		return nil, nil, err
 	}
 
 	config.Burst = burst

--- a/platform-connectors/pkg/connectors/kubernetes/k8s_connector_init_test.go
+++ b/platform-connectors/pkg/connectors/kubernetes/k8s_connector_init_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nvidia/nvsentinel/platform-connectors/pkg/ringbuffer"
+)
+
+func TestInitializeK8sConnector_UsesExplicitKubeconfig(t *testing.T) {
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+
+	kubeconfigPath := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, os.WriteFile(kubeconfigPath, []byte(`
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://10.0.0.1:443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user:
+    token: test-token
+`), 0o600))
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	connector, clientset, err := InitializeK8sConnector(
+		context.Background(),
+		ringbuffer.NewRingBuffer("kubernetes", context.Background()),
+		5,
+		10,
+		stopCh,
+		K8sConnectorConfig{
+			MaxNodeConditionMessageLength: 1024,
+			CompactedHealthEventMsgLen:    72,
+		},
+		kubeconfigPath,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, connector)
+	require.NotNil(t, connector.clientset)
+	require.NotNil(t, clientset)
+}

--- a/platform-connectors/pkg/kubeconfig/loader.go
+++ b/platform-connectors/pkg/kubeconfig/loader.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package kubeconfig resolves Kubernetes client configuration for platform-connectors.
+package kubeconfig
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// Load returns a Kubernetes REST config from an explicit kubeconfig path when provided,
+// otherwise it falls back to standard in-cluster configuration.
+func Load(path string) (*rest.Config, error) {
+	if path == "" {
+		config, err := rest.InClusterConfig()
+		if err != nil {
+			return nil, fmt.Errorf("error creating in-cluster config: %w", err)
+		}
+
+		return config, nil
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", path)
+	if err != nil {
+		return nil, fmt.Errorf("error loading kubeconfig %q: %w", path, err)
+	}
+
+	return config, nil
+}

--- a/platform-connectors/pkg/kubeconfig/loader.go
+++ b/platform-connectors/pkg/kubeconfig/loader.go
@@ -23,19 +23,14 @@ import (
 )
 
 // Load returns a Kubernetes REST config from an explicit kubeconfig path when provided,
-// otherwise it falls back to standard in-cluster configuration.
+// or lets client-go resolve the implicit configuration when the path is empty.
 func Load(path string) (*rest.Config, error) {
-	if path == "" {
-		config, err := rest.InClusterConfig()
-		if err != nil {
+	config, err := clientcmd.BuildConfigFromFlags("", path)
+	if err != nil {
+		if path == "" {
 			return nil, fmt.Errorf("error creating in-cluster config: %w", err)
 		}
 
-		return config, nil
-	}
-
-	config, err := clientcmd.BuildConfigFromFlags("", path)
-	if err != nil {
 		return nil, fmt.Errorf("error loading kubeconfig %q: %w", path, err)
 	}
 

--- a/platform-connectors/pkg/kubeconfig/loader_test.go
+++ b/platform-connectors/pkg/kubeconfig/loader_test.go
@@ -55,11 +55,12 @@ func TestLoadReturnsPathErrorForMissingFile(t *testing.T) {
 	require.ErrorContains(t, err, "/path/does/not/exist")
 }
 
-func TestLoadFallsBackToInClusterConfig(t *testing.T) {
+func TestLoadReturnsErrorWhenNoConfigSourcesAvailable(t *testing.T) {
 	t.Setenv("KUBERNETES_SERVICE_HOST", "")
 	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+	t.Setenv("HOME", t.TempDir())
 
 	_, err := Load("")
 	require.Error(t, err)
-	require.ErrorContains(t, err, "in-cluster")
+	require.ErrorContains(t, err, "no configuration has been provided")
 }

--- a/platform-connectors/pkg/kubeconfig/loader_test.go
+++ b/platform-connectors/pkg/kubeconfig/loader_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubeconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadUsesExplicitKubeconfigPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, os.WriteFile(path, []byte(`
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://10.0.0.1:443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user:
+    token: test-token
+`), 0o600))
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	require.Equal(t, "https://10.0.0.1:443", cfg.Host)
+	require.Equal(t, "test-token", cfg.BearerToken)
+}
+
+func TestLoadReturnsPathErrorForMissingFile(t *testing.T) {
+	_, err := Load("/path/does/not/exist")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "/path/does/not/exist")
+}
+
+func TestLoadFallsBackToInClusterConfig(t *testing.T) {
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+
+	_, err := Load("")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "in-cluster")
+}

--- a/platform-connectors/pkg/pipeline/factory.go
+++ b/platform-connectors/pkg/pipeline/factory.go
@@ -22,7 +22,11 @@ import (
 	"log/slog"
 )
 
-type Factory func(cfg *Config) (Transformer, error)
+type Options struct {
+	KubeconfigPath string
+}
+
+type Factory func(cfg *Config, opts Options) (Transformer, error)
 
 var registry = map[string]Factory{}
 
@@ -30,19 +34,19 @@ func Register(name string, factory Factory) {
 	registry[name] = factory
 }
 
-func Create(cfg *Config) (Transformer, error) {
+func Create(cfg *Config, opts Options) (Transformer, error) {
 	factory, ok := registry[cfg.Name]
 	if !ok {
 		return nil, fmt.Errorf("unknown transformer: %s", cfg.Name)
 	}
 
-	return factory(cfg)
+	return factory(cfg, opts)
 }
 
 // NewFromConfigs creates a Pipeline from a slice of transformer configurations.
 // Disabled transformers are skipped. Returns an error if any enabled transformer
 // fails to initialize.
-func NewFromConfigs(ctx context.Context, configs []Config) (*Pipeline, error) {
+func NewFromConfigs(ctx context.Context, configs []Config, opts Options) (*Pipeline, error) {
 	var transformers []Transformer
 
 	for _, cfg := range configs {
@@ -51,7 +55,7 @@ func NewFromConfigs(ctx context.Context, configs []Config) (*Pipeline, error) {
 			continue
 		}
 
-		t, err := Create(&cfg)
+		t, err := Create(&cfg, opts)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create transformer %s: %w", cfg.Name, err)
 		}

--- a/platform-connectors/pkg/pipeline/factory_test.go
+++ b/platform-connectors/pkg/pipeline/factory_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFromConfigs_PassesOptionsToFactory(t *testing.T) {
+	const transformerName = "TestOptionsTransformer"
+
+	var receivedOpts Options
+	Register(transformerName, func(cfg *Config, opts Options) (Transformer, error) {
+		receivedOpts = opts
+		return &mockTransformer{name: cfg.Name}, nil
+	})
+	t.Cleanup(func() {
+		delete(registry, transformerName)
+	})
+
+	_, err := NewFromConfigs(context.Background(), []Config{
+		{
+			Name:       transformerName,
+			Enabled:    true,
+			ConfigPath: "/tmp/metadata.toml",
+		},
+	}, Options{
+		KubeconfigPath: "/var/lib/kubelet/kubeconfig",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "/var/lib/kubelet/kubeconfig", receivedOpts.KubeconfigPath)
+}

--- a/platform-connectors/pkg/transformers/metadata/factory.go
+++ b/platform-connectors/pkg/transformers/metadata/factory.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 
+	"github.com/nvidia/nvsentinel/platform-connectors/pkg/kubeconfig"
 	"github.com/nvidia/nvsentinel/platform-connectors/pkg/pipeline"
 )
 
@@ -30,8 +30,8 @@ func init() {
 	pipeline.Register("MetadataAugmentor", newFromConfig)
 }
 
-func newFromConfig(cfg *pipeline.Config) (pipeline.Transformer, error) {
-	k8sConfig, err := rest.InClusterConfig()
+func newFromConfig(cfg *pipeline.Config, opts pipeline.Options) (pipeline.Transformer, error) {
+	k8sConfig, err := kubeconfig.Load(opts.KubeconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Kubernetes configuration: %w", err)
 	}

--- a/platform-connectors/pkg/transformers/overrides/factory.go
+++ b/platform-connectors/pkg/transformers/overrides/factory.go
@@ -26,7 +26,7 @@ func init() {
 	pipeline.Register("OverrideTransformer", newFromConfig)
 }
 
-func newFromConfig(cfg *pipeline.Config) (pipeline.Transformer, error) {
+func newFromConfig(cfg *pipeline.Config, _ pipeline.Options) (pipeline.Transformer, error) {
 	if cfg.ConfigPath == "" {
 		return nil, fmt.Errorf("config path required for OverrideTransformer")
 	}


### PR DESCRIPTION
## Summary

Add optional out-of-cluster Kubernetes auth for `platform-connectors` via `--kubeconfig`.

This threads the kubeconfig path through startup, connector initialization, and pipeline transformer creation so both the Kubernetes connector and `MetadataAugmentor` use the same explicit client config when `platform-connectors` runs outside the cluster (for example under `systemd`). When `--kubeconfig` is unset, existing in-cluster auth behavior remains unchanged.

Also updates docs for the new auth mode and adds unit coverage for flag parsing, kubeconfig loading, connector init, and pipeline option propagation

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] Core Services
- [x] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [x] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI flag to enable out-of-cluster Kubernetes authentication via an explicit kubeconfig; runtime now supports passing that kubeconfig through the pipeline and connectors.

* **Documentation**
  * Added Kubernetes Authentication sections and examples describing in-cluster default and out-of-cluster kubeconfig usage.

* **Tests**
  * Added unit tests covering flag parsing, kubeconfig loading, connector initialization, and pipeline option propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->