### PR TITLE
fix: platform connector shouldn't do or-based entities matching for node condition

### DIFF
--- a/platform-connectors/pkg/connectors/kubernetes/k8s_platform_connector_test.go
+++ b/platform-connectors/pkg/connectors/kubernetes/k8s_platform_connector_test.go
@@ -604,6 +604,38 @@ func TestRemoveImpactedEntitiesMessagesScoped(t *testing.T) {
 			},
 		},
 		{
+			name: "composite NIC identity: shared port on different NIC is not cleared",
+			messages: []string{
+				"NIC:mlx5_0 NICPort:1 link down Recommended Action=RESTART_VM;",
+				"NIC:mlx5_1 NICPort:1 link down Recommended Action=RESTART_VM;",
+			},
+			entities: []protos.Entity{
+				{EntityType: "NIC", EntityValue: "mlx5_1"},
+				{EntityType: "NICPort", EntityValue: "1"},
+			},
+			errorCodes: nil,
+			expected: []string{
+				"NIC:mlx5_0 NICPort:1 link down Recommended Action=RESTART_VM;",
+			},
+		},
+		{
+			name: "scoped clear: composite entity identity preserves unrelated code",
+			messages: []string{
+				"ErrorCode:163 PCI:0000:03:00 GPU_UUID:GPU-1 boom Recommended Action=RESTART_VM;",
+				"ErrorCode:98 PCI:0000:03:00 GPU_UUID:GPU-1 unrelated Recommended Action=RESTART_VM;",
+				"ErrorCode:163 PCI:0000:04:00 GPU_UUID:GPU-2 boom Recommended Action=RESTART_VM;",
+			},
+			entities: []protos.Entity{
+				{EntityType: "PCI", EntityValue: "0000:03:00"},
+				{EntityType: "GPU_UUID", EntityValue: "GPU-1"},
+			},
+			errorCodes: []string{"163"},
+			expected: []string{
+				"ErrorCode:98 PCI:0000:03:00 GPU_UUID:GPU-1 unrelated Recommended Action=RESTART_VM;",
+				"ErrorCode:163 PCI:0000:04:00 GPU_UUID:GPU-2 boom Recommended Action=RESTART_VM;",
+			},
+		},
+		{
 			name: "Tier 1 truncated entity cleared by healthy event",
 			messages: []string{
 				"ErrorCode:POD_STUCK_AFTER_DELETION v1/Pod:prod/61f345d08c9a432a-134... Recommended Action=RESTART_VM;",

--- a/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
+++ b/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
@@ -405,8 +405,22 @@ func entityMatchesMessage(msg string, entity *protos.Entity) bool {
 	return false
 }
 
-// removeImpactedEntitiesMessagesScoped removes messages that mention any
-// supplied entity. When errorCodes is non-empty, the message must also carry
+func entitiesMatchMessage(msg string, entities []*protos.Entity) bool {
+	if len(entities) == 0 {
+		return false
+	}
+
+	for _, entity := range entities {
+		if !entityMatchesMessage(msg, entity) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// removeImpactedEntitiesMessagesScoped removes messages that mention all
+// supplied entities. When errorCodes is non-empty, the message must also carry
 // a matching ErrorCode token; this prevents an "X cancels Y" rule from
 // clearing an unrelated fault Z on the same entity.
 func (r *K8sConnector) removeImpactedEntitiesMessagesScoped(
@@ -417,14 +431,7 @@ func (r *K8sConnector) removeImpactedEntitiesMessagesScoped(
 	var newMessages []string
 
 	for _, msg := range messages {
-		entityFound := false
-
-		for _, entity := range entities {
-			if entityMatchesMessage(msg, entity) {
-				entityFound = true
-				break
-			}
-		}
+		entityFound := entitiesMatchMessage(msg, entities)
 
 		if entityFound && !messageMatchesAnyErrorCode(msg, errorCodes) {
 			entityFound = false


### PR DESCRIPTION


## Summary
This MR fixes a platform connector bug where a healthy event could clear an existing unhealthy node condition if the condition message matched any single entity from the healthy event.

For composite identities like `NIC + NICPort`, this is incorrect: `NIC=mlx5_0,NICPort=1` and `NIC=mlx5_1,NICPort=1` are different impacted entities even though they share the same port number.

## Reproduction

I used a Tilt cluster and `simple-health-client` to reproduce the issue.

First, I sent a fatal unhealthy event for NIC `mlx5_0` on port `1`:

```bash
$ curl -sS -X POST "$URL/health-event" \
  -H 'Content-Type: application/json' \
  -d "{
    \"version\": 1,
    \"agent\": \"nic-health-monitor\",
    \"componentClass\": \"NIC\",
    \"checkName\": \"EthernetStateCheck\",
    \"isFatal\": true,
    \"isHealthy\": false,
    \"message\": \"RoCE port mlx5_0 port 1 is DOWN\",
    \"recommendedAction\": 15,
    \"errorCode\": [],
    \"entitiesImpacted\": [
      {\"entityType\": \"NIC\", \"entityValue\": \"mlx5_0\"},
      {\"entityType\": \"NICPort\", \"entityValue\": \"1\"}
    ],
    \"nodeName\": \"$NODE\",
    \"processingStrategy\": 1
  }"
```


The node condition was created as expected:

```bash
$ kd no $NODE | grep EthernetStateCheck
                      [{"version":1,"agent":"nic-health-monitor","componentClass":"NIC","checkName":"EthernetStateCheck","isFatal":true,"message":"RoCE port mlx...
  EthernetStateCheck           True    Wed, 08 Jul 2026 16:20:56 +0530   Wed, 08 Jul 2026 16:20:56 +0530   EthernetStateCheckIsNotHealthy        NIC:mlx5_0 NICPort:1 RoCE port mlx5_0 port 1 is DOWN Recommended Action=RESTART_VM;
```

Then I sent a healthy event for the same port number, but for a different NIC:

```bash
$ curl -sS -X POST "$URL/health-event" \
  -H 'Content-Type: application/json' \
  -d "{
    \"version\": 1,
    \"agent\": \"nic-health-monitor\",
    \"componentClass\": \"NIC\",
    \"checkName\": \"EthernetStateCheck\",
    \"isFatal\": false,
    \"isHealthy\": true,
    \"message\": \"No Health Failures\",
    \"recommendedAction\": 0,
    \"errorCode\": [],
    \"entitiesImpacted\": [
      {\"entityType\": \"NIC\", \"entityValue\": \"mlx5_1\"},
      {\"entityType\": \"NICPort\", \"entityValue\": \"1\"}
    ],
    \"nodeName\": \"$NODE\",
    \"processingStrategy\": 1
  }"
```


This should not clear the `EthernetStateCheck` condition, because `mlx5_0` is still unhealthy. On `main`, however, the condition is incorrectly cleared:

```bash
$ kd no $NODE | grep EthernetStateCheck
                      [{"version":1,"agent":"nic-health-monitor","componentClass":"NIC","checkName":"EthernetStateCheck","isFatal":true,"message":"RoCE port mlx...
  EthernetStateCheck           False   Wed, 08 Jul 2026 16:21:24 +0530   Wed, 08 Jul 2026 16:21:24 +0530   EthernetStateCheckIsHealthy           No Health Failures

```

This also shows an inconsistency between components: fault-quarantine still considers the node unhealthy because the quarantine annotation retains the original `mlx5_0` event, while the platform connector has incorrectly cleared the Kubernetes node condition.

```bash
$ kg node $NODE -o yaml | yq .metadata.annotations.quarantineHealthEvent

[{"version":1,"agent":"nic-health-monitor","componentClass":"NIC","checkName":"EthernetStateCheck","isFatal":true,"message":"RoCE port mlx5_0 port 1 is DOWN","recommendedAction":15,"entitiesImpacted":[{"entityType":"NIC","entityValue":"mlx5_0"},{"entityType":"NICPort","entityValue":"1"}],"metadata":{"providerID":"kind://docker/nvsentinel/nvsentinel-worker","trace_id":"00000000000000000000000000000000"},"generatedTimestamp":{"seconds":1783507856,"nanos":280679754},"nodeName":"nvsentinel-worker","processingStrategy":1,"id":"6a4e2b908d273347469f818e"}]
```

## Validation After Fix

After the fix, the same sequence no longer reproduces the bug.

Using the fixed branch node:

```bash
$ NODE=nvsentinel-worker2
```

Send the fatal unhealthy event:

```bash
$ curl -sS -X POST "$URL/health-event" \
  -H 'Content-Type: application/json' \
  -d "{
    \"version\": 1,
    \"agent\": \"nic-health-monitor\",
    \"componentClass\": \"NIC\",
    \"checkName\": \"EthernetStateCheck\",
    \"isFatal\": true,
    \"isHealthy\": false,
    \"message\": \"RoCE port mlx5_0 port 1 is DOWN\",
    \"recommendedAction\": 15,
    \"errorCode\": [],
    \"entitiesImpacted\": [
      {\"entityType\": \"NIC\", \"entityValue\": \"mlx5_0\"},
      {\"entityType\": \"NICPort\", \"entityValue\": \"1\"}
    ],
    \"nodeName\": \"$NODE\",
    \"processingStrategy\": 1
  }"
```

The node condition is created:

```bash
$ kd no $NODE | grep EthernetStateCheck
                      [{"version":1,"agent":"nic-health-monitor","componentClass":"NIC","checkName":"EthernetStateCheck","isFatal":true,"message":"RoCE port mlx...
  EthernetStateCheck           True    Wed, 08 Jul 2026 16:35:21 +0530   Wed, 08 Jul 2026 16:35:21 +0530   EthernetStateCheckIsNotHealthy        NIC:mlx5_0 NICPort:1 RoCE port mlx5_0 port 1 is DOWN Recommended Action=RESTART_VM;
```

Then send the healthy event for a different NIC on the same port:

```bash
$ curl -sS -X POST "$URL/health-event" \
  -H 'Content-Type: application/json' \
  -d "{
    \"version\": 1,
    \"agent\": \"nic-health-monitor\",
    \"componentClass\": \"NIC\",
    \"checkName\": \"EthernetStateCheck\",
    \"isFatal\": false,
    \"isHealthy\": true,
    \"message\": \"No Health Failures\",
    \"recommendedAction\": 0,
    \"errorCode\": [],
    \"entitiesImpacted\": [
      {\"entityType\": \"NIC\", \"entityValue\": \"mlx5_1\"},
      {\"entityType\": \"NICPort\", \"entityValue\": \"1\"}
    ],
    \"nodeName\": \"$NODE\",
    \"processingStrategy\": 1
  }"
```

The node condition heartbeat time is updated, showing the healthy event was processed, but the unrelated `mlx5_0` failure is not cleared:

```bash
$ kd no $NODE | grep EthernetStateCheck
                      [{"version":1,"agent":"nic-health-monitor","componentClass":"NIC","checkName":"EthernetStateCheck","isFatal":true,"message":"RoCE port mlx...
  EthernetStateCheck           True    Wed, 08 Jul 2026 16:37:17 +0530   Wed, 08 Jul 2026 16:35:21 +0530   EthernetStateCheckIsNotHealthy        NIC:mlx5_0 NICPort:1 RoCE port mlx5_0 port 1 is DOWN Recommended Action=RESTART_VM;
```


## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed scoped message clearing logic to match all specified entities before removal, preventing unrelated messages from being incorrectly cleared when error codes overlap.

* **Tests**
  * Added test cases validating message clearing behavior across composite identity scopes in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->