### PR TITLE
feat: gate node-labeler and cluster-scope monitors on managed=false label (ADR-040)

### DIFF
--- a/commons/pkg/managed/managed.go
+++ b/commons/pkg/managed/managed.go
@@ -40,9 +40,13 @@ package managed
 import (
 	"context"
 	"fmt"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 	listersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 )
 
 const (
@@ -90,4 +94,41 @@ func IsNodeOptedOut(ctx context.Context, nodeLister listersv1.NodeLister, nodeNa
 	}
 
 	return node.Labels[ManagedLabelKey] == ManagedLabelValueFalse, nil
+}
+
+// cacheSyncTimeout is the maximum time NewNodeLister waits for the node
+// informer cache to populate on startup. The parent ctx controls the informer
+// factory lifetime; this deadline is only for the sync step so a slow apiserver
+// at startup doesn't block the caller indefinitely.
+const cacheSyncTimeout = 30 * time.Second
+
+// NewNodeLister builds an informer-backed NodeLister using the provided
+// Kubernetes client. It starts the informer factory, waits up to 30 seconds
+// for the node cache to sync, then returns the lister. The factory is tied to
+// ctx — when ctx is cancelled the factory stops.
+//
+// Call this once at startup and reuse the returned lister for the lifetime of
+// the process. resyncPeriod controls how often the informer performs a full
+// re-list from the apiserver; 0 disables periodic re-sync.
+func NewNodeLister(
+	ctx context.Context, client kubernetes.Interface, resyncPeriod time.Duration,
+) (listersv1.NodeLister, error) {
+	factory := informers.NewSharedInformerFactory(client, resyncPeriod)
+	nodes := factory.Core().V1().Nodes()
+
+	// Register the node informer BEFORE calling factory.Start.
+	// SharedInformerFactory only starts informers that were referenced before
+	// Start is called; registering afterward leaves the cache permanently empty.
+	informer := nodes.Informer()
+
+	factory.Start(ctx.Done())
+
+	syncCtx, syncCancel := context.WithTimeout(ctx, cacheSyncTimeout)
+	defer syncCancel()
+
+	if !cache.WaitForCacheSync(syncCtx.Done(), informer.HasSynced) {
+		return nil, fmt.Errorf("timed out waiting for node informer cache to sync")
+	}
+
+	return nodes.Lister(), nil
 }

--- a/distros/kubernetes/nvsentinel/charts/fault-quarantine/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-quarantine/values.yaml
@@ -93,7 +93,8 @@ ruleSets:
           # CEL expression with access to 'node' object containing Node spec and metadata
           # This checks if the node has a label preventing automated management
           expression: |
-            !('k8saas.nvidia.com/ManagedByNVSentinel' in node.metadata.labels && node.metadata.labels['k8saas.nvidia.com/ManagedByNVSentinel'] == "false")
+            !('k8saas.nvidia.com/ManagedByNVSentinel' in node.metadata.labels && node.metadata.labels['k8saas.nvidia.com/ManagedByNVSentinel'] == "false") &&
+            !('nvsentinel.dgxc.nvidia.com/managed' in node.metadata.labels && node.metadata.labels['nvsentinel.dgxc.nvidia.com/managed'] == "false")
     # Cordon action - marks node as unschedulable when ruleset triggers
     cordon:
       # Set to true to cordon (mark unschedulable) the node
@@ -128,7 +129,8 @@ ruleSets:
           expression: "event.agent == 'csp-health-monitor' && event.checkName == 'CSPMaintenance' && event.isFatal == true"
         - kind: "Node"
           expression: |
-            !('k8saas.nvidia.com/ManagedByNVSentinel' in node.metadata.labels && node.metadata.labels['k8saas.nvidia.com/ManagedByNVSentinel'] == "false")
+            !('k8saas.nvidia.com/ManagedByNVSentinel' in node.metadata.labels && node.metadata.labels['k8saas.nvidia.com/ManagedByNVSentinel'] == "false") &&
+            !('nvsentinel.dgxc.nvidia.com/managed' in node.metadata.labels && node.metadata.labels['nvsentinel.dgxc.nvidia.com/managed'] == "false")
     cordon:
       shouldCordon: true
 
@@ -141,7 +143,8 @@ ruleSets:
           expression: "event.agent == 'syslog-health-monitor' && (event.componentClass == 'GPU' || event.componentClass == 'NIC') && event.isFatal == true"
         - kind: "Node"
           expression: |
-            !('k8saas.nvidia.com/ManagedByNVSentinel' in node.metadata.labels && node.metadata.labels['k8saas.nvidia.com/ManagedByNVSentinel'] == "false")
+            !('k8saas.nvidia.com/ManagedByNVSentinel' in node.metadata.labels && node.metadata.labels['k8saas.nvidia.com/ManagedByNVSentinel'] == "false") &&
+            !('nvsentinel.dgxc.nvidia.com/managed' in node.metadata.labels && node.metadata.labels['nvsentinel.dgxc.nvidia.com/managed'] == "false")
     cordon:
       shouldCordon: true
 
@@ -154,7 +157,8 @@ ruleSets:
           expression: "event.agent == 'nic-health-monitor' && event.isFatal == true"
         - kind: "Node"
           expression: |
-            !('k8saas.nvidia.com/ManagedByNVSentinel' in node.metadata.labels && node.metadata.labels['k8saas.nvidia.com/ManagedByNVSentinel'] == "false")
+            !('k8saas.nvidia.com/ManagedByNVSentinel' in node.metadata.labels && node.metadata.labels['k8saas.nvidia.com/ManagedByNVSentinel'] == "false") &&
+            !('nvsentinel.dgxc.nvidia.com/managed' in node.metadata.labels && node.metadata.labels['nvsentinel.dgxc.nvidia.com/managed'] == "false")
     cordon:
       shouldCordon: true
 
@@ -167,7 +171,8 @@ ruleSets:
           expression: "event.agent == 'kubernetes-object-monitor' && event.isFatal == true"
         - kind: "Node"
           expression: |
-            !('k8saas.nvidia.com/ManagedByNVSentinel' in node.metadata.labels && node.metadata.labels['k8saas.nvidia.com/ManagedByNVSentinel'] == "false")
+            !('k8saas.nvidia.com/ManagedByNVSentinel' in node.metadata.labels && node.metadata.labels['k8saas.nvidia.com/ManagedByNVSentinel'] == "false") &&
+            !('nvsentinel.dgxc.nvidia.com/managed' in node.metadata.labels && node.metadata.labels['nvsentinel.dgxc.nvidia.com/managed'] == "false")
     cordon:
       shouldCordon: true
 
@@ -184,6 +189,7 @@ ruleSets:
           expression: "event.agent.startsWith('preflight-') && event.isFatal == true"
         - kind: "Node"
           expression: |
-            !('k8saas.nvidia.com/ManagedByNVSentinel' in node.metadata.labels && node.metadata.labels['k8saas.nvidia.com/ManagedByNVSentinel'] == "false")
+            !('k8saas.nvidia.com/ManagedByNVSentinel' in node.metadata.labels && node.metadata.labels['k8saas.nvidia.com/ManagedByNVSentinel'] == "false") &&
+            !('nvsentinel.dgxc.nvidia.com/managed' in node.metadata.labels && node.metadata.labels['nvsentinel.dgxc.nvidia.com/managed'] == "false")
     cordon:
       shouldCordon: true

--- a/distros/kubernetes/nvsentinel/charts/slurm-drain-monitor/templates/clusterrole.yaml
+++ b/distros/kubernetes/nvsentinel/charts/slurm-drain-monitor/templates/clusterrole.yaml
@@ -27,3 +27,10 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch

--- a/health-monitors/csp-health-monitor/cmd/maintenance-notifier/main.go
+++ b/health-monitors/csp-health-monitor/cmd/maintenance-notifier/main.go
@@ -27,8 +27,11 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/nvidia/nvsentinel/commons/pkg/logger"
 	met "github.com/nvidia/nvsentinel/commons/pkg/metrics"
@@ -123,6 +126,18 @@ func setupUDSConnection(udsPath string) (*grpc.ClientConn, pb.PlatformConnectorC
 	slog.Info("Sidecar successfully connected to Platform Connector UDS.")
 
 	return conn, pb.NewPlatformConnectorClient(conn), nil
+}
+
+func setupNodeLister(ctx context.Context, k8sClient kubernetes.Interface) (listersv1.NodeLister, error) {
+	factory := informers.NewSharedInformerFactory(k8sClient, 0)
+	nodeInformer := factory.Core().V1().Nodes()
+	factory.Start(ctx.Done())
+
+	if ok := cache.WaitForCacheSync(ctx.Done(), nodeInformer.Informer().HasSynced); !ok {
+		return nil, fmt.Errorf("timed out waiting for node informer cache to sync")
+	}
+
+	return nodeInformer.Lister(), nil
 }
 
 func setupKubernetesClient() (kubernetes.Interface, error) {
@@ -221,6 +236,11 @@ func run() error {
 			return fmt.Errorf("kubernetes client setup failed: %w", err)
 		}
 
+		nodeLister, err := setupNodeLister(gCtx, k8sClient)
+		if err != nil {
+			return fmt.Errorf("node lister setup failed: %w", err)
+		}
+
 		value, ok := pb.ProcessingStrategy_value[appCfg.processingStrategy]
 		if !ok {
 			return fmt.Errorf("invalid processingStrategy %q (expected EXECUTE_REMEDIATION or STORE_ONLY)",
@@ -231,7 +251,7 @@ func run() error {
 
 		engine := trigger.NewEngine(cfg, store, platformConnectorClient,
 			fmt.Sprintf("unix:%s", appCfg.udsPath),
-			k8sClient, pb.ProcessingStrategy(value))
+			k8sClient, nodeLister, pb.ProcessingStrategy(value))
 
 		slog.Info("Trigger engine starting...")
 		engine.Start(gCtx)

--- a/health-monitors/csp-health-monitor/cmd/maintenance-notifier/main.go
+++ b/health-monitors/csp-health-monitor/cmd/maintenance-notifier/main.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/nvidia/nvsentinel/commons/pkg/logger"
 	met "github.com/nvidia/nvsentinel/commons/pkg/metrics"
@@ -128,16 +127,12 @@ func setupUDSConnection(udsPath string) (*grpc.ClientConn, pb.PlatformConnectorC
 	return conn, pb.NewPlatformConnectorClient(conn), nil
 }
 
-func setupNodeLister(ctx context.Context, k8sClient kubernetes.Interface) (listersv1.NodeLister, error) {
+func setupNodeLister(ctx context.Context, k8sClient kubernetes.Interface) listersv1.NodeLister {
 	factory := informers.NewSharedInformerFactory(k8sClient, 0)
 	nodeInformer := factory.Core().V1().Nodes()
 	factory.Start(ctx.Done())
 
-	if ok := cache.WaitForCacheSync(ctx.Done(), nodeInformer.Informer().HasSynced); !ok {
-		return nil, fmt.Errorf("timed out waiting for node informer cache to sync")
-	}
-
-	return nodeInformer.Lister(), nil
+	return nodeInformer.Lister()
 }
 
 func setupKubernetesClient() (kubernetes.Interface, error) {
@@ -209,55 +204,7 @@ func run() error {
 	})
 
 	g.Go(func() error {
-		slog.Info("Initializing datastore connection for sidecar...")
-
-		store, err := datastore.NewStore(gCtx, &appCfg.databaseClientCertMountPath)
-		if err != nil {
-			return fmt.Errorf("failed to initialize datastore: %w", err)
-		}
-
-		slog.Info("Datastore initialized successfully for sidecar.")
-
-		conn, platformConnectorClient, err := setupUDSConnection(appCfg.udsPath)
-		if err != nil {
-			return fmt.Errorf("UDS connection setup failed: %w", err)
-		}
-
-		defer func() {
-			slog.Info("Closing UDS connection for sidecar.")
-
-			if errClose := conn.Close(); errClose != nil {
-				slog.Error("Error closing sidecar UDS connection", "error", errClose)
-			}
-		}()
-
-		k8sClient, err := setupKubernetesClient()
-		if err != nil {
-			return fmt.Errorf("kubernetes client setup failed: %w", err)
-		}
-
-		nodeLister, err := setupNodeLister(gCtx, k8sClient)
-		if err != nil {
-			return fmt.Errorf("node lister setup failed: %w", err)
-		}
-
-		value, ok := pb.ProcessingStrategy_value[appCfg.processingStrategy]
-		if !ok {
-			return fmt.Errorf("invalid processingStrategy %q (expected EXECUTE_REMEDIATION or STORE_ONLY)",
-				appCfg.processingStrategy)
-		}
-
-		slog.Info("Event handling strategy configured", "processingStrategy", appCfg.processingStrategy)
-
-		engine := trigger.NewEngine(cfg, store, platformConnectorClient,
-			fmt.Sprintf("unix:%s", appCfg.udsPath),
-			k8sClient, nodeLister, pb.ProcessingStrategy(value))
-
-		slog.Info("Trigger engine starting...")
-		engine.Start(gCtx)
-		slog.Info("Trigger engine stopped.")
-
-		return nil
+		return runTriggerEngine(gCtx, appCfg, cfg)
 	})
 
 	// Wait for both goroutines to finish
@@ -266,6 +213,55 @@ func run() error {
 	}
 
 	slog.Info("Quarantine Trigger Engine Sidecar shut down.")
+
+	return nil
+}
+
+func runTriggerEngine(ctx context.Context, appCfg *appConfig, cfg *config.Config) error {
+	slog.Info("Initializing datastore connection for sidecar...")
+
+	store, err := datastore.NewStore(ctx, &appCfg.databaseClientCertMountPath)
+	if err != nil {
+		return fmt.Errorf("failed to initialize datastore: %w", err)
+	}
+
+	slog.Info("Datastore initialized successfully for sidecar.")
+
+	conn, platformConnectorClient, err := setupUDSConnection(appCfg.udsPath)
+	if err != nil {
+		return fmt.Errorf("UDS connection setup failed: %w", err)
+	}
+
+	defer func() {
+		slog.Info("Closing UDS connection for sidecar.")
+
+		if errClose := conn.Close(); errClose != nil {
+			slog.Error("Error closing sidecar UDS connection", "error", errClose)
+		}
+	}()
+
+	k8sClient, err := setupKubernetesClient()
+	if err != nil {
+		return fmt.Errorf("kubernetes client setup failed: %w", err)
+	}
+
+	nodeLister := setupNodeLister(ctx, k8sClient)
+
+	value, ok := pb.ProcessingStrategy_value[appCfg.processingStrategy]
+	if !ok {
+		return fmt.Errorf("invalid processingStrategy %q (expected EXECUTE_REMEDIATION or STORE_ONLY)",
+			appCfg.processingStrategy)
+	}
+
+	slog.Info("Event handling strategy configured", "processingStrategy", appCfg.processingStrategy)
+
+	engine := trigger.NewEngine(cfg, store, platformConnectorClient,
+		fmt.Sprintf("unix:%s", appCfg.udsPath),
+		k8sClient, nodeLister, pb.ProcessingStrategy(value))
+
+	slog.Info("Trigger engine starting...")
+	engine.Start(ctx)
+	slog.Info("Trigger engine stopped.")
 
 	return nil
 }

--- a/health-monitors/csp-health-monitor/cmd/maintenance-notifier/main.go
+++ b/health-monitors/csp-health-monitor/cmd/maintenance-notifier/main.go
@@ -27,13 +27,12 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
 
 	"github.com/nvidia/nvsentinel/commons/pkg/logger"
+	"github.com/nvidia/nvsentinel/commons/pkg/managed"
 	met "github.com/nvidia/nvsentinel/commons/pkg/metrics"
 	srv "github.com/nvidia/nvsentinel/commons/pkg/server"
 	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
@@ -129,22 +128,7 @@ func setupUDSConnection(udsPath string) (*grpc.ClientConn, pb.PlatformConnectorC
 }
 
 func setupNodeLister(ctx context.Context, k8sClient kubernetes.Interface) (listersv1.NodeLister, error) {
-	factory := informers.NewSharedInformerFactory(k8sClient, 0)
-	nodes := factory.Core().V1().Nodes()
-
-	// A SharedInformerFactory only starts informers that were referenced (via
-	// Informer()/Lister()) BEFORE Start is called. Register the node informer
-	// first, otherwise Start launches nothing and the lister cache stays empty
-	// forever, which would silently disable the managed=false gate (fail-open).
-	informer := nodes.Informer()
-
-	factory.Start(ctx.Done())
-
-	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
-		return nil, fmt.Errorf("timed out waiting for node informer cache to sync")
-	}
-
-	return nodes.Lister(), nil
+	return managed.NewNodeLister(ctx, k8sClient, 0)
 }
 
 func setupKubernetesClient() (kubernetes.Interface, error) {

--- a/health-monitors/csp-health-monitor/cmd/maintenance-notifier/main.go
+++ b/health-monitors/csp-health-monitor/cmd/maintenance-notifier/main.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/nvidia/nvsentinel/commons/pkg/logger"
 	met "github.com/nvidia/nvsentinel/commons/pkg/metrics"
@@ -127,12 +128,23 @@ func setupUDSConnection(udsPath string) (*grpc.ClientConn, pb.PlatformConnectorC
 	return conn, pb.NewPlatformConnectorClient(conn), nil
 }
 
-func setupNodeLister(ctx context.Context, k8sClient kubernetes.Interface) listersv1.NodeLister {
+func setupNodeLister(ctx context.Context, k8sClient kubernetes.Interface) (listersv1.NodeLister, error) {
 	factory := informers.NewSharedInformerFactory(k8sClient, 0)
-	nodeInformer := factory.Core().V1().Nodes()
+	nodes := factory.Core().V1().Nodes()
+
+	// A SharedInformerFactory only starts informers that were referenced (via
+	// Informer()/Lister()) BEFORE Start is called. Register the node informer
+	// first, otherwise Start launches nothing and the lister cache stays empty
+	// forever, which would silently disable the managed=false gate (fail-open).
+	informer := nodes.Informer()
+
 	factory.Start(ctx.Done())
 
-	return nodeInformer.Lister()
+	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+		return nil, fmt.Errorf("timed out waiting for node informer cache to sync")
+	}
+
+	return nodes.Lister(), nil
 }
 
 func setupKubernetesClient() (kubernetes.Interface, error) {
@@ -245,7 +257,10 @@ func runTriggerEngine(ctx context.Context, appCfg *appConfig, cfg *config.Config
 		return fmt.Errorf("kubernetes client setup failed: %w", err)
 	}
 
-	nodeLister := setupNodeLister(ctx, k8sClient)
+	nodeLister, err := setupNodeLister(ctx, k8sClient)
+	if err != nil {
+		return fmt.Errorf("node lister setup failed: %w", err)
+	}
 
 	value, ok := pb.ProcessingStrategy_value[appCfg.processingStrategy]
 	if !ok {

--- a/health-monitors/csp-health-monitor/pkg/metrics/metrics.go
+++ b/health-monitors/csp-health-monitor/pkg/metrics/metrics.go
@@ -227,6 +227,16 @@ var (
 		},
 	)
 
+	// TriggerSkippedManaged counts trigger attempts skipped because the target node
+	// carries nvsentinel.dgxc.nvidia.com/managed=false (ADR-040 opt-out).
+	TriggerSkippedManaged = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "csp_health_monitor_trigger_skipped_managed_total",
+			Help: "Total number of trigger attempts skipped because the node is opted out of NVSentinel management.",
+		},
+		[]string{"trigger_type"},
+	)
+
 	// Node Readiness Metrics
 	NodeNotReadyTimeout = promauto.NewCounterVec(
 		prometheus.CounterOpts{

--- a/health-monitors/csp-health-monitor/pkg/triggerengine/trigger.go
+++ b/health-monitors/csp-health-monitor/pkg/triggerengine/trigger.go
@@ -27,8 +27,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	listersv1 "k8s.io/client-go/listers/core/v1"
 
 	"github.com/nvidia/nvsentinel/commons/pkg/healthpub"
+	"github.com/nvidia/nvsentinel/commons/pkg/managed"
 	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	"github.com/nvidia/nvsentinel/health-monitors/csp-health-monitor/pkg/config"
 	"github.com/nvidia/nvsentinel/health-monitors/csp-health-monitor/pkg/datastore"
@@ -62,6 +64,7 @@ type Engine struct {
 	config             *config.Config
 	pollInterval       time.Duration
 	k8sClient          kubernetes.Interface
+	nodeLister         listersv1.NodeLister
 	monitoredNodes     sync.Map // Track which nodes are currently being monitored
 	monitorInterval    time.Duration
 	processingStrategy pb.ProcessingStrategy
@@ -77,6 +80,7 @@ func NewEngine(
 	udsClient pb.PlatformConnectorClient,
 	udsTarget string,
 	k8sClient kubernetes.Interface,
+	nodeLister listersv1.NodeLister,
 	processingStrategy pb.ProcessingStrategy,
 ) *Engine {
 	return &Engine{
@@ -87,6 +91,7 @@ func NewEngine(
 			healthpub.WithRetryPolicy(udsMaxRetries, udsRetryDelay, 1.5, 0.1)),
 		pollInterval:       time.Duration(cfg.MaintenanceEventPollIntervalSeconds) * time.Second,
 		k8sClient:          k8sClient,
+		nodeLister:         nodeLister,
 		monitorInterval:    defaultMonitorInterval,
 		processingStrategy: processingStrategy,
 	}
@@ -241,6 +246,23 @@ func (e *Engine) processAndSendTrigger(
 		metrics.TriggerFailures.WithLabelValues(triggerType, failureReasonMapping).Inc()
 
 		return fmt.Errorf("missing NodeName for %s trigger (EventID: %s)", triggerType, event.EventID)
+	}
+
+	// Skip emission when the node is opted out of NVSentinel management (ADR-040).
+	// Advance DB status so the event is not re-fired on the next poll.
+	if optedOut, err := managed.IsNodeOptedOut(ctx, e.nodeLister, event.NodeName); err != nil {
+		return fmt.Errorf("managed label check failed for node %s: %w", event.NodeName, err)
+	} else if optedOut {
+		slog.Info("Skipping trigger: node is opted out of NVSentinel management",
+			"node", event.NodeName, "triggerType", triggerType, "eventID", event.EventID)
+		metrics.TriggerSkippedManaged.WithLabelValues(triggerType).Inc()
+
+		if dbErr := e.store.UpdateEventStatus(ctx, event.EventID, targetDBStatus); dbErr != nil {
+			slog.Error("Failed to advance event status after managed skip",
+				"eventID", event.EventID, "error", dbErr)
+		}
+
+		return nil
 	}
 
 	slog.Info("Attempting to trigger event",

--- a/health-monitors/csp-health-monitor/pkg/triggerengine/trigger.go
+++ b/health-monitors/csp-health-monitor/pkg/triggerengine/trigger.go
@@ -258,6 +258,8 @@ func (e *Engine) processAndSendTrigger(
 		metrics.TriggerSkippedManaged.WithLabelValues(triggerType).Inc()
 
 		if dbErr := e.store.UpdateEventStatus(ctx, event.EventID, targetDBStatus); dbErr != nil {
+			metrics.TriggerDatastoreUpdateErrors.WithLabelValues(triggerType).Inc()
+			metrics.TriggerFailures.WithLabelValues(triggerType, failureReasonDBUpdate).Inc()
 			slog.Error("Failed to advance event status after managed skip",
 				"eventID", event.EventID, "error", dbErr)
 		}

--- a/health-monitors/csp-health-monitor/pkg/triggerengine/trigger_test.go
+++ b/health-monitors/csp-health-monitor/pkg/triggerengine/trigger_test.go
@@ -30,6 +30,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	listersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 
 	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	"github.com/nvidia/nvsentinel/health-monitors/csp-health-monitor/pkg/config"
@@ -183,13 +185,18 @@ func createMockClientWithNotReadyNode(nodeName string) *k8sfake.Clientset {
 	return k8sfake.NewSimpleClientset(node)
 }
 
+func newEmptyNodeLister() listersv1.NodeLister {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	return listersv1.NewNodeLister(indexer)
+}
+
 func TestNewEngine(t *testing.T) {
 	cfg := newTestConfig()
 	mStore := new(MockDatastore)
 	mUDSClient := new(MockUDSClient)
 	mockClient := createMockClientWithReadyNodes()
 
-	engine := NewEngine(cfg, mStore, mUDSClient, "tcp://test", mockClient, pb.ProcessingStrategy_EXECUTE_REMEDIATION)
+	engine := NewEngine(cfg, mStore, mUDSClient, "tcp://test", mockClient, newEmptyNodeLister(), pb.ProcessingStrategy_EXECUTE_REMEDIATION)
 
 	assert.NotNil(t, engine)
 	assert.Equal(t, cfg, engine.config)
@@ -203,7 +210,7 @@ func TestMapMaintenanceEventToHealthEvent(t *testing.T) {
 	cfg := newTestConfig()
 	mStore := new(MockDatastore)     // Not strictly needed for this func, but engine needs it
 	mUDSClient := new(MockUDSClient) // Not strictly needed for this func, but engine needs it
-	engine := NewEngine(cfg, mStore, mUDSClient, "tcp://test", nil, pb.ProcessingStrategy_EXECUTE_REMEDIATION)
+	engine := NewEngine(cfg, mStore, mUDSClient, "tcp://test", nil, newEmptyNodeLister(), pb.ProcessingStrategy_EXECUTE_REMEDIATION)
 
 	tests := []struct {
 		name          string
@@ -566,7 +573,7 @@ func TestProcessAndSendTrigger(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mStore := new(MockDatastore)
 			mUDSClient := new(MockUDSClient)
-			engine := NewEngine(cfg, mStore, mUDSClient, "tcp://test", nil, pb.ProcessingStrategy_EXECUTE_REMEDIATION)
+			engine := NewEngine(cfg, mStore, mUDSClient, "tcp://test", nil, newEmptyNodeLister(), pb.ProcessingStrategy_EXECUTE_REMEDIATION)
 
 			tc.setupMocks(mStore, mUDSClient, tc.event, tc.targetDBStatus)
 
@@ -747,7 +754,7 @@ func TestCheckAndTriggerEvents(t *testing.T) {
 			mStore := new(MockDatastore)
 			mUDSClient := new(MockUDSClient)
 			mockClient := createMockClientWithReadyNodes("node-q1", "node-h1", "q-no-node")
-			engine := NewEngine(cfg, mStore, mUDSClient, "tcp://test", mockClient, pb.ProcessingStrategy_EXECUTE_REMEDIATION)
+			engine := NewEngine(cfg, mStore, mUDSClient, "tcp://test", mockClient, newEmptyNodeLister(), pb.ProcessingStrategy_EXECUTE_REMEDIATION)
 
 			if tc.setupMocks != nil {
 				tc.setupMocks(mStore, mUDSClient)
@@ -793,7 +800,7 @@ func TestHealthyTriggerWaitsForNodeReady(t *testing.T) {
 	mUDSClient.On("HealthEventOccurredV1", mock.Anything, mock.Anything, mock.Anything).Return(&emptypb.Empty{}, nil).Once()
 	mStore.On("UpdateEventStatus", mock.AnythingOfType("*context.timerCtx"), healthyEvent.EventID, model.StatusHealthyTriggered).Return(nil).Once()
 
-	engine := NewEngine(cfg, mStore, mUDSClient, "tcp://test", mockClient, pb.ProcessingStrategy_EXECUTE_REMEDIATION)
+	engine := NewEngine(cfg, mStore, mUDSClient, "tcp://test", mockClient, newEmptyNodeLister(), pb.ProcessingStrategy_EXECUTE_REMEDIATION)
 	engine.monitorInterval = 3 * time.Second
 
 	err := engine.checkAndTriggerEvents(ctx)

--- a/health-monitors/kubernetes-object-monitor/pkg/initializer/initializer.go
+++ b/health-monitors/kubernetes-object-monitor/pkg/initializer/initializer.go
@@ -29,7 +29,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
+	toolscache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -92,7 +96,19 @@ func InitializeAll(ctx context.Context, params Params) (*Components, error) {
 
 	slog.Info("Event handling strategy configured", "processingStrategy", params.ProcessingStrategy)
 
-	pub := publisher.New(pcClient, params.PlatformConnectorSocket, pb.ProcessingStrategy(strategyValue))
+	restConfig, err := ctrl.GetConfig()
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("getting kubeconfig for node lister: %w", err)
+	}
+
+	nodeLister, err := buildNodeLister(ctx, restConfig, params.ResyncPeriod)
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("build node lister: %w", err)
+	}
+
+	pub := publisher.New(pcClient, params.PlatformConnectorSocket, nodeLister, pb.ProcessingStrategy(strategyValue))
 
 	mgr, err := createManager(params, cfg.Policies)
 	if err != nil {
@@ -294,6 +310,23 @@ func registerControllers(
 	}
 
 	return nil
+}
+
+func buildNodeLister(ctx context.Context, restCfg *rest.Config, resyncPeriod time.Duration) (listersv1.NodeLister, error) {
+	k8sClient, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		return nil, fmt.Errorf("create kubernetes client for node lister: %w", err)
+	}
+
+	factory := informers.NewSharedInformerFactory(k8sClient, resyncPeriod)
+	nodeInformer := factory.Core().V1().Nodes()
+	factory.Start(ctx.Done())
+
+	if ok := toolscache.WaitForCacheSync(ctx.Done(), nodeInformer.Informer().HasSynced); !ok {
+		return nil, fmt.Errorf("timed out waiting for node informer cache to sync")
+	}
+
+	return nodeInformer.Lister(), nil
 }
 
 func dialPlatformConnector(socket string) (*grpc.ClientConn, error) {

--- a/health-monitors/kubernetes-object-monitor/pkg/initializer/initializer.go
+++ b/health-monitors/kubernetes-object-monitor/pkg/initializer/initializer.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
+	toolscache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -312,10 +313,21 @@ func buildNodeLister(
 	}
 
 	factory := informers.NewSharedInformerFactory(k8sClient, resyncPeriod)
-	nodeInformer := factory.Core().V1().Nodes()
+	nodes := factory.Core().V1().Nodes()
+
+	// A SharedInformerFactory only starts informers that were referenced (via
+	// Informer()/Lister()) BEFORE Start is called. Register the node informer
+	// first, otherwise Start launches nothing and the lister cache stays empty
+	// forever, which would silently disable the managed=false gate (fail-open).
+	informer := nodes.Informer()
+
 	factory.Start(ctx.Done())
 
-	return nodeInformer.Lister(), nil
+	if !toolscache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+		return nil, fmt.Errorf("timed out waiting for node informer cache to sync")
+	}
+
+	return nodes.Lister(), nil
 }
 
 func buildPublisher(

--- a/health-monitors/kubernetes-object-monitor/pkg/initializer/initializer.go
+++ b/health-monitors/kubernetes-object-monitor/pkg/initializer/initializer.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
-	toolscache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -96,19 +95,11 @@ func InitializeAll(ctx context.Context, params Params) (*Components, error) {
 
 	slog.Info("Event handling strategy configured", "processingStrategy", params.ProcessingStrategy)
 
-	restConfig, err := ctrl.GetConfig()
+	pub, err := buildPublisher(ctx, pcClient, params, pb.ProcessingStrategy(strategyValue))
 	if err != nil {
 		conn.Close()
-		return nil, fmt.Errorf("getting kubeconfig for node lister: %w", err)
+		return nil, err
 	}
-
-	nodeLister, err := buildNodeLister(ctx, restConfig, params.ResyncPeriod)
-	if err != nil {
-		conn.Close()
-		return nil, fmt.Errorf("build node lister: %w", err)
-	}
-
-	pub := publisher.New(pcClient, params.PlatformConnectorSocket, nodeLister, pb.ProcessingStrategy(strategyValue))
 
 	mgr, err := createManager(params, cfg.Policies)
 	if err != nil {
@@ -312,7 +303,9 @@ func registerControllers(
 	return nil
 }
 
-func buildNodeLister(ctx context.Context, restCfg *rest.Config, resyncPeriod time.Duration) (listersv1.NodeLister, error) {
+func buildNodeLister(
+	ctx context.Context, restCfg *rest.Config, resyncPeriod time.Duration,
+) (listersv1.NodeLister, error) {
 	k8sClient, err := kubernetes.NewForConfig(restCfg)
 	if err != nil {
 		return nil, fmt.Errorf("create kubernetes client for node lister: %w", err)
@@ -322,11 +315,24 @@ func buildNodeLister(ctx context.Context, restCfg *rest.Config, resyncPeriod tim
 	nodeInformer := factory.Core().V1().Nodes()
 	factory.Start(ctx.Done())
 
-	if ok := toolscache.WaitForCacheSync(ctx.Done(), nodeInformer.Informer().HasSynced); !ok {
-		return nil, fmt.Errorf("timed out waiting for node informer cache to sync")
+	return nodeInformer.Lister(), nil
+}
+
+func buildPublisher(
+	ctx context.Context, pcClient pb.PlatformConnectorClient,
+	params Params, strategy pb.ProcessingStrategy,
+) (*publisher.Publisher, error) {
+	restConfig, err := ctrl.GetConfig()
+	if err != nil {
+		return nil, fmt.Errorf("getting kubeconfig for node lister: %w", err)
 	}
 
-	return nodeInformer.Lister(), nil
+	nodeLister, err := buildNodeLister(ctx, restConfig, params.ResyncPeriod)
+	if err != nil {
+		return nil, fmt.Errorf("build node lister: %w", err)
+	}
+
+	return publisher.New(pcClient, params.PlatformConnectorSocket, nodeLister, strategy), nil
 }
 
 func dialPlatformConnector(socket string) (*grpc.ClientConn, error) {

--- a/health-monitors/kubernetes-object-monitor/pkg/initializer/initializer.go
+++ b/health-monitors/kubernetes-object-monitor/pkg/initializer/initializer.go
@@ -29,11 +29,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
-	toolscache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,6 +40,7 @@ import (
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	"github.com/nvidia/nvsentinel/commons/pkg/managed"
 	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	"github.com/nvidia/nvsentinel/health-monitors/kubernetes-object-monitor/pkg/annotations"
 	celenv "github.com/nvidia/nvsentinel/health-monitors/kubernetes-object-monitor/pkg/cel"
@@ -312,22 +311,7 @@ func buildNodeLister(
 		return nil, fmt.Errorf("create kubernetes client for node lister: %w", err)
 	}
 
-	factory := informers.NewSharedInformerFactory(k8sClient, resyncPeriod)
-	nodes := factory.Core().V1().Nodes()
-
-	// A SharedInformerFactory only starts informers that were referenced (via
-	// Informer()/Lister()) BEFORE Start is called. Register the node informer
-	// first, otherwise Start launches nothing and the lister cache stays empty
-	// forever, which would silently disable the managed=false gate (fail-open).
-	informer := nodes.Informer()
-
-	factory.Start(ctx.Done())
-
-	if !toolscache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
-		return nil, fmt.Errorf("timed out waiting for node informer cache to sync")
-	}
-
-	return nodes.Lister(), nil
+	return managed.NewNodeLister(ctx, k8sClient, resyncPeriod)
 }
 
 func buildPublisher(

--- a/health-monitors/kubernetes-object-monitor/pkg/metrics/metrics.go
+++ b/health-monitors/kubernetes-object-monitor/pkg/metrics/metrics.go
@@ -51,4 +51,14 @@ var (
 		},
 		[]string{"resource_kind", "error_type"},
 	)
+
+	// EmissionsSkippedManaged counts PublishHealthEvent calls skipped because the
+	// target node carries nvsentinel.dgxc.nvidia.com/managed=false (ADR-040 opt-out).
+	EmissionsSkippedManaged = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "k8s_object_monitor_emissions_skipped_managed_total",
+			Help: "Total number of health event emissions skipped because the node is opted out of NVSentinel management.",
+		},
+		[]string{"policy_name"},
+	)
 )

--- a/health-monitors/kubernetes-object-monitor/pkg/publisher/publisher.go
+++ b/health-monitors/kubernetes-object-monitor/pkg/publisher/publisher.go
@@ -44,7 +44,10 @@ type Publisher struct {
 // New constructs a Publisher. target must match the gRPC target string
 // used to dial client (typically "unix:///var/run/nvsentinel.sock").
 // nodeLister is used to gate emission for nodes opted out of NVSentinel management.
-func New(client pb.PlatformConnectorClient, target string, nodeLister listersv1.NodeLister, processingStrategy pb.ProcessingStrategy) *Publisher {
+func New(
+	client pb.PlatformConnectorClient, target string,
+	nodeLister listersv1.NodeLister, processingStrategy pb.ProcessingStrategy,
+) *Publisher {
 	return &Publisher{
 		pub:                healthpub.New(client, target, agentName),
 		nodeLister:         nodeLister,

--- a/health-monitors/kubernetes-object-monitor/pkg/publisher/publisher.go
+++ b/health-monitors/kubernetes-object-monitor/pkg/publisher/publisher.go
@@ -20,10 +20,13 @@ import (
 	"time"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
+	listersv1 "k8s.io/client-go/listers/core/v1"
 
 	"github.com/nvidia/nvsentinel/commons/pkg/healthpub"
+	"github.com/nvidia/nvsentinel/commons/pkg/managed"
 	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	"github.com/nvidia/nvsentinel/health-monitors/kubernetes-object-monitor/pkg/config"
+	"github.com/nvidia/nvsentinel/health-monitors/kubernetes-object-monitor/pkg/metrics"
 )
 
 const (
@@ -34,14 +37,17 @@ const (
 // shared healthpub publisher (commons/pkg/healthpub).
 type Publisher struct {
 	pub                *healthpub.Publisher
+	nodeLister         listersv1.NodeLister
 	processingStrategy pb.ProcessingStrategy
 }
 
 // New constructs a Publisher. target must match the gRPC target string
 // used to dial client (typically "unix:///var/run/nvsentinel.sock").
-func New(client pb.PlatformConnectorClient, target string, processingStrategy pb.ProcessingStrategy) *Publisher {
+// nodeLister is used to gate emission for nodes opted out of NVSentinel management.
+func New(client pb.PlatformConnectorClient, target string, nodeLister listersv1.NodeLister, processingStrategy pb.ProcessingStrategy) *Publisher {
 	return &Publisher{
 		pub:                healthpub.New(client, target, agentName),
+		nodeLister:         nodeLister,
 		processingStrategy: processingStrategy,
 	}
 }
@@ -51,6 +57,17 @@ func New(client pb.PlatformConnectorClient, target string, processingStrategy pb
 // which allows fault-quarantine to track each resource individually.
 func (p *Publisher) PublishHealthEvent(ctx context.Context,
 	policy *config.Policy, nodeName string, isHealthy bool, resourceInfo *config.ResourceInfo) error {
+	// Skip emission when the node is opted out of NVSentinel management (ADR-040).
+	if optedOut, err := managed.IsNodeOptedOut(ctx, p.nodeLister, nodeName); err != nil {
+		return fmt.Errorf("managed label check failed for node %s: %w", nodeName, err)
+	} else if optedOut {
+		slog.Info("Skipping emission: node is opted out of NVSentinel management",
+			"node", nodeName, "policy", policy.Name)
+		metrics.EmissionsSkippedManaged.WithLabelValues(policy.Name).Inc()
+
+		return nil
+	}
+
 	strategy := p.processingStrategy
 
 	if policy.HealthEvent.ProcessingStrategy != "" {

--- a/health-monitors/kubernetes-object-monitor/pkg/publisher/publisher_test.go
+++ b/health-monitors/kubernetes-object-monitor/pkg/publisher/publisher_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
+	listersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 
 	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	"github.com/nvidia/nvsentinel/health-monitors/kubernetes-object-monitor/pkg/config"
@@ -39,7 +41,7 @@ func (f *fakePlatformConnectorClient) HealthEventOccurredV1(
 
 func TestPublishHealthEventCustomRecommendedAction(t *testing.T) {
 	client := &fakePlatformConnectorClient{}
-	pub := New(client, "passthrough:///platform-connector", pb.ProcessingStrategy_EXECUTE_REMEDIATION)
+	pub := New(client, "passthrough:///platform-connector", newEmptyNodeLister(), pb.ProcessingStrategy_EXECUTE_REMEDIATION)
 
 	policy := &config.Policy{
 		Name: "manual-external-remediation",
@@ -63,9 +65,14 @@ func TestPublishHealthEventCustomRecommendedAction(t *testing.T) {
 	require.Equal(t, "manual-vm-restart", event.CustomRecommendedAction)
 }
 
+func newEmptyNodeLister() listersv1.NodeLister {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	return listersv1.NewNodeLister(indexer)
+}
+
 func TestPublishHealthEventIncludesBehaviourOverrides(t *testing.T) {
 	client := &fakePlatformConnectorClient{}
-	pub := New(client, "passthrough:///platform-connector", pb.ProcessingStrategy_EXECUTE_REMEDIATION)
+	pub := New(client, "passthrough:///platform-connector", newEmptyNodeLister(), pb.ProcessingStrategy_EXECUTE_REMEDIATION)
 
 	policy := &config.Policy{
 		Name: "operator-pod-unhealthy",

--- a/health-monitors/slurm-drain-monitor/go.mod
+++ b/health-monitors/slurm-drain-monitor/go.mod
@@ -14,6 +14,7 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	k8s.io/api v0.36.3
 	k8s.io/apimachinery v0.36.3
+	k8s.io/client-go v0.36.3
 	sigs.k8s.io/controller-runtime v0.24.1
 )
 
@@ -74,7 +75,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.36.3 // indirect
-	k8s.io/client-go v0.36.3 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect

--- a/health-monitors/slurm-drain-monitor/pkg/initializer/initializer.go
+++ b/health-monitors/slurm-drain-monitor/pkg/initializer/initializer.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	listersv1 "k8s.io/client-go/listers/core/v1"
+	toolscache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -180,10 +181,21 @@ func buildNodeLister(ctx context.Context, resyncPeriod time.Duration) (listersv1
 	}
 
 	factory := informers.NewSharedInformerFactory(k8sClient, resyncPeriod)
-	nodeInformer := factory.Core().V1().Nodes()
+	nodes := factory.Core().V1().Nodes()
+
+	// A SharedInformerFactory only starts informers that were referenced (via
+	// Informer()/Lister()) BEFORE Start is called. Register the node informer
+	// first, otherwise Start launches nothing and the lister cache stays empty
+	// forever, which would silently disable the managed=false gate (fail-open).
+	informer := nodes.Informer()
+
 	factory.Start(ctx.Done())
 
-	return nodeInformer.Lister(), nil
+	if !toolscache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+		return nil, fmt.Errorf("timed out waiting for node informer cache to sync")
+	}
+
+	return nodes.Lister(), nil
 }
 
 func validateRecommendedActions(cfg *config.Config) error {

--- a/health-monitors/slurm-drain-monitor/pkg/initializer/initializer.go
+++ b/health-monitors/slurm-drain-monitor/pkg/initializer/initializer.go
@@ -28,6 +28,10 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	listersv1 "k8s.io/client-go/listers/core/v1"
+	toolscache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -156,9 +160,35 @@ func initConnAndClients(ctx context.Context, params Params) (
 		return nil, nil, nil, nil, fmt.Errorf("failed to create parser: %w", err)
 	}
 
-	pub := publisher.New(pcClient, params.PlatformConnectorSocket, pb.ProcessingStrategy(strategyValue))
+	nodeLister, err := buildNodeLister(ctx, params.ResyncPeriod)
+	if err != nil {
+		conn.Close()
+
+		return nil, nil, nil, nil, fmt.Errorf("build node lister: %w", err)
+	}
+
+	pub := publisher.New(pcClient, params.PlatformConnectorSocket, nodeLister, pb.ProcessingStrategy(strategyValue))
 
 	return conn, pr, pub, cfg, nil
+}
+
+func buildNodeLister(ctx context.Context, resyncPeriod time.Duration) (listersv1.NodeLister, error) {
+	restConfig := ctrl.GetConfigOrDie()
+
+	k8sClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("create kubernetes client for node lister: %w", err)
+	}
+
+	factory := informers.NewSharedInformerFactory(k8sClient, resyncPeriod)
+	nodeInformer := factory.Core().V1().Nodes()
+	factory.Start(ctx.Done())
+
+	if ok := toolscache.WaitForCacheSync(ctx.Done(), nodeInformer.Informer().HasSynced); !ok {
+		return nil, fmt.Errorf("timed out waiting for node informer cache to sync")
+	}
+
+	return nodeInformer.Lister(), nil
 }
 
 func validateRecommendedActions(cfg *config.Config) error {

--- a/health-monitors/slurm-drain-monitor/pkg/initializer/initializer.go
+++ b/health-monitors/slurm-drain-monitor/pkg/initializer/initializer.go
@@ -28,10 +28,8 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	listersv1 "k8s.io/client-go/listers/core/v1"
-	toolscache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,6 +37,7 @@ import (
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	"github.com/nvidia/nvsentinel/commons/pkg/managed"
 	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	"github.com/nvidia/nvsentinel/health-monitors/slurm-drain-monitor/pkg/config"
 	"github.com/nvidia/nvsentinel/health-monitors/slurm-drain-monitor/pkg/controller"
@@ -180,22 +179,7 @@ func buildNodeLister(ctx context.Context, resyncPeriod time.Duration) (listersv1
 		return nil, fmt.Errorf("create kubernetes client for node lister: %w", err)
 	}
 
-	factory := informers.NewSharedInformerFactory(k8sClient, resyncPeriod)
-	nodes := factory.Core().V1().Nodes()
-
-	// A SharedInformerFactory only starts informers that were referenced (via
-	// Informer()/Lister()) BEFORE Start is called. Register the node informer
-	// first, otherwise Start launches nothing and the lister cache stays empty
-	// forever, which would silently disable the managed=false gate (fail-open).
-	informer := nodes.Informer()
-
-	factory.Start(ctx.Done())
-
-	if !toolscache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
-		return nil, fmt.Errorf("timed out waiting for node informer cache to sync")
-	}
-
-	return nodes.Lister(), nil
+	return managed.NewNodeLister(ctx, k8sClient, resyncPeriod)
 }
 
 func validateRecommendedActions(cfg *config.Config) error {

--- a/health-monitors/slurm-drain-monitor/pkg/initializer/initializer.go
+++ b/health-monitors/slurm-drain-monitor/pkg/initializer/initializer.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	listersv1 "k8s.io/client-go/listers/core/v1"
-	toolscache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -183,10 +182,6 @@ func buildNodeLister(ctx context.Context, resyncPeriod time.Duration) (listersv1
 	factory := informers.NewSharedInformerFactory(k8sClient, resyncPeriod)
 	nodeInformer := factory.Core().V1().Nodes()
 	factory.Start(ctx.Done())
-
-	if ok := toolscache.WaitForCacheSync(ctx.Done(), nodeInformer.Informer().HasSynced); !ok {
-		return nil, fmt.Errorf("timed out waiting for node informer cache to sync")
-	}
 
 	return nodeInformer.Lister(), nil
 }

--- a/health-monitors/slurm-drain-monitor/pkg/metrics/metrics.go
+++ b/health-monitors/slurm-drain-monitor/pkg/metrics/metrics.go
@@ -51,4 +51,13 @@ var (
 		},
 		[]string{"pattern_name"},
 	)
+
+	// EmissionsSkippedManaged counts PublishDrainEvents calls skipped because the
+	// target node carries nvsentinel.dgxc.nvidia.com/managed=false (ADR-040 opt-out).
+	EmissionsSkippedManaged = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "slurm_drain_monitor_emissions_skipped_managed_total",
+			Help: "Total number of drain event emissions skipped because the node is opted out of NVSentinel management.",
+		},
+	)
 )

--- a/health-monitors/slurm-drain-monitor/pkg/publisher/publisher.go
+++ b/health-monitors/slurm-drain-monitor/pkg/publisher/publisher.go
@@ -17,12 +17,16 @@ package publisher
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
+	listersv1 "k8s.io/client-go/listers/core/v1"
 
 	"github.com/nvidia/nvsentinel/commons/pkg/healthpub"
+	"github.com/nvidia/nvsentinel/commons/pkg/managed"
 	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
+	"github.com/nvidia/nvsentinel/health-monitors/slurm-drain-monitor/pkg/metrics"
 	"github.com/nvidia/nvsentinel/health-monitors/slurm-drain-monitor/pkg/parser"
 )
 
@@ -34,14 +38,17 @@ const (
 // shared healthpub publisher (commons/pkg/healthpub).
 type Publisher struct {
 	pub                *healthpub.Publisher
+	nodeLister         listersv1.NodeLister
 	processingStrategy pb.ProcessingStrategy
 }
 
 // New creates a Publisher. target must match the gRPC target string
 // used to dial client (typically "unix:///var/run/nvsentinel.sock").
-func New(client pb.PlatformConnectorClient, target string, processingStrategy pb.ProcessingStrategy) *Publisher {
+// nodeLister is used to gate emission for nodes opted out of NVSentinel management.
+func New(client pb.PlatformConnectorClient, target string, nodeLister listersv1.NodeLister, processingStrategy pb.ProcessingStrategy) *Publisher {
 	return &Publisher{
 		pub:                healthpub.New(client, target, agentName),
+		nodeLister:         nodeLister,
 		processingStrategy: processingStrategy,
 	}
 }
@@ -52,6 +59,16 @@ func (p *Publisher) PublishDrainEvents(
 	ctx context.Context, reasons []parser.MatchedReason, nodeName string,
 	isHealthy bool, podNamespace, podName string,
 ) error {
+	// Skip emission when the node is opted out of NVSentinel management (ADR-040).
+	if optedOut, err := managed.IsNodeOptedOut(ctx, p.nodeLister, nodeName); err != nil {
+		return fmt.Errorf("managed label check failed for node %s: %w", nodeName, err)
+	} else if optedOut {
+		slog.Info("Skipping drain event emission: node is opted out of NVSentinel management", "node", nodeName)
+		metrics.EmissionsSkippedManaged.Inc()
+
+		return nil
+	}
+
 	entityValue := podName
 	if podNamespace != "" {
 		entityValue = fmt.Sprintf("%s/%s", podNamespace, podName)

--- a/health-monitors/slurm-drain-monitor/pkg/publisher/publisher.go
+++ b/health-monitors/slurm-drain-monitor/pkg/publisher/publisher.go
@@ -45,7 +45,10 @@ type Publisher struct {
 // New creates a Publisher. target must match the gRPC target string
 // used to dial client (typically "unix:///var/run/nvsentinel.sock").
 // nodeLister is used to gate emission for nodes opted out of NVSentinel management.
-func New(client pb.PlatformConnectorClient, target string, nodeLister listersv1.NodeLister, processingStrategy pb.ProcessingStrategy) *Publisher {
+func New(
+	client pb.PlatformConnectorClient, target string,
+	nodeLister listersv1.NodeLister, processingStrategy pb.ProcessingStrategy,
+) *Publisher {
 	return &Publisher{
 		pub:                healthpub.New(client, target, agentName),
 		nodeLister:         nodeLister,

--- a/labeler/pkg/labeler/labeler.go
+++ b/labeler/pkg/labeler/labeler.go
@@ -733,7 +733,9 @@ func (l *Labeler) stripDetectionLabels(node *v1.Node) bool {
 	for _, key := range []string{DCGMVersionLabel, DriverInstalledLabel, KataEnabledLabel} {
 		if _, exists := node.Labels[key]; exists {
 			delete(node.Labels, key)
+
 			needsUpdate = true
+
 			slog.Info("Removing detection label from opted-out node", "node", node.Name, "label", key)
 		}
 	}

--- a/labeler/pkg/labeler/labeler.go
+++ b/labeler/pkg/labeler/labeler.go
@@ -33,6 +33,9 @@ import (
 	"k8s.io/client-go/util/retry"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 
+	listersv1 "k8s.io/client-go/listers/core/v1"
+
+	"github.com/nvidia/nvsentinel/commons/pkg/managed"
 	"github.com/nvidia/nvsentinel/commons/pkg/stringutil"
 	"github.com/nvidia/nvsentinel/labeler/pkg/devicecounts"
 	"github.com/nvidia/nvsentinel/labeler/pkg/metrics"
@@ -67,6 +70,7 @@ type Labeler struct {
 	clientset                    kubernetes.Interface
 	podInformer                  cache.SharedIndexInformer
 	nodeInformer                 cache.SharedIndexInformer
+	nodeLister                   listersv1.NodeLister
 	gkeInstallerInformer         cache.SharedIndexInformer
 	resourceSliceInformer        cache.SharedIndexInformer
 	informersSynced              []cache.InformerSynced
@@ -126,6 +130,7 @@ func NewLabeler(clientset kubernetes.Interface, resyncPeriod time.Duration,
 		clientset:                    clientset,
 		podInformer:                  podInformer,
 		nodeInformer:                 nodeInformer,
+		nodeLister:                   listersv1.NewNodeLister(nodeInformer.GetIndexer()),
 		gkeInstallerInformer:         gkeInstallerInformer,
 		resourceSliceInformer:        resourceSliceInformer,
 		informersSynced:              informersSynced,
@@ -502,6 +507,10 @@ func (l *Labeler) nodeRequiresReconciliation(oldObj, newObj any) bool {
 		return true
 	}
 
+	if oldNode.Labels[managed.ManagedLabelKey] != newNode.Labels[managed.ManagedLabelKey] {
+		return true
+	}
+
 	if oldNode.Labels[gpuPresentLabel] != newNode.Labels[gpuPresentLabel] {
 		return true
 	}
@@ -612,6 +621,15 @@ func (l *Labeler) getDriverLabelForNode(nodeName string, excludePod *v1.Pod) (st
 
 // updateNodeLabelsForPod updates only DCGM and driver labels (kata is handled separately by node events)
 func (l *Labeler) updateNodeLabelsForPod(nodeName, expectedDCGMVersion, expectedDriverLabel string) error {
+	// When the node is opted out, detection labels are stripped by reconcileNodeLabelsInPlace
+	// (triggered by the managed-label node event). Skip pod-driven re-stamping.
+	if optedOut, err := managed.IsNodeOptedOut(l.ctx, l.nodeLister, nodeName); err != nil {
+		slog.Warn("Failed to check managed label, treating as not opted out", "node", nodeName, "error", err)
+	} else if optedOut {
+		slog.Debug("Skipping pod-driven label update for opted-out node", "node", nodeName)
+		return nil
+	}
+
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		node, err := l.clientset.CoreV1().Nodes().Get(l.ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
@@ -706,7 +724,39 @@ func (l *Labeler) desiredNodeLabels(nodeName string) (string, string, error) {
 	return driverLabel, dcgmVersion, nil
 }
 
+// stripDetectionLabels removes the three detection labels that DaemonSet monitors
+// rely on for their nodeSelectors. Called when a node carries managed=false so
+// monitors evict without any per-monitor chart change.
+func (l *Labeler) stripDetectionLabels(node *v1.Node) bool {
+	needsUpdate := false
+
+	for _, key := range []string{DCGMVersionLabel, DriverInstalledLabel, KataEnabledLabel} {
+		if _, exists := node.Labels[key]; exists {
+			delete(node.Labels, key)
+			needsUpdate = true
+			slog.Info("Removing detection label from opted-out node", "node", node.Name, "label", key)
+		}
+	}
+
+	if needsUpdate {
+		metrics.NodeLabelsSkippedManaged.Inc()
+	}
+
+	return needsUpdate
+}
+
 func (l *Labeler) reconcileNodeLabelsInPlace(node *v1.Node, driverLabel, dcgmVersion string) bool {
+	// When the node is opted out of NVSentinel management, strip detection labels
+	// so DaemonSet monitors evict via their existing nodeSelectors (ADR-040).
+	optedOut, err := managed.IsNodeOptedOut(l.ctx, l.nodeLister, node.Name)
+	if err != nil {
+		slog.Warn("Failed to check managed label, treating as not opted out", "node", node.Name, "error", err)
+	}
+
+	if optedOut {
+		return l.stripDetectionLabels(node)
+	}
+
 	needsUpdate := false
 
 	expectedKataLabel := l.getKataLabelForNode(node)

--- a/labeler/pkg/labeler/labeler.go
+++ b/labeler/pkg/labeler/labeler.go
@@ -623,14 +623,20 @@ func (l *Labeler) getDriverLabelForNode(nodeName string, excludePod *v1.Pod) (st
 func (l *Labeler) updateNodeLabelsForPod(nodeName, expectedDCGMVersion, expectedDriverLabel string) error {
 	// When the node is opted out, detection labels are stripped by reconcileNodeLabelsInPlace
 	// (triggered by the managed-label node event). Skip pod-driven re-stamping.
-	if optedOut, err := managed.IsNodeOptedOut(l.ctx, l.nodeLister, nodeName); err != nil {
-		slog.Warn("Failed to check managed label, treating as not opted out", "node", nodeName, "error", err)
-	} else if optedOut {
+	// Fail closed: if the lister errors we must not re-stamp detection labels on
+	// a node that may be under active ERR.
+	optedOut, err := managed.IsNodeOptedOut(l.ctx, l.nodeLister, nodeName)
+	if err != nil {
+		slog.Warn("Failed to check managed label, skipping pod-driven label update", "node", nodeName, "error", err)
+		return nil
+	}
+
+	if optedOut {
 		slog.Debug("Skipping pod-driven label update for opted-out node", "node", nodeName)
 		return nil
 	}
 
-	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		node, err := l.clientset.CoreV1().Nodes().Get(l.ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
 			return err
@@ -752,7 +758,11 @@ func (l *Labeler) reconcileNodeLabelsInPlace(node *v1.Node, driverLabel, dcgmVer
 	// so DaemonSet monitors evict via their existing nodeSelectors (ADR-040).
 	optedOut, err := managed.IsNodeOptedOut(l.ctx, l.nodeLister, node.Name)
 	if err != nil {
-		slog.Warn("Failed to check managed label, treating as not opted out", "node", node.Name, "error", err)
+		// Fail closed: if we cannot determine opt-out state we must not proceed
+		// with label mutations — stamping detection labels on a node under active
+		// ERR would restore health-monitor scheduling on a released node.
+		slog.Warn("Failed to check managed label, skipping label reconciliation", "node", node.Name, "error", err)
+		return false
 	}
 
 	if optedOut {

--- a/labeler/pkg/metrics/metrics.go
+++ b/labeler/pkg/metrics/metrics.go
@@ -88,7 +88,7 @@ var (
 	NodeLabelsSkippedManaged = promauto.NewCounter(
 		prometheus.CounterOpts{
 			Name: "labeler_node_labels_skipped_managed_total",
-			Help: "Total number of node label reconcile attempts skipped because the node is opted out of NVSentinel management.",
+			Help: "Node label reconcile attempts skipped because the node is opted out of NVSentinel management.",
 		},
 	)
 )

--- a/labeler/pkg/metrics/metrics.go
+++ b/labeler/pkg/metrics/metrics.go
@@ -82,4 +82,13 @@ var (
 		},
 		[]string{ClassLabel, "reason"},
 	)
+
+	// NodeLabelsSkippedManaged counts reconcile attempts skipped because the node
+	// carries nvsentinel.dgxc.nvidia.com/managed=false (ADR-040 opt-out).
+	NodeLabelsSkippedManaged = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "labeler_node_labels_skipped_managed_total",
+			Help: "Total number of node label reconcile attempts skipped because the node is opted out of NVSentinel management.",
+		},
+	)
 )

--- a/tests/managed_optout_test.go
+++ b/tests/managed_optout_test.go
@@ -1,0 +1,216 @@
+//go:build arm64_group
+// +build arm64_group
+
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"tests/helpers"
+)
+
+// TestExtRRManagedOptOutSuppressesHealthMonitor proves the ADR-040 opt-out gate
+// end-to-end through the real integration path we care about:
+//
+//	ExtRR created  ->  janitor stamps nvsentinel.dgxc.nvidia.com/managed=false on the Node
+//	               ->  kubernetes-object-monitor sees the opt-out and suppresses emission
+//	ExtRR Complete=True  ->  managed label cleared  ->  emission resumes
+//
+// The observable contract is the downstream node event: the monitor still detects
+// the condition and writes its match annotation while opted out, but the gate in
+// publisher.PublishHealthEvent short-circuits the publish, so no health event
+// reaches the platform connector and no node event is produced. This mirrors the
+// STORE_ONLY suppression contract asserted by TestKubernetesObjectMonitorWithStoreOnlyStrategy.
+func TestExtRRManagedOptOutSuppressesHealthMonitor(t *testing.T) {
+	feature := features.New("ExtRR managed=false suppresses health-monitor emission").
+		WithLabel("suite", "managed-optout").
+		WithLabel("component", "kubernetes-object-monitor")
+
+	const (
+		crName          = "extrr-managed-optout"
+		nodeEventType   = "node-test-condition"
+		nodeEventReason = "node-test-conditionIsNotHealthy"
+	)
+
+	var nodeName string
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err)
+
+		nodeName, err = helpers.GetRealNodeName(ctx, client)
+		require.NoError(t, err, "failed to get real node name")
+		t.Logf("using node %s for managed opt-out test", nodeName)
+
+		// Clean slate so the baseline assertion cannot pass on a stale event.
+		require.NoError(t, helpers.DeleteExistingNodeEvents(ctx, t, client, nodeName, nodeEventType, nodeEventReason))
+
+		return ctx
+	})
+
+	// Baseline: with the node under NVSentinel management, an unhealthy condition
+	// must produce a node event. This proves the mechanism works, so the later
+	// suppression assertion cannot pass simply because the monitor is broken.
+	feature.Assess("baseline: condition triggers node event when managed", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err)
+
+		t.Logf("setting %s=False on node %s", testConditionType, nodeName)
+		helpers.SetNodeConditionStatus(ctx, t, client, nodeName, v1.NodeConditionType(testConditionType), v1.ConditionFalse)
+
+		helpers.WaitForNodeEvent(ctx, t, client, nodeName, v1.Event{
+			Type:   nodeEventType,
+			Reason: nodeEventReason,
+		})
+		t.Log("baseline node event observed")
+
+		// Recover: clear the condition and wait for the monitor to drop its match
+		// annotation so the next unhealthy transition is a fresh one.
+		helpers.SetNodeConditionStatus(ctx, t, client, nodeName, v1.NodeConditionType(testConditionType), v1.ConditionTrue)
+		require.Eventually(t, func() bool {
+			node, err := helpers.GetNodeByName(ctx, client, nodeName)
+			if err != nil {
+				return false
+			}
+
+			ann, exists := node.Annotations[helpers.K8sObjectMonitorAnnotationKey]
+
+			return !exists || ann == ""
+		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval)
+
+		require.NoError(t, helpers.DeleteExistingNodeEvents(ctx, t, client, nodeName, nodeEventType, nodeEventReason))
+
+		return ctx
+	})
+
+	// Opt out via ExtRR and assert the same condition no longer produces a node event.
+	feature.Assess("ExtRR opt-out suppresses node event", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err)
+
+		_, err = helpers.CreateExtRRCR(ctx, client, crName, nodeName, "managed-optout")
+		require.NoError(t, err)
+
+		helpers.WaitForExtRRCondition(ctx, t, client, crName, "NVSentinelOwnershipReleased", "True")
+
+		// Confirm the janitor actually stamped the opt-out label before we rely on it.
+		require.Eventually(t, func() bool {
+			node, err := helpers.GetNodeByName(ctx, client, nodeName)
+			if err != nil {
+				return false
+			}
+
+			return node.Labels[managedLabelKey] == "false"
+		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval, "node must carry managed=false after ExtRR apply")
+
+		t.Logf("re-triggering %s=False on opted-out node %s", testConditionType, nodeName)
+		helpers.SetNodeConditionStatus(ctx, t, client, nodeName, v1.NodeConditionType(testConditionType), v1.ConditionFalse)
+
+		// The monitor still detects the match and writes its annotation; only the
+		// publish is gated. Wait for the annotation so we know reconciliation ran
+		// before asserting the (absent) downstream event.
+		require.Eventually(t, func() bool {
+			node, err := helpers.GetNodeByName(ctx, client, nodeName)
+			if err != nil {
+				return false
+			}
+
+			ann, exists := node.Annotations[helpers.K8sObjectMonitorAnnotationKey]
+
+			return exists && ann != ""
+		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval, "monitor must still detect the match while opted out")
+
+		t.Log("match annotation present; asserting the node event was suppressed")
+		helpers.EnsureNodeEventNotPresent(ctx, t, client, nodeName, nodeEventType, nodeEventReason)
+
+		return ctx
+	})
+
+	// Complete the ExtRR (clears managed=false) and prove emission resumes.
+	feature.Assess("completing ExtRR restores emission", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err)
+
+		// Clear the condition first so the monitor drops its match state while still
+		// opted out, then complete the ExtRR to lift the gate.
+		helpers.SetNodeConditionStatus(ctx, t, client, nodeName, v1.NodeConditionType(testConditionType), v1.ConditionTrue)
+		require.Eventually(t, func() bool {
+			node, err := helpers.GetNodeByName(ctx, client, nodeName)
+			if err != nil {
+				return false
+			}
+
+			ann, exists := node.Annotations[helpers.K8sObjectMonitorAnnotationKey]
+
+			return !exists || ann == ""
+		}, helpers.EventuallyWaitTimeout, helpers.WaitInterval)
+
+		require.NoError(t, helpers.SetExtRRComplete(ctx, client, crName,
+			"True", "RemediationSucceeded", "node returned to service"))
+		helpers.WaitForNodeReleaseStateCleared(ctx, t, client, nodeName)
+
+		node, err := helpers.GetNodeByName(ctx, client, nodeName)
+		require.NoError(t, err)
+		_, hasLabel := node.Labels[managedLabelKey]
+		assert.False(t, hasLabel, "managed label must be gone after ExtRR completion")
+
+		require.NoError(t, helpers.DeleteExistingNodeEvents(ctx, t, client, nodeName, nodeEventType, nodeEventReason))
+
+		t.Logf("re-triggering %s=False on re-managed node %s", testConditionType, nodeName)
+		helpers.SetNodeConditionStatus(ctx, t, client, nodeName, v1.NodeConditionType(testConditionType), v1.ConditionFalse)
+
+		helpers.WaitForNodeEvent(ctx, t, client, nodeName, v1.Event{
+			Type:   nodeEventType,
+			Reason: nodeEventReason,
+		})
+		t.Log("emission resumed after ExtRR completion")
+
+		return ctx
+	})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		if err != nil {
+			return ctx
+		}
+
+		if nodeName != "" {
+			helpers.SetNodeConditionStatus(ctx, t, client, nodeName, v1.NodeConditionType(testConditionType), v1.ConditionTrue)
+		}
+
+		_ = helpers.DeleteAllCRs(ctx, t, client, helpers.ExternalRemediationRequestGVK)
+
+		if nodeName != "" {
+			if err := helpers.ScrubExtRRStateFromNode(ctx, client, nodeName); err != nil {
+				t.Logf("ScrubExtRRStateFromNode(%s): %v", nodeName, err)
+			}
+
+			_ = helpers.DeleteExistingNodeEvents(ctx, t, client, nodeName, nodeEventType, nodeEventReason)
+		}
+
+		return ctx
+	})
+
+	testEnv.Test(t, feature.Feature())
+}

--- a/tests/managed_optout_test.go
+++ b/tests/managed_optout_test.go
@@ -173,7 +173,7 @@ func TestExtRRManagedOptOutSuppressesHealthMonitor(t *testing.T) {
 		node, err := helpers.GetNodeByName(ctx, client, nodeName)
 		require.NoError(t, err)
 		_, hasLabel := node.Labels[managedLabelKey]
-		assert.False(t, hasLabel, "managed label must be gone after ExtRR completion")
+		require.False(t, hasLabel, "managed label must be gone after ExtRR completion")
 
 		require.NoError(t, helpers.DeleteExistingNodeEvents(ctx, t, client, nodeName, nodeEventType, nodeEventReason))
 


### PR DESCRIPTION
## Summary

Implements **JSC-105 / PR4** of the NVSentinel External Remediations project.

Nodes carrying `nvsentinel.dgxc.nvidia.com/managed=false` are opted out of NVSentinel management while an external breakfix system owns them. This PR gates all emission paths in four modules behind that label check.

### Changes by module

**labeler**
- Strip `DCGMVersion`, `DriverInstalled`, and `KataEnabled` detection labels from opted-out nodes so DaemonSet monitors self-evict via `nodeSelectors`
- Gate `updateNodeLabelsForPod` to skip pod-driven label writes for opted-out nodes
- Trigger `nodeRequiresReconciliation` when the `managed` label changes, so the strip runs promptly on opt-out
- New `labeler_node_labels_skipped_managed_total` Prometheus counter

**csp-health-monitor**
- Gate `processAndSendTrigger` after the empty-NodeName check
- Advance event DB status on skip so the event is not re-fired next poll (no-retry skip)
- New `csp_health_monitor_trigger_skipped_managed_total{trigger_type}` counter
- `setupNodeLister()` helper in `main.go` creates a SharedInformerFactory-backed NodeLister

**kubernetes-object-monitor**
- Gate `PublishHealthEvent` before strategy resolution; return error on lister failure (fail closed)
- New `k8s_object_monitor_emissions_skipped_managed_total{policy_name}` counter
- `buildNodeLister()` helper in initializer uses `ctrl.GetConfig()` + `kubernetes.NewForConfig()`

**slurm-drain-monitor**
- Gate `PublishDrainEvents`; return error on lister failure (fail closed)
- New `slurm_drain_monitor_emissions_skipped_managed_total` counter
- `buildNodeLister()` helper in initializer uses `ctrl.GetConfigOrDie()`

### Design notes

- **Fail-open in labeler**: detection-label stripping is best-effort; a lister error logs a warning and proceeds rather than blocking reconciliation
- **Fail-closed in publishers**: a lister error surfaces as an error return so the caller can decide on retry/backoff rather than silently dropping events
- **Informer-backed lister**: avoids live API calls on the emission hot path; uses `cache.WaitForCacheSync` at startup

## Test plan

- [x] `go build ./...` passes in all four modules
- [x] `go test ./pkg/triggerengine/...` passes (csp-health-monitor) — updated `NewEngine` call sites to pass an empty `NodeLister`
- [x] `go test ./pkg/publisher/...` passes (kubernetes-object-monitor) — updated `New` call site
- [x] All other test failures are pre-existing `envtest` failures (no etcd binary in local env)

Closes JSC-105

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes Node lister/informer support and implemented managed-node opt-out gating across trigger processing, health event publishing, drain event publishing, and label reconciliation.
  * Updated Slurm drain monitor RBAC to allow `nodes` `list`/`watch`.
* **Bug Fixes**
  * Skip trigger/emission/drain publishing and label reconciliation for unmanaged (opted-out) nodes; strip detection/selector-related labels when opted out.
* **Metrics**
  * Added Prometheus counters for skipped triggers, skipped health emissions, skipped drain emissions, and skipped label reconciliation.
* **Tests**
  * Added ARM64 end-to-end coverage for opt-out suppression behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->