### PR TITLE
docs: add, modify, disable, apply, and verify fault-quarantine rule sets

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/configmap.yaml
@@ -29,7 +29,7 @@ data:
     
     {{- range .Values.ruleSets }}
     [[rule-sets]]
-      enabled = {{ .enabled | default true }}
+      enabled = {{ if hasKey . "enabled" }}{{ .enabled }}{{ else }}true{{ end }}
       version = {{ .version | quote }}
       name = {{ .name | quote }}
       {{- if .match.all }}

--- a/docs/configuration/fault-quarantine.md
+++ b/docs/configuration/fault-quarantine.md
@@ -133,7 +133,8 @@ Rule sets define conditions for quarantining nodes using CEL expressions. Each r
 ```yaml
 fault-quarantine:
   ruleSets:
-    - version: "1"
+    - enabled: true
+      version: "1"
       name: "ruleset-name"
       priority: 100
       
@@ -159,6 +160,9 @@ fault-quarantine:
 ```
 
 ### Parameters
+
+#### enabled
+When `false`, the ruleset is skipped entirely. Use this to turn off a built-in ruleset without removing its definition.
 
 #### version
 Rule set format version for future compatibility.
@@ -225,3 +229,24 @@ ruleSets:
     cordon:
       shouldCordon: true
 ```
+
+### Adding and Modifying Rule Sets
+
+`fault-quarantine.ruleSets` is a **list**. When Helm merges multiple values files (`-f`), lists are replaced entirely — not merged by `name`. A file that sets only one ruleset replaces the whole list; built-in rulesets from [values.yaml](../../distros/kubernetes/nvsentinel/charts/fault-quarantine/values.yaml) are dropped unless you include them again. The chart has no keyed-merge for rulesets.
+
+Copy the default `ruleSets` from values.yaml into your values file, edit the full list, then upgrade:
+
+- **Disable** a ruleset: set `enabled: false` on that entry in your complete list.
+- **Add** a ruleset: append an entry (see [examples above](#example-rule-sets)).
+- **Modify** a ruleset: change `match`, `cordon`, or `taint` on that entry in your complete list.
+
+```bash
+helm upgrade nvsentinel ./distros/kubernetes/nvsentinel \
+  -n nvsentinel \
+  -f my-values.yaml \
+  --wait
+```
+
+The chart renders the list into the `fault-quarantine` ConfigMap (`config.toml`); a config change triggers a pod restart.
+
+Use `global.dryRun: true` to test without cordoning nodes (see [Dry Run Mode](./README.md#dry-run-mode)). Confirm the rollout with `kubectl -n nvsentinel rollout status deployment/fault-quarantine` and check `kubectl -n nvsentinel logs deployment/fault-quarantine`.

--- a/docs/fault-quarantine.md
+++ b/docs/fault-quarantine.md
@@ -58,6 +58,8 @@ The Fault Quarantine module uses CEL (Common Expression Language) to define flex
 
 ## Configuration
 
+See [Fault Quarantine configuration](configuration/fault-quarantine.md) for the full Helm reference, including how to add, modify, and verify rule sets.
+
 Configure the Fault Quarantine module through Helm values:
 
 ```yaml


### PR DESCRIPTION


## Summary

Document how to add, modify, disable, apply, and verify fault-quarantine rule sets.

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Fault Quarantine rule set YAML examples to include an explicit `enabled: true` field.
  * Clarified ruleset `enabled` behavior: `enabled: false` skips the ruleset entirely while retaining its definition.
  * Added guidance for adding/modifying rulesets via Helm overlays under `fault-quarantine.ruleSets`, including restart expectations and step-by-step commands with dry-run and rollout/log verification.
  * Added an inline link from the Fault Quarantine docs to the full Helm configuration reference.
* **Bug Fixes**
  * Fixed ConfigMap generation to render per-ruleset `enabled` correctly when the field is present vs omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->