### PR TITLE
feat: preserve pre-existing taints and cordons in fault-quarantine

### DIFF
--- a/fault-quarantine/pkg/common/common.go
+++ b/fault-quarantine/pkg/common/common.go
@@ -24,14 +24,16 @@ const (
 
 const (
 	// Annotation keys for storing event on node which causes node to be cordoned or tainted
-	QuarantineHealthEventAnnotationKey                 = "quarantineHealthEvent"
-	QuarantineHealthEventAppliedTaintsAnnotationKey    = "quarantineHealthEventAppliedTaints"
-	QuarantineHealthEventIsCordonedAnnotationKey       = "quarantineHealthEventIsCordoned"
-	QuarantineHealthEventIsCordonedAnnotationValueTrue = "True"
-	QuarantinedNodeUncordonedManuallyAnnotationKey     = "quarantinedNodeUncordonedManually"
-	QuarantinedNodeUncordonedManuallyAnnotationValue   = "True"
-	QuarantinedNodeIsUntaintedManuallyAnnotationKey    = "quarantinedNodeUntaintedManually"
-	QuarantinedNodeIsUntaintedManuallyAnnotationValue  = "True"
+	QuarantineHealthEventAnnotationKey                    = "quarantineHealthEvent"
+	QuarantineHealthEventAppliedTaintsAnnotationKey       = "quarantineHealthEventAppliedTaints"
+	QuarantineHealthEventIsCordonedAnnotationKey          = "quarantineHealthEventIsCordoned"
+	QuarantineHealthEventIsCordonedAnnotationValueTrue    = "True"
+	QuarantineHealthEventCordonPreExistingAnnotationKey   = "quarantineHealthEventCordonPreExisting"
+	QuarantineHealthEventCordonPreExistingAnnotationValue = "True"
+	QuarantinedNodeUncordonedManuallyAnnotationKey        = "quarantinedNodeUncordonedManually"
+	QuarantinedNodeUncordonedManuallyAnnotationValue      = "True"
+	QuarantinedNodeIsUntaintedManuallyAnnotationKey       = "quarantinedNodeUntaintedManually"
+	QuarantinedNodeIsUntaintedManuallyAnnotationValue     = "True"
 
 	ServiceName = "NVSentinel"
 )

--- a/fault-quarantine/pkg/config/config.go
+++ b/fault-quarantine/pkg/config/config.go
@@ -20,9 +20,10 @@ type Rule struct {
 }
 
 type Taint struct {
-	Key    string `toml:"key"`
-	Value  string `toml:"value"`
-	Effect string `toml:"effect"`
+	Key         string `toml:"key"    json:"key"`
+	Value       string `toml:"value"  json:"value"`
+	Effect      string `toml:"effect" json:"effect"`
+	PreExisting bool   `toml:"-"      json:"preExisting"`
 }
 
 type Cordon struct {

--- a/fault-quarantine/pkg/informer/k8s_client.go
+++ b/fault-quarantine/pkg/informer/k8s_client.go
@@ -401,6 +401,7 @@ func (c *FaultQuarantineClient) UnQuarantineNodeAndRemoveAnnotations(
 	ctx context.Context,
 	nodename string,
 	taints []config.Taint,
+	shouldUncordon bool,
 	annotationKeys []string,
 	labelsToRemove []string,
 	labels map[string]string,
@@ -412,7 +413,9 @@ func (c *FaultQuarantineClient) UnQuarantineNodeAndRemoveAnnotations(
 			}
 		}
 
-		c.handleUncordon(ctx, node, labels, nodename)
+		if shouldUncordon {
+			c.handleUncordon(ctx, node, labels, nodename)
+		}
 
 		if len(annotationKeys) > 0 {
 			for _, annotationKey := range annotationKeys {
@@ -527,7 +530,6 @@ func (c *FaultQuarantineClient) HandleManualUncordonCleanup(
 
 // HandleManualUntaintCleanup atomically removes FQ annotations/taints/labels and adds manual untaint annotation
 // This is used when a node is manually untainted while having FQ quarantine state
-// Also uncordons the node to ensure full cleanup
 func (c *FaultQuarantineClient) HandleManualUntaintCleanup(
 	ctx context.Context,
 	nodename string,

--- a/fault-quarantine/pkg/informer/k8s_client_test.go
+++ b/fault-quarantine/pkg/informer/k8s_client_test.go
@@ -248,7 +248,7 @@ func TestUnQuarantineNodeAndRemoveAnnotations(t *testing.T) {
 		uncordonedTimestampLabelKey: time.Now().UTC().Format("2006-01-02T15-04-05Z"),
 	}
 
-	err := k8sClient.UnQuarantineNodeAndRemoveAnnotations(ctx, nodeName, taintsToRemove, annotationKeys, []string{cordonedByLabelKey, cordonedReasonLabelKey, cordonedTimestampLabelKey}, labelsMap)
+	err := k8sClient.UnQuarantineNodeAndRemoveAnnotations(ctx, nodeName, taintsToRemove, true, annotationKeys, []string{cordonedByLabelKey, cordonedReasonLabelKey, cordonedTimestampLabelKey}, labelsMap)
 	if err != nil {
 		t.Fatalf("UnQuarantineNodeAndRemoveAnnotations failed: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestUnTaintAndUnCordonNode_NoChanges(t *testing.T) {
 
 	k8sClient := setupTestClient(t)
 
-	err := k8sClient.UnQuarantineNodeAndRemoveAnnotations(ctx, nodeName, nil, nil, []string{}, map[string]string{})
+	err := k8sClient.UnQuarantineNodeAndRemoveAnnotations(ctx, nodeName, nil, true, nil, []string{}, map[string]string{})
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -385,7 +385,7 @@ func TestUnTaintAndUnCordonNode_PartialTaintRemoval(t *testing.T) {
 	k8sClient := setupTestClient(t)
 
 	taintsToRemove := []config.Taint{{Key: "taint1", Value: "val1", Effect: "NoSchedule"}}
-	err := k8sClient.UnQuarantineNodeAndRemoveAnnotations(ctx, nodeName, taintsToRemove, nil, []string{}, map[string]string{})
+	err := k8sClient.UnQuarantineNodeAndRemoveAnnotations(ctx, nodeName, taintsToRemove, false, nil, []string{}, map[string]string{})
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -436,7 +436,7 @@ func TestUnTaintAndUnCordonNode_PartialAnnotationRemoval(t *testing.T) {
 		uncordonedByLabelKey:        common.ServiceName,
 		uncordonedTimestampLabelKey: time.Now().UTC().Format("2006-01-02T15-04-05Z"),
 	}
-	err := k8sClient.UnQuarantineNodeAndRemoveAnnotations(ctx, nodeName, nil, annotationsToRemove, []string{cordonedByLabelKey, cordonedReasonLabelKey, cordonedTimestampLabelKey}, labelsMap)
+	err := k8sClient.UnQuarantineNodeAndRemoveAnnotations(ctx, nodeName, nil, true, annotationsToRemove, []string{cordonedByLabelKey, cordonedReasonLabelKey, cordonedTimestampLabelKey}, labelsMap)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -509,7 +509,7 @@ func TestUnTaintAndUnCordonNode_AlreadyUntaintedUncordoned(t *testing.T) {
 
 	k8sClient := setupTestClient(t)
 
-	err := k8sClient.UnQuarantineNodeAndRemoveAnnotations(ctx, nodeName, nil, nil, []string{}, map[string]string{})
+	err := k8sClient.UnQuarantineNodeAndRemoveAnnotations(ctx, nodeName, nil, true, nil, []string{}, map[string]string{})
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -589,7 +589,7 @@ func TestUnTaintAndUnCordonNode_NonExistentTaintRemoval(t *testing.T) {
 	k8sClient := setupTestClient(t)
 
 	taintsToRemove := []config.Taint{{Key: "taint-nonexistent", Value: "valX", Effect: "NoSchedule"}}
-	err := k8sClient.UnQuarantineNodeAndRemoveAnnotations(ctx, nodeName, taintsToRemove, nil, []string{}, map[string]string{})
+	err := k8sClient.UnQuarantineNodeAndRemoveAnnotations(ctx, nodeName, taintsToRemove, true, nil, []string{}, map[string]string{})
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -628,7 +628,7 @@ func TestUnTaintAndUnCordonNode_NonExistentAnnotationRemoval(t *testing.T) {
 	k8sClient := setupTestClient(t)
 
 	annotationsToRemove := []string{"nonexistent-annotation"}
-	err := k8sClient.UnQuarantineNodeAndRemoveAnnotations(ctx, nodeName, nil, annotationsToRemove, []string{}, map[string]string{})
+	err := k8sClient.UnQuarantineNodeAndRemoveAnnotations(ctx, nodeName, nil, true, annotationsToRemove, []string{}, map[string]string{})
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -700,7 +700,7 @@ func TestUnTaintAndUnCordonNode_NonExistentNode(t *testing.T) {
 	ctx := context.Background()
 	k8sClient := setupTestClient(t)
 
-	err := k8sClient.UnQuarantineNodeAndRemoveAnnotations(ctx, "no-such-node", nil, nil, []string{}, map[string]string{})
+	err := k8sClient.UnQuarantineNodeAndRemoveAnnotations(ctx, "no-such-node", nil, true, nil, []string{}, map[string]string{})
 	if err == nil {
 		t.Errorf("Expected error for non-existent node, got nil")
 	}

--- a/fault-quarantine/pkg/reconciler/reconciler.go
+++ b/fault-quarantine/pkg/reconciler/reconciler.go
@@ -566,7 +566,20 @@ func (r *Reconciler) handleEvent(
 
 	taintsToBeApplied := r.collectTaintsToApply(taintAppliedMap)
 
-	annotationsMap := r.prepareAnnotations(ctx, taintsToBeApplied, &labelsMap, &isCordoned)
+	node, err := r.k8sClient.NodeInformer.GetNode(event.HealthEvent.NodeName)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to get node from cache", "node", event.HealthEvent.NodeName, "error", err)
+		metrics.ProcessingErrors.WithLabelValues("get_node_cache_error").Inc()
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("fault_quarantine.error.type", "get_node_cache_error"),
+			attribute.String("fault_quarantine.error.message", err.Error()),
+		)
+
+		return nil
+	}
+
+	annotationsMap := r.prepareAnnotations(ctx, node, taintsToBeApplied, &labelsMap, &isCordoned)
 
 	isNodeQuarantined := len(taintsToBeApplied) > 0 || isCordoned.Load()
 
@@ -860,6 +873,7 @@ func (r *Reconciler) collectTaintsToApply(taintAppliedMap map[keyValTaint]string
 // prepareAnnotations prepares annotations and labels to be applied if any
 func (r *Reconciler) prepareAnnotations(
 	ctx context.Context,
+	node *corev1.Node,
 	taintsToBeApplied []config.Taint,
 	labelsMap *sync.Map,
 	isCordoned *atomic.Bool,
@@ -867,6 +881,8 @@ func (r *Reconciler) prepareAnnotations(
 	annotationsMap := map[string]string{}
 
 	if len(taintsToBeApplied) > 0 {
+		markPreExistingTaints(node, taintsToBeApplied)
+
 		taintsJsonStr, err := json.Marshal(taintsToBeApplied)
 		if err != nil {
 			slog.ErrorContext(ctx, "Failed to marshal taints for annotation", "error", err)
@@ -879,8 +895,18 @@ func (r *Reconciler) prepareAnnotations(
 		annotationsMap[common.QuarantineHealthEventIsCordonedAnnotationKey] =
 			common.QuarantineHealthEventIsCordonedAnnotationValueTrue
 
-		labelsMap.LoadOrStore(r.cordonedByLabelKey, common.ServiceName)
-		labelsMap.Store(r.cordonedTimestampLabelKey, time.Now().UTC().Format("2006-01-02T15-04-05Z"))
+		// The cordon-by and cordon-reason labels would have already been set in evaluateRulesets. We will remove
+		// them from the set of labels we're applying if the node has a pre-existing cordon.
+		if node.Spec.Unschedulable {
+			annotationsMap[common.QuarantineHealthEventCordonPreExistingAnnotationKey] =
+				common.QuarantineHealthEventCordonPreExistingAnnotationValue
+
+			labelsMap.Delete(r.cordonedByLabelKey)
+			labelsMap.Delete(r.cordonedReasonLabelKey)
+		} else {
+			labelsMap.LoadOrStore(r.cordonedByLabelKey, common.ServiceName)
+			labelsMap.Store(r.cordonedTimestampLabelKey, time.Now().UTC().Format("2006-01-02T15-04-05Z"))
+		}
 	}
 
 	if len(taintsToBeApplied) > 0 || isCordoned.Load() {
@@ -888,6 +914,20 @@ func (r *Reconciler) prepareAnnotations(
 	}
 
 	return annotationsMap
+}
+
+// markPreExistingTaints sets PreExisting on any taint that already exists with the same key, value, and effect.
+func markPreExistingTaints(node *corev1.Node, taintsToBeApplied []config.Taint) {
+	existingTaints := make(map[config.Taint]bool, len(node.Spec.Taints))
+	for _, t := range node.Spec.Taints {
+		existingTaints[config.Taint{Key: t.Key, Value: t.Value, Effect: string(t.Effect)}] = true
+	}
+
+	for i, t := range taintsToBeApplied {
+		if existingTaints[config.Taint{Key: t.Key, Value: t.Value, Effect: t.Effect}] {
+			taintsToBeApplied[i].PreExisting = true
+		}
+	}
 }
 
 // applyQuarantine applies quarantine actions to a node (taints, cordon, annotations)
@@ -931,18 +971,23 @@ func (r *Reconciler) applyQuarantine(
 
 	slog.DebugContext(ctx, "Added health event annotation successfully", "node", event.HealthEvent.NodeName)
 
-	// Remove manual uncordon annotation if present before applying new quarantine
-	if err := r.cleanupManualUncordonAnnotation(ctx, event.HealthEvent.NodeName, annotations); err != nil {
-		slog.ErrorContext(ctx, "Failed to cleanup manual uncordon annotation",
-			"error", err, "node", event.HealthEvent.NodeName)
-		metrics.ProcessingErrors.WithLabelValues("cleanup_manual_uncordon_annotation_error").Inc()
-		tracing.RecordError(span, err)
-		span.SetAttributes(
-			attribute.String("fault_quarantine.error.type", "cleanup_manual_uncordon_annotation_error"),
-			attribute.String("fault_quarantine.error.message", err.Error()),
-		)
+	// Remove manual uncordon/untaint annotations if present before applying new quarantine
+	for _, annotationKey := range []string{
+		common.QuarantinedNodeUncordonedManuallyAnnotationKey,
+		common.QuarantinedNodeIsUntaintedManuallyAnnotationKey,
+	} {
+		if err := r.cleanupManualAnnotation(ctx, event.HealthEvent.NodeName, annotations, annotationKey); err != nil {
+			slog.ErrorContext(ctx, "Failed to cleanup manual annotation",
+				"error", err, "node", event.HealthEvent.NodeName, "annotation", annotationKey)
+			metrics.ProcessingErrors.WithLabelValues("cleanup_manual_annotation_error").Inc()
+			tracing.RecordError(span, err)
+			span.SetAttributes(
+				attribute.String("fault_quarantine.error.type", "cleanup_manual_annotation_error"),
+				attribute.String("fault_quarantine.error.message", err.Error()),
+			)
 
-		return nil
+			return nil
+		}
 	}
 
 	if !r.config.CircuitBreakerEnabled {
@@ -1395,17 +1440,12 @@ func (r *Reconciler) performUncordon(
 		return true, fmt.Errorf("failed to prepare uncordon params for node %s: %w", event.NodeName, err)
 	}
 
-	if len(taintsToBeRemoved) == 0 && !isUnCordon {
+	if len(taintsToBeRemoved) == 0 && !isUnCordon && len(annotationsToBeRemoved) == 0 {
 		span.SetAttributes(attribute.String("fault_quarantine.event.processing_status", EventProcessingStatusSkipped),
 			attribute.String("fault_quarantine.skip.reason", "No quarantine taints or annotations present to remove"),
 		)
 
 		return false, nil
-	}
-
-	if !isUnCordon {
-		slog.WarnContext(ctx, "Node is not cordoned but has quarantine taints/annotations, proceeding with cleanup",
-			"node", event.NodeName)
 	}
 
 	annotationsToBeRemoved = append(annotationsToBeRemoved, common.QuarantineHealthEventAnnotationKey)
@@ -1426,6 +1466,7 @@ func (r *Reconciler) performUncordon(
 		ctx,
 		event.NodeName,
 		taintsToBeRemoved,
+		isUnCordon,
 		annotationsToBeRemoved,
 		labelsToRemove,
 		labelsMap,
@@ -1469,21 +1510,33 @@ func (r *Reconciler) prepareUncordonParams(
 		annotationsToBeRemoved = append(annotationsToBeRemoved,
 			common.QuarantineHealthEventAppliedTaintsAnnotationKey)
 
-		err := json.Unmarshal([]byte(quarantineAnnotationEventTaintsAppliedStr), &taintsToBeRemoved)
-		if err != nil {
+		var allTaints []config.Taint
+		if err := json.Unmarshal([]byte(quarantineAnnotationEventTaintsAppliedStr), &allTaints); err != nil {
 			return nil, nil, false, nil, fmt.Errorf("failed to unmarshal taints annotation for node %s: %w", event.NodeName, err)
+		}
+
+		for _, t := range allTaints {
+			if !t.PreExisting {
+				taintsToBeRemoved = append(taintsToBeRemoved, t)
+			}
 		}
 	}
 
 	quarantineAnnotationEventIsCordonStr, cordonExists :=
 		annotations[common.QuarantineHealthEventIsCordonedAnnotationKey]
 	if cordonExists && quarantineAnnotationEventIsCordonStr == common.QuarantineHealthEventIsCordonedAnnotationValueTrue {
-		isUnCordon = true
-
 		annotationsToBeRemoved = append(annotationsToBeRemoved,
 			common.QuarantineHealthEventIsCordonedAnnotationKey)
-		labelsMap[r.uncordonedByLabelKey] = common.ServiceName
-		labelsMap[r.uncordonedTimestampLabelKey] = time.Now().UTC().Format("2006-01-02T15-04-05Z")
+
+		cordonPreExistingStr := annotations[common.QuarantineHealthEventCordonPreExistingAnnotationKey]
+		if cordonPreExistingStr == common.QuarantineHealthEventCordonPreExistingAnnotationValue {
+			annotationsToBeRemoved = append(annotationsToBeRemoved,
+				common.QuarantineHealthEventCordonPreExistingAnnotationKey)
+		} else {
+			isUnCordon = true
+			labelsMap[r.uncordonedByLabelKey] = common.ServiceName
+			labelsMap[r.uncordonedTimestampLabelKey] = time.Now().UTC().Format("2006-01-02T15-04-05Z")
+		}
 	}
 
 	return taintsToBeRemoved, annotationsToBeRemoved, isUnCordon, labelsMap, nil
@@ -1534,7 +1587,9 @@ func (r *Reconciler) getNodeQuarantineAnnotations(ctx context.Context, nodeName 
 		common.QuarantineHealthEventAnnotationKey,
 		common.QuarantineHealthEventAppliedTaintsAnnotationKey,
 		common.QuarantineHealthEventIsCordonedAnnotationKey,
+		common.QuarantineHealthEventCordonPreExistingAnnotationKey,
 		common.QuarantinedNodeUncordonedManuallyAnnotationKey,
+		common.QuarantinedNodeIsUntaintedManuallyAnnotationKey,
 	}
 
 	if node.Annotations != nil {
@@ -1550,32 +1605,27 @@ func (r *Reconciler) getNodeQuarantineAnnotations(ctx context.Context, nodeName 
 	return quarantineAnnotations, nil
 }
 
-func (r *Reconciler) cleanupManualUncordonAnnotation(ctx context.Context, nodeName string,
-	annotations map[string]string) error {
-	if _, hasManualUncordon := annotations[common.QuarantinedNodeUncordonedManuallyAnnotationKey]; hasManualUncordon {
-		slog.InfoContext(ctx, "Removing manual uncordon annotation from node before applying new quarantine",
-			"node", nodeName)
+func (r *Reconciler) cleanupManualAnnotation(ctx context.Context, nodeName string,
+	annotations map[string]string, annotationKey string) error {
+	if _, exists := annotations[annotationKey]; !exists {
+		return nil
+	}
 
-		updateFn := func(node *corev1.Node) error {
-			if node.Annotations == nil {
-				slog.DebugContext(ctx, "Node has no annotations, manual uncordon annotation already absent", "node", nodeName)
-				return nil
-			}
+	slog.InfoContext(ctx, "Removing manual annotation from node before applying new quarantine",
+		"node", nodeName, "annotation", annotationKey)
 
-			if _, exists := node.Annotations[common.QuarantinedNodeUncordonedManuallyAnnotationKey]; !exists {
-				slog.DebugContext(ctx, "Manual uncordon annotation already removed from node", "node", nodeName)
-				return nil
-			}
-
-			delete(node.Annotations, common.QuarantinedNodeUncordonedManuallyAnnotationKey)
-
+	updateFn := func(node *corev1.Node) error {
+		if node.Annotations == nil {
 			return nil
 		}
 
-		if err := r.k8sClient.UpdateNode(ctx, nodeName, updateFn); err != nil {
-			slog.ErrorContext(ctx, "Failed to remove manual uncordon annotation from node", "node", nodeName, "error", err)
-			return fmt.Errorf("failed to remove manual uncordon annotation from node %s: %w", nodeName, err)
-		}
+		delete(node.Annotations, annotationKey)
+
+		return nil
+	}
+
+	if err := r.k8sClient.UpdateNode(ctx, nodeName, updateFn); err != nil {
+		return fmt.Errorf("failed to remove manual annotation %s from node %s: %w", annotationKey, nodeName, err)
 	}
 
 	return nil
@@ -1616,6 +1666,10 @@ func (r *Reconciler) handleManualUncordon(nodeName string) error {
 
 	if _, exists := annotations[common.QuarantineHealthEventIsCordonedAnnotationKey]; exists {
 		annotationsToRemove = append(annotationsToRemove, common.QuarantineHealthEventIsCordonedAnnotationKey)
+	}
+
+	if _, exists := annotations[common.QuarantineHealthEventCordonPreExistingAnnotationKey]; exists {
+		annotationsToRemove = append(annotationsToRemove, common.QuarantineHealthEventCordonPreExistingAnnotationKey)
 	}
 
 	slog.DebugContext(ctx, "Prepared annotations to remove", "node", nodeName, "count", len(annotationsToRemove))
@@ -1708,6 +1762,10 @@ func (r *Reconciler) handleManualUntaint(nodeName string) error {
 
 	if _, exists := annotations[common.QuarantineHealthEventIsCordonedAnnotationKey]; exists {
 		annotationsToRemove = append(annotationsToRemove, common.QuarantineHealthEventIsCordonedAnnotationKey)
+	}
+
+	if _, exists := annotations[common.QuarantineHealthEventCordonPreExistingAnnotationKey]; exists {
+		annotationsToRemove = append(annotationsToRemove, common.QuarantineHealthEventCordonPreExistingAnnotationKey)
 	}
 
 	slog.DebugContext(ctx, "Prepared annotations to remove", "node", nodeName, "count", len(annotationsToRemove))

--- a/fault-quarantine/pkg/reconciler/reconciler_e2e_test.go
+++ b/fault-quarantine/pkg/reconciler/reconciler_e2e_test.go
@@ -599,13 +599,30 @@ func verifyNodeTaintsMatch(t *testing.T, node *corev1.Node, expectedTaints []con
 	}
 }
 
-func verifyQuarantineLabels(t *testing.T, node *corev1.Node, expectedCordonReason string) {
+func verifyQuarantineLabels(t *testing.T, node *corev1.Node, expectedCordonReason, expectedLabelValue string) {
 	t.Helper()
 
 	assert.Equal(t, common.ServiceName, node.Labels["k8s.nvidia.com/cordon-by"], "cordon-by label should be set")
 	assert.Contains(t, node.Labels["k8s.nvidia.com/cordon-reason"], expectedCordonReason, "cordon-reason should contain expected value")
 	assert.NotEmpty(t, node.Labels["k8s.nvidia.com/cordon-timestamp"], "cordon-timestamp should be set")
-	assert.Equal(t, string(statemanager.QuarantinedLabelValue), node.Labels[statemanager.NVSentinelStateLabelKey], "nvsentinel-state should be quarantined")
+	assert.Equal(t, node.Labels[statemanager.NVSentinelStateLabelKey], expectedLabelValue, "nvsentinel-state should have expected value")
+
+}
+
+func verifyQuarantineLabelsAbsent(t *testing.T, node *corev1.Node) {
+	t.Helper()
+
+	assert.NotContains(t, node.Labels, "k8s.nvidia.com/cordon-by", "cordon-by label should be removed")
+	assert.NotContains(t, node.Labels, "k8s.nvidia.com/cordon-reason", "cordon-reason label should be removed")
+	assert.NotContains(t, node.Labels, "k8s.nvidia.com/cordon-timestamp", "cordon-timestamp label should be removed")
+}
+
+func verifyUnquarantineLabelsAbsent(t *testing.T, node *corev1.Node) {
+	t.Helper()
+
+	assert.NotContains(t, node.Labels, "k8s.nvidia.com/uncordon-by", "uncordon-by label should be removed")
+	assert.NotContains(t, node.Labels, "k8s.nvidia.com/uncordon-reason", "uncordon-reason label should be removed")
+	assert.NotContains(t, node.Labels, "k8s.nvidia.com/uncordon-timestamp", "uncordon-timestamp label should be removed")
 }
 
 func verifyUnquarantineLabels(t *testing.T, node *corev1.Node) {
@@ -718,7 +735,8 @@ func TestE2E_BasicQuarantineAndUnquarantine(t *testing.T) {
 	verifyAppliedTaintsAnnotation(t, node, expectedTaints)
 	verifyNodeTaintsMatch(t, node, expectedTaints)
 	assert.Equal(t, "True", node.Annotations[quarantineHealthEventIsCordonedAnnotationKey], "Cordon annotation should be True")
-	verifyQuarantineLabels(t, node, "gpu-xid-critical-errors")
+	assert.Empty(t, node.Annotations[common.QuarantineHealthEventCordonPreExistingAnnotationKey], "CordonPreExisting annotation should not be set")
+	verifyQuarantineLabels(t, node, "gpu-xid-critical-errors", string(statemanager.QuarantinedLabelValue))
 
 	afterProcessed := getCounterValue(t, metrics.TotalEventsSuccessfullyProcessed)
 	afterQuarantined := getCounterVecValue(t, metrics.TotalNodesQuarantined, nodeName)
@@ -774,6 +792,7 @@ func TestE2E_BasicQuarantineAndUnquarantine(t *testing.T) {
 	assert.Empty(t, node.Annotations[quarantineHealthEventAnnotationKey], "Quarantine annotation should be removed")
 	assert.Empty(t, node.Annotations[quarantineHealthEventAppliedTaintsAnnotationKey], "Applied taints annotation should be removed")
 	assert.Empty(t, node.Annotations[quarantineHealthEventIsCordonedAnnotationKey], "Cordoned annotation should be removed")
+	assert.Empty(t, node.Annotations[common.QuarantineHealthEventCordonPreExistingAnnotationKey], "CordonPreExisting annotation should not exist")
 	verifyUnquarantineLabels(t, node)
 
 	afterUnquarantined := getCounterVecValue(t, metrics.TotalNodesUnquarantined, nodeName)
@@ -2146,7 +2165,7 @@ func TestE2E_SkipRedundantCordoning(t *testing.T) {
 	}, neverTimeout, neverPollInterval, "Node cordon state should not change")
 }
 
-func TestE2E_NodeAlreadyCordonedManually(t *testing.T) {
+func TestE2E_PreExistingCordon(t *testing.T) {
 	ctx, cancel := context.WithTimeout(e2eTestContext, 20*time.Second)
 	defer cancel()
 
@@ -2177,18 +2196,12 @@ func TestE2E_NodeAlreadyCordonedManually(t *testing.T) {
 		},
 	}
 
-	_, mockWatcher, _, _ := setupE2EReconciler(t, ctx, tomlConfig, nil)
+	_, mockWatcher, getStatus, _ := setupE2EReconciler(t, ctx, tomlConfig, nil)
 
 	t.Log("Send unhealthy event - FQM should apply taints/annotations to manually cordoned node")
-	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(
-		generateTestID(),
-		nodeName,
-		"GpuXidError",
-		false,
-		true,
-		[]*protos.Entity{{EntityType: "GPU", EntityValue: "0"}},
-		model.StatusInProgress,
-	)}
+	unhealthyEventID := generateTestID()
+	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(unhealthyEventID, nodeName,
+		"GpuXidError", false, true, []*protos.Entity{{EntityType: "GPU", EntityValue: "0"}}, model.StatusInProgress)}
 
 	// Verify FQM adds taints and annotations to manually cordoned node
 	require.Eventually(t, func() bool {
@@ -2219,6 +2232,42 @@ func TestE2E_NodeAlreadyCordonedManually(t *testing.T) {
 	}
 	verifyAppliedTaintsAnnotation(t, node, expectedTaints)
 	verifyNodeTaintsMatch(t, node, expectedTaints)
+	assert.Equal(t, common.QuarantineHealthEventIsCordonedAnnotationValueTrue,
+		node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey],
+		"quarantineHealthEventIsCordoned should be True")
+	assert.Equal(t, common.QuarantineHealthEventCordonPreExistingAnnotationValue,
+		node.Annotations[common.QuarantineHealthEventCordonPreExistingAnnotationKey],
+		"quarantineHealthEventCordonPreExisting should be True for a pre-cordoned node")
+	verifyQuarantineLabelsAbsent(t, node)
+
+	t.Log("Sending healthy event should cause fault-quarantine to release quarantine but preserve the pre-existing cordon")
+
+	healthyEventID := generateTestID()
+	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(healthyEventID, nodeName,
+		"GpuXidError", true, false, []*protos.Entity{{EntityType: "GPU", EntityValue: "0"}}, model.StatusInProgress)}
+
+	require.Eventually(t, func() bool {
+		status := getStatus(healthyEventID)
+		return status != nil && *status == model.UnQuarantined
+	}, statusCheckTimeout, statusCheckPollInterval, "Status should be UnQuarantined")
+
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return node.Annotations[common.QuarantineHealthEventAnnotationKey] == ""
+	}, eventuallyTimeout, eventuallyPollInterval, "FQ annotations should be removed after recovery")
+
+	t.Log("Verify pre-existing cordon preserved and FQ annotations removed")
+	node, err = e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.True(t, node.Spec.Unschedulable, "Pre-existing cordon should be preserved after recovery")
+	assert.Empty(t, node.Annotations[common.QuarantineHealthEventAnnotationKey])
+	assert.Empty(t, node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey])
+	assert.Empty(t, node.Annotations[common.QuarantineHealthEventCordonPreExistingAnnotationKey])
+	verifyUnquarantineLabelsAbsent(t, node)
+
 }
 
 func TestE2E_NodeAlreadyQuarantinedStillUnhealthy(t *testing.T) {
@@ -4973,6 +5022,7 @@ func TestE2ECordonAndTaint_ManualUntaint(t *testing.T) {
 		_, hasQuarantineAnnotation := node.Annotations[common.QuarantineHealthEventAnnotationKey]
 		_, hasAppliedTaintsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey]
 		_, hasCordonedAnnotation := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey]
+		_, hasCordonPreExistingAnnotation := node.Annotations[common.QuarantineHealthEventCordonPreExistingAnnotationKey]
 
 		// State label should be removed
 		_, hasStateLabel := node.Labels[statemanager.NVSentinelStateLabelKey]
@@ -4995,6 +5045,7 @@ func TestE2ECordonAndTaint_ManualUntaint(t *testing.T) {
 			!hasQuarantineAnnotation &&
 			!hasAppliedTaintsAnnotation &&
 			!hasCordonedAnnotation &&
+			!hasCordonPreExistingAnnotation &&
 			!hasFQTaint && // FQ taint should be removed
 			isCordoned && // node should still be cordoned
 			!hasStateLabel
@@ -5115,6 +5166,7 @@ func TestE2ECordonAndTaint_ManualUncordon(t *testing.T) {
 		_, hasQuarantineAnnotation := node.Annotations[common.QuarantineHealthEventAnnotationKey]
 		_, hasAppliedTaintsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey]
 		_, hasCordonedAnnotation := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey]
+		_, hasCordonPreExistingAnnotation := node.Annotations[common.QuarantineHealthEventCordonPreExistingAnnotationKey]
 
 		// State label should be removed
 		_, hasStateLabel := node.Labels[statemanager.NVSentinelStateLabelKey]
@@ -5135,10 +5187,17 @@ func TestE2ECordonAndTaint_ManualUncordon(t *testing.T) {
 			!hasQuarantineAnnotation &&
 			!hasAppliedTaintsAnnotation &&
 			!hasCordonedAnnotation &&
+			!hasCordonPreExistingAnnotation &&
 			hasFQTaint && // FQ taint should remain (manual uncordon doesn't remove taints)
 			isUncordoned && // node should be uncordoned
 			!hasStateLabel
 	}, eventuallyTimeout, eventuallyPollInterval, "Manual uncordon should clean up FQ state")
+
+	node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	require.NoError(t, err)
+	// We expect that a manual uncordon will orphan the cordon-by labels if present and will not add the uncordon-by labels
+	verifyQuarantineLabels(t, node, "gpu-xid-errors", "")
+	verifyUnquarantineLabelsAbsent(t, node)
 
 	t.Log("Verify metrics are correctly updated")
 	afterManualUncordon := getCounterVecValue(t, metrics.TotalNodesManuallyUncordoned, nodeName)
@@ -5983,4 +6042,175 @@ func TestSourceDocIDsFromAnnotation(t *testing.T) {
 			assert.ElementsMatch(t, tc.expectedIDs, ids)
 		})
 	}
+}
+
+func TestE2E_PreExistingTaint(t *testing.T) {
+	ctx, cancel := context.WithTimeout(e2eTestContext, 20*time.Second)
+	defer cancel()
+
+	nodeName := "e2e-preexist-taint-" + generateShortTestID()
+
+	// Create node that already has the taint FQ would apply (no FQ annotations)
+	preExistingTaints := []corev1.Taint{
+		{Key: "nvidia.com/gpu-xid-error", Value: "true", Effect: corev1.TaintEffectNoSchedule},
+	}
+	createE2ETestNode(ctx, t, nodeName, nil, nil, preExistingTaints, false)
+	defer func() {
+		_ = e2eTestClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
+	}()
+
+	tomlConfig := config.TomlConfig{
+		LabelPrefix: "k8s.nvidia.com/",
+		RuleSets: []config.RuleSet{
+			{
+				Enabled:  true,
+				Name:     "gpu-xid-errors",
+				Version:  "1",
+				Priority: 10,
+				Match: config.Match{
+					Any: []config.Rule{
+						{Kind: "HealthEvent", Expression: "event.checkName == 'GpuXidError'"},
+					},
+				},
+				Taint:  config.Taint{Key: "nvidia.com/gpu-xid-error", Value: "true", Effect: "NoSchedule"},
+				Cordon: config.Cordon{ShouldCordon: true},
+			},
+		},
+	}
+
+	_, mockWatcher, getStatus, _ := setupE2EReconciler(t, ctx, tomlConfig, nil)
+
+	t.Log("Sending unhealthy event should cause fault-quarantine to apply quarantine and mark the taint as pre-existing")
+	unhealthyEventID := generateTestID()
+	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(unhealthyEventID, nodeName,
+		"GpuXidError", false, true, []*protos.Entity{{EntityType: "GPU", EntityValue: "0"}}, model.StatusInProgress)}
+
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return node.Annotations[common.QuarantineHealthEventAnnotationKey] != ""
+	}, eventuallyTimeout, eventuallyPollInterval, "FQM should add quarantine annotations")
+
+	t.Log("Verify taint is marked pre-existing and not duplicated")
+	node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	require.NoError(t, err)
+	verifyHealthEventInAnnotation(t, node, "GpuXidError", "gpu-health-monitor", "GPU", "GPU", "0")
+
+	taintsAnnotationStr := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey]
+	require.NotEmpty(t, taintsAnnotationStr, "Applied taints annotation should exist")
+	var appliedTaints []config.Taint
+	require.NoError(t, json.Unmarshal([]byte(taintsAnnotationStr), &appliedTaints))
+	require.Len(t, appliedTaints, 1, "Should have exactly one applied taint")
+	assert.True(t, appliedTaints[0].PreExisting, "Taint should be marked as pre-existing in annotation")
+
+	taintCount := 0
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == "nvidia.com/gpu-xid-error" {
+			taintCount++
+		}
+	}
+	assert.Equal(t, 1, taintCount, "Pre-existing taint should not be duplicated on the node")
+
+	t.Log("Sending healthy event should cause fault-quarantine to release quarantine but preserve the pre-existing taint")
+	healthyEventID := generateTestID()
+	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(healthyEventID, nodeName,
+		"GpuXidError", true, false, []*protos.Entity{{EntityType: "GPU", EntityValue: "0"}}, model.StatusInProgress)}
+
+	require.Eventually(t, func() bool {
+		status := getStatus(healthyEventID)
+		return status != nil && *status == model.UnQuarantined
+	}, statusCheckTimeout, statusCheckPollInterval, "Status should be UnQuarantined")
+
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		return node.Annotations[common.QuarantineHealthEventAnnotationKey] == ""
+	}, eventuallyTimeout, eventuallyPollInterval, "FQ annotations should be removed after recovery")
+
+	t.Log("Verify pre-existing taint preserved and FQ annotations removed")
+	node, err = e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, node.Annotations[common.QuarantineHealthEventAnnotationKey])
+	assert.Empty(t, node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey])
+	hasTaint := false
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == "nvidia.com/gpu-xid-error" {
+			hasTaint = true
+			break
+		}
+	}
+	assert.True(t, hasTaint, "Pre-existing taint should be preserved after recovery")
+}
+
+func TestE2E_ManualUntaintAnnotationCleanup(t *testing.T) {
+	ctx, cancel := context.WithTimeout(e2eTestContext, 20*time.Second)
+	defer cancel()
+
+	nodeName := "e2e-untaint-cleanup-" + generateShortTestID()
+
+	// Create node with manual untaint annotation (from previous manual untaint)
+	annotations := map[string]string{
+		common.QuarantinedNodeIsUntaintedManuallyAnnotationKey: common.QuarantinedNodeIsUntaintedManuallyAnnotationValue,
+	}
+
+	createE2ETestNode(ctx, t, nodeName, annotations, nil, nil, false)
+	defer func() {
+		_ = e2eTestClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
+	}()
+
+	tomlConfig := config.TomlConfig{
+		LabelPrefix: "k8s.nvidia.com/",
+		RuleSets: []config.RuleSet{
+			{
+				Enabled:  true,
+				Name:     "gpu-xid-errors",
+				Version:  "1",
+				Priority: 10,
+				Match: config.Match{
+					Any: []config.Rule{
+						{Kind: "HealthEvent", Expression: "event.checkName == 'GpuXidError'"},
+					},
+				},
+				Taint:  config.Taint{Key: "nvidia.com/gpu-xid-error", Value: "true", Effect: "NoSchedule"},
+				Cordon: config.Cordon{ShouldCordon: true},
+			},
+		},
+	}
+
+	_, mockWatcher, getStatus, _ := setupE2EReconciler(t, ctx, tomlConfig, nil)
+
+	t.Log("Sending unhealthy event should remove manual untaint annotation and quarantine")
+	eventID1 := generateTestID()
+	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(eventID1, nodeName,
+		"GpuXidError", false, true, []*protos.Entity{{EntityType: "GPU", EntityValue: "0"}}, model.StatusInProgress)}
+
+	t.Log("Verify status is Quarantined")
+	require.Eventually(t, func() bool {
+		status := getStatus(eventID1)
+		return status != nil && *status == model.Quarantined
+	}, statusCheckTimeout, statusCheckPollInterval, "Status should be Quarantined")
+
+	t.Log("Verify manual untaint annotation is removed and FQ annotations added with taint applied")
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+
+		hasTaint := false
+		for _, taint := range node.Spec.Taints {
+			if taint.Key == "nvidia.com/gpu-xid-error" {
+				hasTaint = true
+				break
+			}
+		}
+
+		return hasTaint &&
+			node.Annotations[common.QuarantineHealthEventAnnotationKey] != "" &&
+			node.Annotations[common.QuarantinedNodeIsUntaintedManuallyAnnotationKey] == ""
+	}, eventuallyTimeout, eventuallyPollInterval, "Manual untaint annotation should be removed, FQ annotations added with taint applied")
 }

--- a/tests/fault_quarantine_test.go
+++ b/tests/fault_quarantine_test.go
@@ -179,6 +179,11 @@ func TestPreCordonedNodeHandling(t *testing.T) {
 		_, exists := node.Annotations["quarantineHealthEvent"]
 		assert.True(t, exists)
 
+		assert.Equal(t, "True", node.Annotations[helpers.QuarantineHealthEventIsCordonedAnnotationKey],
+			"quarantineHealthEventIsCordoned should be True")
+		assert.Equal(t, "True", node.Annotations[helpers.QuarantineHealthEventCordonPreExistingAnnotationKey],
+			"quarantineHealthEventCordonPreExisting should be True since node was pre-cordoned")
+
 		return ctx
 	})
 
@@ -202,10 +207,16 @@ func TestPreCordonedNodeHandling(t *testing.T) {
 				}
 			}
 
-			_, hasAnnotation := node.Annotations["quarantineHealthEvent"]
+			_, hasQuarantineAnnotation := node.Annotations["quarantineHealthEvent"]
+			_, hasIsCordonedAnnotation := node.Annotations[helpers.QuarantineHealthEventIsCordonedAnnotationKey]
+			_, hasCordonPreExistingAnnotation := node.Annotations[helpers.QuarantineHealthEventCordonPreExistingAnnotationKey]
 
-			return !hasFQTaint && !hasAnnotation
+			return !hasFQTaint && !hasQuarantineAnnotation && !hasIsCordonedAnnotation && !hasCordonPreExistingAnnotation
 		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval)
+
+		node, err := helpers.GetNodeByName(ctx, client, testCtx.NodeName)
+		require.NoError(t, err)
+		assert.True(t, node.Spec.Unschedulable, "pre-existing cordon should be preserved after FQ recovery")
 
 		return ctx
 	})

--- a/tests/helpers/fault_quarantine.go
+++ b/tests/helpers/fault_quarantine.go
@@ -44,6 +44,9 @@ const QuarantineHealthEventAnnotationKey = "quarantineHealthEvent"
 // QuarantineHealthEventIsCordonedAnnotationKey records that fault-quarantine cordoned the node.
 const QuarantineHealthEventIsCordonedAnnotationKey = "quarantineHealthEventIsCordoned"
 
+// QuarantineHealthEventCordonPreExistingAnnotationKey records there was a pre-existing cordon.
+const QuarantineHealthEventCordonPreExistingAnnotationKey = "quarantineHealthEventCordonPreExisting"
+
 type faultQuarantineConfig struct {
 	LabelPrefix    string               `toml:"label-prefix"`
 	CircuitBreaker circuitBreakerConfig `toml:"circuitBreaker"`


### PR DESCRIPTION
## Summary
Closes #1424 

This PR updates fault-quarantine to preserve pre-existing taints or node cordons which existed prior to the fault-quarantine applying a quarantine to a given node. 

- preserving cordons: we are adding a new node annotation called quarantineHealthEventCordonPreExisting which indicates whether the cordon existed prior to quarantine. Note that the existing quarantineHealthEventIsCordoned annotation will be preserved
- preserving taints: we are leveraging the existing quarantineHealthEventAppliedTaints annotation but adding a new field to the taint struct called PreExisting to indicate whether a given taint should be preserved after the node is unquarantined. We do not need to add a new annotation because new fields can be added in a backwards compatible way.

There is also a bug fix to remove the quarantinedNodeUntaintedManually annotation when a node is quarantined since previously only the quarantinedNodeUncordonedManually annotation was removed.

**Implementation details:**

- Automatic or manual uncordons will result in the quarantineHealthEventCordonPreExisting annotation being removed (alongside the existing annotations and labels). 
- The cordon-by labels will only be added when a node is quarantined without a pre-existing cordon. This label is removed when the node is unquarantined (if it exists). Additionally, the label is not removed the node is manually uncordoned.
- The uncordon-by label is only added on unquarantine if the cordon was not pre-existing. It is never removed explicitly and is not added on manual uncordons.
- If only taints are applied by fault-quarantine, the cordon-by and uncordon-by labels are not added or removed.
- The quarantinedNodeUncordonedManually annotation is applied if a node is manually uncordoned and existing taints owned by fault-quarantine will be orphaned.
- The quarantinedNodeUntaintedManually annotation is applied if a node is manually untainted and an existing cordon or taints owned by fault-quarantine will be orphaned.
- The quarantinedNodeUncordonedManually and quarantinedNodeUntaintedManually annotations are removed when a node is newly quarantined.

## Examples

**Case 1: Node does not have a pre-existing cordon or taint**

Before quarantine:
```
spec:
  unschedulable: false
  taints: []
labels: {}
annotations: {}
```

After quarantine:
```
spec:
  unschedulable: true
  taints: [{key: AggregatedNodeHealth, value: False, effect: NoSchedule}]
labels:
  cordon-by: NVSentinel
  cordon-reason: Basic-Match-Rule
  cordon-timestamp: 2026-06-30T...
  nvsentinel-state: quarantined
annotations:
  quarantineHealthEvent: '{"events":[...]}'
  quarantineHealthEventIsCordoned: "True"
  quarantineHealthEventAppliedTaints: '[{"key":"AggregatedNodeHealth","value":"False","effect":"NoSchedule","preExisting":false}]'
```

After unquarantine:
```
spec:
  unschedulable: false
  taints: []
labels:
  uncordon-by: NVSentinel
  uncordon-timestamp: 2026-06-30T...
  uncordon-reason: Basic-Match-Rule-removed
annotations: {}
```

**Case 2: Node has a pre-existing cordon and taint**

Before quarantine:
```
spec:
  unschedulable: true
  taints: [{key: AggregatedNodeHealth, value: False, effect: NoSchedule}]
labels: {}
annotations: {}
```

After quarantine:
```
spec:
  unschedulable: true
  taints: [{key: AggregatedNodeHealth, value: False, effect: NoSchedule}]
labels:
  nvsentinel-state: quarantined
annotations:
  quarantineHealthEvent: '{"events":[...]}'
  quarantineHealthEventIsCordoned: "True"
  quarantineHealthEventCordonPreExisting: "True"
  quarantineHealthEventAppliedTaints: '[{"key":"AggregatedNodeHealth","value":"False","effect":"NoSchedule","preExisting":true]'

```

After unquarantine:
```
spec:
  unschedulable: true    
  taints: [{key: AggregatedNodeHealth, value: False, effect: NoSchedule}] 
labels: {}                                                                                                
annotations: {}          
```

**Case 3: Manual uncordon**

During quarantine:
```
spec:
  unschedulable: false 
  taints: [{key: AggregatedNodeHealth, value: False, effect: NoSchedule}] 
labels:
  cordon-by: NVSentinel
  cordon-reason: Basic-Match-Rule
  cordon-timestamp: 2026-06-30T...
  nvsentinel-state: quarantined
annotations:
  quarantineHealthEvent: '{"events":[...]}'
  quarantineHealthEventIsCordoned: "True"
  quarantineHealthEventAppliedTaints: '[...]'
```

After manual uncordon:
```
spec:
  unschedulable: false 
  taints: [{key: AggregatedNodeHealth, value: False, effect: NoSchedule}]  
labels:
  cordon-by: NVSentinel
  cordon-reason: Basic-Match-Rule
  cordon-timestamp: 2026-06-30T...
annotations:
  quarantinedNodeUncordonedManually: "True"
```

**Case 4: Manual taint removal**

During quarantine:
```
spec:
  unschedulable: true  
  taints: []            
labels:
  cordon-by: NVSentinel
  cordon-reason: Basic-Match-Rule
  cordon-timestamp: 2026-06-30T...
  nvsentinel-state: quarantined
annotations:
  quarantineHealthEvent: '{"events":[...]}'
  quarantineHealthEventIsCordoned: "True"
  quarantineHealthEventAppliedTaints: '[...]'
```

After manual taint removal:
```
spec:
  unschedulable: true
  taints: []
labels:
  cordon-by: NVSentinel
  cordon-reason: Basic-Match-Rule
  cordon-timestamp: 2026-06-30T...
annotations:
  quarantinedNodeUntaintedManually: "True"
```

## Tests

Test coverage in reconciler_e2e_test.go:

- TestE2E_BasicQuarantineAndUnquarantine: covers case 1 for a quarantine and unquarantine with a cordon and taint.
- TestE2E_PreExistingCordon: covers case 2 for a quarantine and unquarantine where there's a pre-existing cordon
- TestE2E_PreExistingTaint: covers case 2 for a quarantine and unquarantine where there's a pre-existing taint
- TestE2ECordonAndTaint_ManualUncordon: covers case 3 above
- TestE2ECordonAndTaint_ManualUntaint: covers case 4 above
- TestE2E_ManualUncordonAnnotationCleanup: ensures that the quarantinedNodeUncordonedManually annotation is removed when a node is quarantined
- TestE2E_ManualUnTaintAnnotationCleanup: ensures that the quarantinedNodeUntaintedManually annotation is removed when a node is quarantined (this is a fix for an existing bug)

E2E test coverage in fault_quarantine_test.go:
- TestPreCordonedNodeHandling: ensures that a node with a pre-existing cordon has the quarantineHealthEventCordonPreExisting and quarantineHealthEventIsCordoned annotations added on quarantine and removed on unquarantine. The test also confirms that the pre-existing cordon is preserved. 

## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [X] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit
* **New Features**
  * Added a new quarantine health annotation to report when a node was already cordoned before quarantine.
  * Updated taint configuration serialization to support a `preExisting` flag in JSON.
* **Bug Fixes**
  * Improved node quarantine/restore behavior to preserve pre-existing cordon/taint state and to fully clean up manual untaint/uncordon artifacts.
  * Improved handling when node details can’t be retrieved.
* **Tests**
  * Expanded end-to-end and unit tests to cover pre-existing cordons/taints and manual cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->