### PR TITLE
fix: node-drainer should not process stale AlreadyQuarantined events

### DIFF
--- a/node-drainer/pkg/evaluator/evaluator.go
+++ b/node-drainer/pkg/evaluator/evaluator.go
@@ -549,7 +549,8 @@ skip draining for the current event 70bd4fc9ffa9f5eca91c340c and update its stat
 	    }
 */
 func (e *NodeDrainEvaluator) isNodeAlreadyDrained(ctx context.Context, currentEventId string,
-	currentPartialDrainEntity *protos.Entity, nodeName string, healthEventStore datastore.HealthEventStore) (bool, bool, error) {
+	currentPartialDrainEntity *protos.Entity, nodeName string,
+	healthEventStore datastore.HealthEventStore) (bool, bool, error) {
 	node, err := e.informers.GetNode(nodeName)
 	if err != nil {
 		return false, false, fmt.Errorf("failed to get node %s: %w", nodeName, err)

--- a/node-drainer/pkg/evaluator/evaluator.go
+++ b/node-drainer/pkg/evaluator/evaluator.go
@@ -148,7 +148,7 @@ func (e *NodeDrainEvaluator) handleAlreadyQuarantined(ctx context.Context, statu
 
 	nodeName := healthEvent.HealthEvent.NodeName
 
-	isDrained, err := e.isNodeAlreadyDrained(ctx, healthEvent.HealthEvent.Id, partialDrainEntity,
+	isDrained, hasQuarantineAnnotation, err := e.isNodeAlreadyDrained(ctx, healthEvent.HealthEvent.Id, partialDrainEntity,
 		nodeName, healthEventStore)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to check if node is already drained",
@@ -158,6 +158,16 @@ func (e *NodeDrainEvaluator) handleAlreadyQuarantined(ctx context.Context, statu
 		return &DrainActionResult{
 			Action:    ActionWait,
 			WaitDelay: time.Minute,
+		}
+	}
+
+	if !hasQuarantineAnnotation {
+		slog.InfoContext(ctx, "Cancelling stale AlreadyQuarantined event with no active quarantine annotation",
+			"node", nodeName)
+
+		return &DrainActionResult{
+			Action: ActionCancel,
+			Status: model.Cancelled,
 		}
 	}
 
@@ -539,24 +549,24 @@ skip draining for the current event 70bd4fc9ffa9f5eca91c340c and update its stat
 	    }
 */
 func (e *NodeDrainEvaluator) isNodeAlreadyDrained(ctx context.Context, currentEventId string,
-	currentPartialDrainEntity *protos.Entity, nodeName string, healthEventStore datastore.HealthEventStore) (bool, error) {
+	currentPartialDrainEntity *protos.Entity, nodeName string, healthEventStore datastore.HealthEventStore) (bool, bool, error) {
 	node, err := e.informers.GetNode(nodeName)
 	if err != nil {
-		return false, fmt.Errorf("failed to get node %s: %w", nodeName, err)
+		return false, false, fmt.Errorf("failed to get node %s: %w", nodeName, err)
 	}
 
 	quarantineHealthEventAnnotationStr, ok := node.Annotations[common.QuarantineHealthEventAnnotationKey]
 	if !ok {
 		slog.InfoContext(ctx, "No quarantine annotation found for node", "node", nodeName)
 
-		return false, nil
+		return false, false, nil
 	}
 
 	var healthEventsMap annotation.HealthEventsAnnotationMap
 
 	err = healthEventsMap.UnmarshalJSON([]byte(quarantineHealthEventAnnotationStr))
 	if err != nil {
-		return false, fmt.Errorf("failed to unmarshal quarantine annotation for node %s: %w", nodeName, err)
+		return false, true, fmt.Errorf("failed to unmarshal quarantine annotation for node %s: %w", nodeName, err)
 	}
 
 	slog.InfoContext(ctx, "HealthEvents which are part of quarantineHealthEvent annotation",
@@ -577,24 +587,24 @@ func (e *NodeDrainEvaluator) isNodeAlreadyDrained(ctx context.Context, currentEv
 
 		healthEventWithStatus, healthEvent, err := getHealthEventFromId(ctx, id, nodeName, healthEventStore)
 		if err != nil {
-			return false, err
+			return false, true, err
 		}
 		// none of HealthEventStatus, UserPodsEvictionStatus, or Status are ptr values
 		drainCompleted := healthEventWithStatus.HealthEventStatus.UserPodsEvictionStatus.Status == datastore.StatusSucceeded
 
 		partialDrainEntity, err := e.shouldExecutePartialDrain(healthEvent)
 		if err != nil {
-			return false, err
+			return false, true, err
 		}
 
 		skipDrain := canSkipDrain(ctx, drainCompleted, partialDrainEntity, currentPartialDrainEntity, id, nodeName)
 		if skipDrain {
-			return true, nil
+			return true, true, nil
 		}
 		// continue checking any other HealthEvents on quarantineHealthEvent annotation
 	}
 
-	return false, nil
+	return false, true, nil
 }
 
 func getHealthEventFromId(ctx context.Context, id string, nodeName string,

--- a/node-drainer/pkg/evaluator/evaluator_integration_test.go
+++ b/node-drainer/pkg/evaluator/evaluator_integration_test.go
@@ -617,7 +617,7 @@ func TestEvaluator_IsNodeAlreadyDrained(t *testing.T) {
 			setup.healthEventStore.healthEvents = tt.healthEventsFromStore
 			setup.healthEventStore.err = tt.healthEventStoreError
 
-			isDrained, err := setup.evaluator.isNodeAlreadyDrained(setup.ctx, tt.currentEventId, tt.partialDrainEntity,
+			isDrained, _, err := setup.evaluator.isNodeAlreadyDrained(setup.ctx, tt.currentEventId, tt.partialDrainEntity,
 				tt.nodeName, setup.healthEventStore)
 
 			if tt.expectError {

--- a/node-drainer/pkg/evaluator/types.go
+++ b/node-drainer/pkg/evaluator/types.go
@@ -74,29 +74,24 @@ type DrainActionResult struct {
 	PartialDrainEntity *protos.Entity
 }
 
+var drainActionNames = map[DrainAction]string{
+	ActionSkip:               "Skip",
+	ActionWait:               "Wait",
+	ActionCreateCR:           "CreateCR",
+	ActionEvictImmediate:     "EvictImmediate",
+	ActionEvictWithTimeout:   "EvictWithTimeout",
+	ActionCheckCompletion:    "CheckCompletion",
+	ActionMarkAlreadyDrained: "MarkAlreadyDrained",
+	ActionUpdateStatus:       "UpdateStatus",
+	ActionCancel:             "Cancel",
+}
+
 func (a DrainAction) String() string {
-	switch a {
-	case ActionSkip:
-		return "Skip"
-	case ActionWait:
-		return "Wait"
-	case ActionCreateCR:
-		return "CreateCR"
-	case ActionEvictImmediate:
-		return "EvictImmediate"
-	case ActionEvictWithTimeout:
-		return "EvictWithTimeout"
-	case ActionCheckCompletion:
-		return "CheckCompletion"
-	case ActionMarkAlreadyDrained:
-		return "MarkAlreadyDrained"
-	case ActionUpdateStatus:
-		return "UpdateStatus"
-	case ActionCancel:
-		return "Cancel"
-	default:
-		return "Unknown"
+	if name, ok := drainActionNames[a]; ok {
+		return name
 	}
+
+	return "Unknown"
 }
 
 type namespaces struct {

--- a/node-drainer/pkg/evaluator/types.go
+++ b/node-drainer/pkg/evaluator/types.go
@@ -62,6 +62,7 @@ const (
 	ActionCheckCompletion
 	ActionMarkAlreadyDrained
 	ActionUpdateStatus
+	ActionCancel
 )
 
 type DrainActionResult struct {
@@ -69,7 +70,7 @@ type DrainActionResult struct {
 	Namespaces         []string
 	Timeout            time.Duration
 	WaitDelay          time.Duration // For ActionWait
-	Status             model.Status  // For ActionUpdateStatus
+	Status             model.Status  // For ActionUpdateStatus and ActionCancel
 	PartialDrainEntity *protos.Entity
 }
 
@@ -91,6 +92,8 @@ func (a DrainAction) String() string {
 		return "MarkAlreadyDrained"
 	case ActionUpdateStatus:
 		return "UpdateStatus"
+	case ActionCancel:
+		return "Cancel"
 	default:
 		return "Unknown"
 	}

--- a/node-drainer/pkg/reconciler/reconciler.go
+++ b/node-drainer/pkg/reconciler/reconciler.go
@@ -479,6 +479,10 @@ func (r *Reconciler) executeAction(ctx context.Context, action *evaluator.DrainA
 		r.clearEventStatus(eventID, nodeName)
 		return r.executeUpdateStatus(ctx, healthEvent, event, database, action.Status)
 
+	case evaluator.ActionCancel:
+		r.clearEventStatus(eventID, nodeName)
+		return r.executeCancelStatus(ctx, healthEvent, event, database, action.Status)
+
 	default:
 		return fmt.Errorf("unknown action: %s", action.Action.String())
 	}
@@ -723,6 +727,39 @@ func (r *Reconciler) executeMarkAlreadyDrained(ctx context.Context,
 
 	return r.updateNodeUserPodsEvictedStatus(ctx, database, event, podsEvictionStatus,
 		nodeName, metrics.DrainStatusSkipped)
+}
+
+func (r *Reconciler) executeCancelStatus(ctx context.Context,
+	healthEvent model.HealthEventWithStatus, event datastore.Event, database queue.DataStore, status model.Status) error {
+	ctx, span := tracing.StartSpan(ctx, "node_drainer.execute_cancel_status")
+	defer span.End()
+
+	nodeName := healthEvent.HealthEvent.NodeName
+
+	if healthEvent.HealthEventStatus.UserPodsEvictionStatus == nil {
+		slog.ErrorContext(ctx, "HealthEventStatus is missing UserPodsEvictionStatus",
+			"node", nodeName)
+
+		return errors.New("missing UserPodsEvictionStatus")
+	}
+
+	podsEvictionStatus := healthEvent.HealthEventStatus.UserPodsEvictionStatus
+	podsEvictionStatus.Status = string(status)
+
+	if err := r.updateNodeUserPodsEvictedStatus(ctx, database, event, podsEvictionStatus,
+		nodeName, metrics.DrainStatusCancelled); err != nil {
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("node_drainer.error.type", "update_cancel_status_error"),
+			attribute.String("node_drainer.error.message", err.Error()),
+		)
+
+		return err
+	}
+
+	metrics.CancelledEvent.WithLabelValues(nodeName, healthEvent.HealthEvent.CheckName).Inc()
+
+	return nil
 }
 
 func (r *Reconciler) executeUpdateStatus(ctx context.Context, healthEvent model.HealthEventWithStatus,

--- a/node-drainer/pkg/reconciler/reconciler.go
+++ b/node-drainer/pkg/reconciler/reconciler.go
@@ -438,15 +438,60 @@ func (r *Reconciler) ProcessEventGeneric(ctx context.Context,
 
 func (r *Reconciler) executeAction(ctx context.Context, action *evaluator.DrainActionResult,
 	healthEvent model.HealthEventWithStatus, event datastore.Event, database queue.DataStore, eventID string) error {
-	nodeName := healthEvent.HealthEvent.NodeName
-
 	r.updateDrainSessionTracing(ctx, action, healthEvent)
+
+	if isTerminalAction(action.Action) {
+		return r.executeTerminalAction(ctx, action, healthEvent, event, database, eventID)
+	}
+
+	return r.executeDrainAction(ctx, action, healthEvent, event, database, eventID)
+}
+
+func isTerminalAction(action evaluator.DrainAction) bool {
+	switch action {
+	case evaluator.ActionSkip, evaluator.ActionMarkAlreadyDrained, evaluator.ActionUpdateStatus, evaluator.ActionCancel:
+		return true
+	case evaluator.ActionWait, evaluator.ActionCreateCR, evaluator.ActionEvictImmediate, evaluator.ActionEvictWithTimeout,
+		evaluator.ActionCheckCompletion:
+		return false
+	}
+
+	return false
+}
+
+func (r *Reconciler) executeTerminalAction(ctx context.Context, action *evaluator.DrainActionResult,
+	healthEvent model.HealthEventWithStatus, event datastore.Event, database queue.DataStore, eventID string) error {
+	nodeName := healthEvent.HealthEvent.NodeName
 
 	switch action.Action {
 	case evaluator.ActionSkip:
 		r.clearEventStatus(eventID, nodeName)
 		return r.executeSkip(ctx, nodeName, healthEvent, event, database)
 
+	case evaluator.ActionMarkAlreadyDrained:
+		return r.handleMarkAlreadyDrained(ctx, eventID, nodeName, healthEvent, event, database, action.Status)
+
+	case evaluator.ActionUpdateStatus:
+		r.clearEventStatus(eventID, nodeName)
+		return r.executeUpdateStatus(ctx, healthEvent, event, database, action.Status)
+
+	case evaluator.ActionCancel:
+		r.clearEventStatus(eventID, nodeName)
+		return r.executeCancelStatus(ctx, healthEvent, event, database, action.Status)
+
+	case evaluator.ActionWait, evaluator.ActionCreateCR, evaluator.ActionEvictImmediate, evaluator.ActionEvictWithTimeout,
+		evaluator.ActionCheckCompletion:
+		return fmt.Errorf("unknown action: %s", action.Action.String())
+	}
+
+	return fmt.Errorf("unknown action: %s", action.Action.String())
+}
+
+func (r *Reconciler) executeDrainAction(ctx context.Context, action *evaluator.DrainActionResult,
+	healthEvent model.HealthEventWithStatus, event datastore.Event, database queue.DataStore, eventID string) error {
+	nodeName := healthEvent.HealthEvent.NodeName
+
+	switch action.Action {
 	case evaluator.ActionWait:
 		slog.InfoContext(ctx, "Waiting for node",
 			"node", nodeName,
@@ -472,20 +517,11 @@ func (r *Reconciler) executeAction(ctx context.Context, action *evaluator.DrainA
 
 		return r.executeCheckCompletion(ctx, action, healthEvent, action.PartialDrainEntity)
 
-	case evaluator.ActionMarkAlreadyDrained:
-		return r.handleMarkAlreadyDrained(ctx, eventID, nodeName, healthEvent, event, database, action.Status)
-
-	case evaluator.ActionUpdateStatus:
-		r.clearEventStatus(eventID, nodeName)
-		return r.executeUpdateStatus(ctx, healthEvent, event, database, action.Status)
-
-	case evaluator.ActionCancel:
-		r.clearEventStatus(eventID, nodeName)
-		return r.executeCancelStatus(ctx, healthEvent, event, database, action.Status)
-
-	default:
+	case evaluator.ActionSkip, evaluator.ActionMarkAlreadyDrained, evaluator.ActionUpdateStatus, evaluator.ActionCancel:
 		return fmt.Errorf("unknown action: %s", action.Action.String())
 	}
+
+	return fmt.Errorf("unknown action: %s", action.Action.String())
 }
 
 func (r *Reconciler) updateDrainSessionTracing(

--- a/node-drainer/pkg/reconciler/reconciler.go
+++ b/node-drainer/pkg/reconciler/reconciler.go
@@ -755,7 +755,7 @@ func (r *Reconciler) executeMarkAlreadyDrained(ctx context.Context,
 		slog.ErrorContext(ctx, "HealthEventStatus is missing UserPodsEvictionStatus",
 			"node", nodeName)
 
-		return errors.New("missing UserPodsEvictionStatus")
+		return fmt.Errorf("missing UserPodsEvictionStatus for node %s", nodeName)
 	}
 
 	podsEvictionStatus := healthEvent.HealthEventStatus.UserPodsEvictionStatus
@@ -790,7 +790,7 @@ func (r *Reconciler) executeCancelStatus(ctx context.Context,
 			attribute.String("node_drainer.error.message", err.Error()),
 		)
 
-		return err
+		return fmt.Errorf("failed to update cancelled status for node %s: %w", nodeName, err)
 	}
 
 	metrics.CancelledEvent.WithLabelValues(nodeName, healthEvent.HealthEvent.CheckName).Inc()

--- a/node-drainer/pkg/reconciler/reconciler_integration_test.go
+++ b/node-drainer/pkg/reconciler/reconciler_integration_test.go
@@ -225,6 +225,8 @@ func TestReconciler_ProcessEvent(t *testing.T) {
 		recommendedAction               protos.RecommendedAction
 		entitiesImpacted                []*protos.Entity
 		existingNodeLabels              map[string]string
+		nodeAnnotations                 map[string]string
+		annotationHealthEvents          []*protos.HealthEvent
 		findHealthEventsByQueryResponse []datastore.HealthEventWithStatus
 		expectError                     bool
 		expectedNodeLabel               *string
@@ -698,6 +700,16 @@ func TestReconciler_ProcessEvent(t *testing.T) {
 			namespaces:      []string{"test-ns"},
 			nodeQuarantined: model.AlreadyQuarantined,
 			pods:            []*v1.Pod{},
+			annotationHealthEvents: []*protos.HealthEvent{
+				{
+					Id:             "previous-event",
+					NodeName:       "already-drained-node",
+					Agent:          "test-agent",
+					CheckName:      "test-check",
+					ComponentClass: "GPU",
+					Version:        1,
+				},
+			},
 			findHealthEventsByQueryResponse: []datastore.HealthEventWithStatus{
 				{
 					HealthEventStatus: datastore.HealthEventStatus{
@@ -714,6 +726,24 @@ func TestReconciler_ProcessEvent(t *testing.T) {
 			expectError: false,
 			validateFunc: func(t *testing.T, client kubernetes.Interface, ctx context.Context, nodeName string, err error) {
 				assert.NoError(t, err)
+			},
+		},
+		{
+			name:              "AlreadyQuarantined with missing quarantine annotation is cancelled as stale",
+			nodeName:          "stale-already-quarantined-node",
+			namespaces:        []string{"test-ns"},
+			nodeQuarantined:   model.AlreadyQuarantined,
+			pods:              []*v1.Pod{},
+			expectError:       false,
+			expectedNodeLabel: ptr.To(""),
+			validateFunc: func(t *testing.T, client kubernetes.Interface, ctx context.Context, nodeName string, err error) {
+				assert.NoError(t, err)
+
+				node, getErr := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+				require.NoError(t, getErr)
+
+				_, exists := node.Labels[statemanager.NVSentinelStateLabelKey]
+				assert.False(t, exists, "stale AlreadyQuarantined events should not mutate node state label")
 			},
 		},
 		{
@@ -852,7 +882,14 @@ func TestReconciler_ProcessEvent(t *testing.T) {
 			if nodeLabels == nil {
 				nodeLabels = map[string]string{"test-label": "test-value"}
 			}
-			createNodeWithLabelsAndAnnotations(setup.ctx, t, setup.client, tt.nodeName, nodeLabels, nil)
+			nodeAnnotations := tt.nodeAnnotations
+			if nodeAnnotations == nil && tt.annotationHealthEvents != nil {
+				annotationValue, err := createHealthEventAnnotationsMap(tt.annotationHealthEvents)
+				require.NoError(t, err)
+				nodeAnnotations = map[string]string{common.QuarantineHealthEventAnnotationKey: annotationValue}
+			}
+
+			createNodeWithLabelsAndAnnotations(setup.ctx, t, setup.client, tt.nodeName, nodeLabels, nodeAnnotations)
 
 			for _, ns := range tt.namespaces {
 				createNamespace(setup.ctx, t, setup.client, ns)

--- a/tests/node_drainer_test.go
+++ b/tests/node_drainer_test.go
@@ -19,6 +19,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
 	"github.com/nvidia/nvsentinel/commons/pkg/statemanager"
+	"github.com/nvidia/nvsentinel/data-models/pkg/protos"
 )
 
 func TestNodeDrainerEvictionModes(t *testing.T) {
@@ -189,6 +191,126 @@ func TestNodeDrainerEvictionModes(t *testing.T) {
 
 		helpers.DeleteNamespace(ctx, t, client, "allowcompletion-test")
 		helpers.DeleteNamespace(ctx, t, client, "delete-timeout-test")
+
+		return helpers.TeardownNodeDrainer(ctx, t, c)
+	})
+
+	testEnv.Test(t, feature.Feature())
+}
+
+func TestNodeDrainerCancelsColdStartStaleAlreadyQuarantinedEvent(t *testing.T) {
+	feature := features.New("TestNodeDrainerCancelsColdStartStaleAlreadyQuarantinedEvent").
+		WithLabel("suite", "node-drainer")
+
+	var testCtx *helpers.NodeDrainerTestContext
+	var syslogMessage string
+	var dcgmMessage string
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err)
+
+		var newCtx context.Context
+		newCtx, testCtx = helpers.SetupNodeDrainerTest(ctx, t, c, "data/nd-all-modes.yaml", "stale-alreadyq-test")
+		require.NoError(t, helpers.ScaleDeployment(newCtx, t, client, "fault-remediation",
+			helpers.NVSentinelNamespace, 0))
+		helpers.WaitForDeploymentRollout(newCtx, t, client, "fault-remediation", helpers.NVSentinelNamespace)
+
+		testID := time.Now().UnixNano()
+		syslogMessage = fmt.Sprintf("stale AlreadyQuarantined syslog trigger %d", testID)
+		dcgmMessage = fmt.Sprintf("stale AlreadyQuarantined dcgm trigger %d", testID)
+
+		return newCtx
+	})
+
+	feature.Assess("missed AlreadyQuarantined event is cancelled after node unquarantine",
+		func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+			client, err := c.NewClient()
+			require.NoError(t, err)
+
+			nodeName := testCtx.NodeName
+
+			syslogFailure := helpers.NewHealthEvent(nodeName).
+				WithAgent("syslog-health-monitor").
+				WithCheckName("SysLogsXIDError").
+				WithErrorCode("79").
+				WithMessage(syslogMessage).
+				WithRecommendedAction(int(protos.RecommendedAction_RESTART_BM))
+			helpers.SendHealthEvent(ctx, t, syslogFailure)
+
+			helpers.WaitForNodeLabel(ctx, t, client, nodeName, statemanager.NVSentinelStateLabelKey,
+				helpers.DrainSucceededLabelValue)
+
+			require.NoError(t, helpers.ScaleDeployment(ctx, t, client, "node-drainer", helpers.NVSentinelNamespace, 0))
+			helpers.WaitForDeploymentRollout(ctx, t, client, "node-drainer", helpers.NVSentinelNamespace)
+
+			dcgmFailure := helpers.NewHealthEvent(nodeName).
+				WithAgent("gpu-health-monitor").
+				WithCheckName("GpuDcgmConnectivityFailure").
+				WithFatal(true).
+				WithHealthy(false).
+				WithMessage(dcgmMessage).
+				WithRecommendedAction(int(protos.RecommendedAction_CONTACT_SUPPORT)).
+				WithEntitiesImpacted(nil)
+			helpers.SendHealthEvent(ctx, t, dcgmFailure)
+
+			helpers.AssertQuarantineState(ctx, t, client, nodeName, helpers.QuarantineAssertion{
+				ExpectCordoned: true,
+				AnnotationChecks: []helpers.AnnotationCheck{
+					{Key: helpers.QuarantineHealthEventAnnotationKey, Pattern: dcgmMessage, ShouldExist: true},
+				},
+			})
+
+			helpers.SendHealthEvent(ctx, t, helpers.NewHealthEvent(nodeName).
+				WithAgent("syslog-health-monitor").
+				WithCheckName("SysLogsXIDError").
+				WithFatal(false).
+				WithHealthy(true).
+				WithMessage("No Health Failures").
+				WithRecommendedAction(int(protos.RecommendedAction_NONE)))
+
+			helpers.SendHealthEvent(ctx, t, helpers.NewHealthEvent(nodeName).
+				WithAgent("gpu-health-monitor").
+				WithCheckName("GpuDcgmConnectivityFailure").
+				WithFatal(false).
+				WithHealthy(true).
+				WithMessage("DCGM connectivity reported no errors").
+				WithRecommendedAction(int(protos.RecommendedAction_NONE)).
+				WithEntitiesImpacted(nil))
+
+			helpers.AssertQuarantineState(ctx, t, client, nodeName, helpers.QuarantineAssertion{
+				ExpectCordoned: false,
+				AnnotationChecks: []helpers.AnnotationCheck{
+					{Key: helpers.QuarantineHealthEventAnnotationKey, ShouldExist: false},
+				},
+			})
+
+			require.NoError(t, helpers.RemoveNodeLabel(ctx, client, nodeName, statemanager.NVSentinelStateLabelKey))
+
+			require.NoError(t, helpers.ScaleDeployment(ctx, t, client, "node-drainer", helpers.NVSentinelNamespace, 1))
+			helpers.WaitForDeploymentRollout(ctx, t, client, "node-drainer", helpers.NVSentinelNamespace)
+
+			require.Never(t, func() bool {
+				node, err := helpers.GetNodeByName(ctx, client, nodeName)
+				if err != nil {
+					return false
+				}
+
+				return node.Labels[statemanager.NVSentinelStateLabelKey] == helpers.DrainingLabelValue ||
+					node.Labels[statemanager.NVSentinelStateLabelKey] == helpers.DrainSucceededLabelValue
+			}, helpers.NeverWaitTimeout, helpers.WaitInterval, "stale event should not restart node draining")
+
+			return ctx
+		})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err)
+
+		_ = helpers.ScaleDeployment(ctx, t, client, "node-drainer", helpers.NVSentinelNamespace, 1)
+		helpers.WaitForDeploymentRollout(ctx, t, client, "node-drainer", helpers.NVSentinelNamespace)
+		_ = helpers.ScaleDeployment(ctx, t, client, "fault-remediation", helpers.NVSentinelNamespace, 1)
+		helpers.WaitForDeploymentRollout(ctx, t, client, "fault-remediation", helpers.NVSentinelNamespace)
 
 		return helpers.TeardownNodeDrainer(ctx, t, c)
 	})

--- a/tests/node_drainer_test.go
+++ b/tests/node_drainer_test.go
@@ -19,7 +19,6 @@ package tests
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -31,7 +30,6 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
 	"github.com/nvidia/nvsentinel/commons/pkg/statemanager"
-	"github.com/nvidia/nvsentinel/data-models/pkg/protos"
 )
 
 func TestNodeDrainerEvictionModes(t *testing.T) {
@@ -191,126 +189,6 @@ func TestNodeDrainerEvictionModes(t *testing.T) {
 
 		helpers.DeleteNamespace(ctx, t, client, "allowcompletion-test")
 		helpers.DeleteNamespace(ctx, t, client, "delete-timeout-test")
-
-		return helpers.TeardownNodeDrainer(ctx, t, c)
-	})
-
-	testEnv.Test(t, feature.Feature())
-}
-
-func TestNodeDrainerCancelsColdStartStaleAlreadyQuarantinedEvent(t *testing.T) {
-	feature := features.New("TestNodeDrainerCancelsColdStartStaleAlreadyQuarantinedEvent").
-		WithLabel("suite", "node-drainer")
-
-	var testCtx *helpers.NodeDrainerTestContext
-	var syslogMessage string
-	var dcgmMessage string
-
-	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-		client, err := c.NewClient()
-		require.NoError(t, err)
-
-		var newCtx context.Context
-		newCtx, testCtx = helpers.SetupNodeDrainerTest(ctx, t, c, "data/nd-all-modes.yaml", "stale-alreadyq-test")
-		require.NoError(t, helpers.ScaleDeployment(newCtx, t, client, "fault-remediation",
-			helpers.NVSentinelNamespace, 0))
-		helpers.WaitForDeploymentRollout(newCtx, t, client, "fault-remediation", helpers.NVSentinelNamespace)
-
-		testID := time.Now().UnixNano()
-		syslogMessage = fmt.Sprintf("stale AlreadyQuarantined syslog trigger %d", testID)
-		dcgmMessage = fmt.Sprintf("stale AlreadyQuarantined dcgm trigger %d", testID)
-
-		return newCtx
-	})
-
-	feature.Assess("missed AlreadyQuarantined event is cancelled after node unquarantine",
-		func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-			client, err := c.NewClient()
-			require.NoError(t, err)
-
-			nodeName := testCtx.NodeName
-
-			syslogFailure := helpers.NewHealthEvent(nodeName).
-				WithAgent("syslog-health-monitor").
-				WithCheckName("SysLogsXIDError").
-				WithErrorCode("79").
-				WithMessage(syslogMessage).
-				WithRecommendedAction(int(protos.RecommendedAction_RESTART_BM))
-			helpers.SendHealthEvent(ctx, t, syslogFailure)
-
-			helpers.WaitForNodeLabel(ctx, t, client, nodeName, statemanager.NVSentinelStateLabelKey,
-				helpers.DrainSucceededLabelValue)
-
-			require.NoError(t, helpers.ScaleDeployment(ctx, t, client, "node-drainer", helpers.NVSentinelNamespace, 0))
-			helpers.WaitForDeploymentRollout(ctx, t, client, "node-drainer", helpers.NVSentinelNamespace)
-
-			dcgmFailure := helpers.NewHealthEvent(nodeName).
-				WithAgent("gpu-health-monitor").
-				WithCheckName("GpuDcgmConnectivityFailure").
-				WithFatal(true).
-				WithHealthy(false).
-				WithMessage(dcgmMessage).
-				WithRecommendedAction(int(protos.RecommendedAction_CONTACT_SUPPORT)).
-				WithEntitiesImpacted(nil)
-			helpers.SendHealthEvent(ctx, t, dcgmFailure)
-
-			helpers.AssertQuarantineState(ctx, t, client, nodeName, helpers.QuarantineAssertion{
-				ExpectCordoned: true,
-				AnnotationChecks: []helpers.AnnotationCheck{
-					{Key: helpers.QuarantineHealthEventAnnotationKey, Pattern: dcgmMessage, ShouldExist: true},
-				},
-			})
-
-			helpers.SendHealthEvent(ctx, t, helpers.NewHealthEvent(nodeName).
-				WithAgent("syslog-health-monitor").
-				WithCheckName("SysLogsXIDError").
-				WithFatal(false).
-				WithHealthy(true).
-				WithMessage("No Health Failures").
-				WithRecommendedAction(int(protos.RecommendedAction_NONE)))
-
-			helpers.SendHealthEvent(ctx, t, helpers.NewHealthEvent(nodeName).
-				WithAgent("gpu-health-monitor").
-				WithCheckName("GpuDcgmConnectivityFailure").
-				WithFatal(false).
-				WithHealthy(true).
-				WithMessage("DCGM connectivity reported no errors").
-				WithRecommendedAction(int(protos.RecommendedAction_NONE)).
-				WithEntitiesImpacted(nil))
-
-			helpers.AssertQuarantineState(ctx, t, client, nodeName, helpers.QuarantineAssertion{
-				ExpectCordoned: false,
-				AnnotationChecks: []helpers.AnnotationCheck{
-					{Key: helpers.QuarantineHealthEventAnnotationKey, ShouldExist: false},
-				},
-			})
-
-			require.NoError(t, helpers.RemoveNodeLabel(ctx, client, nodeName, statemanager.NVSentinelStateLabelKey))
-
-			require.NoError(t, helpers.ScaleDeployment(ctx, t, client, "node-drainer", helpers.NVSentinelNamespace, 1))
-			helpers.WaitForDeploymentRollout(ctx, t, client, "node-drainer", helpers.NVSentinelNamespace)
-
-			require.Never(t, func() bool {
-				node, err := helpers.GetNodeByName(ctx, client, nodeName)
-				if err != nil {
-					return false
-				}
-
-				return node.Labels[statemanager.NVSentinelStateLabelKey] == helpers.DrainingLabelValue ||
-					node.Labels[statemanager.NVSentinelStateLabelKey] == helpers.DrainSucceededLabelValue
-			}, helpers.NeverWaitTimeout, helpers.WaitInterval, "stale event should not restart node draining")
-
-			return ctx
-		})
-
-	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-		client, err := c.NewClient()
-		require.NoError(t, err)
-
-		_ = helpers.ScaleDeployment(ctx, t, client, "node-drainer", helpers.NVSentinelNamespace, 1)
-		helpers.WaitForDeploymentRollout(ctx, t, client, "node-drainer", helpers.NVSentinelNamespace)
-		_ = helpers.ScaleDeployment(ctx, t, client, "fault-remediation", helpers.NVSentinelNamespace, 1)
-		helpers.WaitForDeploymentRollout(ctx, t, client, "fault-remediation", helpers.NVSentinelNamespace)
 
 		return helpers.TeardownNodeDrainer(ctx, t, c)
 	})


### PR DESCRIPTION
## Summary

Fix `node-drainer` processing stale `AlreadyQuarantined` events after the node has already been unquarantined and the quarantine annotation has been removed.

Previously, if an old `AlreadyQuarantined` event was reprocessed after the quarantine annotation was gone, `node-drainer` treated the missing annotation as "not already drained" and fell through to normal drain evaluation. That could mark the stale event as `Succeeded` and mutate the node state label even though there was no active quarantine context.

## Problem

A stale `AlreadyQuarantined` event can be re-enqueued via a later MongoDB update/change-stream event. If the node no longer has `quarantineHealthEvent`, the existing evaluator path returned `false, nil` from the already-drained check. That made `node-drainer` continue into normal drain logic.

Observed bad behavior before this fix:

```json
{
  "time": "2026-06-25T03:56:36.225626604Z",
  "level": "INFO",
  "msg": "No quarantine annotation found for node",
  "module": "node-drainer",
  "version": "dev",
  "node": "kwok-kata-test-node-0"
}
{
  "time": "2026-06-25T03:56:36.225750034Z",
  "level": "INFO",
  "msg": "Evaluated action for node",
  "module": "node-drainer",
  "version": "dev",
  "node": "kwok-kata-test-node-0",
  "action": "CheckCompletion"
}
{
  "time": "2026-06-25T03:56:36.24043105Z",
  "level": "INFO",
  "msg": "Labeling node",
  "module": "node-drainer",
  "version": "dev",
  "node": "kwok-kata-test-node-0",
  "from": "",
  "to": "draining"
}
{
  "time": "2026-06-25T03:56:36.240770203Z",
  "level": "WARN",
  "msg": "Invalid state transition",
  "module": "node-drainer",
  "version": "dev",
  "node": "kwok-kata-test-node-0",
  "from": "",
  "to": "draining",
  "error": "unexpected state transition: none -> draining (expected first state: quarantined)"
}
{
  "time": "2026-06-25T03:56:36.270169837Z",
  "level": "INFO",
  "msg": "Label updated successfully for node",
  "module": "node-drainer",
  "version": "dev",
  "label": "dgxc.nvidia.com/nvsentinel-state",
  "node": "kwok-kata-test-node-0"
}
{
  "time": "2026-06-25T03:56:36.270264771Z",
  "level": "ERROR",
  "msg": "Failed to update node label to draining",
  "module": "node-drainer",
  "version": "dev",
  "node": "kwok-kata-test-node-0",
  "error": "unexpected state transition: none -> draining (expected first state: quarantined)"
}
```

After the blocking pod was deleted, the stale event incorrectly completed as succeeded:

```json
{
  "time": "2026-06-25T03:57:46.390087119Z",
  "level": "INFO",
  "msg": "No quarantine annotation found for node",
  "module": "node-drainer",
  "version": "dev",
  "node": "kwok-kata-test-node-0"
}
{
  "time": "2026-06-25T03:57:46.390142024Z",
  "level": "INFO",
  "msg": "All pods evicted successfully on node",
  "module": "node-drainer",
  "version": "dev",
  "node": "kwok-kata-test-node-0"
}
{
  "time": "2026-06-25T03:57:46.390149091Z",
  "level": "INFO",
  "msg": "Evaluated action for node",
  "module": "node-drainer",
  "version": "dev",
  "node": "kwok-kata-test-node-0",
  "action": "UpdateStatus"
}
{
  "time": "2026-06-25T03:57:46.398301071Z",
  "level": "INFO",
  "msg": "Labeling node",
  "module": "node-drainer",
  "version": "dev",
  "node": "kwok-kata-test-node-0",
  "from": "draining",
  "to": "drain-succeeded"
}
{
  "time": "2026-06-25T03:57:46.414433473Z",
  "level": "INFO",
  "msg": "Label updated successfully for node",
  "module": "node-drainer",
  "version": "dev",
  "label": "dgxc.nvidia.com/nvsentinel-state",
  "node": "kwok-kata-test-node-0"
}
{
  "time": "2026-06-25T03:57:46.421201599Z",
  "level": "INFO",
  "msg": "Node drainer evictionDuration is",
  "module": "node-drainer",
  "version": "dev",
  "evictionDuration": 690.182277575
}
{
  "time": "2026-06-25T03:57:46.421238393Z",
  "level": "INFO",
  "msg": "Health event status has been updated",
  "module": "node-drainer",
  "version": "dev",
  "documentID": "6a3ca4884ed0835a72addf42",
  "evictionStatus": "Succeeded"
}
```

MongoDB state before the fix:

```json
{
  "_id": "ObjectId('6a3ca4884ed0835a72addf42')",
  "healthevent": {
    "checkname": "GpuDcgmConnectivityFailure"
  },
  "healtheventstatus": {
    "nodequarantined": "AlreadyQuarantined",
    "userpodsevictionstatus": {
      "status": "Succeeded",
      "message": ""
    },
    "drainfinishtimestamp": {
      "seconds": "Long('1782359866')",
      "nanos": 414623723
    }
  }
}
```

## Fix

This MR adds explicit handling for stale `AlreadyQuarantined` events:

- `isNodeAlreadyDrained()` now returns whether the quarantine annotation exists.
- `handleAlreadyQuarantined()` treats a missing quarantine annotation as a stale event.
- A new `ActionCancel` closes the stale event with `userpodsevictionstatus.status=Cancelled`.
- `ActionCancel` does not update node drain labels, evict pods, or mark the drain as succeeded.
- Existing `AlreadyQuarantined` behavior with a valid quarantine annotation is preserved.

## Testing

After Tilt rolled the updated `node-drainer`, replayed the same stale `AlreadyQuarantined` document:

```text
6a3ca4884ed0835a72addf42
```

The fixed code path cancelled the stale event instead of draining:

```json
{
  "time": "2026-06-25T04:08:47.941443618Z",
  "level": "DEBUG",
  "msg": "Preprocessing event",
  "module": "node-drainer",
  "version": "dev",
  "node": "kwok-kata-test-node-0",
  "nodeQuarantined": "AlreadyQuarantined"
}
{
  "time": "2026-06-25T04:08:47.954164787Z",
  "level": "INFO",
  "msg": "No quarantine annotation found for node",
  "module": "node-drainer",
  "version": "dev",
  "node": "kwok-kata-test-node-0"
}
{
  "time": "2026-06-25T04:08:47.954483223Z",
  "level": "INFO",
  "msg": "Cancelling stale AlreadyQuarantined event with no active quarantine annotation",
  "module": "node-drainer",
  "version": "dev",
  "node": "kwok-kata-test-node-0"
}
{
  "time": "2026-06-25T04:08:47.954514258Z",
  "level": "INFO",
  "msg": "Evaluated action for node",
  "module": "node-drainer",
  "version": "dev",
  "node": "kwok-kata-test-node-0",
  "action": "Cancel"
}
{
  "time": "2026-06-25T04:08:47.971033718Z",
  "level": "INFO",
  "msg": "Health event status has been updated",
  "module": "node-drainer",
  "version": "dev",
  "documentID": "6a3ca4884ed0835a72addf42",
  "evictionStatus": "Cancelled"
}
```

MongoDB state after the fix:

```json
{
  "_id": "ObjectId('6a3ca4884ed0835a72addf42')",
  "healthevent": {
    "checkname": "GpuDcgmConnectivityFailure"
  },
  "healtheventstatus": {
    "nodequarantined": "AlreadyQuarantined",
    "userpodsevictionstatus": {
      "message": "",
      "status": "Cancelled"
    }
  }
}
```

Node state after the fix:

```text
quarantineHealthEvent annotation: ""
dgxc.nvidia.com/nvsentinel-state label: ""
```

## Notes

This intentionally does not use `ActionSkip` because `ActionSkip` does not durably close an `AlreadyQuarantined` event. It would leave the event in a non-terminal state and allow future replay. `ActionCancel` records a terminal status without mutating node labels.


## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a terminal **Cancel** action for node drain processing, including tracing and cancellation metrics.

* **Bug Fixes**
  * Cancel stale “AlreadyQuarantined” events when no active quarantine annotation is present, preventing unintended drain-state transitions.
  * Improved “already drained” evaluation using prior health-event context.

* **Tests**
  * Expanded integration and end-to-end coverage for quarantine annotation handling and stale cancellation behavior.

* **Refactor**
  * Reworked action execution flow into distinct terminal vs non-terminal handling paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->