### PR TITLE
fix: test flake fix for TestNICCounterIBDegradation

### DIFF
--- a/tests/gpu_health_monitor_test.go
+++ b/tests/gpu_health_monitor_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"tests/helpers"
 
@@ -43,6 +44,14 @@ const (
 	GPUHealthMonitorContainerName = "gpu-health-monitor"
 	GPUHealthMonitorDaemonSetName = "gpu-health-monitor-dcgm-4.x"
 )
+
+// dcgmConnectivityFailureObserveWindow bounds how long we wait for the fatal
+// GpuDcgmConnectivityFailure that the gpu-health-monitor emits on its first
+// poll after its DCGM connection breaks. The monitor polls every 15s
+// (PollIntervalSeconds in the gpu-health-monitor chart configmap), so three
+// poll cycles plus pipeline latency is ample; if nothing shows up by then the
+// connection survived and no fatal is in flight.
+const dcgmConnectivityFailureObserveWindow = 50 * time.Second
 
 const (
 	keyGpuHealthMonitorPodName      contextKey = "gpuHealthMonitorPodName"
@@ -957,6 +966,14 @@ func TestDCGMBootstrapCompletedAnnotation(t *testing.T) {
 		testNodeName = gpuHealthMonitorPod.Spec.NodeName
 		t.Logf("Using node: %s", testNodeName)
 
+		// Deleting the nvidia-dcgm pod below breaks the gpu-health-monitor's DCGM
+		// connection; its next poll emits a fatal GpuDcgmConnectivityFailure, which
+		// would quarantine this node and leak a cordon into whichever test runs
+		// next. Mark the node unmanaged so fault-quarantine ignores that event.
+		t.Logf("Setting ManagedByNVSentinel=false on node %s", testNodeName)
+		err = helpers.SetNodeManagedByNVSentinel(ctx, client, testNodeName, false)
+		require.NoError(t, err, "failed to set ManagedByNVSentinel label")
+
 		node, err := helpers.GetNodeByName(ctx, client, testNodeName)
 		require.NoError(t, err, "failed to get node %s", testNodeName)
 		require.NotEmpty(t, node.Annotations[dcgmBootstrapAnnotation],
@@ -1000,6 +1017,75 @@ func TestDCGMBootstrapCompletedAnnotation(t *testing.T) {
 
 			return ctx
 		})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		if testNodeName == "" {
+			t.Log("Skipping teardown: node not selected (setup likely failed early)")
+			return ctx
+		}
+
+		client, err := c.NewClient()
+		require.NoError(t, err, "failed to create kubernetes client for teardown")
+
+		// The nvidia-dcgm pod restart leaves the gpu-health-monitor with a stale
+		// DCGM handle, so its next poll emits a fatal GpuDcgmConnectivityFailure.
+		// Before handing the node back as managed, wait for that failure to show
+		// up and for the monitor to reconnect and report healthy again — otherwise
+		// the fatal lands after this test ends and cordons the node under the
+		// next test (see the TestNICCounterIBDegradation flake).
+		t.Logf("Waiting up to %v for GpuDcgmConnectivityFailure to appear on node %s",
+			dcgmConnectivityFailureObserveWindow, testNodeName)
+		sawConnectivityFailure := false
+		deadline := time.Now().Add(dcgmConnectivityFailureObserveWindow)
+		for time.Now().Before(deadline) {
+			condition, err := helpers.CheckNodeConditionExists(ctx, client, testNodeName,
+				"GpuDcgmConnectivityFailure", "GpuDcgmConnectivityFailureIsNotHealthy")
+			if err != nil {
+				t.Logf("Error checking condition: %v", err)
+			} else if condition != nil && condition.Status == v1.ConditionTrue {
+				sawConnectivityFailure = true
+				break
+			}
+			time.Sleep(helpers.WaitInterval)
+		}
+
+		if sawConnectivityFailure {
+			t.Logf("Waiting for GpuDcgmConnectivityFailure to become healthy on node %s", testNodeName)
+			require.Eventually(t, func() bool {
+				condition, err := helpers.CheckNodeConditionExists(ctx, client, testNodeName,
+					"GpuDcgmConnectivityFailure", "GpuDcgmConnectivityFailureIsHealthy")
+				if err != nil {
+					t.Logf("Error checking condition: %v", err)
+					return false
+				}
+				return condition != nil && condition.Status == v1.ConditionFalse
+			}, helpers.EventuallyWaitTimeout, helpers.WaitInterval,
+				"GpuDcgmConnectivityFailure should become healthy on node %s", testNodeName)
+		} else {
+			t.Logf("No GpuDcgmConnectivityFailure observed within %v on node %s; "+
+				"gpu-health-monitor connection survived the nvidia-dcgm restart",
+				dcgmConnectivityFailureObserveWindow, testNodeName)
+		}
+
+		require.Never(t, func() bool {
+			condition, err := helpers.CheckNodeConditionExists(ctx, client, testNodeName,
+				"GpuDcgmConnectivityFailure", "GpuDcgmConnectivityFailureIsNotHealthy")
+			if err != nil {
+				t.Logf("Error checking condition during stability check: %v", err)
+				return false
+			}
+			return condition != nil && condition.Status == v1.ConditionTrue
+		}, helpers.NeverWaitTimeout, helpers.WaitInterval,
+			"GpuDcgmConnectivityFailure should stay healthy on node %s", testNodeName)
+
+		t.Logf("Removing ManagedByNVSentinel label from node %s", testNodeName)
+		err = helpers.RemoveNodeManagedByNVSentinelLabel(ctx, client, testNodeName)
+		if err != nil {
+			t.Logf("Warning: failed to remove ManagedByNVSentinel label: %v", err)
+		}
+
+		return ctx
+	})
 
 	testEnv.Test(t, feature.Feature())
 }

--- a/tests/gpu_health_monitor_test.go
+++ b/tests/gpu_health_monitor_test.go
@@ -1030,9 +1030,7 @@ func TestDCGMBootstrapCompletedAnnotation(t *testing.T) {
 		// The nvidia-dcgm pod restart leaves the gpu-health-monitor with a stale
 		// DCGM handle, so its next poll emits a fatal GpuDcgmConnectivityFailure.
 		// Before handing the node back as managed, wait for that failure to show
-		// up and for the monitor to reconnect and report healthy again — otherwise
-		// the fatal lands after this test ends and cordons the node under the
-		// next test (see the TestNICCounterIBDegradation flake).
+		// up and for the monitor to reconnect and report healthy again
 		t.Logf("Waiting up to %v for GpuDcgmConnectivityFailure to appear on node %s",
 			dcgmConnectivityFailureObserveWindow, testNodeName)
 		sawConnectivityFailure := false

--- a/tests/gpu_health_monitor_test.go
+++ b/tests/gpu_health_monitor_test.go
@@ -1071,32 +1071,16 @@ func TestDCGMBootstrapCompletedAnnotation(t *testing.T) {
 
 		if sawConnectivityFailure {
 			t.Logf("Waiting for GpuDcgmConnectivityFailure to become healthy on node %s", testNodeName)
-			require.Eventually(t, func() bool {
-				condition, checkErr := helpers.CheckNodeConditionExists(ctx, client, testNodeName,
-					"GpuDcgmConnectivityFailure", "GpuDcgmConnectivityFailureIsHealthy")
-				if checkErr != nil {
-					t.Logf("Error checking condition: %v", checkErr)
-					return false
-				}
-				return condition != nil && condition.Status == v1.ConditionFalse
-			}, helpers.EventuallyWaitTimeout, helpers.WaitInterval,
-				"GpuDcgmConnectivityFailure should become healthy on node %s", testNodeName)
+			helpers.WaitForNodeConditionWithCheckName(ctx, t, client, testNodeName,
+				"GpuDcgmConnectivityFailure", "", "GpuDcgmConnectivityFailureIsHealthy", v1.ConditionFalse)
 		} else {
 			t.Logf("No GpuDcgmConnectivityFailure observed within %v on node %s; "+
 				"gpu-health-monitor connection survived the nvidia-dcgm restart",
 				dcgmConnectivityFailureObserveWindow, testNodeName)
 		}
 
-		require.Never(t, func() bool {
-			condition, checkErr := helpers.CheckNodeConditionExists(ctx, client, testNodeName,
-				"GpuDcgmConnectivityFailure", "GpuDcgmConnectivityFailureIsNotHealthy")
-			if checkErr != nil {
-				t.Logf("Error checking condition during stability check: %v", checkErr)
-				return false
-			}
-			return condition != nil && condition.Status == v1.ConditionTrue
-		}, helpers.NeverWaitTimeout, helpers.WaitInterval,
-			"GpuDcgmConnectivityFailure should stay healthy on node %s", testNodeName)
+		t.Logf("Verifying GpuDcgmConnectivityFailure stays healthy on node %s", testNodeName)
+		helpers.EnsureNodeConditionNotPresent(ctx, t, client, testNodeName, "GpuDcgmConnectivityFailure")
 
 		// Restore the original ManagedByNVSentinel label state.
 		if hadManagedLabel {

--- a/tests/gpu_health_monitor_test.go
+++ b/tests/gpu_health_monitor_test.go
@@ -954,6 +954,8 @@ func TestDCGMBootstrapCompletedAnnotation(t *testing.T) {
 
 	var testNodeName string
 	var dcgmPodName string
+	var originalManagedLabel string
+	var hadManagedLabel bool
 
 	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		client, err := c.NewClient()
@@ -966,16 +968,20 @@ func TestDCGMBootstrapCompletedAnnotation(t *testing.T) {
 		testNodeName = gpuHealthMonitorPod.Spec.NodeName
 		t.Logf("Using node: %s", testNodeName)
 
+		// Capture original label state so teardown can restore it exactly.
+		node, err := helpers.GetNodeByName(ctx, client, testNodeName)
+		require.NoError(t, err, "failed to get node %s", testNodeName)
+		originalManagedLabel, hadManagedLabel = node.Labels["k8saas.nvidia.com/ManagedByNVSentinel"]
+
 		// Deleting the nvidia-dcgm pod below breaks the gpu-health-monitor's DCGM
 		// connection; its next poll emits a fatal GpuDcgmConnectivityFailure, which
 		// would quarantine this node and leak a cordon into whichever test runs
 		// next. Mark the node unmanaged so fault-quarantine ignores that event.
-		t.Logf("Setting ManagedByNVSentinel=false on node %s", testNodeName)
+		t.Logf("Setting ManagedByNVSentinel=false on node %s (original: present=%v, value=%q)",
+			testNodeName, hadManagedLabel, originalManagedLabel)
 		err = helpers.SetNodeManagedByNVSentinel(ctx, client, testNodeName, false)
 		require.NoError(t, err, "failed to set ManagedByNVSentinel label")
 
-		node, err := helpers.GetNodeByName(ctx, client, testNodeName)
-		require.NoError(t, err, "failed to get node %s", testNodeName)
 		require.NotEmpty(t, node.Annotations[dcgmBootstrapAnnotation],
 			"node %s should have annotation %s set", testNodeName, dcgmBootstrapAnnotation)
 		t.Logf("Node %s has annotation %s: %s", testNodeName, dcgmBootstrapAnnotation,
@@ -1030,30 +1036,46 @@ func TestDCGMBootstrapCompletedAnnotation(t *testing.T) {
 		// The nvidia-dcgm pod restart leaves the gpu-health-monitor with a stale
 		// DCGM handle, so its next poll emits a fatal GpuDcgmConnectivityFailure.
 		// Before handing the node back as managed, wait for that failure to show
-		// up and for the monitor to reconnect and report healthy again
+		// up and for the monitor to reconnect and report healthy again.
 		t.Logf("Waiting up to %v for GpuDcgmConnectivityFailure to appear on node %s",
 			dcgmConnectivityFailureObserveWindow, testNodeName)
 		sawConnectivityFailure := false
-		deadline := time.Now().Add(dcgmConnectivityFailureObserveWindow)
-		for time.Now().Before(deadline) {
-			condition, err := helpers.CheckNodeConditionExists(ctx, client, testNodeName,
-				"GpuDcgmConnectivityFailure", "GpuDcgmConnectivityFailureIsNotHealthy")
-			if err != nil {
-				t.Logf("Error checking condition: %v", err)
-			} else if condition != nil && condition.Status == v1.ConditionTrue {
-				sawConnectivityFailure = true
-				break
+		hadSuccessfulCheck := false
+		ticker := time.NewTicker(helpers.WaitInterval)
+		defer ticker.Stop()
+		deadline := time.After(dcgmConnectivityFailureObserveWindow)
+	observeLoop:
+		for {
+			select {
+			case <-ctx.Done():
+				t.Logf("Context canceled while waiting for GpuDcgmConnectivityFailure on node %s", testNodeName)
+				break observeLoop
+			case <-deadline:
+				break observeLoop
+			case <-ticker.C:
+				condition, checkErr := helpers.CheckNodeConditionExists(ctx, client, testNodeName,
+					"GpuDcgmConnectivityFailure", "GpuDcgmConnectivityFailureIsNotHealthy")
+				if checkErr != nil {
+					t.Logf("Error checking condition: %v", checkErr)
+					continue
+				}
+				hadSuccessfulCheck = true
+				if condition != nil && condition.Status == v1.ConditionTrue {
+					sawConnectivityFailure = true
+					break observeLoop
+				}
 			}
-			time.Sleep(helpers.WaitInterval)
 		}
+		require.True(t, hadSuccessfulCheck,
+			"never got a successful condition check for node %s during observe window", testNodeName)
 
 		if sawConnectivityFailure {
 			t.Logf("Waiting for GpuDcgmConnectivityFailure to become healthy on node %s", testNodeName)
 			require.Eventually(t, func() bool {
-				condition, err := helpers.CheckNodeConditionExists(ctx, client, testNodeName,
+				condition, checkErr := helpers.CheckNodeConditionExists(ctx, client, testNodeName,
 					"GpuDcgmConnectivityFailure", "GpuDcgmConnectivityFailureIsHealthy")
-				if err != nil {
-					t.Logf("Error checking condition: %v", err)
+				if checkErr != nil {
+					t.Logf("Error checking condition: %v", checkErr)
 					return false
 				}
 				return condition != nil && condition.Status == v1.ConditionFalse
@@ -1066,20 +1088,25 @@ func TestDCGMBootstrapCompletedAnnotation(t *testing.T) {
 		}
 
 		require.Never(t, func() bool {
-			condition, err := helpers.CheckNodeConditionExists(ctx, client, testNodeName,
+			condition, checkErr := helpers.CheckNodeConditionExists(ctx, client, testNodeName,
 				"GpuDcgmConnectivityFailure", "GpuDcgmConnectivityFailureIsNotHealthy")
-			if err != nil {
-				t.Logf("Error checking condition during stability check: %v", err)
+			if checkErr != nil {
+				t.Logf("Error checking condition during stability check: %v", checkErr)
 				return false
 			}
 			return condition != nil && condition.Status == v1.ConditionTrue
 		}, helpers.NeverWaitTimeout, helpers.WaitInterval,
 			"GpuDcgmConnectivityFailure should stay healthy on node %s", testNodeName)
 
-		t.Logf("Removing ManagedByNVSentinel label from node %s", testNodeName)
-		err = helpers.RemoveNodeManagedByNVSentinelLabel(ctx, client, testNodeName)
-		if err != nil {
-			t.Logf("Warning: failed to remove ManagedByNVSentinel label: %v", err)
+		// Restore the original ManagedByNVSentinel label state.
+		if hadManagedLabel {
+			t.Logf("Restoring ManagedByNVSentinel=%s on node %s", originalManagedLabel, testNodeName)
+			require.NoError(t, helpers.SetNodeManagedByNVSentinel(ctx, client, testNodeName, originalManagedLabel == "true"),
+				"failed to restore ManagedByNVSentinel label on node %s", testNodeName)
+		} else {
+			t.Logf("Removing ManagedByNVSentinel label from node %s (was not present before test)", testNodeName)
+			require.NoError(t, helpers.RemoveNodeManagedByNVSentinelLabel(ctx, client, testNodeName),
+				"failed to remove ManagedByNVSentinel label from node %s", testNodeName)
 		}
 
 		return ctx


### PR DESCRIPTION
## Summary

Fixes a flaky E2E failure where `TestNICCounterIBDegradation` fails with `node nvsentinel-worker is still cordoned` due to test pollution from the preceding `TestDCGMBootstrapCompletedAnnotation`.

### Root Cause

`TestDCGMBootstrapCompletedAnnotation` (introduced in #1425) deletes the `nvidia-dcgm` pod to verify that the bootstrap annotation persists across pod restarts. However, deleting the DCGM pod breaks the gpu-health-monitor's DCGM connection. When the monitor's next 15-second periodic health check fires against the broken connection, it emits a **fatal `GpuDcgmConnectivityFailure`** event (`DCGM_CONNECTIVITY_ERROR`). This is correct product behavior — post-bootstrap, DCGM connectivity loss is treated as a real node fault.

The problem: the test only waited for the replacement DCGM pod to be Running/Ready, then ended — it never waited for the gpu-health-monitor to reconnect to DCGM. The fatal event propagated asynchronously through the pipeline (gpu-health-monitor → platform-connector → PostgreSQL → fault-quarantine) and arrived **after** the test had already passed, cordoning the node ~3.5 seconds later. When `TestNICCounterIBDegradation` started immediately after on the same node, its `require.Never` stability check saw the unexpected cordon and failed.

The flake was timing-dependent: it only reproduced when (a) the monitor's 15s poll tick fired during the DCGM connection gap, and (b) both tests selected the same worker node.

### Fix

Two changes to `TestDCGMBootstrapCompletedAnnotation` in `tests/gpu_health_monitor_test.go`, following the existing pattern from its sibling test `TestGPUHealthMonitorDCGMConnectionError`:

1. **Setup labels the node `ManagedByNVSentinel=false`** before deleting the DCGM pod. Fault-quarantine's rulesets (CEL expressions in `charts/fault-quarantine/values.yaml`) skip nodes with this label, so the fatal `GpuDcgmConnectivityFailure` cannot cordon the node — neither during this test nor after it ends.

2. **New Teardown waits for the full failure→recovery cycle** before handing the node back:
   - Waits up to 50s (covers three 15s poll cycles plus pipeline latency) for the `GpuDcgmConnectivityFailure` condition to appear. If it doesn't appear, the monitor's connection survived the restart — no cleanup needed.
   - If the condition appeared, waits with `require.Eventually` for it to become healthy (monitor successfully reconnected to DCGM).
   - Runs a 10s `require.Never` stability check to confirm the condition stays healthy.
   - Removes the `ManagedByNVSentinel` label, restoring the node to managed state.

### Test Plan

Tested locally against a Kind cluster (`make cluster-create` → `make tilt-up` → `make -C tests test`):

- **Without the fix (git stash):** Ran `TestDCGMBootstrapCompletedAnnotation|TestNICCounterIBDegradation` 3 times. On the 3rd run, both tests selected `nvsentinel-worker` and `TestNICCounterIBDegradation` failed with `node nvsentinel-worker is still cordoned` — same failure signature as CI.
- **With the fix (git stash pop):** Ran the same test pair 6 times, including runs where both tests landed on the same node. All passed. The teardown log shows the fix in action: `Waiting up to 50s for GpuDcgmConnectivityFailure to appear` → condition detected → `Waiting for GpuDcgmConnectivityFailure to become healthy` → recovery confirmed → label removed.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [x] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Strengthened the GPU health monitor test to more reliably validate connectivity recovery after restarting DCGM.
  * Added a deadline-bounded observation window that polls for connectivity failure recovery before proceeding.
  * Added stability checks for observed healthy connectivity, and now verifies the connectivity failure signal is absent afterward.
  * Preserves and restores the node’s original management label state to avoid side effects in later test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->