### PR TITLE
fix: remove check that concurrent reboots have overlapping periods

### DIFF
--- a/tests/janitor_test.go
+++ b/tests/janitor_test.go
@@ -262,44 +262,29 @@ func TestJanitorNodeLocking(t *testing.T) {
 		require.NoError(t, err, "failed to get real node")
 		t.Logf("Selected real node for Janitor node-level locking test: %s", nodeName)
 
-		// use a KWOK node for the second RebootNode
-		nodes, err := helpers.GetAllNodesNames(ctx, client)
-		require.NoError(t, err, "failed to get cluster nodes")
-		require.True(t, len(nodes) > 0, "no nodes found in cluster")
-		kwokNodeName := nodes[len(nodes)-1]
-
-		// Create a RebootNode and GPUReset targeting the same node and a second RebootNode targeting a different node
+		// Create a RebootNode and GPUReset targeting the same node
 		rebootNodeCRName := fmt.Sprintf("reboot-%s", nodeName)
 		_, err = helpers.CreateRebootNodeCR(ctx, client, nodeName, rebootNodeCRName)
-		require.NoError(t, err, "RebootNode should be created successfully")
-
-		rebootNodeCRName2 := fmt.Sprintf("reboot-%s", kwokNodeName)
-		_, err = helpers.CreateRebootNodeCR(ctx, client, kwokNodeName, rebootNodeCRName2)
 		require.NoError(t, err, "RebootNode should be created successfully")
 
 		gpuResetCRName := fmt.Sprintf("gpu-reset-%s", nodeName)
 		_, err = helpers.CreateGPUResetCR(ctx, client, nodeName, gpuResetCRName, "GPU-455d8f70-2051-db6c-0430-ffc457bff834")
 		require.NoError(t, err, "GPUReset should be created successfully")
-		t.Logf("Created RebootNodes: %s, %s and GPUReset %s", rebootNodeCRName, rebootNodeCRName2, gpuResetCRName)
+		t.Logf("Created RebootNodes: %s and GPUReset %s", rebootNodeCRName, gpuResetCRName)
 
-		// Wait for all 3 CRs to reach a terminal status
+		// Wait for the 2 CRs to reach a terminal status
 		rebootNodeCR := helpers.WaitForCR(ctx, t, client, nodeName, helpers.RebootNodeGVK)
-		rebootNodeCR2 := helpers.WaitForCR(ctx, t, client, kwokNodeName, helpers.RebootNodeGVK)
 		gpuResetCR := helpers.WaitForCR(ctx, t, client, nodeName, helpers.GPUResetGVK)
 
 		// Confirm that start and completion times have no overlap for the RebootNode and GPUReset CRs targeting the same
-		// node. The 2 RebootNodes on different nodes should overlap.
+		// node.
 		startTimeReboot, completionTimeReboot, err := helpers.GetStartAndCompletionTimes(rebootNodeCR)
-		require.NoError(t, err)
-		startTimeReboot2, completionTimeReboot2, err := helpers.GetStartAndCompletionTimes(rebootNodeCR2)
 		require.NoError(t, err)
 		startTimeReset, completionTimeReset, err := helpers.GetStartAndCompletionTimes(gpuResetCR)
 		require.NoError(t, err)
 
 		t.Logf("RebootNode startTime: %s completionTime: %s", startTimeReboot.Format(time.RFC3339),
 			completionTimeReboot.Format(time.RFC3339))
-		t.Logf("RebootNode startTime: %s completionTime: %s", startTimeReboot2.Format(time.RFC3339),
-			completionTimeReboot2.Format(time.RFC3339))
 		t.Logf("GPUReset startTime: %s completionTime: %s", startTimeReset.Format(time.RFC3339),
 			completionTimeReset.Format(time.RFC3339))
 
@@ -307,21 +292,10 @@ func TestJanitorNodeLocking(t *testing.T) {
 		// Before — intervals that merely touch at a boundary still satisfy
 		// "did not overlap".
 		periodOverlapsOnNode1 := startTimeReboot.Before(*completionTimeReset) && startTimeReset.Before(*completionTimeReboot)
-		// Different-node pair should be able to run concurrently. Use !After
-		// rather than Before so two intervals that touch exactly (the second
-		// starting at the same instant the first ends) still count as
-		// "concurrent enough": the janitor did not serialize them across
-		// different nodes, which is the property under test. Strict Before
-		// was a boundary-flaky assertion on fast KWOK/kind workflows.
-		periodOverlapsOnNode1And2 := !startTimeReboot.After(*completionTimeReboot2) &&
-			!startTimeReboot2.After(*completionTimeReboot)
 		assert.False(t, periodOverlapsOnNode1, "RebootNode and GPUReset periods should not overlap")
-		assert.True(t, periodOverlapsOnNode1And2, "RebootNode periods on different nodes should overlap (or touch)")
 
 		// Clean up both CRs
 		err = helpers.DeleteCR(ctx, t, client, rebootNodeCR, false)
-		require.NoError(t, err, "RebootNode should be deleted successfully")
-		err = helpers.DeleteCR(ctx, t, client, rebootNodeCR2, false)
 		require.NoError(t, err, "RebootNode should be deleted successfully")
 		err = helpers.DeleteCR(ctx, t, client, gpuResetCR, false)
 		require.NoError(t, err, "GPUReset should be deleted successfully")


### PR DESCRIPTION
## Summary
Remove check that concurrent reboots have overlapping periods. The TestJanitorNodeLocking e2e test has experienced the following test flake: https://github.com/NVIDIA/NVSentinel/actions/runs/27307018136/job/80667471882
```
=== RUN   TestJanitorNodeLocking/TestJanitorNodeLocking/RebootNode_and_GPUReset_for_same_node_run_sequentially
    janitor_test.go:263: Selected real node for Janitor node-level locking test: nvsentinel-worker
    janitor_test.go:283: Created RebootNodes: reboot-nvsentinel-worker, reboot-kwok-node-9 and GPUReset gpu-reset-nvsentinel-worker
    kube.go:659: CR for node nvsentinel-worker: waiting for completion reboot-nvsentinel-worker
    kube.go:664: CR for node nvsentinel-worker completed at 2026-06-10T21:57:00Z
...
    kube.go:664: CR for node kwok-node-9 completed at 2026-06-10T21:58:05Z
    kube.go:664: CR for node nvsentinel-worker completed at 2026-06-10T21:57:14Z
    janitor_test.go:299: RebootNode startTime: 2026-06-10T21:56:56Z completionTime: 2026-06-10T21:57:00Z
    janitor_test.go:301: RebootNode startTime: 2026-06-10T21:57:01Z completionTime: 2026-06-10T21:58:05Z
    janitor_test.go:303: GPUReset startTime: 2026-06-10T21:57:07Z completionTime: 2026-06-10T21:57:14Z
    janitor_test.go:319: 
        	Error Trace:	/home/runner/_work/NVSentinel/NVSentinel/tests/janitor_test.go:319
        	            				/home/runner/go/pkg/mod/sigs.k8s.io/e2e-framework@v0.7.0/pkg/env/env.go:479
        	            				/home/runner/go/pkg/mod/sigs.k8s.io/e2e-framework@v0.7.0/pkg/env/env.go:523
        	Error:      	Should be true
        	Test:       	TestJanitorNodeLocking/TestJanitorNodeLocking/RebootNode_and_GPUReset_for_same_node_run_sequentially
        	Messages:   	RebootNode periods on different nodes should overlap (or touch)
--- FAIL: TestJanitorNodeLocking/TestJanitorNodeLocking/RebootNode_and_GPUReset_for_same_node_run_sequentially (70.10s)
--- FAIL: TestJanitorNodeLocking/TestJanitorNodeLocking (70.10s)
--- FAIL: TestJanitorNodeLocking (70.10s)
FAIL
coverage: [no statements]
FAIL	tests	1574.333s
```
The Janitor logs from the test execution above shows the following sequence:
```
{"time":"2026-06-10T21:56:56.950888417Z","level":"INFO","msg":"Validation for Janitor CR upon creation","module":"janitor","version":"dev","logger":"janitor-webhook","type":"RebootNode","name":"reboot-nvsentinel-worker"}
{"time":"2026-06-10T21:56:56.961427354Z","level":"INFO","msg":"Validation for Janitor CR upon update","module":"janitor","version":"dev","logger":"janitor-webhook","type":"RebootNode","name":"reboot-nvsentinel-worker"}
{"time":"2026-06-10T21:56:56.963943102Z","level":"INFO","msg":"Validation for Janitor CR upon creation","module":"janitor","version":"dev","logger":"janitor-webhook","type":"RebootNode","name":"reboot-kwok-node-9"}
```
This shows the following controller processing order:
1. Test execution created RebootNode reboot-nvsentinel-worker. The controller processed the CR, sent the reboot signal, and set the status StartTime. The controller specifies a 30s RequeueAfter period.
2. Despite the 30s RequeueAfter period, the status update to the reboot-nvsentinel-worker CR triggers a re-reconcile of the reboot-nvsentinel-worker CR immediately. We only add a reboot delay to Kind 5% of the time, in this case the reboot reported as completed and the controller set the CompletionTime on the status.
3. Test execution created the second RebootNode reboot-kwok-node-9.

Since we're using a MaxConcurrentReconciles of 1 for the controller, there's no delay for the reboot completing which would force a re-queue of the first RebootNode before we set the CompletionTime, and we're not preventing re-queues of objects from status writes that the controller itself does, there's no guarantee that the 2 RebootNodes will have overlapping periods. 

## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [X] Janitor
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X]  No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Simplified node locking test to focus on single-node serialization scenarios between operations, improving test clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->