### PR TITLE
fix: init ResourceSlice informers laziliy and normalize string digit to numbers

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/labeler/templates/_helpers.tpl
+++ b/distros/kubernetes/nvsentinel/charts/labeler/templates/_helpers.tpl
@@ -6,6 +6,21 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+Whether expected device-count configuration needs ResourceSlice access.
+*/}}
+{{- define "labeler.expectedDeviceCountsRequiresResourceSlices" -}}
+{{- $requires := false -}}
+{{- if .Values.expectedDeviceCounts.enabled -}}
+{{- range .Values.expectedDeviceCounts.classes }}
+{{- if and .enabled (contains "resourceSlices" (default "" .currentExpression)) -}}
+{{- $requires = true -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- $requires -}}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 */}}
 {{- define "labeler.fullname" -}}

--- a/distros/kubernetes/nvsentinel/charts/labeler/templates/clusterrole.yaml
+++ b/distros/kubernetes/nvsentinel/charts/labeler/templates/clusterrole.yaml
@@ -37,6 +37,7 @@ rules:
       - watch
       - patch
       - update
+  {{ if eq (include "labeler.expectedDeviceCountsRequiresResourceSlices" .) "true" }}
   - apiGroups:
       - resource.k8s.io
     resources:
@@ -45,3 +46,4 @@ rules:
       - get
       - list
       - watch
+  {{ end }}

--- a/labeler/pkg/devicecounts/device_counts.go
+++ b/labeler/pkg/devicecounts/device_counts.go
@@ -124,6 +124,21 @@ func (m *Manager) Enabled() bool {
 	return m != nil && len(m.classes) > 0
 }
 
+// RequiresResourceSlices reports whether any enabled class reads ResourceSlices.
+func (m *Manager) RequiresResourceSlices() bool {
+	if !m.Enabled() {
+		return false
+	}
+
+	for _, class := range m.classes {
+		if class.referencesResourceSlices() {
+			return true
+		}
+	}
+
+	return false
+}
+
 // ClassCount returns the number of compiled device-count classes.
 func (m *Manager) ClassCount() int {
 	return len(m.classes)

--- a/labeler/pkg/devicecounts/device_counts.go
+++ b/labeler/pkg/devicecounts/device_counts.go
@@ -358,8 +358,10 @@ func (m *Manager) evaluateCurrent(
 
 	// Kubernetes labels are strings, but the documented GPU expression uses
 	// int(node.metadata.labels['nvidia.com/gpu.count']). Normalizing numeric
-	// strings avoids CEL runtime conversion gaps for dynamic map values.
-	normalizeNumericNodeLabels(nodeMap)
+	// strings avoids CEL runtime conversion gaps for dynamic map values. Do the
+	// same for resource quantities so device-plugin allocatable counts can use
+	// int(node.status.allocatable['...']).
+	normalizeNumericNodeInputs(nodeMap)
 
 	resourceSliceMaps := make([]map[string]any, 0, len(resourceSlices))
 	for _, resourceSlice := range resourceSlices {
@@ -412,18 +414,30 @@ func celResultToInt(result ref.Val) (int, bool) {
 	}
 }
 
-func normalizeNumericNodeLabels(nodeMap map[string]any) {
+func normalizeNumericNodeInputs(nodeMap map[string]any) {
 	metadata, ok := nodeMap["metadata"].(map[string]any)
+	if ok {
+		if nodeLabels, ok := metadata["labels"].(map[string]any); ok {
+			normalizeNumericMapValues(nodeLabels)
+		}
+	}
+
+	status, ok := nodeMap["status"].(map[string]any)
 	if !ok {
 		return
 	}
 
-	nodeLabels, ok := metadata["labels"].(map[string]any)
-	if !ok {
-		return
+	if allocatable, ok := status["allocatable"].(map[string]any); ok {
+		normalizeNumericMapValues(allocatable)
 	}
 
-	for key, value := range nodeLabels {
+	if capacity, ok := status["capacity"].(map[string]any); ok {
+		normalizeNumericMapValues(capacity)
+	}
+}
+
+func normalizeNumericMapValues(values map[string]any) {
+	for key, value := range values {
 		raw, ok := value.(string)
 		if !ok {
 			continue
@@ -431,7 +445,7 @@ func normalizeNumericNodeLabels(nodeMap map[string]any) {
 
 		parsed, err := strconv.ParseInt(raw, 10, 64)
 		if err == nil {
-			nodeLabels[key] = parsed
+			values[key] = parsed
 		}
 	}
 }

--- a/labeler/pkg/devicecounts/device_counts_test.go
+++ b/labeler/pkg/devicecounts/device_counts_test.go
@@ -148,6 +148,46 @@ func TestExpectedDeviceCountsOverridePrecedence(t *testing.T) {
 	require.Equal(t, "8", node.Labels[testGPUCountExpectedLabel])
 }
 
+func TestManagerRequiresResourceSlices(t *testing.T) {
+	t.Run("node-only expression does not require ResourceSlices", func(t *testing.T) {
+		manager := newTestManager(t, Config{
+			Enabled: true,
+			Classes: []ClassConfig{
+				{
+					Name:    "gpu",
+					Enabled: true,
+					Labels: Labels{
+						Current:  testGPUCountCurrentLabel,
+						Expected: testGPUCountExpectedLabel,
+					},
+					CurrentExpression: "int(node.metadata.labels['nvidia.com/gpu.count'])",
+				},
+			},
+		})
+
+		require.False(t, manager.RequiresResourceSlices())
+	})
+
+	t.Run("ResourceSlice expression requires ResourceSlices", func(t *testing.T) {
+		manager := newTestManager(t, Config{
+			Enabled: true,
+			Classes: []ClassConfig{
+				{
+					Name:    "nic",
+					Enabled: true,
+					Labels: Labels{
+						Current:  testNICCountCurrentLabel,
+						Expected: testNICCountExpectedLabel,
+					},
+					CurrentExpression: "resourceSlices.size()",
+				},
+			},
+		})
+
+		require.True(t, manager.RequiresResourceSlices())
+	})
+}
+
 func newTestManager(t *testing.T, config Config) *Manager {
 	t.Helper()
 

--- a/labeler/pkg/devicecounts/device_counts_test.go
+++ b/labeler/pkg/devicecounts/device_counts_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -146,6 +147,40 @@ func TestExpectedDeviceCountsOverridePrecedence(t *testing.T) {
 	require.True(t, updated)
 	require.Equal(t, "4", node.Labels[testGPUCountCurrentLabel])
 	require.Equal(t, "8", node.Labels[testGPUCountExpectedLabel])
+}
+
+func TestExpectedDeviceCountsFromAllocatableResourceQuantity(t *testing.T) {
+	config := Config{
+		Enabled: true,
+		Classes: []ClassConfig{
+			{
+				Name:    "nic",
+				Enabled: true,
+				Labels: Labels{
+					Current:  testNICCountCurrentLabel,
+					Expected: testNICCountExpectedLabel,
+				},
+				CurrentExpression: "int(node.status.allocatable['nvidia.com/mlnxnics'])",
+			},
+		},
+	}
+
+	node := testNode("node-a", map[string]string{})
+	node.Status.Allocatable = corev1.ResourceList{
+		corev1.ResourceName("nvidia.com/mlnxnics"): resource.MustParse("8"),
+	}
+
+	manager := newTestManager(t, config)
+	updated := manager.ReconcileNodeLabelsInPlace(
+		context.Background(),
+		node,
+		[]*corev1.Node{node},
+		func(*corev1.Node) []*resourcev1.ResourceSlice { return nil },
+	)
+
+	require.True(t, updated)
+	require.Equal(t, "8", node.Labels[testNICCountCurrentLabel])
+	require.Equal(t, "8", node.Labels[testNICCountExpectedLabel])
 }
 
 func TestManagerRequiresResourceSlices(t *testing.T) {

--- a/labeler/pkg/labeler/labeler.go
+++ b/labeler/pkg/labeler/labeler.go
@@ -109,7 +109,7 @@ func NewLabeler(clientset kubernetes.Interface, resyncPeriod time.Duration,
 	}
 
 	var resourceSliceInformer cache.SharedIndexInformer
-	if deviceCounts.Enabled() {
+	if deviceCounts.RequiresResourceSlices() {
 		resourceSliceInformer = createResourceSliceInformer(clientset, resyncPeriod)
 		informersSynced = append(informersSynced, resourceSliceInformer.HasSynced)
 	}

--- a/labeler/pkg/labeler/labeler_test.go
+++ b/labeler/pkg/labeler/labeler_test.go
@@ -811,7 +811,7 @@ func TestNewLabeler_ResourceSliceInformerEnabled(t *testing.T) {
 		require.Len(t, labeler.informersSynced, 3)
 	})
 
-	t.Run("enabled config creates ResourceSlice informer", func(t *testing.T) {
+	t.Run("node-only enabled config does not create ResourceSlice informer", func(t *testing.T) {
 		labeler, err := NewLabeler(
 			clientset,
 			time.Minute,
@@ -821,6 +821,22 @@ func TestNewLabeler_ResourceSliceInformerEnabled(t *testing.T) {
 			"",
 			false,
 			testDeviceCountConfig(),
+		)
+		require.NoError(t, err)
+		require.Nil(t, labeler.resourceSliceInformer)
+		require.Len(t, labeler.informersSynced, 3)
+	})
+
+	t.Run("ResourceSlice expression creates ResourceSlice informer", func(t *testing.T) {
+		labeler, err := NewLabeler(
+			clientset,
+			time.Minute,
+			"nvidia-dcgm",
+			"nvidia-driver-daemonset",
+			"nvidia-driver-installer",
+			"",
+			false,
+			testResourceSliceDeviceCountConfig(),
 		)
 		require.NoError(t, err)
 		require.NotNil(t, labeler.resourceSliceInformer)
@@ -877,7 +893,7 @@ func TestLabelerResourceSlicesForNodeFiltersByNodeName(t *testing.T) {
 		"nvidia-driver-installer",
 		"",
 		false,
-		testDeviceCountConfig(),
+		testResourceSliceDeviceCountConfig(),
 	)
 	require.NoError(t, err)
 	require.NotNil(t, labeler.resourceSliceInformer)
@@ -924,6 +940,13 @@ func testDeviceCountConfig() devicecounts.Config {
 			},
 		},
 	}
+}
+
+func testResourceSliceDeviceCountConfig() devicecounts.Config {
+	config := testDeviceCountConfig()
+	config.Classes[0].CurrentExpression = "resourceSlices.size()"
+
+	return config
 }
 
 // TestKataLabelOverrideIsolation verifies that creating multiple labeler instances


### PR DESCRIPTION
## Summary

This PR fixes couple of bugs:

### Eager initialization of ResourceSlice informer
While enabling device count functionality in labeler, even though we were using only device-plugin method count:
```
$ kg configmap -n nvsentinel labeler -o yaml | yq .data
expected-device-counts.toml: |
  enabled = true

  [[classes]]
  name = "gpu"
  enabled = true
  groupingLabels = ["node.kubernetes.io/instance-type", "nvidia.com/gpu.product"]
  currentExpression = '''
  int(node.metadata.labels['nvidia.com/gpu.count'])
  '''

  [classes.labels]
  current = "nvsentinel.dgxc.nvidia.com/gpu.count.current"
  expected = "nvsentinel.dgxc.nvidia.com/gpu.count.expected"

  [[classes]]
  name = "nic"
  enabled = true
  groupingLabels = ["node.kubernetes.io/instance-type"]
  currentExpression = '''
  int(node.status.allocatable['nvidia.com/mlnxnics'])
  '''

  [classes.labels]
  current = "nvsentinel.dgxc.nvidia.com/nic.count.current"
  expected = "nvsentinel.dgxc.nvidia.com/nic.count.expected"
```

but labeler was trying initialize resource slice informer:
```
0625 12:08:12.665182       1 reflector.go:227] "Failed to watch" err="failed to list *v1.ResourceSlice: the server could not find the requested resource (get resourceslices.resource.k8s.io)" logger="UnhandledError" reflector="k8s.io/client-go@v0.36.2/tools/cache/reflector.go:343" type="*v1.ResourceSlice"
E0625 12:08:17.346261       1 reflector.go:227] "Failed to watch" err="failed to list *v1.ResourceSlice: the server could not find the requested resource (get resourceslices.resource.k8s.io)" logger="UnhandledError" reflector="k8s.io/client-go@v0.36.2/tools/cache/reflector.go:343" type="*v1.ResourceSlice"
E0625 12:08:28.137644       1 reflector.go:227] "Failed to watch" err="failed to list *v1.ResourceSlice: the server could not find the requested resource (get resourceslices.resource.k8s.io)" logger="UnhandledError" reflector="k8s.io/client-go@v0.36.2/tools/cache/reflector.go:343" type="*v1.ResourceSlice"

```

After this change:
```
$ klog deploy/labeler -n nvsentinel
{"time":"2026-06-25T12:20:30.605405859Z","level":"INFO","msg":"Starting labeler","module":"labeler","version":"v1.11.0","version":"v1.11.0","commit":"a6408f9cf9141c7b4612065834bfb94b4fdbd0d6","date":"2026-06-25T12:18:51Z"}
{"time":"2026-06-25T12:20:30.606059767Z","level":"INFO","msg":"server initialized","module":"labeler","version":"v1.11.0","port":2112,"read_timeout":10000000000,"write_timeout":10000000000}
{"time":"2026-06-25T12:20:30.606089533Z","level":"INFO","msg":"Starting labeler module initialization","module":"labeler","version":"v1.11.0"}
W0625 12:20:30.606129       1 client_config.go:683] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
{"time":"2026-06-25T12:20:30.60691692Z","level":"INFO","msg":"Successfully initialized kubernetes client","module":"labeler","version":"v1.11.0"}
{"time":"2026-06-25T12:20:30.60907109Z","level":"INFO","msg":"Labeler configured to reconcile expected device count labels","module":"labeler","version":"v1.11.0","classes":2}
{"time":"2026-06-25T12:20:30.609088283Z","level":"INFO","msg":"Labeler created, watching DCGM and driver pods, and nodes for kata detection","module":"labeler","version":"v1.11.0"}
{"time":"2026-06-25T12:20:30.609091909Z","level":"INFO","msg":"Initialization completed successfully","module":"labeler","version":"v1.11.0"}
{"time":"2026-06-25T12:20:30.609136393Z","level":"INFO","msg":"Waiting for Labeler caches to sync...","module":"labeler","version":"v1.11.0"}
{"time":"2026-06-25T12:20:30.609146732Z","level":"INFO","msg":"Starting metrics server","module":"labeler","version":"v1.11.0","port":2112}
{"time":"2026-06-25T12:20:30.609531152Z","level":"INFO","msg":"starting server","module":"labeler","version":"v1.11.0","addr":":2112"}
{"time":"2026-06-25T12:20:30.709194315Z","level":"INFO","msg":"Labeler caches synced","module":"labeler","version":"v1.11.0"}
{"time":"2026-06-25T12:20:30.722469414Z","level":"WARN","msg":"Skipping device count label update after current count evaluation failed","module":"labeler","version":"v1.11.0","node":"aks-gpu-123-vmss00000x","class":"gpu","error":"evaluate currentExpression: no such key: nvidia.com/gpu.count"}
```

### String digit normalization

Before:
```
{"time":"2026-06-25T12:12:47.425631024Z","level":"WARN","msg":"Skipping device count label update after current count evaluation failed","module":"labeler","version":"v1.11.0","node":"aks-gpu-123-vmss00001b","class":"nic","error":"evaluate currentExpression: no such overload: int(string)"}
```

After:
```
$ kd no aks-gpu-123-vmss00001b | grep nvsentinel.dgxc.nvidia.com/nic.count.current
                    nvsentinel.dgxc.nvidia.com/nic.count.current=8
```
## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Resource-slice support is now enabled only when the device-count configuration explicitly depends on it.

- **Bug Fixes**
  - Prevents unnecessary ResourceSlice RBAC/informer usage for node-only device-count setups.
  - Improves device-count evaluation by correctly normalizing numeric values from node allocatable/capacity when computing expected counts.

- **Tests**
  - Added/updated coverage for ResourceSlice-dependent vs node-only configurations and for expected counts derived from allocatable resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->