### PR TITLE
feat: add affinity in platform connector

### DIFF
--- a/distros/kubernetes/nvsentinel/templates/daemonset.yaml
+++ b/distros/kubernetes/nvsentinel/templates/daemonset.yaml
@@ -200,6 +200,10 @@ spec:
         {{- if .Values.global.auditLogging.enabled }}
         {{- include "nvsentinel.auditLogging.volume" . | nindent 8 }}
         {{- end }}
+      {{- with .Values.platformConnector.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with (.Values.global.tolerations | default .Values.platformConnector.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/distros/kubernetes/nvsentinel/templates/daemonset.yaml
+++ b/distros/kubernetes/nvsentinel/templates/daemonset.yaml
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/distros/kubernetes/nvsentinel/values-full.yaml
+++ b/distros/kubernetes/nvsentinel/values-full.yaml
@@ -269,6 +269,9 @@ platformConnector:
   # Used when global.tolerations is not specified
   tolerations: []
 
+  # Affinity rules for platform-connector pods
+  affinity: {}
+
   # Kubernetes connector configuration
   # Handles updating Kubernetes node status and conditions
   k8sConnector:

--- a/distros/kubernetes/nvsentinel/values.yaml
+++ b/distros/kubernetes/nvsentinel/values.yaml
@@ -207,6 +207,8 @@ platformConnector:
 
   tolerations: []
 
+  affinity: {}
+
   logLevel: info
 
   mongodbStore:

--- a/docs/configuration/platform-connectors.md
+++ b/docs/configuration/platform-connectors.md
@@ -30,6 +30,16 @@ platformConnector:
   logLevel: info  # Options: debug, info, warn, error
 ```
 
+### Scheduling
+
+Controls where platform-connectors pods can be scheduled.
+
+```yaml
+platformConnector:
+  tolerations: []
+  affinity: {}
+```
+
 ## Transformer Pipeline
 
 Configures the event transformation pipeline that processes health events before storage and Kubernetes propagation.


### PR DESCRIPTION
## Summary

With `platformConnector.affinity` set:
```
$ helm template nvsentinel distros/kubernetes/nvsentinel --show-only templates/daemonset.yaml --set-json 'platformConnector.affinity={"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"nvsentinel.test/connector","operator":"In","values":["enabled"]}]}]}}}' | yq .spec.template.spec.affinity
nodeAffinity:
  requiredDuringSchedulingIgnoredDuringExecution:
    nodeSelectorTerms:
      - matchExpressions:
          - key: nvsentinel.test/connector
            operator: In
            values:
              - enabled
```

With empty affinity:
```
$ helm template nvsentinel distros/kubernetes/nvsentinel --show-only templates/daemonset.yaml | yq .spec.template.spec.affinity
null
```


## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kubernetes deployments can now configure pod affinity settings for platform connectors to control workload scheduling.

* **Documentation**
  * Added scheduling configuration reference for affinity and tolerations settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->