### PR TITLE
feat: add kernel filter in syslog HM along with GPU reset ack handling

### DIFF
--- a/gpu-reset/gpu_reset.sh
+++ b/gpu-reset/gpu_reset.sh
@@ -144,7 +144,8 @@ if [ "${WRITE_SYSLOG_EVENT:-true}" = "true" ]; then
     fi
 
     log "Writing reset result for ${UUID} to syslog (success: ${SYSLOG_SUCCESS})"
-    logger -p daemon.err "GPU reset executed: ${UUID}, success: ${SYSLOG_SUCCESS}"
+    logger -t nvsentinel-gpu-reset -p daemon.err \
+      "GPU reset executed: ${UUID}, success: ${SYSLOG_SUCCESS}"
 
   done
   IFS=$ORIGINAL_IFS

--- a/health-monitors/syslog-health-monitor/main.go
+++ b/health-monitors/syslog-health-monitor/main.go
@@ -197,6 +197,22 @@ func dialPlatformConnector(ctx context.Context, socket string) (*grpc.ClientConn
 	return conn, nil
 }
 
+// kernelOriginChecks lists checks whose source events are emitted by the kernel
+// (NVIDIA driver, NVSwitch, PCI subsystem). They must only consume kernel
+// (_TRANSPORT=kernel) journal entries: scanning every transport lets unrelated
+// high-volume userspace logs (audit, containers) push the read cursor behind
+// journald's retention window, so the segment holding an XID can be vacuumed
+// before the monitor processes it. See NVIDIA/NVSentinel#1417.
+//
+// On Kata nodes this default is overridden in applyKataConfig, because there the
+// GPU runs in the guest VM and XIDs surface via containerd rather than as host
+// kernel entries.
+var kernelOriginChecks = map[string]bool{
+	fd.XIDErrorCheck:     true,
+	fd.SXIDErrorCheck:    true,
+	fd.GPUFallenOffCheck: true,
+}
+
 func buildChecksFromFlag() ([]fd.CheckDefinition, error) {
 	list := make([]fd.CheckDefinition, 0)
 
@@ -206,10 +222,19 @@ func buildChecksFromFlag() ([]fd.CheckDefinition, error) {
 			continue
 		}
 
-		list = append(list, fd.CheckDefinition{
+		check := fd.CheckDefinition{
 			Name:        name,
 			JournalPath: "/nvsentinel/var/log/journal/",
-		})
+		}
+
+		// Kernel-origin checks only consume kernel (_TRANSPORT=kernel) entries by
+		// default so they keep up with journald instead of falling behind under
+		// retention pressure from unrelated logs. See NVIDIA/NVSentinel#1417.
+		if kernelOriginChecks[name] {
+			check.Tags = []string{"-k"}
+		}
+
+		list = append(list, check)
 	}
 
 	if len(list) == 0 {
@@ -227,11 +252,12 @@ func applyKataConfig(list []fd.CheckDefinition) []fd.CheckDefinition {
 	slog.Info("Kata mode enabled, adding containerd service filter and removing SysLogsSXIDError check")
 
 	for i := range list {
-		if list[i].Tags == nil {
-			list[i].Tags = []string{"-u containerd.service"}
-		} else {
-			list[i].Tags = append(list[i].Tags, "-u containerd.service")
-		}
+		// On Kata nodes XIDs surface via the guest kernel relayed through
+		// containerd, not as host _TRANSPORT=kernel entries, so filter by the
+		// containerd unit and drop any kernel-transport default set in
+		// buildChecksFromFlag (the two would AND together and match nothing).
+		// See NVIDIA/NVSentinel#1417.
+		list[i].Tags = []string{"-u containerd.service"}
 	}
 
 	filtered := make([]fd.CheckDefinition, 0, len(list))

--- a/health-monitors/syslog-health-monitor/main_test.go
+++ b/health-monitors/syslog-health-monitor/main_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	fd "github.com/nvidia/nvsentinel/health-monitors/syslog-health-monitor/pkg/syslog-monitor"
+)
+
+func tagsOf(checks []fd.CheckDefinition, name string) ([]string, bool) {
+	for _, c := range checks {
+		if c.Name == name {
+			return c.Tags, true
+		}
+	}
+
+	return nil, false
+}
+
+// TestBuildChecksFromFlag_KernelOriginGetKernelFilter verifies the regular
+// (non-Kata) path defaults the kernel-origin checks to the "-k"
+// (_TRANSPORT=kernel) filter so they only consume kernel entries.
+// Regression coverage for NVIDIA/NVSentinel#1417.
+func TestBuildChecksFromFlag_KernelOriginGetKernelFilter(t *testing.T) {
+	origChecks, origKata := *checksList, *kataEnabled
+	defer func() { *checksList, *kataEnabled = origChecks, origKata }()
+
+	*kataEnabled = "false"
+	*checksList = fd.XIDErrorCheck + "," + fd.SXIDErrorCheck + "," + fd.GPUFallenOffCheck
+
+	checks, err := buildChecksFromFlag()
+	if err != nil {
+		t.Fatalf("buildChecksFromFlag: %v", err)
+	}
+
+	for _, name := range []string{fd.XIDErrorCheck, fd.SXIDErrorCheck, fd.GPUFallenOffCheck} {
+		tags, ok := tagsOf(checks, name)
+		if !ok {
+			t.Fatalf("check %q not built", name)
+		}
+
+		if len(tags) != 1 || tags[0] != "-k" {
+			t.Errorf("check %q: expected tags [-k], got %v", name, tags)
+		}
+	}
+}
+
+// TestBuildChecksFromFlag_NonKernelCheckHasNoFilter verifies the kernel filter
+// is scoped to kernel-origin checks only, so a userspace-origin check keeps the
+// full-journal view it needs.
+func TestBuildChecksFromFlag_NonKernelCheckHasNoFilter(t *testing.T) {
+	origChecks, origKata := *checksList, *kataEnabled
+	defer func() { *checksList, *kataEnabled = origChecks, origKata }()
+
+	*kataEnabled = "false"
+	*checksList = "SomeUserspaceCheck"
+
+	checks, err := buildChecksFromFlag()
+	if err != nil {
+		t.Fatalf("buildChecksFromFlag: %v", err)
+	}
+
+	tags, ok := tagsOf(checks, "SomeUserspaceCheck")
+	if !ok {
+		t.Fatalf("check not built")
+	}
+
+	if len(tags) != 0 {
+		t.Errorf("non-kernel check should have no facility filter, got tags %v", tags)
+	}
+}
+
+// TestApplyKataConfig_OverridesKernelFilterWithContainerdUnit verifies the Kata
+// path filters by the containerd unit instead of "-k": on Kata nodes XIDs
+// surface via the guest kernel relayed through containerd, so a
+// _TRANSPORT=kernel filter would AND with the unit filter and match nothing.
+func TestApplyKataConfig_OverridesKernelFilterWithContainerdUnit(t *testing.T) {
+	origChecks, origKata := *checksList, *kataEnabled
+	defer func() { *checksList, *kataEnabled = origChecks, origKata }()
+
+	*kataEnabled = "true"
+	*checksList = fd.XIDErrorCheck + "," + fd.SXIDErrorCheck + "," + fd.GPUFallenOffCheck
+
+	checks, err := buildChecksFromFlag()
+	if err != nil {
+		t.Fatalf("buildChecksFromFlag: %v", err)
+	}
+
+	checks = applyKataConfig(checks)
+
+	// SXID is not collectable on Kata nodes and is dropped.
+	if _, ok := tagsOf(checks, fd.SXIDErrorCheck); ok {
+		t.Errorf("Kata mode should drop %q", fd.SXIDErrorCheck)
+	}
+
+	for _, name := range []string{fd.XIDErrorCheck, fd.GPUFallenOffCheck} {
+		tags, ok := tagsOf(checks, name)
+		if !ok {
+			t.Fatalf("check %q not built", name)
+		}
+
+		if len(tags) != 1 || tags[0] != "-u containerd.service" {
+			t.Errorf("check %q in Kata mode: expected [-u containerd.service], got %v", name, tags)
+		}
+
+		for _, tag := range tags {
+			if tag == "-k" {
+				t.Errorf("check %q in Kata mode must not carry -k (would AND with the unit filter)", name)
+			}
+		}
+	}
+}

--- a/health-monitors/syslog-health-monitor/pkg/syslog-monitor/fake_journal.go
+++ b/health-monitors/syslog-health-monitor/pkg/syslog-monitor/fake_journal.go
@@ -27,11 +27,12 @@ type FakeJournalEntry struct {
 
 // FakeJournal is a test implementation of the Journal interface
 type FakeJournal struct {
-	Entries         []FakeJournalEntry
-	CurrentPosition int
-	Matches         []string
-	Path            string
-	Closed          bool
+	Entries            []FakeJournalEntry
+	CurrentPosition    int
+	Matches            []string
+	DisjunctionIndexes []int
+	Path               string
+	Closed             bool
 }
 
 // NewFakeJournal creates a new fake journal
@@ -66,6 +67,17 @@ func (j *FakeJournal) AddMatch(match string) error {
 	}
 
 	j.Matches = append(j.Matches, match)
+
+	return nil
+}
+
+// AddDisjunction implements the Journal interface.
+func (j *FakeJournal) AddDisjunction() error {
+	if j.Closed {
+		return fmt.Errorf("journal is closed")
+	}
+
+	j.DisjunctionIndexes = append(j.DisjunctionIndexes, len(j.Matches))
 
 	return nil
 }
@@ -225,9 +237,28 @@ func (j *FakeJournal) SeekTail() error {
 	return nil
 }
 
-// matchesFilters checks if an entry matches all the filters
+// matchesFilters checks if an entry matches any disjunction group. Matches
+// within each group are ANDed, matching systemd journal semantics.
 func (j *FakeJournal) matchesFilters(entry FakeJournalEntry) bool {
-	for _, match := range j.Matches {
+	groupStart := 0
+
+	for _, groupEnd := range append(j.DisjunctionIndexes, len(j.Matches)) {
+		if j.matchesAll(entry, j.Matches[groupStart:groupEnd]) {
+			return true
+		}
+
+		groupStart = groupEnd
+	}
+
+	return false
+}
+
+func (j *FakeJournal) matchesAll(entry FakeJournalEntry, matches []string) bool {
+	if len(matches) == 0 {
+		return false
+	}
+
+	for _, match := range matches {
 		parts := strings.SplitN(match, "=", 2)
 		if len(parts) != 2 {
 			// Invalid match format

--- a/health-monitors/syslog-health-monitor/pkg/syslog-monitor/journal_iface.go
+++ b/health-monitors/syslog-health-monitor/pkg/syslog-monitor/journal_iface.go
@@ -18,6 +18,9 @@ type Journal interface {
 	// AddMatch adds a match filter for journal entries
 	AddMatch(match string) error
 
+	// AddDisjunction inserts an OR between the matches added before and after it.
+	AddDisjunction() error
+
 	// Close closes the journal
 	Close() error
 

--- a/health-monitors/syslog-health-monitor/pkg/syslog-monitor/journal_real.go
+++ b/health-monitors/syslog-health-monitor/pkg/syslog-monitor/journal_real.go
@@ -29,6 +29,11 @@ func (j *RealJournal) AddMatch(match string) error {
 	return j.journal.AddMatch(match)
 }
 
+// AddDisjunction inserts an OR between journal match groups.
+func (j *RealJournal) AddDisjunction() error {
+	return j.journal.AddDisjunction()
+}
+
 // Close closes the journal
 func (j *RealJournal) Close() error {
 	return j.journal.Close()

--- a/health-monitors/syslog-health-monitor/pkg/syslog-monitor/journal_stub.go
+++ b/health-monitors/syslog-health-monitor/pkg/syslog-monitor/journal_stub.go
@@ -53,6 +53,15 @@ func (j *StubJournal) AddMatch(match string) error {
 	return nil
 }
 
+// AddDisjunction inserts an OR between journal match groups.
+func (j *StubJournal) AddDisjunction() error {
+	if j.closed {
+		return errors.New(JOURNAL_CLOSED_ERROR_MESSAGE)
+	}
+
+	return nil
+}
+
 // Close closes the journal
 func (j *StubJournal) Close() error {
 	j.closed = true

--- a/health-monitors/syslog-health-monitor/pkg/syslog-monitor/syslogmonitor.go
+++ b/health-monitors/syslog-health-monitor/pkg/syslog-monitor/syslogmonitor.go
@@ -639,6 +639,26 @@ func (sm *SyslogMonitor) configureTagFilters(journal Journal, check CheckDefinit
 			if err := journal.AddMatch(matchExpr); err != nil {
 				return fmt.Errorf("check '%s': failed to add kernel match ('%s'): %w", check.Name, matchExpr, err)
 			}
+
+			// GPU reset acknowledgements are emitted through logger rather than
+			// the kernel. Keep them visible to the XID handler without admitting
+			// unrelated userspace logs:
+			// (_TRANSPORT=kernel) OR (SYSLOG_IDENTIFIER=nvsentinel-gpu-reset).
+			if check.Name == XIDErrorCheck {
+				if err := journal.AddDisjunction(); err != nil {
+					return fmt.Errorf("check '%s': failed to add GPU reset filter disjunction: %w", check.Name, err)
+				}
+
+				resetMatchExpr := FieldSyslogID + "=" + GPUResetSyslogID
+				slog.Info("Adding GPU reset acknowledgement filter",
+					"check", check.Name,
+					"match", resetMatchExpr)
+
+				if err := journal.AddMatch(resetMatchExpr); err != nil {
+					return fmt.Errorf("check '%s': failed to add GPU reset match ('%s'): %w",
+						check.Name, resetMatchExpr, err)
+				}
+			}
 		case "-b", "--boot":
 			slog.Info("Processing explicit boot tag",
 				"check", check.Name,

--- a/health-monitors/syslog-health-monitor/pkg/syslog-monitor/syslogmonitor.go
+++ b/health-monitors/syslog-health-monitor/pkg/syslog-monitor/syslogmonitor.go
@@ -626,8 +626,10 @@ func (sm *SyslogMonitor) configureTagFilters(journal Journal, check CheckDefinit
 
 		switch trimmedTag {
 		case "-k", "--dmesg":
-			// Facility 0 is typically KERNEL messages.
-			matchExpr := FieldSyslogFacility + "=0"
+			// Kernel-transport logs (printk + /dev/kmsg), independent of the
+			// syslog facility. This is generic across devices that may not set
+			// SYSLOG_FACILITY=kern, and naturally excludes journal/audit noise.
+			matchExpr := FieldTransport + "=" + TransportKernel
 
 			slog.Info("Adding kernel log filter",
 				"check", check.Name,
@@ -798,7 +800,49 @@ func (sm *SyslogMonitor) resumeFromLastCursor(
 		return false, nil
 	}
 
-	// Journal cursor is now positioned at the first new entry to process.
+	ready, err := sm.skipBookmarkedEntryIfPresent(journal, check, lastKnownCursor)
+	if err != nil {
+		return false, err
+	}
+
+	return ready, nil
+}
+
+// skipBookmarkedEntryIfPresent advances past lastKnownCursor when a filtered
+// journal read returns the bookmarked entry itself after SeekCursor+Next.
+// systemd may return the entry at the cursor on the first Next() after
+// SeekCursor when journal matches (e.g. _TRANSPORT=kernel for "-k") are active.
+// Without this skip, the last processed kernel XID is re-read every poll cycle.
+func (sm *SyslogMonitor) skipBookmarkedEntryIfPresent(
+	journal Journal, check CheckDefinition, lastKnownCursor string,
+) (bool, error) {
+	cur, err := journal.GetCursor()
+	if err != nil {
+		return false, fmt.Errorf("check '%s': failed to get cursor after resume advance: %w", check.Name, err)
+	}
+
+	if cur != lastKnownCursor {
+		return true, nil
+	}
+
+	slog.Debug("Skipping bookmarked journal entry re-read after filtered resume",
+		"check", check.Name,
+		"cursor", lastKnownCursor)
+
+	advanced, nextErr := journal.Next()
+	if nextErr != nil && !errors.Is(nextErr, io.EOF) {
+		return false, fmt.Errorf("check '%s': error advancing past bookmarked cursor '%s': %w",
+			check.Name, lastKnownCursor, nextErr)
+	}
+
+	if errors.Is(nextErr, io.EOF) || advanced == 0 {
+		slog.Info("No new entries since last cursor",
+			"check", check.Name,
+			"cursor", lastKnownCursor)
+
+		return false, nil
+	}
+
 	return true, nil
 }
 

--- a/health-monitors/syslog-health-monitor/pkg/syslog-monitor/syslogmonitor_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/syslog-monitor/syslogmonitor_test.go
@@ -59,6 +59,7 @@ type MockJournal struct {
 	Path            string
 	CurrentPosition int
 	MatchFilters    []string
+	Disjunctions    int
 	Closed          bool
 	TestBootID      string
 	TestCursor      string
@@ -81,6 +82,17 @@ func (j *MockJournal) AddMatch(match string) error {
 	}
 
 	j.MatchFilters = append(j.MatchFilters, match)
+
+	return nil
+}
+
+// AddDisjunction inserts an OR between journal match groups.
+func (j *MockJournal) AddDisjunction() error {
+	if j.Closed {
+		return errors.New(JOURNAL_CLOSED_ERROR)
+	}
+
+	j.Disjunctions++
 
 	return nil
 }
@@ -821,11 +833,10 @@ func TestGPUFallenOffHandlerInitialization(t *testing.T) {
 	assert.NotNil(t, sm.checkToHandlerMap[GPUFallenOffCheck], "GPU Fallen Off handler should be initialized")
 }
 
-// TestConfigureTagFilters_KernelTagAddsTransportMatch verifies that a check
-// carrying the "-k" tag restricts the journal to kernel-transport entries via a
-// _TRANSPORT=kernel match. This is the filter the kernel-origin checks rely on
-// to keep up with journald; see NVIDIA/NVSentinel#1417.
-func TestConfigureTagFilters_KernelTagAddsTransportMatch(t *testing.T) {
+// TestConfigureTagFilters_XIDTagIncludesGPUResetAcknowledgements verifies that
+// the XID reader consumes kernel messages or tagged GPU reset acknowledgements,
+// while still excluding unrelated userspace journal traffic.
+func TestConfigureTagFilters_XIDTagIncludesGPUResetAcknowledgements(t *testing.T) {
 	for _, tag := range []string{"-k", "--dmesg"} {
 		t.Run(tag, func(t *testing.T) {
 			sm := &SyslogMonitor{}
@@ -834,10 +845,58 @@ func TestConfigureTagFilters_KernelTagAddsTransportMatch(t *testing.T) {
 
 			err := sm.configureTagFilters(mock, check)
 			assert.NoError(t, err)
-			assert.Contains(t, mock.MatchFilters, FieldTransport+"="+TransportKernel,
-				"tag %q should add a kernel-transport (_TRANSPORT=kernel) journal match", tag)
+			assert.Equal(t, []string{
+				FieldTransport + "=" + TransportKernel,
+				FieldSyslogID + "=" + GPUResetSyslogID,
+			}, mock.MatchFilters)
+			assert.Equal(t, 1, mock.Disjunctions,
+				"kernel and GPU reset identifier matches must be ORed")
 		})
 	}
+}
+
+func TestConfigureTagFilters_NonXIDKernelCheckExcludesGPUResetAcknowledgements(t *testing.T) {
+	sm := &SyslogMonitor{}
+	mock := &MockJournal{}
+	check := CheckDefinition{Name: SXIDErrorCheck, Tags: []string{"-k"}}
+
+	err := sm.configureTagFilters(mock, check)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{FieldTransport + "=" + TransportKernel}, mock.MatchFilters)
+	assert.Zero(t, mock.Disjunctions)
+}
+
+func TestFakeJournal_KernelOrGPUResetIdentifierFilter(t *testing.T) {
+	journal := NewFakeJournal()
+	journal.AddEntry(map[string]string{
+		FieldTransport: "journal",
+		FieldSyslogID:  "unrelated-service",
+	}, "unrelated")
+	journal.AddEntry(map[string]string{
+		FieldTransport: TransportKernel,
+	}, "kernel")
+	journal.AddEntry(map[string]string{
+		FieldTransport: "syslog",
+		FieldSyslogID:  GPUResetSyslogID,
+	}, "gpu-reset")
+
+	assert.NoError(t, journal.AddMatch(FieldTransport+"="+TransportKernel))
+	assert.NoError(t, journal.AddDisjunction())
+	assert.NoError(t, journal.AddMatch(FieldSyslogID+"="+GPUResetSyslogID))
+
+	advanced, err := journal.Next()
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(1), advanced)
+	cursor, err := journal.GetCursor()
+	assert.NoError(t, err)
+	assert.Equal(t, "kernel", cursor)
+
+	advanced, err = journal.Next()
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(1), advanced)
+	cursor, err = journal.GetCursor()
+	assert.NoError(t, err)
+	assert.Equal(t, "gpu-reset", cursor)
 }
 
 // TestConfigureTagFilters_NoTagsAddsNoMatch verifies that a check with no tags

--- a/health-monitors/syslog-health-monitor/pkg/syslog-monitor/syslogmonitor_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/syslog-monitor/syslogmonitor_test.go
@@ -68,6 +68,10 @@ type MockJournal struct {
 	FailGetData     bool
 	FailSeekCursor  bool
 	FailSeekTail    bool
+	// InclusiveSeekCursor simulates systemd behavior with journal matches active:
+	// the first Next() after SeekCursor returns the bookmarked entry itself.
+	InclusiveSeekCursor  bool
+	replayBookmarkOnNext bool
 }
 
 // AddMatch adds a match filter for journal entries
@@ -165,6 +169,15 @@ func (j *MockJournal) Next() (uint64, error) {
 		return 0, fmt.Errorf("forced Next failure")
 	}
 
+	if j.replayBookmarkOnNext {
+		j.replayBookmarkOnNext = false
+		if j.CurrentPosition >= 0 && j.CurrentPosition < len(j.Entries) {
+			return 1, nil
+		}
+
+		return 0, io.EOF
+	}
+
 	j.CurrentPosition++
 	if j.CurrentPosition >= len(j.Entries) {
 		return 0, io.EOF
@@ -201,6 +214,10 @@ func (j *MockJournal) SeekCursor(cursor string) error {
 	for i, entry := range j.Entries {
 		if entry.Cursor == cursor {
 			j.CurrentPosition = i
+			if j.InclusiveSeekCursor {
+				j.replayBookmarkOnNext = true
+			}
+
 			return nil
 		}
 	}
@@ -509,7 +526,7 @@ func TestJournalStateManagement(t *testing.T) {
 		pb.ProcessingStrategy_EXECUTE_REMEDIATION,
 		"", "",
 		nil,
-    "tcp://test",
+		"tcp://test",
 	)
 	assert.NoError(t, err)
 
@@ -544,7 +561,7 @@ func TestJournalStateManagement(t *testing.T) {
 		pb.ProcessingStrategy_EXECUTE_REMEDIATION,
 		"", "",
 		nil,
-    "tcp://test",
+		"tcp://test",
 	)
 	assert.NoError(t, err)
 
@@ -802,4 +819,61 @@ func TestGPUFallenOffHandlerInitialization(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, sm.checkToHandlerMap[GPUFallenOffCheck], "GPU Fallen Off handler should be initialized")
+}
+
+// TestConfigureTagFilters_KernelTagAddsTransportMatch verifies that a check
+// carrying the "-k" tag restricts the journal to kernel-transport entries via a
+// _TRANSPORT=kernel match. This is the filter the kernel-origin checks rely on
+// to keep up with journald; see NVIDIA/NVSentinel#1417.
+func TestConfigureTagFilters_KernelTagAddsTransportMatch(t *testing.T) {
+	for _, tag := range []string{"-k", "--dmesg"} {
+		t.Run(tag, func(t *testing.T) {
+			sm := &SyslogMonitor{}
+			mock := &MockJournal{}
+			check := CheckDefinition{Name: XIDErrorCheck, Tags: []string{tag}}
+
+			err := sm.configureTagFilters(mock, check)
+			assert.NoError(t, err)
+			assert.Contains(t, mock.MatchFilters, FieldTransport+"="+TransportKernel,
+				"tag %q should add a kernel-transport (_TRANSPORT=kernel) journal match", tag)
+		})
+	}
+}
+
+// TestConfigureTagFilters_NoTagsAddsNoMatch verifies that a check with no tags
+// adds no journal match, i.e. it consumes every facility. This is the
+// pre-fix default behavior the kernel-origin checks must no longer rely on.
+func TestConfigureTagFilters_NoTagsAddsNoMatch(t *testing.T) {
+	sm := &SyslogMonitor{}
+	mock := &MockJournal{}
+	check := CheckDefinition{Name: "SomeUserspaceCheck"}
+
+	err := sm.configureTagFilters(mock, check)
+	assert.NoError(t, err)
+	assert.Empty(t, mock.MatchFilters, "a check with no tags should add no journal match")
+}
+
+// TestResumeFromLastCursor_SkipsBookmarkReReadWithFilteredJournal verifies that
+// resuming from a bookmark does not re-read the last processed kernel entry when
+// systemd returns that entry on the first Next() after SeekCursor with matches
+// active (_TRANSPORT=kernel / "-k"). See NVIDIA/NVSentinel#1417.
+func TestResumeFromLastCursor_SkipsBookmarkReReadWithFilteredJournal(t *testing.T) {
+	sm := &SyslogMonitor{
+		checkLastCursors: map[string]string{
+			XIDErrorCheck: "xid-cursor",
+		},
+	}
+	journal := &MockJournal{
+		InclusiveSeekCursor: true,
+		Entries: []MockJournalEntry{
+			{Cursor: "xid-cursor", Message: "NVRM: Xid (PCI:0008:06:00): 48"},
+		},
+		CurrentPosition: 0,
+		MatchFilters:    []string{FieldTransport + "=" + TransportKernel},
+	}
+	check := CheckDefinition{Name: XIDErrorCheck, Tags: []string{"-k"}}
+
+	ready, err := sm.resumeFromLastCursor(journal, check, "xid-cursor")
+	assert.NoError(t, err)
+	assert.False(t, ready, "should not re-read the bookmarked kernel XID when no newer entries exist")
 }

--- a/health-monitors/syslog-health-monitor/pkg/syslog-monitor/types.go
+++ b/health-monitors/syslog-health-monitor/pkg/syslog-monitor/types.go
@@ -29,10 +29,12 @@ const (
 	FieldBootID         = "_BOOT_ID"
 	FieldMessage        = "MESSAGE"
 	FieldSyslogFacility = "SYSLOG_FACILITY"
+	FieldSyslogID       = "SYSLOG_IDENTIFIER"
 	FieldSystemdUnit    = "_SYSTEMD_UNIT"
 	FieldTransport      = "_TRANSPORT"
 	TransportKernel     = "kernel"
 
+	GPUResetSyslogID    = "nvsentinel-gpu-reset"
 	XIDErrorCheck       = "SysLogsXIDError"
 	SXIDErrorCheck      = "SysLogsSXIDError"
 	GPUFallenOffCheck   = "SysLogsGPUFallenOff"

--- a/health-monitors/syslog-health-monitor/pkg/syslog-monitor/types.go
+++ b/health-monitors/syslog-health-monitor/pkg/syslog-monitor/types.go
@@ -30,6 +30,8 @@ const (
 	FieldMessage        = "MESSAGE"
 	FieldSyslogFacility = "SYSLOG_FACILITY"
 	FieldSystemdUnit    = "_SYSTEMD_UNIT"
+	FieldTransport      = "_TRANSPORT"
+	TransportKernel     = "kernel"
 
 	XIDErrorCheck       = "SysLogsXIDError"
 	SXIDErrorCheck      = "SysLogsSXIDError"


### PR DESCRIPTION
## Summary

This PR builts on top of https://github.com/NVIDIA/NVSentinel/pull/1426 with addition of special handling of GPU reset. 

The special handling of GPU reset ack has been achieved in two steps:
1. Add tag`nvsentinel-gpu-reset` in GPU reset script message:
```
    logger -t nvsentinel-gpu-reset -p daemon.err \
      "GPU reset executed: ${UUID}, success: ${SYSLOG_SUCCESS}"
```
3. Add an extra disjunction for tag `nvsentinel-gpu-reset` to catch the reset event:
```
			if check.Name == XIDErrorCheck {
				if err := journal.AddDisjunction(); err != nil {
					return fmt.Errorf("check '%s': failed to add GPU reset filter disjunction: %w", check.Name, err)
				}

				resetMatchExpr := FieldSyslogID + "=" + GPUResetSyslogID
				slog.Info("Adding GPU reset acknowledgement filter",
					"check", check.Name,
					"match", resetMatchExpr)

				if err := journal.AddMatch(resetMatchExpr); err != nil {
					return fmt.Errorf("check '%s': failed to add GPU reset match ('%s'): %w",
						check.Name, resetMatchExpr, err)
				}
			}
```

## Validation
#### UAT-style validation
```
$ kubectl exec -n gpu-operator "$TEST_DCGM_POD" -- \
  nvidia-smi --query-gpu=index,uuid,pci.bus_id,name --format=csv,noheader

0, GPU-52f37cd4-d92a-7b6d-2b9f-9ab862e27708, 00000001:00:00.0, NVIDIA A100-SXM4-80GB
1, GPU-56f8feab-af81-3f47-1f6e-a95ecd49b071, 00000002:00:00.0, NVIDIA A100-SXM4-80GB
...
```
Picked GPU 0

Injected error through /dev/kmsg:
```
$ kubectl exec -n gpu-operator "$TEST_DCGM_POD" -- sh -c \
  "echo '<3>[6085126.134786] NVRM: Xid (PCI:0001:00:00): 119, pid=1582259, name=nvc:[driver], Timeout after 6s of waiting for RPC response from GPU1 GSP! Expected function 76 (GSP_RM_CONTROL) (0x20802a02 0x8).' > /dev/kmsg"
```

Got XID error reported on the node:
```
$ kubectl -n nvsentinel logs syslog-health-monitor-regular-ltjth \
  -c syslog-health-monitor \
  --since-time=2026-07-10T07:35:58Z

{"time":"2026-07-10T07:36:20.415716323Z","level":"INFO","msg":"Attempting to send health event","module":"syslog-health-monitor","version":"e2e-6bc8cbc4","events":{"version":1,"events":[{"version":1,"agent":"syslog-health-monitor","componentClass":"GPU","checkName":"SysLogsXIDError","isFatal":true,"message":"MESSAGE=[6085126.134786] NVRM: Xid (PCI:0001:00:00): 119, pid=1582259, name=nvc:[driver], Timeout after 6s of waiting for RPC response from GPU1 GSP! Expected function 76 (GSP_RM_CONTROL) (0x20802a02 0x8).","recommendedAction":2,"errorCode":["119"],"entitiesImpacted":[{"entityType":"PCI","entityValue":"0001:00:00"},{"entityType":"GPU_UUID","entityValue":"GPU-52f37cd4-d92a-7b6d-2b9f-9ab862e27708"}],"generatedTimestamp":{"seconds":1783668980,"nanos":415707346},"nodeName":"aks-gpu-123-vmss00000r","processingStrategy":1}]}}
{"time":"2026-07-10T07:36:20.451438581Z","level":"INFO","msg":"Successfully sent health events","module":"syslog-health-monitor","version":"e2e-6bc8cbc4","monitor":"syslog-health-monitor","count":1}
{"time":"2026-07-10T07:36:20.451475339Z","level":"INFO","msg":"Successfully sent health events","module":"syslog-health-monitor","version":"e2e-6bc8cbc4","events":{"version":1,"events":[{"version":1,"agent":"syslog-health-monitor","componentClass":"GPU","checkName":"SysLogsXIDError","isFatal":true,"message":"MESSAGE=[6085126.134786] NVRM: Xid (PCI:0001:00:00): 119, pid=1582259, name=nvc:[driver], Timeout after 6s of waiting for RPC response from GPU1 GSP! Expected function 76 (GSP_RM_CONTROL) (0x20802a02 0x8).","recommendedAction":2,"errorCode":["119"],"entitiesImpacted":[{"entityType":"PCI","entityValue":"0001:00:00"},{"entityType":"GPU_UUID","entityValue":"GPU-52f37cd4-d92a-7b6d-2b9f-9ab862e27708"}],"generatedTimestamp":{"seconds":1783668980,"nanos":415707346},"nodeName":"aks-gpu-123-vmss00000r","processingStrategy":1}]}}

$ kubectl get node "$TEST_NODE" -o json |
  jq '.status.conditions[] | select(.type=="SysLogsXIDError")'
{
  "lastTransitionTime": "2026-07-10T07:36:20Z",
  "message": "ErrorCode:119 PCI:0001:00:00 GPU_UUID:GPU-52f37cd4-d92a-7b6d-2b9f-9ab862e27708 ... Recommended Action=COMPONENT_RESET;",
  "reason": "SysLogsXIDErrorIsNotHealthy",
  "status": "True",
  "type": "SysLogsXIDError"
}
```


GPU reset CR got created and succeeded:
```
$ kubectl get gpureset \
  maintenance-aks-gpu-123-vmss00000r-6a50a0f45c5b7b40c28255b4 \
  -o json | jq '.status.conditions'
{
  "message": "GPU(s) reset successfully",
  "reason": "ResetJobSucceeded",
  "status": "True",
  "type": "ResetJobCompleted"
}
{
  "message": "gpu-operator managed services are Ready",
  "reason": "ServiceRestoreSucceeded",
  "status": "True",
  "type": "ServicesRestored"
}
{
  "message": "GPU(s) reset successfully",
  "reason": "GPUResetSucceeded",
  "status": "True",
  "type": "Complete"
}
```

Logs of GPU reset job:
```
$ kubectl -n dgxc-janitor-system logs \
  maintenance-aks-gpu-123-vmss00000-5d6b7907-reset-job-x5vws

(2026-07-10 07:36:55) INFO: Using DRIVER_ROOT=/
(2026-07-10 07:36:55) INFO: Testing nvidia-smi invocation: chroot / nvidia-smi --version
NVIDIA-SMI version  : 570.148.08
NVML version        : 570.148
DRIVER version      : 570.148.08
CUDA Version        : 13.3
(2026-07-10 07:36:55) INFO: Starting GPU reset workflow...
(2026-07-10 07:36:55) INFO: Determining target devices...
(2026-07-10 07:36:55) INFO: Targets:
  GPU-52f37cd4-d92a-7b6d-2b9f-9ab862e27708
(2026-07-10 07:36:55) INFO: Resetting GPUs...
  GPU 00000001:00:00.0 was successfully reset
(2026-07-10 07:37:53) INFO: GPU reset complete.
(2026-07-10 07:37:53) INFO: Running post-reset health check...
(2026-07-10 07:37:54) INFO: Post-reset health check passed.
(2026-07-10 07:37:55) SUCCESS: GPU reset workflow completed in 59.682s.
(2026-07-10 07:37:55) Writing reset result for GPU-52f37cd4-d92a-7b6d-2b9f-9ab862e27708 to syslog (success: true)
```


Acking of GPU reset:
```
$ kubectl -n nvsentinel logs syslog-health-monitor-regular-ltjth \
  -c syslog-health-monitor \
  --since-time=2026-07-10T07:37:45Z

{"time":"2026-07-10T07:38:05.415073664Z","level":"INFO","msg":"Adding GPU reset acknowledgement filter","module":"syslog-health-monitor","version":"e2e-6bc8cbc4","check":"SysLogsXIDError","match":"SYSLOG_IDENTIFIER=nvsentinel-gpu-reset"}
{"time":"2026-07-10T07:38:05.417243336Z","level":"INFO","msg":"GPU reset syslog event received, creating HealthEvent","module":"syslog-health-monitor","version":"e2e-6bc8cbc4","GPU_UUID":"GPU-52f37cd4-d92a-7b6d-2b9f-9ab862e27708","success":true}
{"time":"2026-07-10T07:38:05.417260137Z","level":"INFO","msg":"Attempting to send health event","module":"syslog-health-monitor","version":"e2e-6bc8cbc4","events":{"version":1,"events":[{"version":1,"agent":"syslog-health-monitor","componentClass":"GPU","checkName":"SysLogsXIDError","isHealthy":true,"message":"No Health Failures","entitiesImpacted":[{"entityType":"PCI","entityValue":"0001:00:00"},{"entityType":"GPU_UUID","entityValue":"GPU-52f37cd4-d92a-7b6d-2b9f-9ab862e27708"}],"generatedTimestamp":{"seconds":1783669085,"nanos":417257973},"nodeName":"aks-gpu-123-vmss00000r","processingStrategy":1}]}}
{"time":"2026-07-10T07:38:05.418007531Z","level":"INFO","msg":"Successfully sent health events","module":"syslog-health-monitor","version":"e2e-6bc8cbc4","monitor":"syslog-health-monitor","count":1}
{"time":"2026-07-10T07:38:05.418019162Z","level":"INFO","msg":"Successfully sent health events","module":"syslog-health-monitor","version":"e2e-6bc8cbc4","events":{"version":1,"events":[{"version":1,"agent":"syslog-health-monitor","componentClass":"GPU","checkName":"SysLogsXIDError","isHealthy":true,"message":"No Health Failures","entitiesImpacted":[{"entityType":"PCI","entityValue":"0001:00:00"},{"entityType":"GPU_UUID","entityValue":"GPU-52f37cd4-d92a-7b6d-2b9f-9ab862e27708"}],"generatedTimestamp":{"seconds":1783669085,"nanos":417257973},"nodeName":"aks-gpu-123-vmss00000r","processingStrategy":1}]}}
```

GPU reset CR:
```
kubectl get gpureset \
  maintenance-aks-gpu-123-vmss00000r-6a50a0f45c5b7b40c28255b4 \
  -o json |
jq '{metadata:{name:.metadata.name,creationTimestamp:.metadata.creationTimestamp},spec:.spec,status:.status}'
{
  "metadata": {
    "name": "maintenance-aks-gpu-123-vmss00000r-6a50a0f45c5b7b40c28255b4",
    "creationTimestamp": "2026-07-10T07:36:31Z"
  },
  "spec": {
    "nodeName": "aks-gpu-123-vmss00000r",
    "selector": {
      "uuids": [
        "GPU-52f37cd4-d92a-7b6d-2b9f-9ab862e27708"
      ]
    }
  },
  "status": {
    "completionTime": "2026-07-10T07:38:16Z",
    "conditions": [
      {
        "lastTransitionTime": "2026-07-10T07:36:31Z",
        "message": "Node ready for GPU reset",
        "reason": "ReadyForReset",
        "status": "True",
        "type": "Ready"
      },
      {
        "lastTransitionTime": "2026-07-10T07:36:36Z",
        "message": "gpu-operator managed services have been removed",
        "reason": "ServiceTeardownSucceeded",
        "status": "True",
        "type": "ServicesTornDown"
      },
      {
        "lastTransitionTime": "2026-07-10T07:36:36Z",
        "message": "GPU reset job created",
        "reason": "ResetJobCreationSucceeded",
        "status": "True",
        "type": "ResetJobCreated"
      },
      {
        "lastTransitionTime": "2026-07-10T07:37:58Z",
        "message": "GPU(s) reset successfully",
        "reason": "ResetJobSucceeded",
        "status": "True",
        "type": "ResetJobCompleted"
      },
      {
        "lastTransitionTime": "2026-07-10T07:38:16Z",
        "message": "gpu-operator managed services are Ready",
        "reason": "ServiceRestoreSucceeded",
        "status": "True",
        "type": "ServicesRestored"
      },
      {
        "lastTransitionTime": "2026-07-10T07:38:16Z",
        "message": "GPU(s) reset successfully",
        "reason": "GPUResetSucceeded",
        "status": "True",
        "type": "Complete"
      }
    ],
    "jobRef": {
      "kind": "Job",
      "name": "maintenance-aks-gpu-123-vmss00000-5d6b7907-reset-job",
      "namespace": "dgxc-janitor-system"
    },
    "phase": "Succeeded",
    "startTime": "2026-07-10T07:36:31Z"
  }
}
```

final node state:
```
kubectl get node aks-gpu-123-vmss00000r -o json |
jq '{
  bootID:.status.nodeInfo.bootID,
  unschedulable:.spec.unschedulable,
  taints:.spec.taints,
  xidCondition:(.status.conditions[]|select(.type=="SysLogsXIDError"))
}'
{
  "bootID": "64e53f5b-a4da-4763-9b08-8379d756a00e",
  "unschedulable": null,
  "taints": null,
  "xidCondition": {
    "lastHeartbeatTime": "2026-07-10T07:38:05Z",
    "lastTransitionTime": "2026-07-10T07:38:05Z",
    "message": "No Health Failures",
    "reason": "SysLogsXIDErrorIsHealthy",
    "status": "False",
    "type": "SysLogsXIDError"
  }
}
```

### XIDs through a faulty program:
Started a script:
```
    set -x
    date -u +%FT%TZ
    nvidia-smi \
      --query-gpu=uuid,pci.bus_id,name,driver_version \
      --format=csv,noheader
    cat > /tmp/xid_trigger.cu << 'CU'
    #include <cuda_runtime.h>
    #include <stdio.h>
    __global__ void trigger_xid() {
        // Intentionally access invalid memory to trigger XID 13
        int* invalid_ptr = (int*)0xDEADBEEF;
        *invalid_ptr = 42;
    }
    int main() {
        trigger_xid<<<1, 1>>>();
        cudaDeviceSynchronize();
        return 0;
    }
    CU
    nvcc -o /tmp/xid_trigger /tmp/xid_trigger.cu
    set +e
    /tmp/xid_trigger
    RC=$?
    set -e
    echo "xid_trigger exit code: ${RC}"
```

Output:
```
+ date -u +%FT%TZ
2026-07-10T08:41:23Z
+ nvidia-smi --query-gpu=uuid,pci.bus_id,name,driver_version --format=csv,noheader
GPU-6c893248-04ee-68c6-dfb4-df0c4395a591, 0000000B:00:00.0, NVIDIA A100-SXM4-80GB, 570.148.08
+ cat
+ nvcc -o /tmp/xid_trigger /tmp/xid_trigger.cu
+ set +e
+ /tmp/xid_trigger
+ RC=0
+ set -e
+ echo 'xid_trigger exit code: 0'
xid_trigger exit code: 0
+ sleep 20
```

Logs from syslog health monitor:
```
$ kubectl logs \
  -n nvsentinel \
  syslog-health-monitor-regular-b75jr \
  -c syslog-health-monitor \
  --since=10m
{"time":"2026-07-10T08:41:31.076382647Z","level":"INFO","msg":"Attempting to send health event","module":"syslog-health-monitor","version":"e2e-6bc8cbc4","events":{"version":1,"events":[{"version":1,"agent":"syslog-health-monitor","componentClass":"GPU","checkName":"SysLogsXIDError","message":"MESSAGE=NVRM: Xid (PCI:000b:00:00): 13, pid=3737626, name=xid_trigger, Graphics Exception: ChID 000a, Class 0000c6c0, Offset 00000510, Data 0017e2ac","errorCode":["13"],"entitiesImpacted":[{"entityType":"PCI","entityValue":"000b:00:00"},{"entityType":"GPU_UUID","entityValue":"GPU-6c893248-04ee-68c6-dfb4-df0c4395a591"}],"generatedTimestamp":{"seconds":1783672891,"nanos":76379992},"nodeName":"aks-gpu-123-vmss00000r","processingStrategy":1}]}}
{"time":"2026-07-10T08:41:31.076629657Z","level":"INFO","msg":"Successfully sent health events","module":"syslog-health-monitor","version":"e2e-6bc8cbc4","monitor":"syslog-health-monitor","count":1}
{"time":"2026-07-10T08:41:31.076640126Z","level":"INFO","msg":"Successfully sent health events","module":"syslog-health-monitor","version":"e2e-6bc8cbc4","events":{"version":1,"events":[{"version":1,"agent":"syslog-health-monitor","componentClass":"GPU","checkName":"SysLogsXIDError","message":"MESSAGE=NVRM: Xid (PCI:000b:00:00): 13, pid=3737626, name=xid_trigger, Graphics Exception: ChID 000a, Class 0000c6c0, Offset 00000510, Data 0017e2ac","errorCode":["13"],"entitiesImpacted":[{"entityType":"PCI","entityValue":"000b:00:00"},{"entityType":"GPU_UUID","entityValue":"GPU-6c893248-04ee-68c6-dfb4-df0c4395a591"}],"generatedTimestamp":{"seconds":1783672891,"nanos":76379992},"nodeName":"aks-gpu-123-vmss00000r","processingStrategy":1}]}}
{"time":"2026-07-10T08:41:31.077419193Z","level":"INFO","msg":"Attempting to send health event","module":"syslog-health-monitor","version":"e2e-6bc8cbc4","events":{"version":1,"events":[{"version":1,"agent":"syslog-health-monitor","componentClass":"GPU","checkName":"SysLogsXIDError","message":"MESSAGE=NVRM: Xid (PCI:000b:00:00): 31, pid=3737626, name=xid_trigger, Ch 0000000a, intr 00000000. MMU Fault: ENGINE GRAPHICS GPC2 GPCCLIENT_T1_0 faulted @ 0x0_deadb000. Fault is of type FAULT_PDE ACCESS_TYPE_VIRT_WRITE","errorCode":["31"],"entitiesImpacted":[{"entityType":"PCI","entityValue":"000b:00:00"},{"entityType":"GPU_UUID","entityValue":"GPU-6c893248-04ee-68c6-dfb4-df0c4395a591"}],"generatedTimestamp":{"seconds":1783672891,"nanos":77416257},"nodeName":"aks-gpu-123-vmss00000r","processingStrategy":1}]}}
{"time":"2026-07-10T08:41:31.077671793Z","level":"INFO","msg":"Successfully sent health events","module":"syslog-health-monitor","version":"e2e-6bc8cbc4","monitor":"syslog-health-monitor","count":1}
{"time":"2026-07-10T08:41:31.077681Z","level":"INFO","msg":"Successfully sent health events","module":"syslog-health-monitor","version":"e2e-6bc8cbc4","events":{"version":1,"events":[{"version":1,"agent":"syslog-health-monitor","componentClass":"GPU","checkName":"SysLogsXIDError","message":"MESSAGE=NVRM: Xid (PCI:000b:00:00): 31, pid=3737626, name=xid_trigger, Ch 0000000a, intr 00000000. MMU Fault: ENGINE GRAPHICS GPC2 GPCCLIENT_T1_0 faulted @ 0x0_deadb000. Fault is of type FAULT_PDE ACCESS_TYPE_VIRT_WRITE","errorCode":["31"],"entitiesImpacted":[{"entityType":"PCI","entityValue":"000b:00:00"},{"entityType":"GPU_UUID","entityValue":"GPU-6c893248-04ee-68c6-dfb4-df0c4395a591"}],"generatedTimestamp":{"seconds":1783672891,"nanos":77416257},"nodeName":"aks-gpu-123-vmss00000r","processingStrategy":1}]}}
```

Other than that I've also validated that general noise that is not part of either kernel facility or matches that gpu-reset tag doesn't get into syslog HM
## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kernel log filtering to use the correct transport signals for more reliable health checks.
  * Refined XID monitoring to include GPU reset acknowledgements while excluding unrelated userspace logs.
  * Prevented reprocessing of the same journal entry after cursor recovery.
  * Corrected Kata-mode log filtering to avoid incompatible kernel/containerd matches.
  * Added a consistent syslog tag to GPU reset error logging.
* **Tests**
  * Expanded unit test coverage for kernel/containerd filtering, journal match OR/disjunction behavior, and cursor recovery edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->