### PR TITLE
fix: flakiness in preflight tests due to webhook restart

### DIFF
--- a/tests/helpers/preflight.go
+++ b/tests/helpers/preflight.go
@@ -510,6 +510,29 @@ func CreateGPUPodInGang(
 ) string {
 	t.Helper()
 
+	var podName string
+
+	require.Eventually(t, func() bool {
+		pod := newPreflightGangPod(namespace, nodeName, podGroupName)
+
+		err := client.Resources().Create(ctx, pod)
+		if err != nil {
+			t.Logf("Retrying GPU pod create for gang %s after error: %v", podGroupName, err)
+
+			return false
+		}
+
+		podName = pod.Name
+
+		return podName != ""
+	}, EventuallyWaitTimeout, WaitInterval, "create GPU pod in gang %s", podGroupName)
+
+	require.NotEmpty(t, podName)
+
+	return podName
+}
+
+func newPreflightGangPod(namespace, nodeName, podGroupName string) *v1.Pod {
 	pod := NewGPUPodSpec(namespace, 1)
 	if pod.Annotations == nil {
 		pod.Annotations = make(map[string]string)
@@ -535,11 +558,7 @@ func CreateGPUPodInGang(
 		pod.Spec.NodeName = nodeName
 	}
 
-	err := client.Resources().Create(ctx, pod)
-	require.NoError(t, err, "create GPU pod in gang %s", podGroupName)
-	require.NotEmpty(t, pod.Name)
-
-	return pod.Name
+	return pod
 }
 
 // ExpectedKAIGangID returns the gang ID the preflight webhook generates


### PR DESCRIPTION
## Summary

<!-- Brief description of your changes -->

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [x] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved GPU pod creation reliability in the test suite with automatic retry mechanisms.
  * Fixed pod object construction and initialization in test utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->