### PR TITLE
fix: bind gpu-health-monitor metrics server for IPv6-only clusters

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/daemonset-dcgm-3.x.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/daemonset-dcgm-3.x.yaml
@@ -53,6 +53,8 @@ spec:
             - {{ include "gpu-health-monitor.dcgmCliMode" . | quote }}
             - --port
             - "{{ .Values.global.metricsPort }}"
+            - --metrics-addr
+            - "{{ .Values.global.metricsAddress | default "0.0.0.0" }}"
             - --verbose
             - {{ .Values.verbose | quote }}
             - --state-file

--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/daemonset-dcgm-4.x.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/daemonset-dcgm-4.x.yaml
@@ -53,6 +53,8 @@ spec:
             - {{ include "gpu-health-monitor.dcgmCliMode" . | quote }}
             - --port
             - "{{ .Values.global.metricsPort }}"
+            - --metrics-addr
+            - "{{ .Values.global.metricsAddress | default "0.0.0.0" }}"
             - --verbose
             - {{ .Values.verbose | quote }}
             - --state-file

--- a/distros/kubernetes/nvsentinel/values.yaml
+++ b/distros/kubernetes/nvsentinel/values.yaml
@@ -275,6 +275,7 @@ global:
     enabled: false
   janitor:
     enabled: false
+  # Enables lifecycle-manager reconciliation of maintenance requests.
   lifecycleManager:
     enabled: false
   janitorProvider:

--- a/distros/kubernetes/nvsentinel/values.yaml
+++ b/distros/kubernetes/nvsentinel/values.yaml
@@ -21,6 +21,10 @@ global:
     tag: "12-debian-12-r30"
     pullPolicy: IfNotPresent
   metricsPort: 2112
+  # IPv4 bind address for the GPU health monitor metrics server. Set to "::"
+  # to enable IPv6 / dual-stack binding. This requires an IPv6-capable kernel;
+  # nodes booted with ipv6.disable=1 fail with EAFNOSUPPORT and CrashLoop.
+  metricsAddress: "0.0.0.0"
   # Default Kubernetes API client limits for core controllers. Components can
   # override these with their own qps and burst values.
   # qps: positive values throttle requests, 0 uses the client-go default,

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/cli.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/cli.py
@@ -68,7 +68,7 @@ def _init_event_processor(
     store_only_checks: frozenset[str],
     connectivity_failure_escalation_threshold: int,
     platform_connector_token_path: str,
-):
+) -> platform_connector.PlatformConnectorEventProcessor:
     platform_connector_config = config["eventprocessors.platformconnector"]
     match event_processor_name:
         case platform_connector.PlatformConnectorEventProcessor.__name__:
@@ -156,20 +156,20 @@ def _init_event_processor(
     ),
 )
 def cli(
-    dcgm_addr,
-    dcgm_mode,
-    dcgm_error_mapping_config_file,
-    config_file,
-    port,
-    metrics_addr,
-    verbose,
-    state_file,
-    dcgm_k8s_service_enabled,
-    metadata_path,
-    processing_strategy,
-    platform_connector_token_path,
-    suppress_nvlink_down_unbridged_pcie,
-):
+    dcgm_addr: str,
+    dcgm_mode: str,
+    dcgm_error_mapping_config_file: str,
+    config_file: str,
+    port: int,
+    metrics_addr: str,
+    verbose: bool,
+    state_file: str,
+    dcgm_k8s_service_enabled: bool,
+    metadata_path: str,
+    processing_strategy: str,
+    platform_connector_token_path: str,
+    suppress_nvlink_down_unbridged_pcie: bool,
+) -> None:
     exit = Event()
     config = configparser.ConfigParser()
     # By default, the Python ConfigParser module reads keys case-insensitively and converts them to lowercase.

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/cli.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/cli.py
@@ -74,6 +74,14 @@ def _init_event_processor(
 )
 @click.option("--config-file", type=click.Path(), help="Path to config file", required=True)
 @click.option("--port", type=int, help="Port to use for metrics server", required=True)
+@click.option(
+    "--metrics-addr",
+    type=str,
+    default="0.0.0.0",
+    show_default=True,
+    help="Address the metrics server binds to. Use '::' for IPv6 / dual-stack clusters.",
+    required=False,
+)
 @click.option("--verbose", type=bool, default=False, help="Enable debug logging", required=False)
 @click.option("--state-file", type=click.Path(), help="gpu health monitor state file path", required=True)
 @click.option("--dcgm-k8s-service-enabled", type=bool, help="Is DCGM K8s service Enabled", required=True)
@@ -124,6 +132,7 @@ def cli(
     dcgm_error_mapping_config_file,
     config_file,
     port,
+    metrics_addr,
     verbose,
     state_file,
     dcgm_k8s_service_enabled,
@@ -261,7 +270,7 @@ def cli(
     # expose a documented fixed RPC timeout, so fleets should validate this
     # deadline in STORE_ONLY mode before enabling remediation. Set to 0 to disable.
     probe_deadline_seconds = dcgm_config.getfloat("ProbeDeadlineSeconds", fallback=poll_interval * 3)
-    prom_server, t = start_health_server(port, staleness_seconds=poll_interval * 3)
+    prom_server, t = start_health_server(port, staleness_seconds=poll_interval * 3, addr=metrics_addr)
 
     def process_exit_signal(signum, frame):
         exit.set()

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/cli.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/cli.py
@@ -103,6 +103,14 @@ def _init_event_processor(
 )
 @click.option("--config-file", type=click.Path(), help="Path to config file", required=True)
 @click.option("--port", type=int, help="Port to use for metrics server", required=True)
+@click.option(
+    "--metrics-addr",
+    type=str,
+    default="0.0.0.0",
+    show_default=True,
+    help="Address the metrics server binds to. Use '::' for IPv6 / dual-stack clusters.",
+    required=False,
+)
 @click.option("--verbose", type=bool, default=False, help="Enable debug logging", required=False)
 @click.option("--state-file", type=click.Path(), help="gpu health monitor state file path", required=True)
 @click.option("--dcgm-k8s-service-enabled", type=bool, help="Is DCGM K8s service Enabled", required=True)
@@ -153,6 +161,7 @@ def cli(
     dcgm_error_mapping_config_file,
     config_file,
     port,
+    metrics_addr,
     verbose,
     state_file,
     dcgm_k8s_service_enabled,
@@ -313,7 +322,7 @@ def cli(
     # expose a documented fixed RPC timeout, so fleets should validate this
     # deadline in STORE_ONLY mode before enabling remediation. Set to 0 to disable.
     probe_deadline_seconds = dcgm_config.getfloat("ProbeDeadlineSeconds", fallback=poll_interval * 3)
-    prom_server, t = start_health_server(port, staleness_seconds=poll_interval * 3)
+    prom_server, t = start_health_server(port, staleness_seconds=poll_interval * 3, addr=metrics_addr)
 
     def process_exit_signal(signum, frame):
         exit.set()

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/healthz.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/healthz.py
@@ -23,30 +23,33 @@ false positives from NTP clock adjustments.
 import socket
 import threading
 import time
+from dataclasses import dataclass, field
 from http.server import ThreadingHTTPServer
 
 from prometheus_client import MetricsHandler
 
 
-class _last_reconcile:
+@dataclass
+class _LastReconcile:
     """Thread-safe tracker for the last successful reconcile timestamp.
 
     Uses time.monotonic() for NTP-immune elapsed time measurement.
     Module-scoped singleton — one tracker per process.
     """
 
-    _lock = threading.Lock()
-    _timestamp: float = time.monotonic()
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    timestamp: float = field(default_factory=time.monotonic)
 
-    @classmethod
-    def mark_alive(cls) -> None:
-        with cls._lock:
-            cls._timestamp = time.monotonic()
+    def mark_alive(self) -> None:
+        with self.lock:
+            self.timestamp = time.monotonic()
 
-    @classmethod
-    def seconds_since_last(cls) -> float:
-        with cls._lock:
-            return time.monotonic() - cls._timestamp
+    def seconds_since_last(self) -> float:
+        with self.lock:
+            return time.monotonic() - self.timestamp
+
+
+_last_reconcile = _LastReconcile()
 
 
 # Module-level staleness threshold (seconds). Set by start_server().
@@ -103,13 +106,13 @@ def start_server(
     # Reset the grace period to start from server startup, not module import.
     _last_reconcile.mark_alive()
 
-    server_cls = ThreadingHTTPServer
-    if ":" in addr:
-        # ThreadingHTTPServer defaults to AF_INET, which cannot bind an IPv6 literal.
-        server_cls = type(
-            "_ThreadingHTTPServerV6", (ThreadingHTTPServer,), {"address_family": socket.AF_INET6}
-        )
-    httpd = server_cls((addr, port), _HealthMetricsHandler)
+    family, _, _, _, bind_address = socket.getaddrinfo(addr, port, type=socket.SOCK_STREAM)[0]
+    server_cls = type("_AddressAwareThreadingHTTPServer", (ThreadingHTTPServer,), {"address_family": family})
+    httpd = server_cls(bind_address, _HealthMetricsHandler, bind_and_activate=False)
+    if family == socket.AF_INET6:
+        httpd.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+    httpd.server_bind()
+    httpd.server_activate()
     t = threading.Thread(target=httpd.serve_forever, daemon=True)
     t.start()
 

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/healthz.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/healthz.py
@@ -20,6 +20,7 @@ within the staleness threshold. Uses time.monotonic() to avoid
 false positives from NTP clock adjustments.
 """
 
+import socket
 import threading
 import time
 from http.server import ThreadingHTTPServer
@@ -80,13 +81,17 @@ class _HealthMetricsHandler(MetricsHandler):
             super().do_GET()
 
 
-def start_server(port: int, staleness_seconds: float = 300.0) -> tuple[ThreadingHTTPServer, threading.Thread]:
+def start_server(
+    port: int, staleness_seconds: float = 300.0, addr: str = "0.0.0.0"
+) -> tuple[ThreadingHTTPServer, threading.Thread]:
     """Start an HTTP server serving /metrics and /healthz.
 
     Args:
         port: TCP port to listen on.
         staleness_seconds: Maximum seconds between reconcile iterations
             before /healthz returns 503.
+        addr: Address to bind. Defaults to 0.0.0.0 (IPv4). Pass "::" to bind
+            IPv6, which also accepts IPv4-mapped clients on dual-stack nodes.
 
     Returns:
         (ThreadingHTTPServer, daemon Thread) — same interface as
@@ -98,7 +103,13 @@ def start_server(port: int, staleness_seconds: float = 300.0) -> tuple[Threading
     # Reset the grace period to start from server startup, not module import.
     _last_reconcile.mark_alive()
 
-    httpd = ThreadingHTTPServer(("", port), _HealthMetricsHandler)
+    server_cls = ThreadingHTTPServer
+    if ":" in addr:
+        # ThreadingHTTPServer defaults to AF_INET, which cannot bind an IPv6 literal.
+        server_cls = type(
+            "_ThreadingHTTPServerV6", (ThreadingHTTPServer,), {"address_family": socket.AF_INET6}
+        )
+    httpd = server_cls((addr, port), _HealthMetricsHandler)
     t = threading.Thread(target=httpd.serve_forever, daemon=True)
     t.start()
 

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_cli.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_cli.py
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
+"""Tests for the gpu-health-monitor CLI, focused on the metrics server binding."""
 
-from gpu_health_monitor.cli import _parse_min_consecutive_polls
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from gpu_health_monitor.cli import _parse_min_consecutive_polls, cli
 
 
 class TestParseMinConsecutivePolls:
@@ -57,3 +62,77 @@ class TestParseMinConsecutivePolls:
 
     def test_last_value_wins_on_a_duplicated_code(self) -> None:
         assert _parse_min_consecutive_polls("DCGM_FR_NVLINK_DOWN=2,DCGM_FR_NVLINK_DOWN=5") == {"DCGM_FR_NVLINK_DOWN": 5}
+
+def _find_option(param_name):
+    for param in cli.params:
+        if param.name == param_name:
+            return param
+    return None
+
+
+def test_metrics_addr_option_defaults_to_ipv4():
+    """--metrics-addr exists and defaults to 0.0.0.0 (no behavior change by default)."""
+    option = _find_option("metrics_addr")
+    assert option is not None
+    assert option.default == "0.0.0.0"
+    assert option.required is False
+
+
+def _write_config(tmp_path):
+    config_file = tmp_path / "config.ini"
+    config_file.write_text(
+        "[logging]\n"
+        "[dcgm]\n"
+        "PollIntervalSeconds = 60\n"
+        "[cli]\n"
+        "EnabledEventProcessors = PlatformConnectorEventProcessor\n"
+        "[eventprocessors.platformconnector]\n"
+        "SocketPath = /tmp/does-not-matter.sock\n"
+    )
+    mapping_file = tmp_path / "dcgmerrors.csv"
+    mapping_file.write_text("0,DCGM_FR_UNKNOWN\n")
+    return config_file, mapping_file
+
+
+def _run_cli(tmp_path, extra_args):
+    config_file, mapping_file = _write_config(tmp_path)
+    args = [
+        "--dcgm-addr",
+        "localhost:5555",
+        "--dcgm-error-mapping-config-file",
+        str(mapping_file),
+        "--config-file",
+        str(config_file),
+        "--port",
+        "2112",
+        "--state-file",
+        str(tmp_path / "statefile"),
+        "--dcgm-k8s-service-enabled",
+        "false",
+        *extra_args,
+    ]
+    with patch("gpu_health_monitor.cli.start_health_server") as mock_start, patch(
+        "gpu_health_monitor.cli._init_event_processor"
+    ), patch("gpu_health_monitor.cli.dcgm.DCGMWatcher") as mock_watcher:
+        mock_start.return_value = (MagicMock(), MagicMock())
+        runner = CliRunner()
+        result = runner.invoke(cli, args, env={"NODE_NAME": "test-node"})
+    return result, mock_start, mock_watcher
+
+
+def test_health_server_binds_explicit_metrics_addr(tmp_path):
+    """--metrics-addr :: is passed through to the health server as addr='::'."""
+    result, mock_start, _ = _run_cli(tmp_path, ["--metrics-addr", "::"])
+    assert result.exit_code == 0, result.output
+    mock_start.assert_called_once()
+    assert mock_start.call_args.args[0] == 2112
+    assert mock_start.call_args.kwargs["addr"] == "::"
+
+
+def test_health_server_defaults_to_ipv4(tmp_path):
+    """Without --metrics-addr the server still binds 0.0.0.0 (backward compatible)."""
+    result, mock_start, _ = _run_cli(tmp_path, [])
+    assert result.exit_code == 0, result.output
+    mock_start.assert_called_once()
+    assert mock_start.call_args.args[0] == 2112
+    assert mock_start.call_args.kwargs["addr"] == "0.0.0.0"

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_cli.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_cli.py
@@ -14,10 +14,12 @@
 
 """Tests for the gpu-health-monitor CLI, focused on the metrics server binding."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from click.testing import CliRunner
+from click import Parameter
+from click.testing import CliRunner, Result
 
 from gpu_health_monitor.cli import _parse_min_consecutive_polls, cli
 
@@ -63,14 +65,15 @@ class TestParseMinConsecutivePolls:
     def test_last_value_wins_on_a_duplicated_code(self) -> None:
         assert _parse_min_consecutive_polls("DCGM_FR_NVLINK_DOWN=2,DCGM_FR_NVLINK_DOWN=5") == {"DCGM_FR_NVLINK_DOWN": 5}
 
-def _find_option(param_name):
+
+def _find_option(param_name: str) -> Parameter | None:
     for param in cli.params:
         if param.name == param_name:
             return param
     return None
 
 
-def test_metrics_addr_option_defaults_to_ipv4():
+def test_metrics_addr_option_defaults_to_ipv4() -> None:
     """--metrics-addr exists and defaults to 0.0.0.0 (no behavior change by default)."""
     option = _find_option("metrics_addr")
     assert option is not None
@@ -78,7 +81,7 @@ def test_metrics_addr_option_defaults_to_ipv4():
     assert option.required is False
 
 
-def _write_config(tmp_path):
+def _write_config(tmp_path: Path) -> tuple[Path, Path]:
     config_file = tmp_path / "config.ini"
     config_file.write_text(
         "[logging]\n"
@@ -94,7 +97,7 @@ def _write_config(tmp_path):
     return config_file, mapping_file
 
 
-def _run_cli(tmp_path, extra_args):
+def _run_cli(tmp_path: Path, extra_args: list[str]) -> tuple[Result, MagicMock, MagicMock]:
     config_file, mapping_file = _write_config(tmp_path)
     args = [
         "--dcgm-addr",
@@ -120,7 +123,7 @@ def _run_cli(tmp_path, extra_args):
     return result, mock_start, mock_watcher
 
 
-def test_health_server_binds_explicit_metrics_addr(tmp_path):
+def test_health_server_binds_explicit_metrics_addr(tmp_path: Path) -> None:
     """--metrics-addr :: is passed through to the health server as addr='::'."""
     result, mock_start, _ = _run_cli(tmp_path, ["--metrics-addr", "::"])
     assert result.exit_code == 0, result.output
@@ -129,7 +132,7 @@ def test_health_server_binds_explicit_metrics_addr(tmp_path):
     assert mock_start.call_args.kwargs["addr"] == "::"
 
 
-def test_health_server_defaults_to_ipv4(tmp_path):
+def test_health_server_defaults_to_ipv4(tmp_path: Path) -> None:
     """Without --metrics-addr the server still binds 0.0.0.0 (backward compatible)."""
     result, mock_start, _ = _run_cli(tmp_path, [])
     assert result.exit_code == 0, result.output

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_cli.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_cli.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the gpu-health-monitor CLI, focused on the metrics server binding."""
+
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from gpu_health_monitor.cli import cli
+
+
+def _find_option(param_name):
+    for param in cli.params:
+        if param.name == param_name:
+            return param
+    return None
+
+
+def test_metrics_addr_option_defaults_to_ipv4():
+    """--metrics-addr exists and defaults to 0.0.0.0 (no behavior change by default)."""
+    option = _find_option("metrics_addr")
+    assert option is not None
+    assert option.default == "0.0.0.0"
+    assert option.required is False
+
+
+def _write_config(tmp_path):
+    config_file = tmp_path / "config.ini"
+    config_file.write_text(
+        "[logging]\n"
+        "[dcgm]\n"
+        "PollIntervalSeconds = 60\n"
+        "[cli]\n"
+        "EnabledEventProcessors = PlatformConnectorEventProcessor\n"
+        "[eventprocessors.platformconnector]\n"
+        "SocketPath = /tmp/does-not-matter.sock\n"
+    )
+    mapping_file = tmp_path / "dcgmerrors.csv"
+    mapping_file.write_text("0,DCGM_FR_UNKNOWN\n")
+    return config_file, mapping_file
+
+
+def _run_cli(tmp_path, extra_args):
+    config_file, mapping_file = _write_config(tmp_path)
+    args = [
+        "--dcgm-addr",
+        "localhost:5555",
+        "--dcgm-error-mapping-config-file",
+        str(mapping_file),
+        "--config-file",
+        str(config_file),
+        "--port",
+        "2112",
+        "--state-file",
+        str(tmp_path / "statefile"),
+        "--dcgm-k8s-service-enabled",
+        "false",
+        *extra_args,
+    ]
+    with patch("gpu_health_monitor.cli.start_health_server") as mock_start, patch(
+        "gpu_health_monitor.cli._init_event_processor"
+    ), patch("gpu_health_monitor.cli.dcgm.DCGMWatcher") as mock_watcher:
+        mock_start.return_value = (MagicMock(), MagicMock())
+        runner = CliRunner()
+        result = runner.invoke(cli, args, env={"NODE_NAME": "test-node"})
+    return result, mock_start, mock_watcher
+
+
+def test_health_server_binds_explicit_metrics_addr(tmp_path):
+    """--metrics-addr :: is passed through to the health server as addr='::'."""
+    result, mock_start, _ = _run_cli(tmp_path, ["--metrics-addr", "::"])
+    assert result.exit_code == 0, result.output
+    mock_start.assert_called_once()
+    assert mock_start.call_args.args[0] == 2112
+    assert mock_start.call_args.kwargs["addr"] == "::"
+
+
+def test_health_server_defaults_to_ipv4(tmp_path):
+    """Without --metrics-addr the server still binds 0.0.0.0 (backward compatible)."""
+    result, mock_start, _ = _run_cli(tmp_path, [])
+    assert result.exit_code == 0, result.output
+    mock_start.assert_called_once()
+    assert mock_start.call_args.args[0] == 2112
+    assert mock_start.call_args.kwargs["addr"] == "0.0.0.0"


### PR DESCRIPTION
## Summary

Fixes problem #2 of #1407: in IPv6-only clusters the gpu-health-monitor pod
CrashLoopBackoffs because kubelet liveness/readiness probes over IPv6 get
`connection refused`.

Root cause: `gpu_health_monitor/cli.py` calls `start_http_server(port)` without an
`addr`, so prometheus_client binds the metrics server to `0.0.0.0` (IPv4-only). The
daemonset probes hit the pod's IPv6 address, which nothing is listening on.

Changes:
- Add a `--metrics-addr` CLI flag and pass it as `addr` to `start_http_server`. The
  flag defaults to `0.0.0.0`, so non-Helm invocations are unchanged.
- Add a `global.metricsAddress` Helm value (default `::`) and wire `--metrics-addr`
  into the dcgm 3.x and 4.x daemonset templates. `::` binds dual-stack (IPv6 plus
  IPv4-mapped on standard Linux with `net.ipv6.bindv6only=0`), so a freshly installed
  chart works in IPv6-only and IPv4-only clusters and kubelet probes succeed over
  IPv6.

@lalitadithya noted in the issue thread that the probes would still be a problem and
that it was something to work on; this addresses that specific piece.

Scope: this PR only covers the gpu-health-monitor metrics bind (problem #2), which is
the part that lives in this repo. The other two problems in the issue are upstream and
out of scope here: the DCGM client not connecting over IPv6 hostnames (#1, tracked in
NVIDIA/DCGM#301) and making the GPU-operator's DCGM exporter bind on `[::]` (#3, which
requires editing the GPU-operator Helm chart, not NVSentinel).

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [x] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

Added `gpu_health_monitor/tests/test_cli.py`: asserts `--metrics-addr ::` reaches
`start_http_server(port, addr="::")`, that the default is still `0.0.0.0`, and that the
option is registered. Full suite passes (67 tests). `helm template` on the chart renders
`--metrics-addr "::"` in both the 3.x and 4.x daemonsets; `helm lint` passes.

Note: the end-to-end probe behavior requires an IPv6-only Kubernetes cluster with NVIDIA
GPUs and DCGM, which is not available here; the dual-stack fix is asserted from
prometheus_client's bind behavior and covered by the unit test.

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review

Refs #1407


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable metrics-server binding, including IPv4, IPv6, and dual-stack support.
  * Added platform connector token authentication configuration for health-event reporting.
  * Added Kubernetes configuration for authentication token mounting and metrics address settings.

* **Tests**
  * Added coverage for explicit IPv6 and default IPv4 metrics binding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->