### PR TITLE
fix: ignore deleted nodes in fault remediation

### DIFF
--- a/fault-remediation/pkg/reconciler/reconciler.go
+++ b/fault-remediation/pkg/reconciler/reconciler.go
@@ -393,13 +393,8 @@ func (r *FaultRemediationReconciler) handleCancellationEvent(
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			slog.WarnContext(ctx, "Node no longer exists, marking cancellation event as terminal", "node", nodeName)
-			if updateErr := r.updateNodeRemediatedStatus(ctx, healthEventStore, eventWithToken, true); updateErr != nil {
-				return ctrl.Result{}, updateErr
-			}
-			if err := safeMarkProcessed(ctx, watcherInstance, eventWithToken.ResumeToken, nodeName); err != nil {
-				return ctrl.Result{}, err
-			}
-			return ctrl.Result{}, nil
+
+			return r.markEventTerminalAndProcessed(ctx, healthEventStore, eventWithToken, watcherInstance, nodeName, true)
 		}
 
 		slog.ErrorContext(ctx, "Failed to get remediation state for node",
@@ -485,10 +480,8 @@ func (r *FaultRemediationReconciler) handleRemediationEvent(
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			slog.WarnContext(ctx, "Node no longer exists, marking remediation event as stale", "node", nodeName)
-			if updateErr := r.updateNodeRemediatedStatus(ctx, healthEventStore, eventWithToken, false); updateErr != nil {
-				return ctrl.Result{}, updateErr
-			}
-			return r.markProcessedOrError(ctx, watcherInstance, eventWithToken, nodeName)
+
+			return r.markEventTerminalAndProcessed(ctx, healthEventStore, eventWithToken, watcherInstance, nodeName, false)
 		}
 
 		metrics.ProcessingErrors.WithLabelValues("cr_status_check_error", nodeName).Inc()
@@ -841,6 +834,23 @@ func (r *FaultRemediationReconciler) markProcessedOrError(
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// markEventTerminalAndProcessed writes faultRemediated and advances the change-stream token.
+// Used when the target Node no longer exists so the event is not retried.
+func (r *FaultRemediationReconciler) markEventTerminalAndProcessed(
+	ctx context.Context,
+	healthEventStore datastore.HealthEventStore,
+	eventWithToken datastore.EventWithToken,
+	watcherInstance datastore.ChangeStreamWatcher,
+	nodeName string,
+	remediated bool,
+) (ctrl.Result, error) {
+	if err := r.updateNodeRemediatedStatus(ctx, healthEventStore, eventWithToken, remediated); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return r.markProcessedOrError(ctx, watcherInstance, eventWithToken, nodeName)
 }
 
 func (r *FaultRemediationReconciler) updateNodeRemediatedStatus(

--- a/fault-remediation/pkg/reconciler/reconciler.go
+++ b/fault-remediation/pkg/reconciler/reconciler.go
@@ -26,6 +26,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	oteltrace "go.opentelemetry.io/otel/trace"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -390,6 +391,17 @@ func (r *FaultRemediationReconciler) handleCancellationEvent(
 
 	remediationState, _, err := r.annotationManager.GetRemediationState(ctx, nodeName)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			slog.WarnContext(ctx, "Node no longer exists, marking cancellation event as terminal", "node", nodeName)
+			if updateErr := r.updateNodeRemediatedStatus(ctx, healthEventStore, eventWithToken, true); updateErr != nil {
+				return ctrl.Result{}, updateErr
+			}
+			if err := safeMarkProcessed(ctx, watcherInstance, eventWithToken.ResumeToken, nodeName); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
+		}
+
 		slog.ErrorContext(ctx, "Failed to get remediation state for node",
 			"node", nodeName,
 			"error", err)
@@ -471,6 +483,14 @@ func (r *FaultRemediationReconciler) handleRemediationEvent(
 	shouldCreateCR, existingCR, existingCRRemediated, err := r.checkExistingCRStatus(ctx, healthEvent,
 		healthEventWithStatus.CreatedAt, groupConfig)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			slog.WarnContext(ctx, "Node no longer exists, marking remediation event as stale", "node", nodeName)
+			if updateErr := r.updateNodeRemediatedStatus(ctx, healthEventStore, eventWithToken, false); updateErr != nil {
+				return ctrl.Result{}, updateErr
+			}
+			return r.markProcessedOrError(ctx, watcherInstance, eventWithToken, nodeName)
+		}
+
 		metrics.ProcessingErrors.WithLabelValues("cr_status_check_error", nodeName).Inc()
 		slog.ErrorContext(ctx, "Error checking existing CR status", "node", nodeName, "error", err)
 

--- a/fault-remediation/pkg/reconciler/reconciler_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/nvidia/nvsentinel/commons/pkg/statemanager"
@@ -147,12 +149,17 @@ func (w *MockCRStatusCheckerWrapper) IsSuccessful(ctx context.Context, crName st
 }
 
 type MockNodeAnnotationManager struct {
-	existingCRs       map[string]string
-	existingCRCreated time.Time
-	createdByGroup    map[string]time.Time
+	existingCRs            map[string]string
+	existingCRCreated      time.Time
+	createdByGroup         map[string]time.Time
+	getRemediationStateErr error
 }
 
 func (m *MockNodeAnnotationManager) GetRemediationState(ctx context.Context, nodeName string) (*annotation.RemediationStateAnnotation, *corev1.Node, error) {
+	if m.getRemediationStateErr != nil {
+		return nil, nil, m.getRemediationStateErr
+	}
+
 	if m.existingCRs == nil {
 		return &annotation.RemediationStateAnnotation{
 			EquivalenceGroups: make(map[string]annotation.EquivalenceGroupState),
@@ -1434,4 +1441,96 @@ func TestAdaptEvents_ForwardsEvents(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("event was not forwarded through AdaptEvents")
 	}
+}
+
+func nodeNotFoundErr(nodeName string) error {
+	return apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "nodes"}, nodeName)
+}
+
+func TestDeletedNodeRemediationEventMarkedTerminal(t *testing.T) {
+	ctx := context.Background()
+	nodeName := "deleted-node"
+	eventID := "stale-event-id"
+	updated := false
+
+	mockAnnotation := &MockNodeAnnotationManager{
+		getRemediationStateErr: nodeNotFoundErr(nodeName),
+	}
+	mockK8sClient := &MockK8sClient{
+		annotationManagerOverride: mockAnnotation,
+	}
+	cfg := ReconcilerConfig{RemediationClient: mockK8sClient}
+	r := NewFaultRemediationReconciler(nil, nil, nil, cfg, false)
+
+	mockWatcher := &MockChangeStreamWatcher{}
+	mockStore := &MockHealthEventStore{
+		UpdateHealthEventStatusFn: func(_ context.Context, id string, status datastore.HealthEventStatus) error {
+			assert.Equal(t, eventID, id)
+			assert.NotNil(t, status.FaultRemediated)
+			assert.False(t, *status.FaultRemediated)
+			updated = true
+			return nil
+		},
+	}
+
+	healthEventDoc := &events.HealthEventDoc{
+		ID: eventID,
+		HealthEventWithStatus: model.HealthEventWithStatus{
+			HealthEvent: &protos.HealthEvent{
+				NodeName:          nodeName,
+				RecommendedAction: protos.RecommendedAction_RESTART_BM,
+			},
+			HealthEventStatus: &protos.HealthEventStatus{},
+		},
+	}
+	eventWithToken := datastore.EventWithToken{
+		Event:       testRawHealthEvent(eventID, nodeName, protos.RecommendedAction_RESTART_BM),
+		ResumeToken: []byte("resume-token"),
+	}
+
+	result, err := r.handleRemediationEvent(ctx, healthEventDoc, eventWithToken, mockWatcher, mockStore)
+	assert.NoError(t, err)
+	assert.True(t, result.IsZero())
+	assert.True(t, updated, "expected faultRemediated=false to be written")
+	_, markProcessedCount, _, _ := mockWatcher.GetCallCounts()
+	assert.Equal(t, 1, markProcessedCount, "expected resume token to be marked processed")
+}
+
+func TestDeletedNodeCancellationEventMarkedTerminal(t *testing.T) {
+	ctx := context.Background()
+	nodeName := "deleted-node"
+	eventID := "stale-cancel-event-id"
+	updated := false
+
+	mockAnnotation := &MockNodeAnnotationManager{
+		getRemediationStateErr: nodeNotFoundErr(nodeName),
+	}
+	mockK8sClient := &MockK8sClient{
+		annotationManagerOverride: mockAnnotation,
+	}
+	cfg := ReconcilerConfig{RemediationClient: mockK8sClient}
+	r := NewFaultRemediationReconciler(nil, nil, nil, cfg, false)
+
+	mockWatcher := &MockChangeStreamWatcher{}
+	mockStore := &MockHealthEventStore{
+		UpdateHealthEventStatusFn: func(_ context.Context, id string, status datastore.HealthEventStatus) error {
+			assert.Equal(t, eventID, id)
+			assert.NotNil(t, status.FaultRemediated)
+			assert.True(t, *status.FaultRemediated)
+			updated = true
+			return nil
+		},
+	}
+
+	eventWithToken := datastore.EventWithToken{
+		Event:       testRawHealthEvent(eventID, nodeName, protos.RecommendedAction_RESTART_BM),
+		ResumeToken: []byte("resume-token"),
+	}
+
+	result, err := r.handleCancellationEvent(ctx, nodeName, model.Cancelled, mockWatcher, eventWithToken, mockStore)
+	assert.NoError(t, err)
+	assert.True(t, result.IsZero())
+	assert.True(t, updated, "expected faultRemediated=true to be written")
+	_, markProcessedCount, _, _ := mockWatcher.GetCallCounts()
+	assert.Equal(t, 1, markProcessedCount, "expected resume token to be marked processed")
 }


### PR DESCRIPTION
## Summary

Set remediated to false if the error is not found

## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [X] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [ ] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review

Closes #1387 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fault-remediation handling when a node’s remediation state is missing: cancellation events are treated as terminal and marked completed, and remediation events for deleted nodes are treated as stale and marked processed; health-event statuses and processing tokens are updated accordingly.

* **Tests**
  * Added tests covering deleted-node scenarios for both remediation and cancellation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->