### PR TITLE
fix: skip thermal margin monitoring in dcgm 3.x as it is not supported

### DIFF
--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/dcgm.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/dcgm.py
@@ -47,13 +47,14 @@ def _run_dcgm_server(port: int, bind_address: str) -> None:
 # 1. Add a new entry here (key = config key from [dcgmfieldsmonitoring])
 # 2. Add the key to configmap.yaml under [dcgmfieldsmonitoring]
 # 3. Add evaluation logic in _evaluate_* method if needed
-DCGM_FIELDS_MONITORING: dict[str, types.DCGMFieldMonitor] = {
-    "gputemplimitmonitoringenabled": types.DCGMFieldMonitor(
-        field_id=getattr(dcgm_fields, "DCGM_FI_DEV_GPU_TEMP_LIMIT", 153),
+DCGM_FIELDS_MONITORING: dict[str, types.DCGMFieldMonitor] = {}
+_gpu_temp_limit_field_id = getattr(dcgm_fields, "DCGM_FI_DEV_GPU_TEMP_TLIMIT", None)
+if _gpu_temp_limit_field_id is not None:
+    DCGM_FIELDS_MONITORING["gputemplimitmonitoringenabled"] = types.DCGMFieldMonitor(
+        field_id=_gpu_temp_limit_field_id,
         watch_name="DCGM_HEALTH_WATCH_THERMAL_MARGIN",
         violation_code="GPU_TEMP_HW_SLOWDOWN_VIOLATION",
-    ),
-}
+    )
 
 
 class DCGMWatcher:
@@ -70,7 +71,13 @@ class DCGMWatcher:
         self._addr = addr
         self._poll_interval_seconds = poll_interval_seconds
         self._callbacks = callbacks
-        self._thermal_margin_enabled = thermal_margin_enabled
+        thermal_margin_supported = "gputemplimitmonitoringenabled" in DCGM_FIELDS_MONITORING
+        self._thermal_margin_enabled = thermal_margin_enabled and thermal_margin_supported
+        if thermal_margin_enabled and not thermal_margin_supported:
+            log.warning(
+                "GpuThermalMarginWatch requested but DCGM_FI_DEV_GPU_TEMP_TLIMIT (field 153) is unavailable; "
+                "disabling the optional monitor"
+            )
         self._metadata_reader = metadata_reader
         self._field_group = None
         self._dcgm_mode = dcgm_mode

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/conftest.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/conftest.py
@@ -175,6 +175,8 @@ class MockDCGMFields:
     # Add device field constants as needed
     for i in range(320):  # Mock 320 device fields as expected by tests
         locals()[f"DCGM_FI_DEV_FIELD_{i}"] = i
+    DCGM_FI_DEV_GPU_TEMP_TLIMIT = 153
+    del DCGM_FI_DEV_FIELD_153
 
 
 class MockDCGMValue:

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_dcgm_watcher/test_dcgm.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_dcgm_watcher/test_dcgm.py
@@ -63,6 +63,27 @@ class TestDCGMHealthChecks:
         incident.entityInfo.entityId = entity_id
         return incident
 
+    def test_unsupported_thermal_margin_field_is_disabled(self, monkeypatch):
+        monkeypatch.delitem(dcgm.DCGM_FIELDS_MONITORING, "gputemplimitmonitoringenabled")
+        watcher = dcgm.DCGMWatcher(
+            addr="localhost:5555",
+            poll_interval_seconds=10,
+            callbacks=[],
+            dcgm_k8s_service_enabled=False,
+            thermal_margin_enabled=True,
+            metadata_reader=MagicMock(),
+        )
+        dcgm_group = MagicMock()
+        dcgm_group.GetGpuIds.return_value = [0]
+        watcher._create_dcgm_group_with_all_entities = MagicMock(return_value=dcgm_group)
+        watcher._get_gpu_serial_numbers = MagicMock(return_value={})
+
+        watcher._initialize_dcgm_monitoring(MagicMock())
+
+        assert watcher._thermal_margin_enabled is False
+        dcgm_group.health.Set.assert_called_once_with(dcgm_structs.DCGM_HEALTH_WATCH_ALL)
+        dcgm_group.samples.WatchFields.assert_not_called()
+
     def test_get_available_health_watches(self):
         watcher = dcgm.DCGMWatcher(
             addr="localhost:5555",


### PR DESCRIPTION
## Summary
https://github.com/NVIDIA/NVSentinel/issues/1449

Capability-gates GpuThermalMarginWatch based on the availability of DCGM field 153. DCGM 3.x now skips the unsupported monitor instead of failing initialization, while DCGM 4.x behavior remains unchanged.

<!-- Brief description of your changes -->

1. Added field-availability detection with a clear warning and continued standard health monitoring.
2. Validated DCGM 3.3.7 and 4.5.2 across all three modes and validated injection/recovery with zero GHM restarts.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [x] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review
