### PR TITLE
docs: adds Percona Operator documentation to mongodb-store documentation

### DIFF
--- a/docs/configuration/mongodb-store.md
+++ b/docs/configuration/mongodb-store.md
@@ -6,10 +6,6 @@ The MongoDB Store module provides persistent storage for health events collected
 
 Two in-cluster backends are supported: **Bitnami** (default) and **Percona Operator** (recommended for new deployments). This page covers Helm configuration for both.
 
-> Note: cert-manager must be installed in the cluster before deploying mongodb-store.
-
-> Note: Several modules (fault-quarantine, node-drainer, fault-remediation, event-exporter) depend on the datastore. Enable the datastore when using these modules.
-
 ## Backend selection
 
 | Backend | Helm flags | Configuration keys |
@@ -35,7 +31,7 @@ mongodb-store:
   usePerconaOperator: true
 ```
 
-When Percona is enabled, `mongodb.*` values are ignored — configure the replica set under `psmdb-db` (see defaults in `distros/kubernetes/nvsentinel/charts/mongodb-store/values.yaml`). Example overlay: `distros/kubernetes/nvsentinel/values-tilt-mongodb-percona.yaml`.
+When Percona is enabled, the replica set is configured under `psmdb-db` instead of `mongodb.*` (see defaults in `distros/kubernetes/nvsentinel/charts/mongodb-store/values.yaml`).
 
 - **Service endpoint:** `mongodb-rs0.<namespace>.svc.cluster.local:27017`
 - **Metrics:** `percona/mongodb_exporter` sidecar on port `9216` (configured in default `psmdb-db` values)
@@ -47,8 +43,6 @@ Verify after install:
 kubectl get perconaservermongodb -n <namespace>
 kubectl get pods -n <namespace> -l app.kubernetes.io/name=percona-server-mongodb
 ```
-
-Connect via the [Datastore Connection runbook](../runbooks/datastore-connection.md).
 
 ## Configuration Reference
 
@@ -80,10 +74,6 @@ Node selector for scheduling MongoDB initialization jobs.
 
 ##### tolerations
 Tolerations for MongoDB initialization jobs to run on tainted nodes.
-
-### Bitnami backend
-
-The sections below apply when `usePerconaOperator: false` (default). For Percona node placement, use `psmdb-db.replsets.rs0.nodeSelector` and `tolerations`.
 
 ### Node Placement
 

--- a/docs/configuration/mongodb-store.md
+++ b/docs/configuration/mongodb-store.md
@@ -2,7 +2,53 @@
 
 ## Overview
 
-The MongoDB Store module provides persistent storage for health events collected by NVSentinel monitors. It deploys a MongoDB replica set with TLS encryption and authentication. This document covers all Helm configuration options for system administrators.
+The MongoDB Store module provides persistent storage for health events collected by NVSentinel monitors. It deploys a MongoDB replica set with TLS encryption and authentication.
+
+Two in-cluster backends are supported: **Bitnami** (default) and **Percona Operator** (recommended for new deployments). This page covers Helm configuration for both.
+
+> Note: cert-manager must be installed in the cluster before deploying mongodb-store.
+
+> Note: Several modules (fault-quarantine, node-drainer, fault-remediation, event-exporter) depend on the datastore. Enable the datastore when using these modules.
+
+## Backend selection
+
+| Backend | Helm flags | Configuration keys |
+| ------- | ---------- | ------------------ |
+| Bitnami (default) | `useBitnami: true`, `usePerconaOperator: false` | `mongodb-store.mongodb.*` |
+| Percona Operator | `useBitnami: false`, `usePerconaOperator: true` | `mongodb-store.psmdb-db.*`, `psmdb-operator.*` |
+
+Both flags must be set explicitly when switching backends. See [ADR-013: MongoDB Migration from Bitnami](../designs/013-mongodb-bitnami-migration.md) for rationale, Bitnami → Percona migration steps, and licensing.
+
+To use a cloud-managed MongoDB (DocumentDB, Atlas, etc.) instead of in-cluster storage, see [External Datastore](../external-datastore.md).
+
+## Percona Operator
+
+Enable Percona on install or upgrade:
+
+```yaml
+global:
+  mongodbStore:
+    enabled: true
+
+mongodb-store:
+  useBitnami: false
+  usePerconaOperator: true
+```
+
+When Percona is enabled, `mongodb.*` values are ignored — configure the replica set under `psmdb-db` (see defaults in `distros/kubernetes/nvsentinel/charts/mongodb-store/values.yaml`). Example overlay: `distros/kubernetes/nvsentinel/values-tilt-mongodb-percona.yaml`.
+
+- **Service endpoint:** `mongodb-rs0.<namespace>.svc.cluster.local:27017`
+- **Metrics:** `percona/mongodb_exporter` sidecar on port `9216` (configured in default `psmdb-db` values)
+- **Operator reference:** [Percona Operator for MongoDB](https://docs.percona.com/percona-operator-for-mongodb/)
+
+Verify after install:
+
+```bash
+kubectl get perconaservermongodb -n <namespace>
+kubectl get pods -n <namespace> -l app.kubernetes.io/name=percona-server-mongodb
+```
+
+Connect via the [Datastore Connection runbook](../runbooks/datastore-connection.md).
 
 ## Configuration Reference
 
@@ -16,14 +62,9 @@ global:
     enabled: true
 ```
 
-> Note: Several modules (fault-quarantine, node-drainer, fault-remediation, event-exporter) depend on the datastore. Enable the datastore when using these modules.
-
-
-> Note: cert-manager must be installed in the cluster before deploying mongodb-store.
-
 ### Initialization Job Placement
 
-Configures node placement for initialization jobs.
+Configures node placement for initialization jobs (applies to both backends).
 
 ```yaml
 mongodb-store:
@@ -39,6 +80,10 @@ Node selector for scheduling MongoDB initialization jobs.
 
 ##### tolerations
 Tolerations for MongoDB initialization jobs to run on tainted nodes.
+
+### Bitnami backend
+
+The sections below apply when `usePerconaOperator: false` (default). For Percona node placement, use `psmdb-db.replsets.rs0.nodeSelector` and `tolerations`.
 
 ### Node Placement
 

--- a/docs/configuration/mongodb-store.md
+++ b/docs/configuration/mongodb-store.md
@@ -4,7 +4,7 @@
 
 The MongoDB Store module provides persistent storage for health events collected by NVSentinel monitors. It deploys a MongoDB replica set with TLS encryption and authentication.
 
-Two in-cluster backends are supported: **Bitnami** (default) and **Percona Operator** (recommended for new deployments). This page covers Helm configuration for both.
+Two in-cluster backends are supported: **Bitnami** (default) and **Percona Operator**. This page covers Helm configuration for both.
 
 ## Backend selection
 

--- a/docs/configuration/mongodb-store.md
+++ b/docs/configuration/mongodb-store.md
@@ -11,7 +11,7 @@ Two in-cluster backends are supported: **Bitnami** (default) and **Percona Opera
 | Backend | Helm flags | Configuration keys |
 | ------- | ---------- | ------------------ |
 | Bitnami (default) | `useBitnami: true`, `usePerconaOperator: false` | `mongodb-store.mongodb.*` |
-| Percona Operator | `useBitnami: false`, `usePerconaOperator: true` | `mongodb-store.psmdb-db.*`, `psmdb-operator.*` |
+| Percona Operator | `useBitnami: false`, `usePerconaOperator: true` | `mongodb-store.psmdb-db.*`, `mongodb-store.psmdb-operator.*` |
 
 Both flags must be set explicitly when switching backends. See [ADR-013: MongoDB Migration from Bitnami](../designs/013-mongodb-bitnami-migration.md) for rationale, Bitnami → Percona migration steps, and licensing.
 


### PR DESCRIPTION
## Summary

Adds Percona Operator documentation to mongodb-store


## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked MongoDB Store documentation with clearer module purpose and streamlined guidance for supported in-cluster backends.
  * Added a “Backend selection” section with Bitnami vs Percona Helm-flag guidance and notes on switching and external datastores.
  * Introduced a dedicated Percona Operator setup guide with enablement, operational references, and verification steps.
  * Updated module enablement and initialization job placement coverage to apply consistently across both backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->