### PR TITLE
feat: add image caching daemonset for preflight images

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/_helpers.tpl
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/_helpers.tpl
@@ -56,6 +56,52 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Image cache DaemonSet name.
+*/}}
+{{- define "preflight.imageCacheName" -}}
+{{- printf "%s-image-cache" (include "preflight.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Image cache selector labels. Keep these distinct from the webhook Deployment selector.
+*/}}
+{{- define "preflight.imageCacheSelectorLabels" -}}
+app.kubernetes.io/name: {{ printf "%s-image-cache" (include "preflight.name" .) | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: image-cache
+{{- end }}
+
+{{/*
+Image cache common labels.
+*/}}
+{{- define "preflight.imageCacheLabels" -}}
+helm.sh/chart: {{ include "preflight.chart" . }}
+{{ include "preflight.imageCacheSelectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/part-of: {{ include "preflight.name" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Resolve a configured preflight init container image, honoring global.image.tag.
+*/}}
+{{- define "preflight.initContainerImage" -}}
+{{- $root := .root -}}
+{{- $container := .container -}}
+{{- $image := $container.image -}}
+{{- if kindIs "string" $image -}}
+{{- $image -}}
+{{- else -}}
+{{- $global := $root.Values.global | default dict -}}
+{{- $globalImage := $global.image | default dict -}}
+{{- $tag := $image.tag | default $globalImage.tag | default $root.Chart.AppVersion -}}
+{{- printf "%s:%s" $image.repository $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "preflight.serviceAccountName" -}}

--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/configmap.yaml
@@ -79,13 +79,10 @@ data:
     {{- end }}
     initContainers:
       {{- $extraEnv := .Values.ncclAllreduceExtraEnv | default list }}
-      {{- $globalTag := ((.Values.global).image).tag | default "" }}
-      {{- $appVersion := .Chart.AppVersion }}
       {{- $result := list }}
       {{- range .Values.initContainers }}
       {{- $container := deepCopy . }}
-      {{- $tag := $container.image.tag | default $globalTag | default $appVersion }}
-      {{- $_ := set $container "image" (printf "%s:%s" $container.image.repository $tag) }}
+      {{- $_ := set $container "image" (include "preflight.initContainerImage" (dict "root" $ "container" $container)) }}
       {{- if and (eq .name "preflight-nccl-allreduce") $extraEnv }}
       {{- $_ := set $container "env" (concat (.env | default list) $extraEnv) }}
       {{- end }}

--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/deployment.yaml
@@ -26,6 +26,9 @@ spec:
       {{- include "preflight.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        # Force pod restart when configmap changes
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "preflight.selectorLabels" . | nindent 8 }}
     spec:

--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/image-cache-daemonset.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/image-cache-daemonset.yaml
@@ -1,0 +1,79 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.imageCache.enabled }}
+{{- $global := .Values.global | default dict }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "preflight.imageCacheName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "preflight.imageCacheLabels" . | nindent 4 }}
+spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
+  selector:
+    matchLabels:
+      {{- include "preflight.imageCacheSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        # Force pod restart when configmap changes
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.imageCache.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "preflight.imageCacheSelectorLabels" . | nindent 8 }}
+    spec:
+      {{- with ($global.imagePullSecrets | default .Values.imagePullSecrets) }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- range . }}
+        - name: {{ .name }}
+          image: {{ include "preflight.initContainerImage" (dict "root" $ "container" .) | quote }}
+          {{- with .imagePullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
+          command:
+            - /bin/sh
+            - -c
+            - "true"
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: pause
+          image: "{{ .Values.imageCache.pauseImage.repository }}:{{ .Values.imageCache.pauseImage.tag }}"
+          imagePullPolicy: {{ .Values.imageCache.pauseImage.pullPolicy }}
+          resources:
+            {{- toYaml .Values.imageCache.resources | nindent 12 }}
+      {{- with ($global.nodeSelector | default .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with ($global.affinity | default .Values.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with ($global.tolerations | default .Values.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/image-cache-daemonset.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/image-cache-daemonset.yaml
@@ -25,7 +25,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 10%
+      maxUnavailable: 100%
   selector:
     matchLabels:
       {{- include "preflight.imageCacheSelectorLabels" . | nindent 6 }}
@@ -44,9 +44,8 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.initContainers }}
-      initContainers:
-        {{- range . }}
+      containers:
+        {{- range .Values.initContainers }}
         - name: {{ .name }}
           image: {{ include "preflight.initContainerImage" (dict "root" $ "container" .) | quote }}
           {{- with .imagePullPolicy }}
@@ -55,15 +54,10 @@ spec:
           command:
             - /bin/sh
             - -c
-            - "true"
-        {{- end }}
-      {{- end }}
-      containers:
-        - name: pause
-          image: "{{ .Values.imageCache.pauseImage.repository }}:{{ .Values.imageCache.pauseImage.tag }}"
-          imagePullPolicy: {{ .Values.imageCache.pauseImage.pullPolicy }}
+            - "while true; do sleep 3600; done"
           resources:
-            {{- toYaml .Values.imageCache.resources | nindent 12 }}
+            {{- toYaml $.Values.imageCache.resources | nindent 12 }}
+        {{- end }}
       {{- with ($global.nodeSelector | default .Values.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/distros/kubernetes/nvsentinel/charts/preflight/templates/image-cache-daemonset.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/templates/image-cache-daemonset.yaml
@@ -54,7 +54,7 @@ spec:
           command:
             - /bin/sh
             - -c
-            - "while true; do sleep 3600; done"
+            - "trap 'exit 0' TERM INT; sleep infinity & wait $!"
           resources:
             {{- toYaml $.Values.imageCache.resources | nindent 12 }}
         {{- end }}

--- a/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
@@ -21,6 +21,24 @@ image:
 
 imagePullSecrets: []
 
+imageCache:
+  # Enables a DaemonSet that pre-pulls all configured preflight check images
+  # onto matching nodes. The configured check images are rendered as init
+  # containers; the pause container keeps the pod alive after pulls complete.
+  enabled: false
+  pauseImage:
+    repository: registry.k8s.io/pause
+    tag: "3.10"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: 10m
+      memory: 16Mi
+    limits:
+      cpu: 50m
+      memory: 64Mi
+  podAnnotations: {}
+
 serviceAccount:
   create: true
   annotations: {}

--- a/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/preflight/values.yaml
@@ -22,14 +22,9 @@ image:
 imagePullSecrets: []
 
 imageCache:
-  # Enables a DaemonSet that pre-pulls all configured preflight check images
-  # onto matching nodes. The configured check images are rendered as init
-  # containers; the pause container keeps the pod alive after pulls complete.
+  # Enables a DaemonSet that keeps all configured preflight check images
+  # running on matching nodes so kubelet considers them in use.
   enabled: false
-  pauseImage:
-    repository: registry.k8s.io/pause
-    tag: "3.10"
-    pullPolicy: IfNotPresent
   resources:
     requests:
       cpu: 10m

--- a/distros/kubernetes/nvsentinel/values-full.yaml
+++ b/distros/kubernetes/nvsentinel/values-full.yaml
@@ -1542,14 +1542,9 @@ preflight:
   imagePullSecrets: []
 
   imageCache:
-    # Enables a DaemonSet that pre-pulls all configured preflight check images
-    # onto matching nodes. The configured check images are rendered as init
-    # containers; the pause container keeps the pod alive after pulls complete.
+    # Enables a DaemonSet that keeps all configured preflight check images
+    # running on matching nodes so kubelet considers them in use.
     enabled: false
-    pauseImage:
-      repository: registry.k8s.io/pause
-      tag: "3.10"
-      pullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 10m

--- a/distros/kubernetes/nvsentinel/values-full.yaml
+++ b/distros/kubernetes/nvsentinel/values-full.yaml
@@ -1541,6 +1541,24 @@ preflight:
 
   imagePullSecrets: []
 
+  imageCache:
+    # Enables a DaemonSet that pre-pulls all configured preflight check images
+    # onto matching nodes. The configured check images are rendered as init
+    # containers; the pause container keeps the pod alive after pulls complete.
+    enabled: false
+    pauseImage:
+      repository: registry.k8s.io/pause
+      tag: "3.10"
+      pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+      limits:
+        cpu: 50m
+        memory: 64Mi
+    podAnnotations: {}
+
   # Service account for the preflight webhook (needs ClusterRole for
   # pods, configmaps, and scheduler CRDs when gang coordination is enabled)
   serviceAccount:
@@ -1630,7 +1648,9 @@ preflight:
     #   DCGM_DIAG_LEVEL       - diagnostic depth 1-4 (default 2)
     #   DCGM_HOSTENGINE_ADDR  - hostengine gRPC endpoint (default nvidia-dcgm.gpu-operator.svc:5555)
     - name: preflight-dcgm-diag
-      image: ghcr.io/nvidia/nvsentinel/preflight-dcgm-diag:latest
+      image:
+        repository: ghcr.io/nvidia/nvsentinel/preflight-dcgm-diag
+        tag: ""
       volumeMounts:
         - name: nvsentinel-socket
           mountPath: /var/run
@@ -1645,7 +1665,9 @@ preflight:
     #   TEST_SIZE_MB       - message size in MB (default 256)
     #   SKIP_BANDWIDTH_CHECK - "true" to pass if benchmark completes (default false)
     - name: preflight-nccl-loopback
-      image: ghcr.io/nvidia/nvsentinel/preflight-nccl-loopback:latest
+      image:
+        repository: ghcr.io/nvidia/nvsentinel/preflight-nccl-loopback
+        tag: ""
       env:
         - name: BW_THRESHOLD_GBPS
           value: "150"
@@ -1667,7 +1689,9 @@ preflight:
     #   NCCL_DEBUG           - NCCL log verbosity (e.g. INFO, WARN)
     #   NCCL_DEBUG_SUBSYS    - NCCL subsystems to log (e.g. INIT,NET)
     - name: preflight-nccl-allreduce
-      image: ghcr.io/nvidia/nvsentinel/preflight-nccl-allreduce:latest
+      image:
+        repository: ghcr.io/nvidia/nvsentinel/preflight-nccl-allreduce
+        tag: ""
       securityContext:
         capabilities:
           add: ["IPC_LOCK"]  # Required for RDMA memory registration


### PR DESCRIPTION
## Summary

Add an optional daemonset for caching preflight containers. 
```bash
$ helm template preflight distros/kubernetes/nvsentinel/charts/preflight   --show-only templates/image-cache-daemonset.yaml   --set imageCache.enabled=true   --set global.image.tag=v1.8.0   --set-json 'global={"imagePullSecrets":[],"nodeSelector":{},"affinity":{},"tolerations":[]}'
---
# Source: preflight/templates/image-cache-daemonset.yaml
# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: preflight-image-cache
  namespace: default
  labels:
    helm.sh/chart: preflight-0.1.0
    app.kubernetes.io/name: preflight-image-cache
    app.kubernetes.io/instance: preflight
    app.kubernetes.io/component: image-cache
    app.kubernetes.io/version: "1.0.0"
    app.kubernetes.io/part-of: preflight
    app.kubernetes.io/managed-by: Helm
spec:
  updateStrategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 100%
  selector:
    matchLabels:
      app.kubernetes.io/name: preflight-image-cache
      app.kubernetes.io/instance: preflight
      app.kubernetes.io/component: image-cache
  template:
    metadata:
      annotations:
        # Force pod restart when configmap changes
        checksum/config: 87e238bb5d9685600ed144f6e5bf4fe48db47715c50774e61ef0b6e86c8e75aa
      labels:
        app.kubernetes.io/name: preflight-image-cache
        app.kubernetes.io/instance: preflight
        app.kubernetes.io/component: image-cache
    spec:
      containers:
        - name: preflight-dcgm-diag
          image: "ghcr.io/nvidia/nvsentinel/preflight-dcgm-diag:v1.8.0"
          command:
            - /bin/sh
            - -c
            - "while true; do sleep 3600; done"
          resources:
            limits:
              cpu: 50m
              memory: 64Mi
            requests:
              cpu: 10m
              memory: 16Mi
        - name: preflight-nccl-loopback
          image: "ghcr.io/nvidia/nvsentinel/preflight-nccl-loopback:v1.8.0"
          command:
            - /bin/sh
            - -c
            - "while true; do sleep 3600; done"
          resources:
            limits:
              cpu: 50m
              memory: 64Mi
            requests:
              cpu: 10m
              memory: 16Mi
        - name: preflight-nccl-allreduce
          image: "ghcr.io/nvidia/nvsentinel/preflight-nccl-allreduce:v1.8.0"
          command:
            - /bin/sh
            - -c
            - "while true; do sleep 3600; done"
          resources:
            limits:
              cpu: 50m
              memory: 64Mi
            requests:
              cpu: 10m
              memory: 16Mi
```



## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [x] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional DaemonSet-based image cache to pre-pull preflight check images across nodes, with configurable enablement, resources, pod annotations, and scheduling overrides.
  * Improved init-container image resolution to support richer image configuration formats and fallback tagging.

* **Chores**
  * Pod templates now include config checksum annotations to trigger automatic rollouts when config content changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->