### PR TITLE
fix: avoid caching driver version in syslog health monitor

### DIFF
--- a/health-monitors/syslog-health-monitor/main.go
+++ b/health-monitors/syslog-health-monitor/main.go
@@ -451,7 +451,7 @@ func waitForSidecarIfEnabled(ctx context.Context, nodeName string) error {
 		return nil
 	}
 
-	sidecar := parser.NewSidecarParser(*xidAnalyserEndpoint, nodeName, "")
+	sidecar := parser.NewSidecarParser(*xidAnalyserEndpoint, nodeName, func() string { return "" })
 
 	if err := sidecar.WaitUntilReady(ctx, 30, 2*time.Second); err != nil {
 		return fmt.Errorf("sidecar readiness check failed: %w", err)

--- a/health-monitors/syslog-health-monitor/pkg/common/common.go
+++ b/health-monitors/syslog-health-monitor/pkg/common/common.go
@@ -96,14 +96,20 @@ func MapActionStringToProto(s string) pb.RecommendedAction {
 	}
 }
 
-// NVL5DecodingRule represents a rule for NVL5 XID decoding (144-150) from the Excel sheet
+// NVL5DecodingRule represents a rule for NVL5 XID decoding (144-150) from the Excel sheet.
+//
+// Both the V1 (driver < R575) and V2 (driver >= R575) IntrInfo binary patterns are
+// retained so the matcher can pick the correct one per message based on the driver
+// version resolved at processing time, rather than baking a single column in at load
+// time (which would be wrong if the driver version was unavailable at startup).
 type NVL5DecodingRule struct {
-	XIDNumber      int
-	IntrInfoBinary string   // V1 binary pattern for matching
-	ErrorStatusHex []string // List of error status values as strings
-	Resolution     string
-	Severity       string
-	Mnemonic       string
+	XIDNumber        int
+	IntrInfoBinaryV1 string   // Column C: binary pattern for driver < R575
+	IntrInfoBinaryV2 string   // Column D: binary pattern for driver >= R575
+	ErrorStatusHex   []string // List of error status values as strings
+	Resolution       string
+	Severity         string
+	Mnemonic         string
 }
 
 func LoadErrorResolutionMap() (map[int]types.ErrorResolution, error) {
@@ -130,7 +136,7 @@ func LoadErrorResolutionMap() (map[int]types.ErrorResolution, error) {
 }
 
 // loadNVL5DecodingRules loads NVL5-specific decoding rules using exact column indices
-func loadNVL5DecodingRules(xl *xlsxreader.XlsxFile, driverVersion string) (map[int][]NVL5DecodingRule, error) {
+func loadNVL5DecodingRules(xl *xlsxreader.XlsxFile) (map[int][]NVL5DecodingRule, error) {
 	nvl5DecodingMap := make(map[int][]NVL5DecodingRule)
 
 	sheetName := "Xid 144-150 Decode"
@@ -150,7 +156,7 @@ func loadNVL5DecodingRules(xl *xlsxreader.XlsxFile, driverVersion string) (map[i
 			continue
 		}
 
-		rule, err := parseNVL5Row(row, driverVersion)
+		rule, err := parseNVL5Row(row)
 		if err != nil {
 			slog.Debug("Skipping NVL5 row", "row", rowIndex+1, "error", err)
 			continue
@@ -169,7 +175,7 @@ func loadNVL5DecodingRules(xl *xlsxreader.XlsxFile, driverVersion string) (map[i
 }
 
 // parseNVL5Row parses a single row from the NVL5 sheet using column letters to handle gaps
-func parseNVL5Row(row xlsxreader.Row, driverVersion string) (*NVL5DecodingRule, error) {
+func parseNVL5Row(row xlsxreader.Row) (*NVL5DecodingRule, error) {
 	// Column A: 'Xid'
 	// Column B: 'Subcode V1(<R575)/V2(>=R575)...' - This is actually intrInfo decode info, not subcode
 	// Column C: '(V1(<R575)) IntrInfo decode...' - This is the binary pattern for matching for driver version < R575
@@ -196,11 +202,8 @@ func parseNVL5Row(row xlsxreader.Row, driverVersion string) (*NVL5DecodingRule, 
 		XIDNumber: xidCode,
 	}
 
-	if IsDriverVersionR575OrNewer(driverVersion) {
-		rule.IntrInfoBinary = strings.TrimSpace(columnValues["D"])
-	} else {
-		rule.IntrInfoBinary = strings.TrimSpace(columnValues["C"])
-	}
+	rule.IntrInfoBinaryV1 = strings.TrimSpace(columnValues["C"])
+	rule.IntrInfoBinaryV2 = strings.TrimSpace(columnValues["D"])
 
 	errorStatusStr := columnValues["E"]
 	for errStatus := range strings.SplitSeq(errorStatusStr, "/") {
@@ -235,14 +238,17 @@ func IsDriverVersionR575OrNewer(version string) bool {
 }
 
 // GetNVL5DecodingRules returns the NVL5 decoding rules for use in parsing.
-// driverVersion should be in NVIDIA format (e.g., "570.148.08").
-func GetNVL5DecodingRules(driverVersion string) (map[int][]NVL5DecodingRule, error) {
+//
+// Both the V1 and V2 IntrInfo patterns are loaded for every rule; the caller
+// selects the correct one per message using the driver version available at
+// processing time (see CSVParser).
+func GetNVL5DecodingRules() (map[int][]NVL5DecodingRule, error) {
 	xl, err := xlsxreader.NewReader(embeddedXidCatalog)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Excel reader from embedded data: %w", err)
 	}
 
-	return loadNVL5DecodingRules(xl, driverVersion)
+	return loadNVL5DecodingRules(xl)
 }
 
 func findXidsSheet(xl *xlsxreader.XlsxFile) (string, error) {

--- a/health-monitors/syslog-health-monitor/pkg/common/common_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/common/common_test.go
@@ -136,43 +136,34 @@ func TestMapActionStringToProto(t *testing.T) {
 }
 
 func TestGetNVL5DecodingRules(t *testing.T) {
-	// Load rules for both driver version ranges
-	rulesV1, err := GetNVL5DecodingRules("570.148.08") // Pre-R575: uses Column C
-	assert.NoError(t, err)
-	rulesV2, err := GetNVL5DecodingRules("580.0.0") // R575+: uses Column D
+	// Rules carry both V1 and V2 IntrInfo patterns; selection happens per message.
+	rules, err := GetNVL5DecodingRules()
 	assert.NoError(t, err)
 
 	// Verify all NVL5 XIDs (144-150) are loaded
 	for xid := 144; xid <= 150; xid++ {
-		assert.Contains(t, rulesV1, xid)
-		assert.Contains(t, rulesV2, xid)
+		assert.Contains(t, rules, xid)
 	}
 
 	// Test concrete values from xlsx for XID 145
-	assert.Len(t, rulesV1[145], 33, "XID 145 should have 33 rules")
+	assert.Len(t, rules[145], 33, "XID 145 should have 33 rules")
 
 	// Verify first rule (RLW_CTRL) - concrete values from xlsx
-	rule0V1 := rulesV1[145][0]
-	assert.Equal(t, 145, rule0V1.XIDNumber)
-	assert.Equal(t, "RLW_CTRL", rule0V1.Mnemonic)
-	assert.Equal(t, "Non-fatal", rule0V1.Severity)
-	assert.Equal(t, "IGNORE", rule0V1.Resolution)
-	assert.Equal(t, "------000000----------0001100010", rule0V1.IntrInfoBinary) // V1 pattern
-	assert.Equal(t, []string{"0x80000000"}, rule0V1.ErrorStatusHex)
-
-	// Verify same rule uses different IntrInfoBinary in V2
-	rule0V2 := rulesV2[145][0]
-	assert.Equal(t, "------000000-------------0000011", rule0V2.IntrInfoBinary) // V2 pattern
-	assert.Equal(t, rule0V1.Mnemonic, rule0V2.Mnemonic)                         // Same mnemonic
-	assert.Equal(t, rule0V1.Resolution, rule0V2.Resolution)                     // Same resolution
+	rule0 := rules[145][0]
+	assert.Equal(t, 145, rule0.XIDNumber)
+	assert.Equal(t, "RLW_CTRL", rule0.Mnemonic)
+	assert.Equal(t, "Non-fatal", rule0.Severity)
+	assert.Equal(t, "IGNORE", rule0.Resolution)
+	assert.Equal(t, "------000000----------0001100010", rule0.IntrInfoBinaryV1) // V1 pattern (Column C)
+	assert.Equal(t, "------000000-------------0000011", rule0.IntrInfoBinaryV2)  // V2 pattern (Column D)
+	assert.Equal(t, []string{"0x80000000"}, rule0.ErrorStatusHex)
 
 	// Verify second rule (RLW_REMAP with XID_154_EVAL)
-	rule1V1 := rulesV1[145][1]
-	assert.Equal(t, "RLW_REMAP", rule1V1.Mnemonic)
-	assert.Equal(t, "XID_154_EVAL", rule1V1.Resolution)
-	assert.Equal(t, "------000000----------0010000010", rule1V1.IntrInfoBinary) // V1
-	rule1V2 := rulesV2[145][1]
-	assert.Equal(t, "------000000-------------0000100", rule1V2.IntrInfoBinary) // V2
+	rule1 := rules[145][1]
+	assert.Equal(t, "RLW_REMAP", rule1.Mnemonic)
+	assert.Equal(t, "XID_154_EVAL", rule1.Resolution)
+	assert.Equal(t, "------000000----------0010000010", rule1.IntrInfoBinaryV1) // V1
+	assert.Equal(t, "------000000-------------0000100", rule1.IntrInfoBinaryV2)  // V2
 }
 
 func TestIsDriverVersionR575OrNewer(t *testing.T) {

--- a/health-monitors/syslog-health-monitor/pkg/metadata/reader.go
+++ b/health-monitors/syslog-health-monitor/pkg/metadata/reader.go
@@ -80,10 +80,17 @@ func (r *Reader) load() error {
 	r.metadata = &metadata
 	r.buildMaps()
 
-	slog.Info("GPU metadata loaded",
-		"gpus", len(metadata.GPUs),
-		"nvswitches", len(metadata.NVSwitches),
-		"chassis_serial", metadata.ChassisSerial != nil)
+	if r.loaded {
+		slog.Debug("GPU metadata reloaded",
+			"gpus", len(metadata.GPUs),
+			"driver_version", metadata.DriverVersion)
+	} else {
+		slog.Info("GPU metadata loaded",
+			"gpus", len(metadata.GPUs),
+			"nvswitches", len(metadata.NVSwitches),
+			"chassis_serial", metadata.ChassisSerial != nil,
+			"driver_version", metadata.DriverVersion)
+	}
 
 	return nil
 }
@@ -171,9 +178,29 @@ func (r *Reader) GetChassisSerial() *string {
 	return r.metadata.ChassisSerial
 }
 
+// GetDriverVersion returns the GPU driver version from the metadata file.
+//
+// Unlike the other accessors, the driver version is typically consumed early
+// (e.g. when constructing the XID parser) and may still be empty if the
+// metadata-collector has not finished writing the file yet. Permanently caching
+// that empty value is dangerous: the XID sidecar would keep receiving an empty
+// driver_version and silently fall back to the wrong (V1) NVL5 decode table for
+// R575+ drivers, mis-classifying errors. To avoid that, re-attempt a load
+// whenever the cached driver version is still empty. Once a non-empty value is
+// observed it is cached like every other field.
 func (r *Reader) GetDriverVersion() string {
-	if err := r.ensureLoaded(); err != nil {
-		return ""
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if !r.loaded || r.metadata == nil || r.metadata.DriverVersion == "" {
+		if err := r.load(); err != nil {
+			slog.Warn("Failed to load GPU metadata for driver version",
+				"path", r.path, "error", err)
+
+			return ""
+		}
+
+		r.loaded = true
 	}
 
 	return r.metadata.DriverVersion

--- a/health-monitors/syslog-health-monitor/pkg/xid/metrics/metrics.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/metrics/metrics.go
@@ -54,6 +54,17 @@ var (
 		},
 		[]string{"check", "source_error_code", "target_error_code"},
 	)
+
+	// XidEmptyDriverVersion counts XID decode requests issued with an empty driver
+	// version. A non-zero value means NVL5 (R575+) decoding may be selecting the
+	// wrong (V1) table, typically because GPU metadata was not yet populated.
+	XidEmptyDriverVersion = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "syslog_health_monitor_xid_empty_driver_version_total",
+			Help: "Total number of XID decode requests issued with an empty driver version",
+		},
+		[]string{"node"},
+	)
 )
 
 // PreInitialize materializes XidCounterMetric at zero for the local node and

--- a/health-monitors/syslog-health-monitor/pkg/xid/parser/csv.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/parser/csv.go
@@ -74,18 +74,30 @@ type CSVParser struct {
 	nodeName           string
 	errorResolutionMap map[int]types.ErrorResolution
 	nvl5Rules          map[int][]common.NVL5DecodingRule
+	driverVersionFn    func() string
 }
 
-// NewCSVParser creates a new CSV parser with error resolution mapping
+// NewCSVParser creates a new CSV parser with error resolution mapping.
+//
+// driverVersionFn is invoked per message to decide whether to match against the
+// V1 (driver < R575) or V2 (driver >= R575) NVL5 IntrInfo pattern. It is resolved
+// lazily (rather than snapshotted) so a driver version that becomes available
+// after startup is honored without a restart.
 func NewCSVParser(
 	nodeName string,
 	errorResolutionMap map[int]types.ErrorResolution,
 	nvl5Rules map[int][]common.NVL5DecodingRule,
+	driverVersionFn func() string,
 ) *CSVParser {
+	if driverVersionFn == nil {
+		driverVersionFn = func() string { return "" }
+	}
+
 	return &CSVParser{
 		nodeName:           nodeName,
 		errorResolutionMap: errorResolutionMap,
 		nvl5Rules:          nvl5Rules,
+		driverVersionFn:    driverVersionFn,
 	}
 }
 
@@ -130,13 +142,15 @@ func (p *CSVParser) parseNVL5XID(message string) (*Response, error) {
 		return nil, nil
 	}
 
+	useV2 := common.IsDriverVersionR575OrNewer(p.driverVersionFn())
+
 	var ruleMnemonic string
 
 	var recommendedAction pb.RecommendedAction
 
 	for _, rule := range rules {
-		if p.matchesNVL5Rule(rule, intrInfo, errorStatusStr) {
-			slog.Debug("Found matching NVL5 rule", "xidCode", xidCode)
+		if p.matchesNVL5Rule(rule, intrInfo, errorStatusStr, useV2) {
+			slog.Debug("Found matching NVL5 rule", "xidCode", xidCode, "useV2", useV2)
 
 			recommendedAction = common.MapActionStringToProto(rule.Resolution)
 			ruleMnemonic = rule.Mnemonic
@@ -257,7 +271,9 @@ func (p *CSVParser) getRecommendedActionForXid(xidCode int, message string) pb.R
 	return recommendedAction
 }
 
-func (p *CSVParser) matchesNVL5Rule(rule common.NVL5DecodingRule, intrInfo int64, errorStatusStr string) bool {
+func (p *CSVParser) matchesNVL5Rule(
+	rule common.NVL5DecodingRule, intrInfo int64, errorStatusStr string, useV2 bool,
+) bool {
 	foundMatch := false
 	allEmpty := true
 
@@ -278,7 +294,12 @@ func (p *CSVParser) matchesNVL5Rule(rule common.NVL5DecodingRule, intrInfo int64
 		return false
 	}
 
-	return p.doesXIDIntrInfoMatchRule(rule.IntrInfoBinary, intrInfo)
+	intrInfoPattern := rule.IntrInfoBinaryV1
+	if useV2 {
+		intrInfoPattern = rule.IntrInfoBinaryV2
+	}
+
+	return p.doesXIDIntrInfoMatchRule(intrInfoPattern, intrInfo)
 }
 
 func (p *CSVParser) doesXIDIntrInfoMatchRule(intrinfoBinaryPattern string, intrInfoInMessage int64) bool {

--- a/health-monitors/syslog-health-monitor/pkg/xid/parser/csv_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/parser/csv_test.go
@@ -31,13 +31,14 @@ func TestCSVParser_Parse(t *testing.T) {
 	}
 	require.NotEmpty(t, errorResolutionMap, "XID error resolution map should not be empty")
 
-	nvl5Rules, err := common.GetNVL5DecodingRules("570.148.08")
+	nvl5Rules, err := common.GetNVL5DecodingRules()
 	if err != nil {
 		t.Fatalf("Failed to load embedded XID mapping: %v", err)
 	}
 	require.NotEmpty(t, nvl5Rules, "XID error resolution map should not be empty")
 
-	parser := NewCSVParser("test-node", errorResolutionMap, nvl5Rules)
+	// Pre-R575 driver so NVL5 matching uses the V1 IntrInfo patterns.
+	parser := NewCSVParser("test-node", errorResolutionMap, nvl5Rules, func() string { return "570.148.08" })
 
 	testCases := []struct {
 		name              string
@@ -221,6 +222,57 @@ func TestCSVParser_Parse(t *testing.T) {
 
 			assert.Empty(t, result.Result.Driver, "Driver should be empty as requested")
 			assert.Empty(t, result.Error, "Error field should be empty for successful parse")
+		})
+	}
+}
+
+// TestCSVParser_NVL5PerMessageDriverVersionSelection verifies that a single
+// CSVParser selects the V1 vs V2 NVL5 IntrInfo pattern per message based on the
+// driver version resolved at parse time (not snapshotted at construction). The
+// same parser instance must decode the same message differently as the live
+// driver version changes.
+func TestCSVParser_NVL5PerMessageDriverVersionSelection(t *testing.T) {
+	errorResolutionMap, err := common.LoadErrorResolutionMap()
+	require.NoError(t, err)
+
+	nvl5Rules, err := common.GetNVL5DecodingRules()
+	require.NoError(t, err)
+
+	// intrInfo=0x00000082 matches the V1 IntrInfo pattern for XID 145 RLW_REMAP
+	// (RESET_GPU -> COMPONENT_RESET) but matches no V2 pattern.
+	msgMatchesV1 := "NVRM: Xid (PCI:0000:00:08.0): 145, RLW_REMAP Nonfatal XC1 i0 Link 10 " +
+		"(0x00000082 0x00000040 0x00000000 0x00000000 0x00000000 0x00000000)"
+	// intrInfo=0x00000004 matches the V2 pattern but no V1 pattern.
+	msgMatchesV2 := "NVRM: Xid (PCI:0000:00:08.0): 145, RLW_REMAP Nonfatal XC1 i0 Link 10 " +
+		"(0x00000004 0x00000040 0x00000000 0x00000000 0x00000000 0x00000000)"
+
+	// Single parser instance whose driver version is mutated between calls.
+	driverVersion := ""
+	parser := NewCSVParser("test-node", errorResolutionMap, nvl5Rules, func() string { return driverVersion })
+
+	cases := []struct {
+		name           string
+		driver         string
+		message        string
+		wantResolution pb.RecommendedAction
+	}{
+		{"pre-R575 matches V1", "570.148.08", msgMatchesV1, pb.RecommendedAction_COMPONENT_RESET},
+		{"pre-R575 does not match V2", "570.148.08", msgMatchesV2, pb.RecommendedAction_NONE},
+		{"R575+ matches V2", "580.105.08", msgMatchesV2, pb.RecommendedAction_COMPONENT_RESET},
+		{"R575+ does not match V1", "580.105.08", msgMatchesV1, pb.RecommendedAction_NONE},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			driverVersion = tc.driver
+
+			result, parseErr := parser.Parse(tc.message)
+			require.NoError(t, parseErr)
+			require.NotNil(t, result)
+			require.True(t, result.Success)
+
+			assert.Equal(t, tc.wantResolution.String(), result.Result.Resolution,
+				"driver %q on same parser should select the matching NVL5 pattern", tc.driver)
 		})
 	}
 }

--- a/health-monitors/syslog-health-monitor/pkg/xid/parser/factory.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/parser/factory.go
@@ -24,7 +24,7 @@ import (
 // ParserConfig holds configuration for parser creation
 type ParserConfig struct {
 	NodeName            string
-	DriverVersion       string
+	DriverVersionFn     func() string
 	XidAnalyserEndpoint string
 	SidecarEnabled      bool
 }
@@ -38,7 +38,7 @@ func CreateParser(config ParserConfig) (Parser, error) {
 
 		slog.Info("Creating sidecar parser", "endpoint", config.XidAnalyserEndpoint)
 
-		return NewSidecarParser(config.XidAnalyserEndpoint, config.NodeName, config.DriverVersion), nil
+		return NewSidecarParser(config.XidAnalyserEndpoint, config.NodeName, config.DriverVersionFn), nil
 	}
 
 	slog.Info("Creating Excel parser with embedded mapping file")
@@ -48,7 +48,7 @@ func CreateParser(config ParserConfig) (Parser, error) {
 		return nil, fmt.Errorf("failed to load XID error resolution map from embedded Excel file: %w", err)
 	}
 
-	nvl5Rules, err := common.GetNVL5DecodingRules(config.DriverVersion)
+	nvl5Rules, err := common.GetNVL5DecodingRules()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load NVL5 decoding rules from embedded Excel file: %w", err)
 	}
@@ -57,5 +57,5 @@ func CreateParser(config ParserConfig) (Parser, error) {
 		"errorResolutionCount", len(errorResolutionMap),
 		"nvl5RuleTypes", len(nvl5Rules))
 
-	return NewCSVParser(config.NodeName, errorResolutionMap, nvl5Rules), nil
+	return NewCSVParser(config.NodeName, errorResolutionMap, nvl5Rules, config.DriverVersionFn), nil
 }

--- a/health-monitors/syslog-health-monitor/pkg/xid/parser/sidecar.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/parser/sidecar.go
@@ -32,22 +32,32 @@ import (
 
 // SidecarParser implements Parser interface using external sidecar service
 type SidecarParser struct {
-	url           string
-	client        *retryablehttp.Client
-	nodeName      string
-	driverVersion string
+	url             string
+	client          *retryablehttp.Client
+	nodeName        string
+	driverVersionFn func() string
 }
 
-// NewSidecarParser creates a new sidecar parser
-func NewSidecarParser(endpoint, nodeName, driverVersion string) *SidecarParser {
+// NewSidecarParser creates a new sidecar parser.
+//
+// driverVersionFn is invoked on every Parse call so the driver version is
+// resolved live rather than snapshotted at construction. This matters because
+// the sidecar selects its NVL5 (R575+) decode table based on the driver version;
+// snapshotting an empty value at startup (before metadata-collector has written
+// the file) would permanently send an empty driver_version to the sidecar.
+func NewSidecarParser(endpoint, nodeName string, driverVersionFn func() string) *SidecarParser {
 	c := retryablehttp.NewClient()
 	c.Logger = slog.With("http", "retryablehttp-client")
 
+	if driverVersionFn == nil {
+		driverVersionFn = func() string { return "" }
+	}
+
 	return &SidecarParser{
-		url:           fmt.Sprintf("%s/decode-xid", endpoint),
-		client:        c,
-		nodeName:      nodeName,
-		driverVersion: driverVersion,
+		url:             fmt.Sprintf("%s/decode-xid", endpoint),
+		client:          c,
+		nodeName:        nodeName,
+		driverVersionFn: driverVersionFn,
 	}
 }
 
@@ -93,7 +103,15 @@ func (p *SidecarParser) WaitUntilReady(ctx context.Context, maxRetries int, retr
 
 // Parse sends the message to sidecar service for XID parsing
 func (p *SidecarParser) Parse(message string) (*Response, error) {
-	reqBody := Request{XIDMessage: message, DriverVersion: p.driverVersion}
+	driverVersion := p.driverVersionFn()
+	if driverVersion == "" {
+		slog.Warn("Sending XID decode request with empty driver version; "+
+			"sidecar NVL5 decode may fall back to the wrong table",
+			"node", p.nodeName)
+		metrics.XidEmptyDriverVersion.WithLabelValues(p.nodeName).Inc()
+	}
+
+	reqBody := Request{XIDMessage: message, DriverVersion: driverVersion}
 
 	jsonBody, err := json.Marshal(reqBody)
 	if err != nil {

--- a/health-monitors/syslog-health-monitor/pkg/xid/parser/sidecar.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/parser/sidecar.go
@@ -101,8 +101,10 @@ func (p *SidecarParser) WaitUntilReady(ctx context.Context, maxRetries int, retr
 	return fmt.Errorf("XID analyzer sidecar at %s not ready after %d attempts", host, maxRetries)
 }
 
-// Parse sends the message to sidecar service for XID parsing
-func (p *SidecarParser) Parse(message string) (*Response, error) {
+// resolveDriverVersion returns the driver version to send to the sidecar,
+// emitting a warning and metric when it is empty (which forces the sidecar to
+// fall back to the wrong NVL5 decode table for R575+ drivers).
+func (p *SidecarParser) resolveDriverVersion() string {
 	driverVersion := p.driverVersionFn()
 	if driverVersion == "" {
 		slog.Warn("Sending XID decode request with empty driver version; "+
@@ -111,7 +113,12 @@ func (p *SidecarParser) Parse(message string) (*Response, error) {
 		metrics.XidEmptyDriverVersion.WithLabelValues(p.nodeName).Inc()
 	}
 
-	reqBody := Request{XIDMessage: message, DriverVersion: driverVersion}
+	return driverVersion
+}
+
+// Parse sends the message to sidecar service for XID parsing
+func (p *SidecarParser) Parse(message string) (*Response, error) {
+	reqBody := Request{XIDMessage: message, DriverVersion: p.resolveDriverVersion()}
 
 	jsonBody, err := json.Marshal(reqBody)
 	if err != nil {

--- a/health-monitors/syslog-health-monitor/pkg/xid/parser/sidecar_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/parser/sidecar_test.go
@@ -34,7 +34,7 @@ func TestSidecarParser_WaitUntilReady_ImmediatelyReady(t *testing.T) {
 	}))
 	defer server.Close()
 
-	p := NewSidecarParser(server.URL, "test-node", "570.148.08")
+	p := NewSidecarParser(server.URL, "test-node", func() string { return "570.148.08" })
 	err := p.WaitUntilReady(context.Background(), 5, 100*time.Millisecond)
 	assert.NoError(t, err)
 }
@@ -63,7 +63,7 @@ func TestSidecarParser_WaitUntilReady_BecomesReadyAfterDelay(t *testing.T) {
 		}
 	}()
 
-	p := NewSidecarParser(fmt.Sprintf("http://%s", addr), "test-node", "570.148.08")
+	p := NewSidecarParser(fmt.Sprintf("http://%s", addr), "test-node", func() string { return "570.148.08" })
 	err = p.WaitUntilReady(context.Background(), 15, 200*time.Millisecond)
 	assert.NoError(t, err)
 }
@@ -78,7 +78,7 @@ func TestSidecarParser_WaitUntilReady_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 
-	p := NewSidecarParser(fmt.Sprintf("http://%s", addr), "test-node", "570.148.08")
+	p := NewSidecarParser(fmt.Sprintf("http://%s", addr), "test-node", func() string { return "570.148.08" })
 	err = p.WaitUntilReady(ctx, 30, 200*time.Millisecond)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "context")
@@ -91,7 +91,7 @@ func TestSidecarParser_WaitUntilReady_ExhaustsRetries(t *testing.T) {
 	addr := listener.Addr().String()
 	listener.Close()
 
-	p := NewSidecarParser(fmt.Sprintf("http://%s", addr), "test-node", "570.148.08")
+	p := NewSidecarParser(fmt.Sprintf("http://%s", addr), "test-node", func() string { return "570.148.08" })
 	err = p.WaitUntilReady(context.Background(), 3, 100*time.Millisecond)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not ready after 3 attempts")
@@ -230,7 +230,7 @@ func TestSidecarParser_Parse(t *testing.T) {
 			}))
 			defer server.Close()
 
-			parser := NewSidecarParser(server.URL, "test-node", "570.148.08")
+			parser := NewSidecarParser(server.URL, "test-node", func() string { return "570.148.08" })
 
 			result, err := parser.Parse(tc.message)
 

--- a/health-monitors/syslog-health-monitor/pkg/xid/xid_handler.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/xid_handler.go
@@ -48,11 +48,20 @@ func NewXIDHandler(nodeName, defaultAgentName,
 	metadataReader := metadata.NewReader(metadataPath)
 	driverVersion := metadataReader.GetDriverVersion()
 
+	if driverVersion == "" {
+		slog.Warn("GPU driver version unavailable at XID handler startup; "+
+			"NVL5 decoding may be inaccurate until GPU metadata is populated",
+			"check", checkName, "metadataPath", metadataPath)
+	} else {
+		slog.Info("Resolved GPU driver version for XID handler",
+			"check", checkName, "driverVersion", driverVersion)
+	}
+
 	config := parser.ParserConfig{
 		NodeName:            nodeName,
 		XidAnalyserEndpoint: xidAnalyserEndpoint,
 		SidecarEnabled:      xidAnalyserEndpoint != "",
-		DriverVersion:       driverVersion,
+		DriverVersionFn:     metadataReader.GetDriverVersion,
 	}
 
 	xidParser, err := parser.CreateParser(config)


### PR DESCRIPTION
## Bug
`syslog-health-monitor` cached the GPU driver version during XID handler startup. If the monitor started before `metadata-collector` populated `/var/lib/nvsentinel/gpu_metadata.json`, the handler initialized with `DriverVersion = ""` and continued using that stale empty value.
This caused driver-version-dependent XID 144-150 decoding to use the wrong behavior even after metadata became available. The same later request could still successfully use metadata for PCI -> GPU UUID mapping, which made the issue subtle: metadata was loaded, but the driver version-dependent recommendation did not recover.
A previous fix in https://github.com/NVIDIA/NVSentinel/pull/1302 ensured GPU metadata could be loaded during request processing, but it did not verify that functionality depending on `driver_version` recovered after startup.
## Summary
This PR fixes the stale driver version by resolving it from metadata at request time instead of passing through the empty value captured during startup.
The core change is in `health-monitors/syslog-health-monitor/pkg/metadata/reader.go`.
Before:
```go
func (r *Reader) GetDriverVersion() string {
	if err := r.ensureLoaded(); err != nil {
		return ""
	}
	return r.metadata.DriverVersion
}
```
After:
```go
func (r *Reader) GetDriverVersion() string {
	r.mu.Lock()
	defer r.mu.Unlock()
	if !r.loaded || r.metadata == nil || r.metadata.DriverVersion == "" {
		if err := r.load(); err != nil {
			slog.Warn("Failed to load GPU metadata for driver version",
				"path", r.path, "error", err)
			return ""
		}
		r.loaded = true
	}
	return r.metadata.DriverVersion
}
```
With this change, if the initial metadata load succeeds but has no driver version, or metadata is not available at startup, `GetDriverVersion()` retries later and can recover once `metadata-collector` writes the file.


## Testing
The validation simulates the startup race:
1. Remove `gpu_metadata.json`.
2. Restart `syslog-health-monitor` so the XID handler starts without metadata.
3. Restart `metadata-collector` so metadata is populated after monitor startup.
4. Inject an XID 145 whose recommendation depends on the driver version.
5. Verify whether `syslog-health-monitor` uses the recovered driver version.

The injected XID was:
```text
NVRM: Xid (PCI:0001:00:00): 145, RLW_REMAP Nonfatal XC1 i0 Link 10 (0x00000004 0x00000040 0x00000000 0x00000000 0x00000000 0x00000000)
```
For this message:
```text
intrInfo          = 0x00000004
error status hex  = 0x00000040
```
The expected catalog recommendation for this case is `RESET_GPU`, which maps to the `COMPONENT_RESET` proto action (`recommendedAction: 2`).


### Before This Fix
Removed metadata and confirmed `syslog-health-monitor` could not see `gpu_metadata.json`:
```bash
$ k exec -it -n nvsentinel syslog-health-monitor-regular-5mmgh -- /bin/cat /var/lib/nvsentinel/gpu_metadata.json
Defaulted container "syslog-health-monitor" out of: syslog-health-monitor, xid-analyzer-sidecar (init)
cat: /var/lib/nvsentinel/gpu_metadata.json: No such file or directory
```
Restarted `syslog-health-monitor` while metadata was still absent:
```bash
$ k delete pod -n nvsentinel syslog-health-monitor-regular-5mmgh
pod "syslog-health-monitor-regular-5mmgh" deleted from nvsentinel namespace
$ k exec -it -n nvsentinel syslog-health-monitor-regular-x2wp5 -- /bin/cat /var/lib/nvsentinel/gpu_metadata.json
Defaulted container "syslog-health-monitor" out of: syslog-health-monitor, xid-analyzer-sidecar (init)
cat: /var/lib/nvsentinel/gpu_metadata.json: No such file or directory
command terminated with exit code 1
```
Restarted `metadata-collector` so metadata appeared after monitor startup:
```bash
$ k delete pod -n nvsentinel metadata-collector-xhpdj
pod "metadata-collector-xhpdj" deleted from nvsentinel namespace
$ k exec -it -n nvsentinel syslog-health-monitor-regular-x2wp5 -- /bin/cat /var/lib/nvsentinel/gpu_metadata.json | wc
Defaulted container "syslog-health-monitor" out of: syslog-health-monitor, xid-analyzer-sidecar (init)
    668    1038   16169
```
Injected XID 145:
```bash
$ k exec -it -n gpu-operator nvidia-device-plugin-daemonset-glhj9 -- /bin/sh
Defaulted container "nvidia-device-plugin" out of: nvidia-device-plugin, toolkit-validation (init)
sh-5.1# chroot /host
# logger -p daemon.err "NVRM: Xid (PCI:0001:00:00): 145, RLW_REMAP Nonfatal XC1 i0 Link 10 (0x00000004 0x00000040 0x00000000 0x00000000 0x00000000 0x00000000)"
```
The bug reproduced: metadata was loaded, but the stale empty driver version caused the analyzer to return `WORKFLOW_NVLINK5_ERR`, which was not a known action string and defaulted to `CONTACT_SUPPORT`.
```json
{
  "msg": "GPU metadata loaded",
  "version": "v1.8.0",
  "gpus": 8,
  "nvswitches": 6,
  "chassis_serial": false
}
{
  "level": "WARN",
  "msg": "Unknown action string, defaulting to CONTACT_SUPPORT",
  "version": "v1.8.0",
  "action": "WORKFLOW_NVLINK5_ERR"
}
{
  "msg": "Attempting to send health event",
  "version": "v1.8.0",
  "events": {
    "events": [
      {
        "message": "MESSAGE=NVRM: Xid (PCI:0001:00:00): 145, RLW_REMAP Nonfatal XC1 i0 Link 10 (0x00000004 0x00000040 0x00000000 0x00000000 0x00000000 0x00000000)",
        "recommendedAction": 5,
        "errorCode": ["145.0h"],
        "entitiesImpacted": [
          {
            "entityType": "PCI",
            "entityValue": "0001:00:00"
          },
          {
            "entityType": "GPU_UUID",
            "entityValue": "GPU-52f37cd4-d92a-7b6d-2b9f-9ab862e27708"
          }
        ]
      }
    ]
  }
}
```
`recommendedAction: 5` is `CONTACT_SUPPORT`.
### After This Fix
Repeated the same race-condition setup by removing metadata:
```bash
$ k exec -it -n nvsentinel metadata-collector-kzjn2 -- /bin/ls /var/lib/nvsentinel
gpu_metadata.json
$ k exec -it -n nvsentinel metadata-collector-kzjn2 -- /bin/rm /var/lib/nvsentinel/gpu_metadata.json
```
Confirmed `syslog-health-monitor` started without metadata:
```bash
$ k exec -it -n nvsentinel syslog-health-monitor-regular-lzh46 -- /bin/cat /var/lib/nvsentinel/gpu_metadata.json
Defaulted container "syslog-health-monitor" out of: syslog-health-monitor, xid-analyzer-sidecar (init)
cat: /var/lib/nvsentinel/gpu_metadata.json: No such file or directory
command terminated with exit code 1
$ k delete pod -n nvsentinel syslog-health-monitor-regular-lzh46
pod "syslog-health-monitor-regular-lzh46" deleted from nvsentinel namespace
$ k exec -it -n nvsentinel syslog-health-monitor-regular-pjp75 -- /bin/cat /var/lib/nvsentinel/gpu_metadata.json
Defaulted container "syslog-health-monitor" out of: syslog-health-monitor, xid-analyzer-sidecar (init)
cat: /var/lib/nvsentinel/gpu_metadata.json: No such file or directory
command terminated with exit code 1
```
Reloaded metadata and confirmed the driver version was available after startup:
```bash
$ k exec -it -n nvsentinel syslog-health-monitor-regular-pjp75 -- /bin/cat /var/lib/nvsentinel/gpu_metadata.json | grep driver_version
Defaulted container "syslog-health-monitor" out of: syslog-health-monitor, xid-analyzer-sidecar (init)
  "driver_version": "580.65.06",
```
Injected the same XID 145:
```bash
$ k exec -it -n gpu-operator nvidia-device-plugin-daemonset-glhj9 -- /bin/sh
Defaulted container "nvidia-device-plugin" out of: nvidia-device-plugin, toolkit-validation (init)
sh-5.1# chroot /host
# logger -p daemon.err "NVRM: Xid (PCI:0001:00:00): 145, RLW_REMAP Nonfatal XC1 i0 Link 10 (0x00000004 0x00000040 0x00000000 0x00000000 0x00000000 0x00000000)"
```
After the fix, `syslog-health-monitor` recovered the driver version after metadata was populated and emitted the expected recommendation:
```json
{
  "msg": "Attempting to send health event",
  "version": "xrfxlp-fix-driver-version-loading",
  "events": {
    "events": [
      {
        "message": "MESSAGE=NVRM: Xid (PCI:0001:00:00): 145, RLW_REMAP Nonfatal XC1 i0 Link 10 (0x00000004 0x00000040 0x00000000 0x00000000 0x00000000 0x00000000)",
        "recommendedAction": 2,
        "errorCode": ["145.0h"],
        "entitiesImpacted": [
          {
            "entityType": "PCI",
            "entityValue": "0001:00:00"
          },
          {
            "entityType": "GPU_UUID",
            "entityValue": "GPU-52f37cd4-d92a-7b6d-2b9f-9ab862e27708"
          }
        ],
        "nodeName": "aks-gpu-12493808-vmss00000r",
        "processingStrategy": 1
      }
    ]
  }
}
```
`recommendedAction: 2` is `COMPONENT_RESET`, which is the expected mapping for the catalog recommendation `RESET_GPU`.
This confirms that the monitor no longer remains stuck with the empty startup driver version and can recover once `metadata-collector` populates `gpu_metadata.json`.


## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [x] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a monitoring metric to track XID decode requests when driver-version is unavailable.

* **Improvements**
  * XID decoding now carries both legacy and newer NVL5 patterns and selects which to use per message, improving decode accuracy across driver versions.
  * Metadata loading emits clearer info/debug logs and warns when driver version is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->