### PR TITLE
fix: fault quarantine annotation handling race condition during health event burst

### DIFF
--- a/fault-quarantine/pkg/healthEventsAnnotation/health_events_annotation_map.go
+++ b/fault-quarantine/pkg/healthEventsAnnotation/health_events_annotation_map.go
@@ -346,6 +346,68 @@ func (he *HealthEventsAnnotationMap) GetAllCheckNames() []string {
 	return checkNames
 }
 
+// MergeAnnotationValues merges an incoming quarantineHealthEvent annotation value into an
+// existing one and returns the merged JSON string.
+//
+// Both values may be in the new map format (a JSON slice of events) or the legacy
+// single-event format; empty strings are treated as "no events". Events are de-duplicated
+// using entity/errorCode-level keys (see AddOrUpdateEvent), so concurrent first-time
+// quarantine events for the same node are preserved instead of one overwriting the other.
+func MergeAnnotationValues(existing, incoming string) (string, error) {
+	merged := NewHealthEventsAnnotationMap()
+
+	if err := mergeAnnotationValueInto(merged, existing); err != nil {
+		return "", fmt.Errorf("failed to parse existing annotation: %w", err)
+	}
+
+	if err := mergeAnnotationValueInto(merged, incoming); err != nil {
+		return "", fmt.Errorf("failed to parse incoming annotation: %w", err)
+	}
+
+	out, err := json.Marshal(merged)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal merged annotation: %w", err)
+	}
+
+	return string(out), nil
+}
+
+// mergeAnnotationValueInto unmarshals a single annotation value (new map format or legacy
+// single-event format) and adds every event it contains into the target map.
+func mergeAnnotationValueInto(target *HealthEventsAnnotationMap, value string) error {
+	if value == "" {
+		return nil
+	}
+
+	parsed := NewHealthEventsAnnotationMap()
+	if err := json.Unmarshal([]byte(value), parsed); err != nil {
+		// Fall back to the legacy single-event format.
+		var singleEvent protos.HealthEvent
+		if err2 := json.Unmarshal([]byte(value), &singleEvent); err2 != nil {
+			return fmt.Errorf("failed to parse annotation (tried both formats): %w", err)
+		}
+
+		target.AddOrUpdateEvent(&singleEvent)
+
+		return nil
+	}
+
+	// Deduplicate event pointers (multiple entity keys may reference the same event object).
+	seen := make(map[*protos.HealthEvent]bool)
+
+	for _, event := range parsed.Events {
+		if seen[event] {
+			continue
+		}
+
+		seen[event] = true
+
+		target.AddOrUpdateEvent(event)
+	}
+
+	return nil
+}
+
 // MarshalJSON converts the map to a JSON-serializable format (slice of events)
 // Deduplicates events since multiple entity keys may point to the same event object
 func (he *HealthEventsAnnotationMap) MarshalJSON() ([]byte, error) {

--- a/fault-quarantine/pkg/healthEventsAnnotation/health_events_annotation_map_test.go
+++ b/fault-quarantine/pkg/healthEventsAnnotation/health_events_annotation_map_test.go
@@ -902,3 +902,149 @@ func TestGetEvent_AsymmetricErrorCodeMatching(t *testing.T) {
 		t.Errorf("matched event ErrorCode = %v, want [98]", got.ErrorCode)
 	}
 }
+
+// nodeLevelEvent builds a fatal node-level health event scoped to a single error code.
+// It models the case where concurrent failures on the same node/check/entity differ only
+// by their error code.
+func nodeLevelEvent(node, errorCode string) *protos.HealthEvent {
+	return &protos.HealthEvent{
+		Version:        1,
+		Agent:          "test-node-monitor",
+		ComponentClass: "Node",
+		CheckName:      "NodeCertFailed",
+		NodeName:       node,
+		IsFatal:        true,
+		ErrorCode:      []string{errorCode},
+		EntitiesImpacted: []*protos.Entity{
+			{EntityType: "v1/Node", EntityValue: node},
+		},
+	}
+}
+
+func mustMarshalSingleEvent(t *testing.T, event *protos.HealthEvent) string {
+	t.Helper()
+
+	b, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("failed to marshal single event: %v", err)
+	}
+
+	return string(b)
+}
+
+func mustMarshalMap(t *testing.T, events ...*protos.HealthEvent) string {
+	t.Helper()
+
+	m := NewHealthEventsAnnotationMap()
+	for _, e := range events {
+		m.AddOrUpdateEvent(e)
+	}
+
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("failed to marshal map: %v", err)
+	}
+
+	return string(b)
+}
+
+// TestMergeAnnotationValues_ConcurrentDistinctErrorCodes reproduces the production race where
+// two first-time fatal events for the same node/check/entity (differing only by error code)
+// are applied nearly simultaneously. Merging must retain both instead of the second
+// overwriting the first.
+func TestMergeAnnotationValues_ConcurrentDistinctErrorCodes(t *testing.T) {
+	node := "test-node-1"
+	firstEvent := nodeLevelEvent(node, "check-a/Failure")
+	secondEvent := nodeLevelEvent(node, "check-b/Failure")
+
+	// Existing annotation already holds the first event; the second event is the incoming
+	// single-event annotation built by the fresh-quarantine path.
+	existing := mustMarshalMap(t, firstEvent)
+	incoming := mustMarshalMap(t, secondEvent)
+
+	merged, err := MergeAnnotationValues(existing, incoming)
+	if err != nil {
+		t.Fatalf("MergeAnnotationValues returned error: %v", err)
+	}
+
+	var mergedMap HealthEventsAnnotationMap
+	if err := json.Unmarshal([]byte(merged), &mergedMap); err != nil {
+		t.Fatalf("failed to unmarshal merged annotation: %v", err)
+	}
+
+	if mergedMap.Count() != 2 {
+		t.Fatalf("merged Count() = %d, want 2 (both events must be retained)", mergedMap.Count())
+	}
+
+	if _, found := mergedMap.GetEvent(firstEvent); !found {
+		t.Errorf("first event missing after merge")
+	}
+
+	if _, found := mergedMap.GetEvent(secondEvent); !found {
+		t.Errorf("second event missing after merge")
+	}
+}
+
+func TestMergeAnnotationValues_EmptyExisting(t *testing.T) {
+	node := "node1"
+	incoming := mustMarshalMap(t, nodeLevelEvent(node, "check-b/Failure"))
+
+	merged, err := MergeAnnotationValues("", incoming)
+	if err != nil {
+		t.Fatalf("MergeAnnotationValues returned error: %v", err)
+	}
+
+	var mergedMap HealthEventsAnnotationMap
+	if err := json.Unmarshal([]byte(merged), &mergedMap); err != nil {
+		t.Fatalf("failed to unmarshal merged annotation: %v", err)
+	}
+
+	if mergedMap.Count() != 1 {
+		t.Fatalf("merged Count() = %d, want 1", mergedMap.Count())
+	}
+}
+
+// TestMergeAnnotationValues_LegacySingleEventExisting ensures the merge handles a node that
+// still carries the legacy single-event annotation format.
+func TestMergeAnnotationValues_LegacySingleEventExisting(t *testing.T) {
+	node := "node1"
+	existing := mustMarshalSingleEvent(t, nodeLevelEvent(node, "check-a/Failure"))
+	incoming := mustMarshalMap(t, nodeLevelEvent(node, "check-b/Failure"))
+
+	merged, err := MergeAnnotationValues(existing, incoming)
+	if err != nil {
+		t.Fatalf("MergeAnnotationValues returned error: %v", err)
+	}
+
+	var mergedMap HealthEventsAnnotationMap
+	if err := json.Unmarshal([]byte(merged), &mergedMap); err != nil {
+		t.Fatalf("failed to unmarshal merged annotation: %v", err)
+	}
+
+	if mergedMap.Count() != 2 {
+		t.Fatalf("merged Count() = %d, want 2 (legacy + new must both be retained)", mergedMap.Count())
+	}
+}
+
+// TestMergeAnnotationValues_DuplicateEventIsIdempotent ensures replaying the same event does
+// not create duplicate entries.
+func TestMergeAnnotationValues_DuplicateEventIsIdempotent(t *testing.T) {
+	node := "node1"
+	event := nodeLevelEvent(node, "check-a/Failure")
+	existing := mustMarshalMap(t, event)
+	incoming := mustMarshalMap(t, event)
+
+	merged, err := MergeAnnotationValues(existing, incoming)
+	if err != nil {
+		t.Fatalf("MergeAnnotationValues returned error: %v", err)
+	}
+
+	var mergedMap HealthEventsAnnotationMap
+	if err := json.Unmarshal([]byte(merged), &mergedMap); err != nil {
+		t.Fatalf("failed to unmarshal merged annotation: %v", err)
+	}
+
+	if mergedMap.Count() != 1 {
+		t.Fatalf("merged Count() = %d, want 1 (duplicate must not be added)", mergedMap.Count())
+	}
+}

--- a/fault-quarantine/pkg/informer/k8s_client.go
+++ b/fault-quarantine/pkg/informer/k8s_client.go
@@ -34,6 +34,7 @@ import (
 	"github.com/nvidia/nvsentinel/fault-quarantine/pkg/breaker"
 	"github.com/nvidia/nvsentinel/fault-quarantine/pkg/common"
 	"github.com/nvidia/nvsentinel/fault-quarantine/pkg/config"
+	"github.com/nvidia/nvsentinel/fault-quarantine/pkg/healthEventsAnnotation"
 )
 
 var customBackoff = wait.Backoff{
@@ -379,6 +380,28 @@ func (c *FaultQuarantineClient) applyAnnotations(
 	slog.InfoContext(ctx, "Setting annotations on node", "node", nodename, "annotations", annotations)
 
 	for annotationKey, annotationValue := range annotations {
+		// The quarantine health-event annotation must be merged with whatever is already on the
+		// live node rather than overwritten. Two first-time fatal events for the same node can be
+		// processed nearly simultaneously; the routing decision is based on the (eventually
+		// consistent) informer cache, so the second event may not yet see the first one's
+		// annotation and would otherwise clobber it here. Merging against the live object (this
+		// runs inside UpdateNode's retry-on-conflict loop) preserves both events.
+		if annotationKey == common.QuarantineHealthEventAnnotationKey {
+			merged, err := healthEventsAnnotation.MergeAnnotationValues(node.Annotations[annotationKey], annotationValue)
+			if err != nil {
+				slog.WarnContext(ctx, "Failed to merge quarantine health event annotation; overwriting",
+					"node", nodename, "error", err)
+
+				node.Annotations[annotationKey] = annotationValue
+
+				continue
+			}
+
+			node.Annotations[annotationKey] = merged
+
+			continue
+		}
+
 		node.Annotations[annotationKey] = annotationValue
 	}
 }


### PR DESCRIPTION
## Summary

<!-- Brief description of your changes -->

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Quarantine health event annotations now merge with existing values instead of replacing them outright.
  - Multiple health events for the same node can be preserved in a single annotation, including older single-event formats.

- **Bug Fixes**
  - Prevents duplicate health events from being added when the same event is reported more than once.
  - If merging cannot be completed, the annotation update still falls back to the latest value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->