### PR TITLE
fix: handle malformed xid 154 gracefully in syslog HM

### DIFF
--- a/health-monitors/syslog-health-monitor/pkg/xid/parser/csv.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/parser/csv.go
@@ -247,7 +247,7 @@ func (p *CSVParser) getRecommendedActionForXid(xidCode int, message string) pb.R
 		lastOpenParan := strings.LastIndex(message, "(")
 		lastCloseParan := strings.LastIndex(message, ")")
 
-		if lastOpenParan != -1 && lastCloseParan != -1 {
+		if lastOpenParan != -1 && lastCloseParan != -1 && lastOpenParan < lastCloseParan {
 			// recommendations should be "GPU Reset Required", i.e., the string inside the last ()
 			recommendation := message[lastOpenParan+1 : lastCloseParan]
 

--- a/health-monitors/syslog-health-monitor/pkg/xid/parser/csv_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/xid/parser/csv_test.go
@@ -194,6 +194,20 @@ func TestCSVParser_Parse(t *testing.T) {
 			expectedErrorCode: "154",
 			expectedMetadata:  map[string]string{},
 		},
+		{
+			// Untrusted/garbage syslog line that matches the XID 154 pattern but has its
+			// last ')' before its last '(' (trailing unmatched '('). The parser must not
+			// panic with slice-bounds-out-of-range and must fall back to CONTACT_SUPPORT.
+			name:              "XID 154 with out-of-order parens does not panic",
+			message:           "NVRM: Xid (PCI:0000:01:00): 154 (",
+			expectedSuccess:   true,
+			expectedXIDCode:   154,
+			expectedPCIAddr:   "0000:01:00",
+			expectedAction:    pb.RecommendedAction_CONTACT_SUPPORT,
+			expectedMnemonic:  "XID 154",
+			expectedErrorCode: "154",
+			expectedMetadata:  map[string]string{},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary

A craft XID 154 line where `)` precedes `(` can crash syslog HM if CSV parser is used. This PR avoids that with:
```
slog.Warn("xid 154 did not have expected format", "msg", message)
```

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [x] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
