### PR TITLE
feat: allow the ability to supress some DCGM error codes

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/configmap.yaml
@@ -30,6 +30,9 @@ data:
     gputemplimitmonitoringenabled = {{ .Values.dcgmFieldsMonitoring.gpuTempLimitMonitoringEnabled }}
     gputemplimitstoreonly = {{ .Values.dcgmFieldsMonitoring.gpuTempLimitStoreOnly }}
 
+    [dcgmhealthcheck]
+    SuppressedErrorCodes = {{ .Values.dcgmHealthCheck.suppressedErrorCodes | join "," }}
+
     [eventprocessors.kubernetes]
     ConflictRetryCount = 10
 

--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/values.yaml
@@ -49,6 +49,12 @@ dcgmFieldsMonitoring:
   # events are emitted with processingStrategy=STORE_ONLY
   gpuTempLimitStoreOnly: true
 
+# DCGM health check incident suppression
+dcgmHealthCheck:
+  # DCGM error codes to drop before they become health events
+  # Example: ["DCGM_FR_CLOCK_THROTTLE_POWER"]
+  suppressedErrorCodes: []
+
 # Use host networking for GPU health monitor pods. external-hostengine mode
 # enables host networking automatically because the configured endpoint is
 # node-local by contract. This value is an opt-in for other modes.

--- a/distros/kubernetes/nvsentinel/values-full.yaml
+++ b/distros/kubernetes/nvsentinel/values-full.yaml
@@ -880,6 +880,16 @@ gpu-health-monitor:
   # Most deployments should use service-based access (false)
   useHostNetworking: false
 
+  # DCGM health check incident suppression
+  # Drops incidents matching specific error codes before they generate a health
+  # event, so they are never persisted or acted on. Useful for high-frequency,
+  # non-actionable flaps (e.g. normal power-cap boost-clock behavior).
+  dcgmHealthCheck:
+    # List of error code names to suppress (native DCGM codes like
+    # DCGM_FR_CLOCK_THROTTLE_POWER, or custom field-monitor codes like
+    # GPU_TEMP_HW_SLOWDOWN_VIOLATION). Empty by default (no suppression).
+    suppressedErrorCodes: []
+
   # Additional volume mounts for GPU health monitor
   # Use when monitor needs access to host files
   # Example:

--- a/docs/configuration/gpu-health-monitor.md
+++ b/docs/configuration/gpu-health-monitor.md
@@ -130,6 +130,28 @@ dcgm:
 useHostNetworking: true
 ```
 
+## DCGM Health Check Incident Suppression
+
+Drops DCGM health check incidents matching specific error codes before they generate a health event, so they are never persisted or acted on. Useful for high-frequency, non-actionable flaps (e.g. normal power-cap boost-clock behavior).
+
+```yaml
+gpu-health-monitor:
+  dcgmHealthCheck:
+    suppressedErrorCodes: []
+```
+
+#### suppressedErrorCodes
+List of DCGM error code names (as reported by DCGM, e.g. `DCGM_FR_CLOCK_THROTTLE_POWER`) to suppress. Empty by default (no suppression). Suppression is scoped to the listed error codes only — other incidents on the same health watch (e.g. other `GpuPowerWatch` error codes) are still reported.
+
+#### Example: Suppress power-cap throttle flaps
+
+```yaml
+gpu-health-monitor:
+  dcgmHealthCheck:
+    suppressedErrorCodes:
+      - DCGM_FR_CLOCK_THROTTLE_POWER
+```
+
 ## Additional Volumes
 
 Extension point for mounting additional host paths required by DCGM in specific environments.

--- a/docs/gpu-health-monitor.md
+++ b/docs/gpu-health-monitor.md
@@ -54,6 +54,7 @@ gpu-health-monitor:
 - **Host Networking**: Enable if DCGM service requires host network access
 - **Polling Interval**: Configure how frequently to check GPU health (set via DCGM configuration)
 - **Verbose Logging**: Enable detailed debug output
+- **Incident Suppression**: Drop specific DCGM error codes before they generate a health event — see [DCGM Health Check Incident Suppression](configuration/gpu-health-monitor.md#dcgm-health-check-incident-suppression)
 
 ## What It Monitors
 

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/cli.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/cli.py
@@ -165,6 +165,15 @@ def cli(
     # or cordon) while every other DCGM check keeps the process-wide strategy.
     store_only_checks = frozenset({"GpuThermalMarginWatch"}) if thermal_margin_store_only else frozenset()
 
+    suppressed_error_codes = frozenset()
+    if config.has_section("dcgmhealthcheck"):
+        suppressed_error_codes_raw = config["dcgmhealthcheck"].get("SuppressedErrorCodes", fallback="")
+        suppressed_error_codes = frozenset(
+            code.strip() for code in suppressed_error_codes_raw.split(",") if code.strip()
+        )
+        if suppressed_error_codes:
+            log.info(f"DCGM error codes suppressed via config: {sorted(suppressed_error_codes)}")
+
     enabled_event_processor_names = cli_config["EnabledEventProcessors"].split(",")
     enabled_event_processors = []
     for event_processor in enabled_event_processor_names:
@@ -202,6 +211,7 @@ def cli(
         thermal_margin_enabled=thermal_margin_enabled,
         metadata_reader=metadata_reader,
         dcgm_mode=dcgm_mode,
+        suppressed_error_codes=suppressed_error_codes,
     )
     dcgm_watcher.start([], exit)
 

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/dcgm.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/dcgm.py
@@ -67,10 +67,14 @@ class DCGMWatcher:
         thermal_margin_enabled: bool = False,
         metadata_reader: MetadataReader | None = None,
         dcgm_mode: str = "remote",
+        suppressed_error_codes: frozenset[str] | None = None,
     ) -> None:
         self._addr = addr
         self._poll_interval_seconds = poll_interval_seconds
         self._callbacks = callbacks
+        self._suppressed_error_codes = frozenset(suppressed_error_codes or ())
+        if self._suppressed_error_codes:
+            log.info(f"Suppressing DCGM incidents for error codes: {sorted(self._suppressed_error_codes)}")
         thermal_margin_supported = "gputemplimitmonitoringenabled" in DCGM_FIELDS_MONITORING
         self._thermal_margin_enabled = thermal_margin_enabled and thermal_margin_supported
         if thermal_margin_enabled and not thermal_margin_supported:
@@ -242,12 +246,21 @@ class DCGMWatcher:
                     metrics.dcgm_health_check_unknown_system_skipped.inc()
                     continue
 
-                health_status[watch_name].status = types.HealthStatus(int(incident.health))
                 gpu_id = incident.entityInfo.entityId
                 fallback_error_code = self._error_codes.get(dcgm_errors.DCGM_FR_UNKNOWN, "DCGM_FR_UNKNOWN")
                 error_code = self._error_codes.get(incident.error.code, fallback_error_code)
                 if error_code == fallback_error_code:
                     log.warning(f"Unknown DCGM error code {incident.error.code} for entity {gpu_id}")
+
+                if error_code in self._suppressed_error_codes:
+                    log.debug(
+                        f"Suppressing incident for watch={watch_name} entity={gpu_id} "
+                        f"error_code={error_code}: high-frequency non-actionable event"
+                    )
+                    metrics.dcgm_health_check_suppressed_incidents.labels(error_code).inc()
+                    continue
+
+                health_status[watch_name].status = types.HealthStatus(int(incident.health))
                 error_msg = incident.error.msg
 
                 log.debug(f"incident.error.code is {incident.error.code} and error msg is {error_msg}")

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/dcgm.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/dcgm.py
@@ -153,6 +153,29 @@ class DCGMWatcher:
             health_status[system_name] = types.HealthDetails(status=types.HealthStatus.PASS, entity_failures={})
         return health_status
 
+    def _suppress_configured_error_codes(self, health_status: dict[str, types.HealthDetails]) -> None:
+        if not self._suppressed_error_codes:
+            return
+
+        for watch_name, details in health_status.items():
+            suppressed_gpu_ids = [
+                gpu_id
+                for gpu_id, failure in details.entity_failures.items()
+                if failure.code in self._suppressed_error_codes
+            ]
+            for gpu_id in suppressed_gpu_ids:
+                error_code = details.entity_failures[gpu_id].code
+                log.debug(
+                    f"Suppressing incident for watch={watch_name} entity={gpu_id} "
+                    f"error_code={error_code}: high-frequency non-actionable event"
+                )
+                metrics.dcgm_health_check_suppressed_incidents.labels(error_code).inc()
+                del details.entity_failures[gpu_id]
+
+            # A watch with no remaining failures is healthy again.
+            if suppressed_gpu_ids and not details.entity_failures:
+                details.status = types.HealthStatus.PASS
+
     def _fire_callback_funcs(self, func_name: str, args: list[any]):
         def done_callback(class_name: str, func_name: str, future):
             e = future.exception()
@@ -246,21 +269,12 @@ class DCGMWatcher:
                     metrics.dcgm_health_check_unknown_system_skipped.inc()
                     continue
 
+                health_status[watch_name].status = types.HealthStatus(int(incident.health))
                 gpu_id = incident.entityInfo.entityId
                 fallback_error_code = self._error_codes.get(dcgm_errors.DCGM_FR_UNKNOWN, "DCGM_FR_UNKNOWN")
                 error_code = self._error_codes.get(incident.error.code, fallback_error_code)
                 if error_code == fallback_error_code:
                     log.warning(f"Unknown DCGM error code {incident.error.code} for entity {gpu_id}")
-
-                if error_code in self._suppressed_error_codes:
-                    log.debug(
-                        f"Suppressing incident for watch={watch_name} entity={gpu_id} "
-                        f"error_code={error_code}: high-frequency non-actionable event"
-                    )
-                    metrics.dcgm_health_check_suppressed_incidents.labels(error_code).inc()
-                    continue
-
-                health_status[watch_name].status = types.HealthStatus(int(incident.health))
                 error_msg = incident.error.msg
 
                 log.debug(f"incident.error.code is {incident.error.code} and error msg is {error_msg}")
@@ -568,6 +582,7 @@ class DCGMWatcher:
                                 health_status[DCGM_FIELDS_MONITORING["gputemplimitmonitoringenabled"].watch_name] = (
                                     margin_details
                                 )
+                            self._suppress_configured_error_codes(health_status)
                             log.debug("Publish DCGM health checks")
                             self._fire_callback_funcs(
                                 types.CallbackInterface.health_event_occurred.__name__,

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/metrics.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/metrics.py
@@ -39,6 +39,11 @@ dcgm_health_check_unknown_system_skipped = Counter(
     "dcgm_health_check_unknown_system_skipped",
     "Number of DCGM health check incidents skipped due to unrecognized system value",
 )
+dcgm_health_check_suppressed_incidents = Counter(
+    "dcgm_health_check_suppressed_incidents",
+    "Number of DCGM health check incidents suppressed due to a non-actionable error code",
+    labelnames=["error_code"],
+)
 gpu_temp_limit_margin_blank = Counter(
     "gpu_temp_limit_margin_blank",
     "Number of poll cycles where DCGM field 153 (T.Limit) returned a blank value",

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/conftest.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/conftest.py
@@ -159,9 +159,10 @@ class MockDCGMErrors:
     DCGM_FR_PCI_REPLAY_RATE = 1
     DCGM_FR_NVLINK_DOWN = 2
     DCGM_FR_THERMAL_VIOLATIONS = 3
+    DCGM_FR_CLOCK_THROTTLE_POWER = 4
 
-    # Add more error codes as needed by tests (4 manual + 109 generated = 113 total)
-    for i in range(4, 113):
+    # Add more error codes as needed by tests (5 manual + 108 generated = 113 total)
+    for i in range(5, 113):
         locals()[f"DCGM_FR_ERROR_{i}"] = i
 
 

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_dcgm_watcher/test_dcgm.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_dcgm_watcher/test_dcgm.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 import dcgm_structs, dcgm_errors, dcgm_fields
 from threading import Event
 from ctypes import pointer
+import copy
 import json
 import pytest
 
@@ -349,8 +350,9 @@ class TestDCGMHealthChecks:
         incident.entityInfo.entityId = entity_id
         return incident
 
-    def test_perform_health_check_does_not_suppress_by_default(self):
-        """Without suppressed_error_codes configured, no incidents are dropped."""
+    def test_perform_health_check_reports_clock_throttle_power(self):
+        """_perform_health_check itself never suppresses; suppression is applied later
+        against the fully assembled health_status (see _suppress_configured_error_codes)."""
         watcher = dcgm.DCGMWatcher(
             addr="localhost:5555",
             poll_interval_seconds=10,
@@ -381,7 +383,33 @@ class TestDCGMHealthChecks:
         assert response == expected_response
         assert connectivity_success == True
 
-    def test_perform_health_check_suppresses_clock_throttle_power(self):
+    def test_suppress_configured_error_codes_noop_by_default(self):
+        """With no suppressed_error_codes configured, health_status is left untouched."""
+        watcher = dcgm.DCGMWatcher(
+            addr="localhost:5555",
+            poll_interval_seconds=10,
+            callbacks=[],
+            dcgm_k8s_service_enabled=False,
+        )
+        health_status = watcher._get_health_status_dict()
+        health_status["DCGM_HEALTH_WATCH_POWER"] = dcgm.types.HealthDetails(
+            status=dcgm.types.HealthStatus.WARN,
+            entity_failures={
+                1: dcgm.types.ErrorDetails(
+                    code="DCGM_FR_CLOCK_THROTTLE_POWER",
+                    message="ErrorCode:DCGM_FR_CLOCK_THROTTLE_POWER GPU:1 Recommended Action=NONE;",
+                )
+            },
+        )
+        expected = copy.deepcopy(health_status)
+
+        watcher._suppress_configured_error_codes(health_status)
+
+        assert health_status == expected
+
+    def test_suppress_configured_error_codes_clears_matching_dcgm_watch(self):
+        """A DCGM health-watch incident (e.g. GpuPowerWatch) matching a suppressed
+        error code is dropped and the watch reverts to PASS."""
         watcher = dcgm.DCGMWatcher(
             addr="localhost:5555",
             poll_interval_seconds=10,
@@ -389,24 +417,24 @@ class TestDCGMHealthChecks:
             dcgm_k8s_service_enabled=False,
             suppressed_error_codes=frozenset({"DCGM_FR_CLOCK_THROTTLE_POWER"}),
         )
-        dcgm_group_mock = MagicMock()
-        mock_response = dcgm_structs.c_dcgmHealthResponse_v4
-        mock_response.version = dcgm_structs.dcgmHealthResponse_version4
-        mock_response.overallHealth = dcgm_structs.DCGM_HEALTH_RESULT_WARN
-        mock_response.incidentCount = 1
-        mock_response.incidents = (dcgm_structs.c_dcgmIncidentInfo_t * dcgm_structs.DCGM_HEALTH_WATCH_MAX_INCIDENTS)()
-        mock_response.incidents[0] = self._get_power_throttle_incident(0, 1)
-        dcgm_group_mock.health.Check.return_value = mock_response()
+        health_status = watcher._get_health_status_dict()
+        health_status["DCGM_HEALTH_WATCH_POWER"] = dcgm.types.HealthDetails(
+            status=dcgm.types.HealthStatus.WARN,
+            entity_failures={
+                1: dcgm.types.ErrorDetails(
+                    code="DCGM_FR_CLOCK_THROTTLE_POWER",
+                    message="ErrorCode:DCGM_FR_CLOCK_THROTTLE_POWER GPU:1 Recommended Action=NONE;",
+                )
+            },
+        )
 
-        response, connectivity_success = watcher._perform_health_check(dcgm_group_mock)
+        watcher._suppress_configured_error_codes(health_status)
 
-        # The suppressed incident must not surface as a watch failure or entity failure.
         expected_response = watcher._get_health_status_dict()
-        assert response == expected_response
-        assert connectivity_success == True
+        assert health_status == expected_response
 
-    def test_perform_health_check_suppresses_only_clock_throttle_power(self):
-        """A genuine (non-suppressed) power incident on another GPU must still be reported."""
+    def test_suppress_configured_error_codes_only_suppresses_matching_entities(self):
+        """A genuine (non-suppressed) incident on another GPU/watch must still be reported."""
         watcher = dcgm.DCGMWatcher(
             addr="localhost:5555",
             poll_interval_seconds=10,
@@ -414,17 +442,27 @@ class TestDCGMHealthChecks:
             dcgm_k8s_service_enabled=False,
             suppressed_error_codes=frozenset({"DCGM_FR_CLOCK_THROTTLE_POWER"}),
         )
-        dcgm_group_mock = MagicMock()
-        mock_response = dcgm_structs.c_dcgmHealthResponse_v4
-        mock_response.version = dcgm_structs.dcgmHealthResponse_version4
-        mock_response.overallHealth = dcgm_structs.DCGM_HEALTH_RESULT_WARN
-        mock_response.incidentCount = 2
-        mock_response.incidents = (dcgm_structs.c_dcgmIncidentInfo_t * dcgm_structs.DCGM_HEALTH_WATCH_MAX_INCIDENTS)()
-        mock_response.incidents[0] = self._get_power_throttle_incident(0, 1)
-        mock_response.incidents[1] = self._get_pcie_incident(0, 2)
-        dcgm_group_mock.health.Check.return_value = mock_response()
+        health_status = watcher._get_health_status_dict()
+        health_status["DCGM_HEALTH_WATCH_POWER"] = dcgm.types.HealthDetails(
+            status=dcgm.types.HealthStatus.WARN,
+            entity_failures={
+                1: dcgm.types.ErrorDetails(
+                    code="DCGM_FR_CLOCK_THROTTLE_POWER",
+                    message="ErrorCode:DCGM_FR_CLOCK_THROTTLE_POWER GPU:1 Recommended Action=NONE;",
+                )
+            },
+        )
+        health_status["DCGM_HEALTH_WATCH_PCIE"] = dcgm.types.HealthDetails(
+            status=dcgm.types.HealthStatus.WARN,
+            entity_failures={
+                2: dcgm.types.ErrorDetails(
+                    code="DCGM_FR_PCI_REPLAY_RATE",
+                    message="Detected more than 8 PCIe replays per minute for GPU 1.",
+                )
+            },
+        )
 
-        response, connectivity_success = watcher._perform_health_check(dcgm_group_mock)
+        watcher._suppress_configured_error_codes(health_status)
 
         expected_response = watcher._get_health_status_dict()
         expected_response["DCGM_HEALTH_WATCH_PCIE"] = dcgm.types.HealthDetails(
@@ -432,12 +470,41 @@ class TestDCGMHealthChecks:
             entity_failures={
                 2: dcgm.types.ErrorDetails(
                     code="DCGM_FR_PCI_REPLAY_RATE",
-                    message="Detected more than 8 PCIe replays per minute for GPU 1 : 99999 Reconnect PCIe card. Run system side PCIE diagnostic utilities to verify hops off the GPU board. If issue is on the board, run the field diagnostic.",
+                    message="Detected more than 8 PCIe replays per minute for GPU 1.",
                 )
             },
         )
-        assert response == expected_response
-        assert connectivity_success == True
+        assert health_status == expected_response
+
+    def test_suppress_configured_error_codes_applies_to_custom_field_monitors(self):
+        """Suppression is generalized: it also applies to non-DCGM-health-watch entries
+        such as GpuThermalMarginWatch (custom field monitoring), not just native
+        DCGM health check incidents."""
+        watcher = dcgm.DCGMWatcher(
+            addr="localhost:5555",
+            poll_interval_seconds=10,
+            callbacks=[],
+            dcgm_k8s_service_enabled=False,
+            suppressed_error_codes=frozenset({"GPU_TEMP_HW_SLOWDOWN_VIOLATION"}),
+        )
+        health_status = watcher._get_health_status_dict()
+        health_status["DCGM_HEALTH_WATCH_THERMAL_MARGIN"] = dcgm.types.HealthDetails(
+            status=dcgm.types.HealthStatus.WARN,
+            entity_failures={
+                0: dcgm.types.ErrorDetails(
+                    code="GPU_TEMP_HW_SLOWDOWN_VIOLATION",
+                    message="GPU 0 thermal margin below HW slowdown T.Limit",
+                )
+            },
+        )
+
+        watcher._suppress_configured_error_codes(health_status)
+
+        expected_response = watcher._get_health_status_dict()
+        expected_response["DCGM_HEALTH_WATCH_THERMAL_MARGIN"] = dcgm.types.HealthDetails(
+            status=dcgm.types.HealthStatus.PASS, entity_failures={}
+        )
+        assert health_status == expected_response
 
     def _get_nvlink_incident(self, group_id, entity_id, link_id):
         """Helper to create NvLink down incident for testing."""

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_dcgm_watcher/test_dcgm.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_dcgm_watcher/test_dcgm.py
@@ -336,6 +336,109 @@ class TestDCGMHealthChecks:
         assert response == expected_response
         assert connectivity_success == True
 
+    def _get_power_throttle_incident(self, group_id, entity_id):
+        """Helper to create a DCGM_FR_CLOCK_THROTTLE_POWER incident for testing."""
+        incident = dcgm_structs.c_dcgmIncidentInfo_t()
+        incident.system = dcgm_structs.DCGM_HEALTH_WATCH_POWER
+        incident.health = dcgm_structs.DCGM_HEALTH_RESULT_WARN
+        incident.error = dcgm_structs.c_dcgmDiagErrorDetail_t()
+        incident.error.msg = f"ErrorCode:DCGM_FR_CLOCK_THROTTLE_POWER GPU:{entity_id} Recommended Action=NONE;"
+        incident.error.code = dcgm_errors.DCGM_FR_CLOCK_THROTTLE_POWER
+        incident.entityInfo = dcgm_structs.c_dcgmGroupEntityPair_t()
+        incident.entityInfo.entityGroupId = group_id
+        incident.entityInfo.entityId = entity_id
+        return incident
+
+    def test_perform_health_check_does_not_suppress_by_default(self):
+        """Without suppressed_error_codes configured, no incidents are dropped."""
+        watcher = dcgm.DCGMWatcher(
+            addr="localhost:5555",
+            poll_interval_seconds=10,
+            callbacks=[],
+            dcgm_k8s_service_enabled=False,
+        )
+        dcgm_group_mock = MagicMock()
+        mock_response = dcgm_structs.c_dcgmHealthResponse_v4
+        mock_response.version = dcgm_structs.dcgmHealthResponse_version4
+        mock_response.overallHealth = dcgm_structs.DCGM_HEALTH_RESULT_WARN
+        mock_response.incidentCount = 1
+        mock_response.incidents = (dcgm_structs.c_dcgmIncidentInfo_t * dcgm_structs.DCGM_HEALTH_WATCH_MAX_INCIDENTS)()
+        mock_response.incidents[0] = self._get_power_throttle_incident(0, 1)
+        dcgm_group_mock.health.Check.return_value = mock_response()
+
+        response, connectivity_success = watcher._perform_health_check(dcgm_group_mock)
+
+        expected_response = watcher._get_health_status_dict()
+        expected_response["DCGM_HEALTH_WATCH_POWER"] = dcgm.types.HealthDetails(
+            status=dcgm.types.HealthStatus.WARN,
+            entity_failures={
+                1: dcgm.types.ErrorDetails(
+                    code="DCGM_FR_CLOCK_THROTTLE_POWER",
+                    message="ErrorCode:DCGM_FR_CLOCK_THROTTLE_POWER GPU:1 Recommended Action=NONE;",
+                )
+            },
+        )
+        assert response == expected_response
+        assert connectivity_success == True
+
+    def test_perform_health_check_suppresses_clock_throttle_power(self):
+        watcher = dcgm.DCGMWatcher(
+            addr="localhost:5555",
+            poll_interval_seconds=10,
+            callbacks=[],
+            dcgm_k8s_service_enabled=False,
+            suppressed_error_codes=frozenset({"DCGM_FR_CLOCK_THROTTLE_POWER"}),
+        )
+        dcgm_group_mock = MagicMock()
+        mock_response = dcgm_structs.c_dcgmHealthResponse_v4
+        mock_response.version = dcgm_structs.dcgmHealthResponse_version4
+        mock_response.overallHealth = dcgm_structs.DCGM_HEALTH_RESULT_WARN
+        mock_response.incidentCount = 1
+        mock_response.incidents = (dcgm_structs.c_dcgmIncidentInfo_t * dcgm_structs.DCGM_HEALTH_WATCH_MAX_INCIDENTS)()
+        mock_response.incidents[0] = self._get_power_throttle_incident(0, 1)
+        dcgm_group_mock.health.Check.return_value = mock_response()
+
+        response, connectivity_success = watcher._perform_health_check(dcgm_group_mock)
+
+        # The suppressed incident must not surface as a watch failure or entity failure.
+        expected_response = watcher._get_health_status_dict()
+        assert response == expected_response
+        assert connectivity_success == True
+
+    def test_perform_health_check_suppresses_only_clock_throttle_power(self):
+        """A genuine (non-suppressed) power incident on another GPU must still be reported."""
+        watcher = dcgm.DCGMWatcher(
+            addr="localhost:5555",
+            poll_interval_seconds=10,
+            callbacks=[],
+            dcgm_k8s_service_enabled=False,
+            suppressed_error_codes=frozenset({"DCGM_FR_CLOCK_THROTTLE_POWER"}),
+        )
+        dcgm_group_mock = MagicMock()
+        mock_response = dcgm_structs.c_dcgmHealthResponse_v4
+        mock_response.version = dcgm_structs.dcgmHealthResponse_version4
+        mock_response.overallHealth = dcgm_structs.DCGM_HEALTH_RESULT_WARN
+        mock_response.incidentCount = 2
+        mock_response.incidents = (dcgm_structs.c_dcgmIncidentInfo_t * dcgm_structs.DCGM_HEALTH_WATCH_MAX_INCIDENTS)()
+        mock_response.incidents[0] = self._get_power_throttle_incident(0, 1)
+        mock_response.incidents[1] = self._get_pcie_incident(0, 2)
+        dcgm_group_mock.health.Check.return_value = mock_response()
+
+        response, connectivity_success = watcher._perform_health_check(dcgm_group_mock)
+
+        expected_response = watcher._get_health_status_dict()
+        expected_response["DCGM_HEALTH_WATCH_PCIE"] = dcgm.types.HealthDetails(
+            status=dcgm.types.HealthStatus.WARN,
+            entity_failures={
+                2: dcgm.types.ErrorDetails(
+                    code="DCGM_FR_PCI_REPLAY_RATE",
+                    message="Detected more than 8 PCIe replays per minute for GPU 1 : 99999 Reconnect PCIe card. Run system side PCIE diagnostic utilities to verify hops off the GPU board. If issue is on the board, run the field diagnostic.",
+                )
+            },
+        )
+        assert response == expected_response
+        assert connectivity_success == True
+
     def _get_nvlink_incident(self, group_id, entity_id, link_id):
         """Helper to create NvLink down incident for testing."""
         incident = dcgm_structs.c_dcgmIncidentInfo_t()


### PR DESCRIPTION
## Summary

Currently we don't have a way to supress specific DCGM error codes and hence all events including the ones that are non-fatal and may not be actionable will get persisted into the database. This creates noise in the datastore and in some cases may cause other unintended side effects

## Testing

Validated by injecting a DCGM error before the change

```
k exec -it -n   gpu-operator                nvidia-dcgm-cgwm7    -- dcgmi test --inject --gpuid 0 -f 240 -v 99999
```

and noticed that the power event was shown

```
GpuPowerWatch  GpuPowerWatchIsNotHealthy  2s (x2 over 2m25s)  gpu-health-monitor  ErrorCode:DCGM_FR_CLOCK_THROTTLE_POWER GPU:0 PCI:0000:0f:00.0 GPU_UUID:GPU-a2874de7-5d01-313a-d773-2872b4cfb888 Detected clocks event due to power violation in GPU 0. Monitor the power conditions. This GPU can still perform workload. Recommended Action=NONE;
```

to validate suppression, I updated the configmap to have:

```
[dcgmhealthcheck]
SuppressedErrorCodes = DCGM_FR_CLOCK_THROTTLE_POWER
```

and injected the same error again and I noticed that the event wasn't fired this time confirming that the error was supressed. 


## Type of Change
- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [X] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review

Closes https://github.com/NVIDIA/NVSentinel/issues/1447

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable incident suppression for GPU health checks to ignore selected DCGM error codes.
  * Added a Prometheus counter metric to track how many incidents were suppressed (labeled by error code).
* **Documentation**
  * Documented the new `dcgmHealthCheck.suppressedErrorCodes` configuration option and added example values.
* **Bug Fixes**
  * Suppression is applied only to explicitly listed error codes, with other incidents reported normally; affected watches can now revert to `PASS` when all their failures are suppressed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->