### PR TITLE
feat(fault-quarantine): manage rule labels

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/configmap.yaml
@@ -32,6 +32,7 @@ data:
       enabled = {{ if hasKey . "enabled" }}{{ .enabled }}{{ else }}true{{ end }}
       version = {{ .version | quote }}
       name = {{ .name | quote }}
+      priority = {{ .priority | default 0 }}
       {{- if .match.all }}
       {{- range .match.all }}
     
@@ -58,6 +59,12 @@ data:
         key = {{ .taint.key | quote }}
         value = {{ .taint.value | quote }}
         effect = {{ .taint.effect | quote }}
+      {{- end }}
+
+      {{- if .label }}
+      [rule-sets.label]
+        key = {{ .label.key | quote }}
+        value = {{ .label.value | quote }}
       {{- end }}
     
       [rule-sets.cordon]

--- a/distros/kubernetes/nvsentinel/charts/fault-quarantine/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-quarantine/values.yaml
@@ -68,7 +68,7 @@ circuitBreaker:
   duration: "5m"
 
 # Rule sets for node quarantine actions
-# Each ruleset defines conditions (match) and actions (taint, cordon) to apply when conditions are met
+# Each ruleset defines conditions (match) and actions (taint, label, cordon) to apply when conditions are met
 # Rules are evaluated using CEL (Common Expression Language) expressions
 # Multiple rulesets can be defined and are evaluated in order
 ruleSets:
@@ -112,6 +112,12 @@ ruleSets:
     #   # PreferNoSchedule: Soft version of NoSchedule (scheduler tries to avoid)
     #   # NoExecute: Existing pods without toleration are evicted
     #   effect: "NoSchedule"
+    # Optional: Label configuration for this ruleset
+    # Labels are applied for the lifetime of the quarantine session and removed
+    # only after all tracked health events on the node recover.
+    # label:
+    #   key: "nvidia.com/gpu-fault"
+    #   value: "active"
 
   - enabled: true
     version: "1"

--- a/docs/configuration/fault-quarantine.md
+++ b/docs/configuration/fault-quarantine.md
@@ -157,6 +157,10 @@ fault-quarantine:
         key: "nvidia.com/gpu-error"
         value: "fatal"
         effect: "NoSchedule"
+
+      label:
+        key: "nvidia.com/gpu-fault"
+        value: "active"
 ```
 
 ### Parameters
@@ -171,7 +175,7 @@ Rule set format version for future compatibility.
 Unique identifier used in logs, metrics, and as part of the cordon-reason label.
 
 #### priority
-Optional integer for resolving conflicts when multiple rule sets apply the same taint key-value pair. Higher values take precedence.
+Optional integer for resolving conflicts when multiple rule sets apply the same taint key-value pair or label key. Higher values take precedence. Label priority is preserved across all matching health events in the same quarantine session; a later lower-priority event cannot downgrade the current label. For labels with equal priority, the later rule set in configuration order wins.
 
 #### match
 Defines conditions that must be satisfied for the rule set to trigger. Supports `all` (AND) and `any` (OR) logic.
@@ -187,6 +191,9 @@ Specifies whether to mark the node as unschedulable when the rule matches.
 
 #### taint
 Optional Kubernetes taint to apply. Taints can prevent pod scheduling or evict existing pods based on the effect.
+
+#### label
+Optional Kubernetes label to apply for the lifetime of the quarantine session. If the key already exists, fault-quarantine overwrites its value. The label, priority, and configuration order are recorded in the `quarantineHealthEventAppliedLabels` node annotation so later events use the same conflict policy. The label is removed after every health event tracked in `quarantineHealthEvent` has recovered. Manual uncordon, manual untaint, and stale-state cleanup remove the tracking annotation but preserve the label itself, mirroring the existing applied-taint behavior. In dry-run mode, the intended label is recorded in annotations for observability, but Kubernetes Node labels are not added, overwritten, or removed.
 
 ### Example Rule Sets
 

--- a/docs/fault-quarantine.md
+++ b/docs/fault-quarantine.md
@@ -90,6 +90,10 @@ fault-quarantine:
       #   key: "nvidia.com/gpu-error"
       #   value: "fatal"
       #   effect: "NoSchedule"
+      # Optional label configuration
+      # label:
+      #   key: "nvidia.com/gpu-fault"
+      #   value: "active"
 ```
 
 ### Defining CEL Rules
@@ -103,6 +107,7 @@ Rules are defined using rulesets that evaluate CEL expressions. Each ruleset has
 **Actions**: What happens when conditions match
 - `cordon.shouldCordon: true` - Cordon (mark unschedulable) the node
 - `taint` (optional) - Apply Kubernetes taints to the node
+- `label` (optional) - Apply a Kubernetes label until all tracked faults recover
 
 **Configuration options:**
 - **Dry Run**: Test rules without cordoning nodes

--- a/fault-quarantine/pkg/common/common.go
+++ b/fault-quarantine/pkg/common/common.go
@@ -26,6 +26,7 @@ const (
 	// Annotation keys for storing event on node which causes node to be cordoned or tainted
 	QuarantineHealthEventAnnotationKey                    = "quarantineHealthEvent"
 	QuarantineHealthEventAppliedTaintsAnnotationKey       = "quarantineHealthEventAppliedTaints"
+	QuarantineHealthEventAppliedLabelsAnnotationKey       = "quarantineHealthEventAppliedLabels"
 	QuarantineHealthEventIsCordonedAnnotationKey          = "quarantineHealthEventIsCordoned"
 	QuarantineHealthEventIsCordonedAnnotationValueTrue    = "True"
 	QuarantineHealthEventCordonPreExistingAnnotationKey   = "quarantineHealthEventCordonPreExisting"

--- a/fault-quarantine/pkg/config/config.go
+++ b/fault-quarantine/pkg/config/config.go
@@ -26,6 +26,22 @@ type Taint struct {
 	PreExisting bool   `toml:"-"      json:"preExisting"`
 }
 
+type Label struct {
+	Key   string `toml:"key"`
+	Value string `toml:"value"`
+}
+
+// AppliedLabel is the persisted quarantine-session label winner. Priority and
+// Order preserve the same conflict policy used while evaluating one event so
+// later events cannot downgrade an active session label. Missing fields in
+// legacy annotations decode as zero and remain backward compatible.
+type AppliedLabel struct {
+	Key      string `json:"key"`
+	Value    string `json:"value"`
+	Priority int    `json:"priority,omitempty"`
+	Order    int    `json:"order,omitempty"`
+}
+
 type Cordon struct {
 	ShouldCordon bool `toml:"shouldCordon"`
 }
@@ -47,6 +63,7 @@ type RuleSet struct {
 	Priority int    `toml:"priority"`
 	Match    Match  `toml:"match"`
 	Taint    Taint  `toml:"taint"`
+	Label    Label  `toml:"label"`
 	Cordon   Cordon `toml:"cordon"`
 }
 

--- a/fault-quarantine/pkg/informer/k8s_client.go
+++ b/fault-quarantine/pkg/informer/k8s_client.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sort"
 	"sync"
 	"time"
 
@@ -313,7 +314,12 @@ func (c *FaultQuarantineClient) QuarantineNodeAndSetAnnotations(
 		}
 
 		if len(labels) > 0 {
-			c.applyLabels(ctx, node, labels, nodename)
+			labelsToApply, err := labelsWithSessionWinners(node, labels)
+			if err != nil {
+				return fmt.Errorf("failed to get merged applied labels on node %s: %w", nodename, err)
+			}
+
+			c.applyLabels(ctx, node, labelsToApply, nodename)
 		}
 
 		return nil
@@ -322,6 +328,29 @@ func (c *FaultQuarantineClient) QuarantineNodeAndSetAnnotations(
 	err := c.UpdateNode(ctx, nodename, updateFn)
 
 	return alreadyQuarantined, err
+}
+
+func labelsWithSessionWinners(node *v1.Node, labels map[string]string) (map[string]string, error) {
+	labelsToApply := make(map[string]string, len(labels))
+	for key, value := range labels {
+		labelsToApply[key] = value
+	}
+
+	appliedLabelsJSON := node.Annotations[common.QuarantineHealthEventAppliedLabelsAnnotationKey]
+	if annotationutil.IsEmptyValue(appliedLabelsJSON) {
+		return labelsToApply, nil
+	}
+
+	appliedLabels, err := parseAppliedLabelsAnnotation(appliedLabelsJSON)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, label := range appliedLabels {
+		labelsToApply[label.Key] = label.Value
+	}
+
+	return labelsToApply, nil
 }
 
 func (c *FaultQuarantineClient) applyTaints(
@@ -405,6 +434,15 @@ func (c *FaultQuarantineClient) applyAnnotations(
 			annotationValue = mergedValue
 		}
 
+		if annotationKey == common.QuarantineHealthEventAppliedLabelsAnnotationKey {
+			mergedValue, err := mergeAppliedLabelsAnnotation(node.Annotations[annotationKey], annotationValue)
+			if err != nil {
+				return fmt.Errorf("failed to merge annotation %q on node %s: %w", annotationKey, nodename, err)
+			}
+
+			annotationValue = mergedValue
+		}
+
 		node.Annotations[annotationKey] = annotationValue
 	}
 
@@ -436,6 +474,16 @@ func mergeAppliedTaintsAnnotation(existingValue, incomingValue string) (string, 
 		"applied taints",
 		parseAppliedTaintsAnnotation,
 		mergeAppliedTaints,
+	)
+}
+
+func mergeAppliedLabelsAnnotation(existingValue, incomingValue string) (string, error) {
+	return mergeAnnotation(
+		existingValue,
+		incomingValue,
+		"applied labels",
+		parseAppliedLabelsAnnotation,
+		mergeAppliedLabels,
 	)
 }
 
@@ -513,6 +561,46 @@ func mergeAppliedTaints(existingTaints, incomingTaints []config.Taint) []config.
 	return mergedTaints
 }
 
+func parseAppliedLabelsAnnotation(value string) ([]config.AppliedLabel, error) {
+	var labels []config.AppliedLabel
+	if err := json.Unmarshal([]byte(value), &labels); err != nil {
+		return nil, err
+	}
+
+	return labels, nil
+}
+
+func mergeAppliedLabels(existingLabels, incomingLabels []config.AppliedLabel) []config.AppliedLabel {
+	mergedByKey := make(map[string]config.AppliedLabel, len(existingLabels)+len(incomingLabels))
+	for _, label := range existingLabels {
+		mergedByKey[label.Key] = label
+	}
+
+	for _, incoming := range incomingLabels {
+		existing, ok := mergedByKey[incoming.Key]
+		if ok && (existing.Priority > incoming.Priority ||
+			(existing.Priority == incoming.Priority && existing.Order > incoming.Order)) {
+			continue
+		}
+
+		mergedByKey[incoming.Key] = incoming
+	}
+
+	keys := make([]string, 0, len(mergedByKey))
+	for key := range mergedByKey {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	mergedLabels := make([]config.AppliedLabel, 0, len(keys))
+	for _, key := range keys {
+		mergedLabels = append(mergedLabels, mergedByKey[key])
+	}
+
+	return mergedLabels
+}
+
 func parseHealthEventsAnnotation(value string) (*healthEventsAnnotation.HealthEventsAnnotationMap, error) {
 	healthEventsMap := healthEventsAnnotation.NewHealthEventsAnnotationMap()
 	if err := json.Unmarshal([]byte(value), healthEventsMap); err == nil {
@@ -532,6 +620,11 @@ func parseHealthEventsAnnotation(value string) (*healthEventsAnnotation.HealthEv
 func (c *FaultQuarantineClient) applyLabels(
 	ctx context.Context, node *v1.Node, labels map[string]string, nodename string,
 ) {
+	if c.DryRunMode {
+		slog.InfoContext(ctx, "DryRun mode enabled, skipping label application", "node", nodename, "labels", labels)
+		return
+	}
+
 	if node.Labels == nil {
 		node.Labels = make(map[string]string)
 	}
@@ -570,17 +663,30 @@ func (c *FaultQuarantineClient) UnQuarantineNodeAndRemoveAnnotations(
 			}
 		}
 
-		if len(labelsToRemove) > 0 {
-			for _, labelKey := range labelsToRemove {
-				slog.InfoContext(ctx, "Removing label key from node", "key", labelKey, "node", nodename)
-				delete(node.Labels, labelKey)
-			}
-		}
+		c.removeLabels(ctx, node, labelsToRemove, nodename)
 
 		return nil
 	}
 
 	return c.UpdateNode(ctx, nodename, updateFn)
+}
+
+func (c *FaultQuarantineClient) removeLabels(
+	ctx context.Context, node *v1.Node, labelKeys []string, nodename string,
+) {
+	if len(labelKeys) == 0 {
+		return
+	}
+
+	if c.DryRunMode {
+		slog.InfoContext(ctx, "DryRun mode enabled, skipping label removal", "node", nodename, "labels", labelKeys)
+		return
+	}
+
+	for _, labelKey := range labelKeys {
+		slog.InfoContext(ctx, "Removing label key from node", "key", labelKey, "node", nodename)
+		delete(node.Labels, labelKey)
+	}
 }
 
 func (c *FaultQuarantineClient) removeTaints(
@@ -662,11 +768,7 @@ func (c *FaultQuarantineClient) HandleManualUncordonCleanup(
 			c.updateNodeAnnotationsForManualUncordon(node, annotationsToRemove, annotationsToAdd)
 		}
 
-		if len(labelsToRemove) > 0 {
-			for _, key := range labelsToRemove {
-				delete(node.Labels, key)
-			}
-		}
+		c.removeLabels(ctx, node, labelsToRemove, nodename)
 
 		return nil
 	}
@@ -688,11 +790,7 @@ func (c *FaultQuarantineClient) HandleManualUntaintCleanup(
 			c.updateNodeAnnotationsForManualUncordon(node, annotationsToRemove, annotationsToAdd)
 		}
 
-		if len(labelsToRemove) > 0 {
-			for _, key := range labelsToRemove {
-				delete(node.Labels, key)
-			}
-		}
+		c.removeLabels(ctx, node, labelsToRemove, nodename)
 
 		return nil
 	}

--- a/fault-quarantine/pkg/informer/k8s_client_test.go
+++ b/fault-quarantine/pkg/informer/k8s_client_test.go
@@ -16,6 +16,7 @@ package informer
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"os"
 	"testing"
@@ -30,6 +31,8 @@ import (
 	"github.com/nvidia/nvsentinel/fault-quarantine/pkg/common"
 	"github.com/nvidia/nvsentinel/fault-quarantine/pkg/config"
 	"github.com/nvidia/nvsentinel/store-client/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -209,6 +212,61 @@ func TestQuarantineNodeAndSetAnnotations(t *testing.T) {
 	if val, ok := updatedNode.Annotations["test-annotation"]; !ok || val != "test-value" {
 		t.Errorf("Annotation not set correctly")
 	}
+}
+
+func TestQuarantineNodeAndSetAnnotationsMergesAppliedLabelWinners(t *testing.T) {
+	ctx := context.Background()
+	nodeName := testutils.GenerateTestNodeName("test-applied-label-winners")
+
+	createTestNode(ctx, t, nodeName, nil, nil, nil, false)
+	defer func() {
+		_ = testClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
+	}()
+
+	k8sClient := setupTestClient(t)
+
+	first, err := json.Marshal([]config.AppliedLabel{{
+		Key: "gpu-fault", Value: "critical", Priority: 10, Order: 0,
+	}})
+	require.NoError(t, err)
+	_, err = k8sClient.QuarantineNodeAndSetAnnotations(
+		ctx,
+		nodeName,
+		nil,
+		false,
+		map[string]string{common.QuarantineHealthEventAppliedLabelsAnnotationKey: string(first)},
+		map[string]string{"gpu-fault": "critical"},
+	)
+	require.NoError(t, err)
+
+	second, err := json.Marshal([]config.AppliedLabel{
+		{Key: "gpu-fault", Value: "degraded", Priority: 5, Order: 1},
+		{Key: "network-fault", Value: "active", Priority: 5, Order: 1},
+	})
+	require.NoError(t, err)
+	_, err = k8sClient.QuarantineNodeAndSetAnnotations(
+		ctx,
+		nodeName,
+		nil,
+		false,
+		map[string]string{common.QuarantineHealthEventAppliedLabelsAnnotationKey: string(second)},
+		map[string]string{"gpu-fault": "degraded", "network-fault": "active"},
+	)
+	require.NoError(t, err)
+
+	node, err := testClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "critical", node.Labels["gpu-fault"])
+	assert.Equal(t, "active", node.Labels["network-fault"])
+
+	var applied []config.AppliedLabel
+	require.NoError(t, json.Unmarshal(
+		[]byte(node.Annotations[common.QuarantineHealthEventAppliedLabelsAnnotationKey]), &applied,
+	))
+	assert.ElementsMatch(t, []config.AppliedLabel{
+		{Key: "gpu-fault", Value: "critical", Priority: 10, Order: 0},
+		{Key: "network-fault", Value: "active", Priority: 5, Order: 1},
+	}, applied)
 }
 
 func TestUnQuarantineNodeAndRemoveAnnotations(t *testing.T) {

--- a/fault-quarantine/pkg/informer/label_actions_test.go
+++ b/fault-quarantine/pkg/informer/label_actions_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package informer
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/nvidia/nvsentinel/fault-quarantine/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeAppliedLabelsAnnotation(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing []config.AppliedLabel
+		incoming []config.AppliedLabel
+		expected []config.AppliedLabel
+	}{
+		{
+			name:     "unions different keys",
+			existing: []config.AppliedLabel{{Key: "fault-a", Value: "active", Priority: 10, Order: 0}},
+			incoming: []config.AppliedLabel{{Key: "fault-b", Value: "active", Priority: 5, Order: 1}},
+			expected: []config.AppliedLabel{
+				{Key: "fault-a", Value: "active", Priority: 10, Order: 0},
+				{Key: "fault-b", Value: "active", Priority: 5, Order: 1},
+			},
+		},
+		{
+			name:     "keeps higher existing priority for the same key",
+			existing: []config.AppliedLabel{{Key: "gpu-fault", Value: "critical", Priority: 10, Order: 0}},
+			incoming: []config.AppliedLabel{{Key: "gpu-fault", Value: "degraded", Priority: 5, Order: 1}},
+			expected: []config.AppliedLabel{{Key: "gpu-fault", Value: "critical", Priority: 10, Order: 0}},
+		},
+		{
+			name:     "accepts higher incoming priority for the same key",
+			existing: []config.AppliedLabel{{Key: "gpu-fault", Value: "degraded", Priority: 5, Order: 1}},
+			incoming: []config.AppliedLabel{{Key: "gpu-fault", Value: "critical", Priority: 10, Order: 0}},
+			expected: []config.AppliedLabel{{Key: "gpu-fault", Value: "critical", Priority: 10, Order: 0}},
+		},
+		{
+			name:     "uses later configuration order at equal priority",
+			existing: []config.AppliedLabel{{Key: "gpu-fault", Value: "first", Priority: 10, Order: 0}},
+			incoming: []config.AppliedLabel{{Key: "gpu-fault", Value: "later", Priority: 10, Order: 2}},
+			expected: []config.AppliedLabel{{Key: "gpu-fault", Value: "later", Priority: 10, Order: 2}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			existingJSON, err := json.Marshal(tt.existing)
+			require.NoError(t, err)
+			incomingJSON, err := json.Marshal(tt.incoming)
+			require.NoError(t, err)
+
+			mergedJSON, err := mergeAppliedLabelsAnnotation(string(existingJSON), string(incomingJSON))
+			require.NoError(t, err)
+
+			var merged []config.AppliedLabel
+			require.NoError(t, json.Unmarshal([]byte(mergedJSON), &merged))
+			assert.ElementsMatch(t, tt.expected, merged)
+		})
+	}
+}
+
+func TestMergeAppliedLabelsAnnotationAcceptsLegacyEntries(t *testing.T) {
+	existing := `[{"key":"gpu-fault","value":"legacy"}]`
+	incoming := `[{"key":"gpu-fault","value":"prioritized","priority":1,"order":0}]`
+
+	mergedJSON, err := mergeAppliedLabelsAnnotation(existing, incoming)
+	require.NoError(t, err)
+
+	var merged []config.AppliedLabel
+	require.NoError(t, json.Unmarshal([]byte(mergedJSON), &merged))
+	require.Len(t, merged, 1)
+	assert.Equal(t, config.AppliedLabel{
+		Key: "gpu-fault", Value: "prioritized", Priority: 1, Order: 0,
+	}, merged[0])
+}
+
+func TestDryRunDoesNotMutateLabels(t *testing.T) {
+	ctx := context.Background()
+	client := &FaultQuarantineClient{DryRunMode: true}
+	node := &v1.Node{}
+	node.Labels = map[string]string{
+		"existing":  "keep",
+		"gpu-fault": "original",
+	}
+
+	client.applyLabels(ctx, node, map[string]string{
+		"gpu-fault": "critical",
+		"new-label": "new-value",
+	}, "node-1")
+	client.removeLabels(ctx, node, []string{"existing", "gpu-fault"}, "node-1")
+
+	assert.Equal(t, map[string]string{
+		"existing":  "keep",
+		"gpu-fault": "original",
+	}, node.Labels)
+}

--- a/fault-quarantine/pkg/metrics/metrics.go
+++ b/fault-quarantine/pkg/metrics/metrics.go
@@ -100,6 +100,20 @@ var (
 		},
 		[]string{"taint_key", "taint_effect"},
 	)
+	LabelsApplied = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "fault_quarantine_labels_applied_total",
+			Help: "Total number of quarantine labels applied to nodes.",
+		},
+		[]string{"label_key"},
+	)
+	LabelsRemoved = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "fault_quarantine_labels_removed_total",
+			Help: "Total number of quarantine labels removed from nodes.",
+		},
+		[]string{"label_key"},
+	)
 	CordonsApplied = promauto.NewCounter(
 		prometheus.CounterOpts{
 			Name: "fault_quarantine_cordons_applied_total",

--- a/fault-quarantine/pkg/reconciler/label_selection_test.go
+++ b/fault-quarantine/pkg/reconciler/label_selection_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import (
+	"testing"
+
+	"github.com/nvidia/nvsentinel/fault-quarantine/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSelectRuleLabelUsesPriorityThenConfigurationOrder(t *testing.T) {
+	selected := map[string]selectedLabel{}
+
+	selectRuleLabel(selected, config.Label{Key: "nvidia.com/gpu-fault", Value: "first"}, 10, 0)
+	selectRuleLabel(selected, config.Label{Key: "nvidia.com/gpu-fault", Value: "lower"}, 5, 2)
+	assert.Equal(t, "first", selected["nvidia.com/gpu-fault"].Value)
+
+	selectRuleLabel(selected, config.Label{Key: "nvidia.com/gpu-fault", Value: "higher"}, 20, 1)
+	assert.Equal(t, "higher", selected["nvidia.com/gpu-fault"].Value)
+
+	selectRuleLabel(selected, config.Label{Key: "nvidia.com/gpu-fault", Value: "later"}, 20, 3)
+	assert.Equal(t, "later", selected["nvidia.com/gpu-fault"].Value)
+}

--- a/fault-quarantine/pkg/reconciler/reconciler.go
+++ b/fault-quarantine/pkg/reconciler/reconciler.go
@@ -64,14 +64,22 @@ type ReconcilerConfig struct {
 
 type rulesetsConfig struct {
 	TaintConfigMap     map[string]*config.Taint
+	LabelConfigMap     map[string]*config.Label
 	CordonConfigMap    map[string]bool
 	RuleSetPriorityMap map[string]int
+	RuleSetOrderMap    map[string]int
 }
 
 // keyValTaint represents a taint key-value pair used for deduplication and priority tracking
 type keyValTaint struct {
 	Key   string
 	Value string
+}
+
+type selectedLabel struct {
+	Value    string
+	Priority int
+	Order    int
 }
 
 type Reconciler struct {
@@ -82,6 +90,7 @@ type Reconciler struct {
 	eventWatcher          eventwatcher.EventWatcherInterface
 	taintInitKeys         []keyValTaint // Pre-computed taint keys for map initialization
 	taintUpdateMu         sync.Mutex    // Protects taint priority updates
+	labelUpdateMu         sync.Mutex    // Protects label priority updates
 
 	// Label keys
 	cordonedByLabelKey        string
@@ -293,12 +302,19 @@ func (r *Reconciler) setupLabelKeys() {
 // buildRulesetsConfig builds the rulesets configuration maps from TOML config
 func (r *Reconciler) buildRulesetsConfig() rulesetsConfig {
 	taintConfigMap := make(map[string]*config.Taint)
+	labelConfigMap := make(map[string]*config.Label)
 	cordonConfigMap := make(map[string]bool)
 	ruleSetPriorityMap := make(map[string]int)
+	ruleSetOrderMap := make(map[string]int)
 
-	for _, ruleSet := range r.config.TomlConfig.RuleSets {
+	for order, ruleSet := range r.config.TomlConfig.RuleSets {
+		ruleSetOrderMap[ruleSet.Name] = order
 		if ruleSet.Taint.Key != "" {
 			taintConfigMap[ruleSet.Name] = &ruleSet.Taint
+		}
+
+		if ruleSet.Label.Key != "" {
+			labelConfigMap[ruleSet.Name] = &ruleSet.Label
 		}
 
 		if ruleSet.Cordon.ShouldCordon {
@@ -312,8 +328,10 @@ func (r *Reconciler) buildRulesetsConfig() rulesetsConfig {
 
 	return rulesetsConfig{
 		TaintConfigMap:     taintConfigMap,
+		LabelConfigMap:     labelConfigMap,
 		CordonConfigMap:    cordonConfigMap,
 		RuleSetPriorityMap: ruleSetPriorityMap,
+		RuleSetOrderMap:    ruleSetOrderMap,
 	}
 }
 
@@ -540,7 +558,7 @@ func (r *Reconciler) handleEvent(
 			"node", event.HealthEvent.NodeName,
 			"checkName", event.HealthEvent.CheckName)
 
-		return r.handleAlreadyQuarantinedNode(ctx, event.HealthEvent, ruleSetEvals)
+		return r.handleAlreadyQuarantinedNode(ctx, event.HealthEvent, ruleSetEvals, rulesetsConfig)
 	}
 
 	// For healthy events, if there's no existing quarantine annotation,
@@ -564,16 +582,21 @@ func (r *Reconciler) handleEvent(
 		taintEffectPriorityMap[keyVal] = -1
 	}
 
-	var labelsMap sync.Map
+	var (
+		labelsMap        sync.Map
+		appliedLabelsMap sync.Map
+		isCordoned       atomic.Bool
+	)
 
-	var isCordoned atomic.Bool
+	selectedLabels := make(map[string]selectedLabel)
 
 	r.evaluateRulesets(
 		ctx, event, ruleSetEvals, rulesetsConfig,
-		taintAppliedMap, &labelsMap, &isCordoned, taintEffectPriorityMap,
+		taintAppliedMap, &labelsMap, &appliedLabelsMap, selectedLabels, &isCordoned, taintEffectPriorityMap,
 	)
 
 	taintsToBeApplied := r.collectTaintsToApply(taintAppliedMap)
+	labelsToBeApplied := collectLabelsToApply(&appliedLabelsMap)
 
 	node, err := r.k8sClient.NodeInformer.GetNode(event.HealthEvent.NodeName)
 	if err != nil {
@@ -588,9 +611,9 @@ func (r *Reconciler) handleEvent(
 		return nil
 	}
 
-	annotationsMap := r.prepareAnnotations(ctx, node, taintsToBeApplied, &labelsMap, &isCordoned)
+	annotationsMap := r.prepareAnnotations(ctx, node, taintsToBeApplied, labelsToBeApplied, &labelsMap, &isCordoned)
 
-	isNodeQuarantined := len(taintsToBeApplied) > 0 || isCordoned.Load()
+	isNodeQuarantined := len(taintsToBeApplied) > 0 || len(labelsToBeApplied) > 0 || isCordoned.Load()
 
 	// In dry-run mode, always apply annotations for observability even if no actions would be taken
 	if !isNodeQuarantined && !r.config.DryRun {
@@ -603,7 +626,7 @@ func (r *Reconciler) handleEvent(
 	}
 
 	status := r.applyQuarantine(
-		ctx, event, annotations, taintsToBeApplied,
+		ctx, event, annotations, taintsToBeApplied, labelsToBeApplied,
 		annotationsMap, &labelsMap, &isCordoned,
 	)
 
@@ -661,6 +684,7 @@ func (r *Reconciler) handleAlreadyQuarantinedNode(
 	ctx context.Context,
 	event *protos.HealthEvent,
 	ruleSetEvals []evaluator.RuleSetEvaluatorIface,
+	rulesetsConfig rulesetsConfig,
 ) *model.Status {
 	ctx, span := tracing.StartSpan(ctx, "fault_quarantine.handle_already_quarantined_node")
 	defer span.End()
@@ -670,7 +694,7 @@ func (r *Reconciler) handleAlreadyQuarantinedNode(
 	}
 
 	// Event will modify FQ annotations, proceed with quarantine handling
-	stayQuarantined := r.handleQuarantinedNode(ctx, event, ruleSetEvals)
+	stayQuarantined := r.handleQuarantinedNode(ctx, event, ruleSetEvals, rulesetsConfig)
 
 	return r.resolveAlreadyQuarantinedStatus(ctx, event, stayQuarantined)
 }
@@ -765,6 +789,8 @@ func (r *Reconciler) evaluateRulesets(
 	rulesetsConfig rulesetsConfig,
 	taintAppliedMap map[keyValTaint]string,
 	labelsMap *sync.Map,
+	appliedLabelsMap *sync.Map,
+	selectedLabels map[string]selectedLabel,
 	isCordoned *atomic.Bool,
 	taintEffectPriorityMap map[keyValTaint]int,
 ) {
@@ -798,7 +824,9 @@ func (r *Reconciler) evaluateRulesets(
 			switch {
 			case ruleEvaluatedResult == common.RuleEvaluationSuccess:
 				r.handleSuccessfulRuleEvaluation(
-					eval, rulesetsConfig, labelsMap, isCordoned, taintAppliedMap, taintEffectPriorityMap)
+					eval, rulesetsConfig, labelsMap, appliedLabelsMap, selectedLabels,
+					isCordoned, taintAppliedMap, taintEffectPriorityMap,
+				)
 			case err != nil:
 				r.handleRuleEvaluationError(ctx, event.HealthEvent, eval.GetName(), err)
 			default:
@@ -815,6 +843,8 @@ func (r *Reconciler) handleSuccessfulRuleEvaluation(
 	eval evaluator.RuleSetEvaluatorIface,
 	rulesetsConfig rulesetsConfig,
 	labelsMap *sync.Map,
+	appliedLabelsMap *sync.Map,
+	selectedLabels map[string]selectedLabel,
 	isCordoned *atomic.Bool,
 	taintAppliedMap map[keyValTaint]string,
 	taintEffectPriorityMap map[keyValTaint]int,
@@ -839,6 +869,36 @@ func (r *Reconciler) handleSuccessfulRuleEvaluation(
 	if taintConfig != nil {
 		r.updateTaintMaps(eval.GetName(), taintConfig, rulesetsConfig, taintAppliedMap, taintEffectPriorityMap)
 	}
+
+	labelConfig := rulesetsConfig.LabelConfigMap[eval.GetName()]
+	if labelConfig != nil {
+		r.labelUpdateMu.Lock()
+		selectRuleLabel(
+			selectedLabels,
+			*labelConfig,
+			rulesetsConfig.RuleSetPriorityMap[eval.GetName()],
+			rulesetsConfig.RuleSetOrderMap[eval.GetName()],
+		)
+
+		selected := selectedLabels[labelConfig.Key]
+		labelsMap.Store(labelConfig.Key, selected.Value)
+		appliedLabelsMap.Store(labelConfig.Key, config.AppliedLabel{
+			Key:      labelConfig.Key,
+			Value:    selected.Value,
+			Priority: selected.Priority,
+			Order:    selected.Order,
+		})
+		r.labelUpdateMu.Unlock()
+	}
+}
+
+func selectRuleLabel(selected map[string]selectedLabel, candidate config.Label, priority, order int) {
+	current, exists := selected[candidate.Key]
+	if exists && (current.Priority > priority || (current.Priority == priority && current.Order > order)) {
+		return
+	}
+
+	selected[candidate.Key] = selectedLabel{Value: candidate.Value, Priority: priority, Order: order}
 }
 
 // updateTaintMaps updates taint maps with priority-based logic to handle multiple rulesets
@@ -902,11 +962,28 @@ func (r *Reconciler) collectTaintsToApply(taintAppliedMap map[keyValTaint]string
 	return taintsToBeApplied
 }
 
+func collectLabelsToApply(labelsMap *sync.Map) []config.AppliedLabel {
+	labels := []config.AppliedLabel{}
+
+	labelsMap.Range(func(_, value any) bool {
+		label, ok := value.(config.AppliedLabel)
+
+		if ok {
+			labels = append(labels, label)
+		}
+
+		return true
+	})
+
+	return labels
+}
+
 // prepareAnnotations prepares annotations and labels to be applied if any
 func (r *Reconciler) prepareAnnotations(
 	ctx context.Context,
 	node *corev1.Node,
 	taintsToBeApplied []config.Taint,
+	labelsToBeApplied []config.AppliedLabel,
 	labelsMap *sync.Map,
 	isCordoned *atomic.Bool,
 ) map[string]string {
@@ -920,6 +997,15 @@ func (r *Reconciler) prepareAnnotations(
 			slog.ErrorContext(ctx, "Failed to marshal taints for annotation", "error", err)
 		} else {
 			annotationsMap[common.QuarantineHealthEventAppliedTaintsAnnotationKey] = string(taintsJsonStr)
+		}
+	}
+
+	if len(labelsToBeApplied) > 0 {
+		labelsJSON, err := json.Marshal(labelsToBeApplied)
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed to marshal labels for annotation", "error", err)
+		} else {
+			annotationsMap[common.QuarantineHealthEventAppliedLabelsAnnotationKey] = string(labelsJSON)
 		}
 	}
 
@@ -941,7 +1027,7 @@ func (r *Reconciler) prepareAnnotations(
 		}
 	}
 
-	if len(taintsToBeApplied) > 0 || isCordoned.Load() {
+	if len(taintsToBeApplied) > 0 || len(labelsToBeApplied) > 0 || isCordoned.Load() {
 		labelsMap.Store(string(statemanager.NVSentinelStateLabelKey), string(statemanager.QuarantinedLabelValue))
 	}
 
@@ -968,6 +1054,7 @@ func (r *Reconciler) applyQuarantine(
 	event *model.HealthEventWithStatus,
 	annotations map[string]string,
 	taintsToBeApplied []config.Taint,
+	labelsToBeApplied []config.AppliedLabel,
 	annotationsMap map[string]string,
 	labelsMap *sync.Map,
 	isCordoned *atomic.Bool,
@@ -1051,7 +1138,7 @@ func (r *Reconciler) applyQuarantine(
 
 	slog.DebugContext(ctx, "QuarantineNodeAndSetAnnotations completed successfully", "node", event.HealthEvent.NodeName)
 
-	r.updateQuarantineMetrics(event.HealthEvent.NodeName, taintsToBeApplied, isCordoned)
+	r.updateQuarantineMetrics(event.HealthEvent.NodeName, taintsToBeApplied, labelsToBeApplied, isCordoned)
 
 	status := model.Quarantined
 	if alreadyQuarantined {
@@ -1104,6 +1191,7 @@ func (r *Reconciler) addHealthEventAnnotation(
 func (r *Reconciler) updateQuarantineMetrics(
 	nodeName string,
 	taintsToBeApplied []config.Taint,
+	labelsToBeApplied []config.AppliedLabel,
 	isCordoned *atomic.Bool,
 ) {
 	metrics.TotalNodesQuarantined.WithLabelValues(nodeName).Inc()
@@ -1111,6 +1199,10 @@ func (r *Reconciler) updateQuarantineMetrics(
 
 	for _, taint := range taintsToBeApplied {
 		metrics.TaintsApplied.WithLabelValues(taint.Key, taint.Effect).Inc()
+	}
+
+	for _, label := range labelsToBeApplied {
+		metrics.LabelsApplied.WithLabelValues(label.Key).Inc()
 	}
 
 	if isCordoned.Load() {
@@ -1147,6 +1239,7 @@ func (r *Reconciler) handleUnhealthyEventOnQuarantinedNode(
 	ctx context.Context,
 	event *protos.HealthEvent,
 	ruleSetEvals []evaluator.RuleSetEvaluatorIface,
+	rulesetsConfig rulesetsConfig,
 	healthEventsAnnotationMap *healthEventsAnnotation.HealthEventsAnnotationMap,
 ) bool {
 	if !r.isForceQuarantine(event) && !r.eventMatchesAnyRule(event, ruleSetEvals) {
@@ -1171,13 +1264,91 @@ func (r *Reconciler) handleUnhealthyEventOnQuarantinedNode(
 			"checkName", event.CheckName, "node", event.NodeName)
 	}
 
+	if err := r.applyRuleLabelsForEvent(ctx, event, ruleSetEvals, rulesetsConfig); err != nil {
+		slog.ErrorContext(ctx, "Failed to apply session rule labels for quarantined node",
+			"checkName", event.CheckName, "node", event.NodeName, "error", err)
+		metrics.ProcessingErrors.WithLabelValues("apply_session_rule_labels_error").Inc()
+	}
+
 	return true
+}
+
+func (r *Reconciler) applyRuleLabelsForEvent(
+	ctx context.Context,
+	event *protos.HealthEvent,
+	ruleSetEvals []evaluator.RuleSetEvaluatorIface,
+	rulesetsConfig rulesetsConfig,
+) error {
+	selected := make(map[string]selectedLabel)
+
+	for _, eval := range ruleSetEvals {
+		result, err := eval.Evaluate(event)
+		if err != nil {
+			r.handleRuleEvaluationError(ctx, event, eval.GetName(), err)
+			continue
+		}
+
+		if result != common.RuleEvaluationSuccess {
+			continue
+		}
+
+		labelConfig := rulesetsConfig.LabelConfigMap[eval.GetName()]
+		if labelConfig == nil {
+			continue
+		}
+
+		selectRuleLabel(
+			selected,
+			*labelConfig,
+			rulesetsConfig.RuleSetPriorityMap[eval.GetName()],
+			rulesetsConfig.RuleSetOrderMap[eval.GetName()],
+		)
+	}
+
+	if len(selected) == 0 {
+		return nil
+	}
+
+	appliedLabels := make([]config.AppliedLabel, 0, len(selected))
+	labels := make(map[string]string, len(selected))
+
+	for key, winner := range selected {
+		appliedLabels = append(appliedLabels, config.AppliedLabel{
+			Key:      key,
+			Value:    winner.Value,
+			Priority: winner.Priority,
+			Order:    winner.Order,
+		})
+		labels[key] = winner.Value
+	}
+
+	appliedLabelsJSON, err := json.Marshal(appliedLabels)
+	if err != nil {
+		return fmt.Errorf("marshal session applied labels: %w", err)
+	}
+
+	_, err = r.k8sClient.QuarantineNodeAndSetAnnotations(
+		ctx,
+		event.NodeName,
+		nil,
+		false,
+		map[string]string{
+			common.QuarantineHealthEventAppliedLabelsAnnotationKey: string(appliedLabelsJSON),
+		},
+		labels,
+	)
+	if err != nil {
+		return fmt.Errorf("merge session applied labels: %w", err)
+	}
+
+	return nil
 }
 
 func (r *Reconciler) handleQuarantinedNode(
 	ctx context.Context,
 	event *protos.HealthEvent,
 	ruleSetEvals []evaluator.RuleSetEvaluatorIface,
+	rulesetsConfig rulesetsConfig,
 ) bool {
 	ctx, span := tracing.StartSpan(ctx, "fault_quarantine.handle_quarantined_node")
 	defer span.End()
@@ -1197,7 +1368,9 @@ func (r *Reconciler) handleQuarantinedNode(
 	_, hasExistingCheck := healthEventsAnnotationMap.GetEvent(event)
 
 	if !event.IsHealthy {
-		return r.handleUnhealthyEventOnQuarantinedNode(ctx, event, ruleSetEvals, healthEventsAnnotationMap)
+		return r.handleUnhealthyEventOnQuarantinedNode(
+			ctx, event, ruleSetEvals, rulesetsConfig, healthEventsAnnotationMap,
+		)
 	}
 
 	if !hasExistingCheck {
@@ -1461,7 +1634,7 @@ func (r *Reconciler) performUncordon(
 		"node", event.NodeName)
 
 	// Prepare uncordon parameters
-	taintsToBeRemoved, annotationsToBeRemoved, isUnCordon, labelsMap, err := r.prepareUncordonParams(
+	taintsToBeRemoved, annotationsToBeRemoved, ruleLabelsToRemove, isUnCordon, labelsMap, err := r.prepareUncordonParams(
 		event, annotations)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to prepare uncordon params for node", "node", event.NodeName, "error", err)
@@ -1475,7 +1648,7 @@ func (r *Reconciler) performUncordon(
 		return true, fmt.Errorf("failed to prepare uncordon params for node %s: %w", event.NodeName, err)
 	}
 
-	if len(taintsToBeRemoved) == 0 && !isUnCordon && len(annotationsToBeRemoved) == 0 {
+	if len(taintsToBeRemoved) == 0 && len(ruleLabelsToRemove) == 0 && !isUnCordon && len(annotationsToBeRemoved) == 0 {
 		span.SetAttributes(attribute.String("fault_quarantine.event.processing_status", EventProcessingStatusSkipped),
 			attribute.String("fault_quarantine.skip.reason", "No quarantine taints or annotations present to remove"),
 		)
@@ -1495,6 +1668,9 @@ func (r *Reconciler) performUncordon(
 		r.cordonedReasonLabelKey,
 		r.cordonedTimestampLabelKey,
 		statemanager.NVSentinelStateLabelKey,
+	}
+	for _, label := range ruleLabelsToRemove {
+		labelsToRemove = append(labelsToRemove, label.Key)
 	}
 
 	if err := r.k8sClient.UnQuarantineNodeAndRemoveAnnotations(
@@ -1517,7 +1693,7 @@ func (r *Reconciler) performUncordon(
 		return true, fmt.Errorf("failed to untaint and uncordon node %s: %w", event.NodeName, err)
 	}
 
-	r.updateUncordonMetrics(ctx, event.NodeName, taintsToBeRemoved, isUnCordon)
+	r.updateUncordonMetrics(ctx, event.NodeName, taintsToBeRemoved, ruleLabelsToRemove, isUnCordon)
 
 	span.SetAttributes(
 		attribute.Bool("fault_quarantine.action.uncordon", isUnCordon),
@@ -1531,7 +1707,7 @@ func (r *Reconciler) performUncordon(
 func (r *Reconciler) prepareUncordonParams(
 	event *protos.HealthEvent,
 	annotations map[string]string,
-) ([]config.Taint, []string, bool, map[string]string, error) {
+) ([]config.Taint, []string, []config.Label, bool, map[string]string, error) {
 	var (
 		annotationsToBeRemoved = []string{}
 		taintsToBeRemoved      []config.Taint
@@ -1547,7 +1723,9 @@ func (r *Reconciler) prepareUncordonParams(
 
 		var allTaints []config.Taint
 		if err := json.Unmarshal([]byte(quarantineAnnotationEventTaintsAppliedStr), &allTaints); err != nil {
-			return nil, nil, false, nil, fmt.Errorf("failed to unmarshal taints annotation for node %s: %w", event.NodeName, err)
+			return nil, nil, nil, false, nil, fmt.Errorf(
+				"failed to unmarshal taints annotation for node %s: %w", event.NodeName, err,
+			)
 		}
 
 		for _, t := range allTaints {
@@ -1556,6 +1734,15 @@ func (r *Reconciler) prepareUncordonParams(
 			}
 		}
 	}
+
+	labelsToBeRemoved, labelAnnotationsToRemove, err := appliedLabelsRemovalParams(annotations)
+	if err != nil {
+		return nil, nil, nil, false, nil, fmt.Errorf(
+			"failed to unmarshal labels annotation for node %s: %w", event.NodeName, err,
+		)
+	}
+
+	annotationsToBeRemoved = append(annotationsToBeRemoved, labelAnnotationsToRemove...)
 
 	quarantineAnnotationEventIsCordonStr, cordonExists :=
 		annotations[common.QuarantineHealthEventIsCordonedAnnotationKey]
@@ -1574,13 +1761,14 @@ func (r *Reconciler) prepareUncordonParams(
 		}
 	}
 
-	return taintsToBeRemoved, annotationsToBeRemoved, isUnCordon, labelsMap, nil
+	return taintsToBeRemoved, annotationsToBeRemoved, labelsToBeRemoved, isUnCordon, labelsMap, nil
 }
 
 func (r *Reconciler) updateUncordonMetrics(
 	ctx context.Context,
 	nodeName string,
 	taintsToBeRemoved []config.Taint,
+	labelsToBeRemoved []config.Label,
 	isUnCordon bool,
 ) {
 	metrics.TotalNodesUnquarantined.WithLabelValues(nodeName).Inc()
@@ -1589,6 +1777,10 @@ func (r *Reconciler) updateUncordonMetrics(
 
 	for _, taint := range taintsToBeRemoved {
 		metrics.TaintsRemoved.WithLabelValues(taint.Key, taint.Effect).Inc()
+	}
+
+	for _, label := range labelsToBeRemoved {
+		metrics.LabelsRemoved.WithLabelValues(label.Key).Inc()
 	}
 
 	if isUnCordon {
@@ -1621,6 +1813,7 @@ func (r *Reconciler) getNodeQuarantineAnnotations(ctx context.Context, nodeName 
 	quarantineKeys := []string{
 		common.QuarantineHealthEventAnnotationKey,
 		common.QuarantineHealthEventAppliedTaintsAnnotationKey,
+		common.QuarantineHealthEventAppliedLabelsAnnotationKey,
 		common.QuarantineHealthEventIsCordonedAnnotationKey,
 		common.QuarantineHealthEventCordonPreExistingAnnotationKey,
 		common.QuarantinedNodeUncordonedManuallyAnnotationKey,
@@ -1689,11 +1882,19 @@ func (r *Reconciler) handleManualUncordon(nodeName string) error {
 		"node", nodeName, "annotationCount", len(annotations))
 
 	annotationsToRemove := []string{}
+	labelsToRemove := []string{statemanager.NVSentinelStateLabelKey}
 
 	// Remove the applied taints annotation (but keep the taints themselves on the node)
 	if _, exists := annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey]; exists {
 		annotationsToRemove = append(annotationsToRemove, common.QuarantineHealthEventAppliedTaintsAnnotationKey)
 	}
+
+	labelAnnotationsToRemove, _, err := appliedLabelCleanupParams(annotations)
+	if err != nil {
+		return fmt.Errorf("failed to read applied labels for manually uncordoned node %s: %w", nodeName, err)
+	}
+
+	annotationsToRemove = append(annotationsToRemove, labelAnnotationsToRemove...)
 
 	if _, exists := annotations[common.QuarantineHealthEventAnnotationKey]; exists {
 		annotationsToRemove = append(annotationsToRemove, common.QuarantineHealthEventAnnotationKey)
@@ -1718,7 +1919,7 @@ func (r *Reconciler) handleManualUncordon(nodeName string) error {
 		nodeName,
 		annotationsToRemove,
 		newAnnotations,
-		[]string{statemanager.NVSentinelStateLabelKey},
+		labelsToRemove,
 	); err != nil {
 		slog.ErrorContext(ctx, "Failed to clean up manually uncordoned node", "node", nodeName, "error", err)
 		metrics.ProcessingErrors.WithLabelValues("manual_uncordon_cleanup_error").Inc()
@@ -1786,10 +1987,18 @@ func (r *Reconciler) handleManualUntaint(nodeName string) error {
 		"node", nodeName, "annotationCount", len(annotations))
 
 	annotationsToRemove := []string{}
+	labelsToRemove := []string{statemanager.NVSentinelStateLabelKey}
 
 	if _, exists := annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey]; exists {
 		annotationsToRemove = append(annotationsToRemove, common.QuarantineHealthEventAppliedTaintsAnnotationKey)
 	}
+
+	labelAnnotationsToRemove, _, err := appliedLabelCleanupParams(annotations)
+	if err != nil {
+		return fmt.Errorf("failed to read applied labels for manually untainted node %s: %w", nodeName, err)
+	}
+
+	annotationsToRemove = append(annotationsToRemove, labelAnnotationsToRemove...)
 
 	if _, exists := annotations[common.QuarantineHealthEventAnnotationKey]; exists {
 		annotationsToRemove = append(annotationsToRemove, common.QuarantineHealthEventAnnotationKey)
@@ -1814,7 +2023,7 @@ func (r *Reconciler) handleManualUntaint(nodeName string) error {
 		nodeName,
 		annotationsToRemove,
 		newAnnotations,
-		[]string{statemanager.NVSentinelStateLabelKey},
+		labelsToRemove,
 	); err != nil {
 		slog.ErrorContext(ctx, "Failed to clean up manually untainted node", "node", nodeName, "error", err)
 		metrics.ProcessingErrors.WithLabelValues("manual_untaint_cleanup_error").Inc()
@@ -1855,4 +2064,39 @@ func (r *Reconciler) handleManualUntaint(nodeName string) error {
 	slog.InfoContext(ctx, "Successfully completed manual untaint handling", "node", nodeName)
 
 	return nil
+}
+
+func appliedLabelsRemovalParams(annotations map[string]string) ([]config.Label, []string, error) {
+	appliedLabelsJSON := annotations[common.QuarantineHealthEventAppliedLabelsAnnotationKey]
+	if appliedLabelsJSON == "" {
+		return nil, nil, nil
+	}
+
+	var persistedLabels []config.AppliedLabel
+	if err := json.Unmarshal([]byte(appliedLabelsJSON), &persistedLabels); err != nil {
+		return nil, nil, fmt.Errorf("unmarshal applied labels annotation: %w", err)
+	}
+
+	appliedLabels := make([]config.Label, 0, len(persistedLabels))
+	for _, label := range persistedLabels {
+		appliedLabels = append(appliedLabels, config.Label{Key: label.Key, Value: label.Value})
+	}
+
+	return appliedLabels, []string{common.QuarantineHealthEventAppliedLabelsAnnotationKey}, nil
+}
+
+func appliedLabelCleanupParams(annotations map[string]string) ([]string, []string, error) {
+	appliedLabels, annotationKeys, err := appliedLabelsRemovalParams(annotations)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	keys := make([]string, 0, len(appliedLabels))
+	for _, label := range appliedLabels {
+		if label.Key != "" {
+			keys = append(keys, label.Key)
+		}
+	}
+
+	return annotationKeys, keys, nil
 }

--- a/fault-quarantine/pkg/reconciler/reconciler_e2e_test.go
+++ b/fault-quarantine/pkg/reconciler/reconciler_e2e_test.go
@@ -63,6 +63,7 @@ var (
 var (
 	quarantineHealthEventAnnotationKey              = common.QuarantineHealthEventAnnotationKey
 	quarantineHealthEventAppliedTaintsAnnotationKey = common.QuarantineHealthEventAppliedTaintsAnnotationKey
+	quarantineHealthEventAppliedLabelsAnnotationKey = common.QuarantineHealthEventAppliedLabelsAnnotationKey
 	quarantineHealthEventIsCordonedAnnotationKey    = common.QuarantineHealthEventIsCordonedAnnotationKey
 )
 
@@ -325,13 +326,18 @@ func setupE2EReconcilerWithOptions(t *testing.T, ctx context.Context, cfg E2ERec
 	// Build rulesets config (mimics reconciler.Start())
 	rulesetsConfig := rulesetsConfig{
 		TaintConfigMap:     make(map[string]*config.Taint),
+		LabelConfigMap:     make(map[string]*config.Label),
 		CordonConfigMap:    make(map[string]bool),
 		RuleSetPriorityMap: make(map[string]int),
+		RuleSetOrderMap:    make(map[string]int),
 	}
 
-	for _, ruleSet := range cfg.TomlConfig.RuleSets {
+	for order, ruleSet := range cfg.TomlConfig.RuleSets {
 		if ruleSet.Taint.Key != "" {
 			rulesetsConfig.TaintConfigMap[ruleSet.Name] = &ruleSet.Taint
+		}
+		if ruleSet.Label.Key != "" {
+			rulesetsConfig.LabelConfigMap[ruleSet.Name] = &ruleSet.Label
 		}
 		if ruleSet.Cordon.ShouldCordon {
 			rulesetsConfig.CordonConfigMap[ruleSet.Name] = true
@@ -339,6 +345,7 @@ func setupE2EReconcilerWithOptions(t *testing.T, ctx context.Context, cfg E2ERec
 		if ruleSet.Priority > 0 {
 			rulesetsConfig.RuleSetPriorityMap[ruleSet.Name] = ruleSet.Priority
 		}
+		rulesetsConfig.RuleSetOrderMap[ruleSet.Name] = order
 	}
 
 	r.precomputeTaintInitKeys(context.Background(), ruleSetEvals, rulesetsConfig)
@@ -475,6 +482,18 @@ func hasNodeTaint(node *corev1.Node, expectedTaint config.Taint) bool {
 	return false
 }
 
+func verifyAppliedLabelsAnnotation(t *testing.T, node *corev1.Node, expectedLabels []config.Label) {
+	t.Helper()
+
+	labelsAnnotationStr := node.Annotations[quarantineHealthEventAppliedLabelsAnnotationKey]
+	require.NotEmpty(t, labelsAnnotationStr, "Applied labels annotation should exist")
+
+	var appliedLabels []config.Label
+	err := json.Unmarshal([]byte(labelsAnnotationStr), &appliedLabels)
+	require.NoError(t, err, "Should unmarshal labels annotation")
+	assert.ElementsMatch(t, expectedLabels, appliedLabels)
+}
+
 // runReconcilerAndQuarantineNode is a helper that:
 // 1. Sets up a reconciler with the given config
 // 2. Sends a health event to quarantine the node
@@ -529,13 +548,18 @@ func runReconcilerAndQuarantineNode(
 
 		rulesetsConfig := rulesetsConfig{
 			TaintConfigMap:     make(map[string]*config.Taint),
+			LabelConfigMap:     make(map[string]*config.Label),
 			CordonConfigMap:    make(map[string]bool),
 			RuleSetPriorityMap: make(map[string]int),
+			RuleSetOrderMap:    make(map[string]int),
 		}
 
-		for _, ruleSet := range tomlConfig.RuleSets {
+		for order, ruleSet := range tomlConfig.RuleSets {
 			if ruleSet.Taint.Key != "" {
 				rulesetsConfig.TaintConfigMap[ruleSet.Name] = &ruleSet.Taint
+			}
+			if ruleSet.Label.Key != "" {
+				rulesetsConfig.LabelConfigMap[ruleSet.Name] = &ruleSet.Label
 			}
 			if ruleSet.Cordon.ShouldCordon {
 				rulesetsConfig.CordonConfigMap[ruleSet.Name] = true
@@ -543,6 +567,7 @@ func runReconcilerAndQuarantineNode(
 			if ruleSet.Priority > 0 {
 				rulesetsConfig.RuleSetPriorityMap[ruleSet.Name] = ruleSet.Priority
 			}
+			rulesetsConfig.RuleSetOrderMap[ruleSet.Name] = order
 		}
 
 		r.precomputeTaintInitKeys(context.Background(), ruleSetEvals, rulesetsConfig)
@@ -682,7 +707,7 @@ func TestE2E_BasicQuarantineAndUnquarantine(t *testing.T) {
 	defer cancel()
 
 	nodeName := "e2e-basic-" + generateShortTestID()
-	createE2ETestNode(ctx, t, nodeName, nil, nil, nil, false)
+	createE2ETestNode(ctx, t, nodeName, nil, map[string]string{"nvidia.com/gpu-fault": "previous"}, nil, false)
 	defer func() {
 		_ = e2eTestClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
 	}()
@@ -701,6 +726,7 @@ func TestE2E_BasicQuarantineAndUnquarantine(t *testing.T) {
 					},
 				},
 				Taint:  config.Taint{Key: "nvidia.com/gpu-xid-error", Value: "true", Effect: "NoSchedule"},
+				Label:  config.Label{Key: "nvidia.com/gpu-fault", Value: "active"},
 				Cordon: config.Cordon{ShouldCordon: true},
 			},
 		},
@@ -711,6 +737,7 @@ func TestE2E_BasicQuarantineAndUnquarantine(t *testing.T) {
 	beforeProcessed := getCounterValue(t, metrics.TotalEventsSuccessfullyProcessed)
 	beforeQuarantined := getCounterVecValue(t, metrics.TotalNodesQuarantined, nodeName)
 	beforeTaints := getCounterVecValue(t, metrics.TaintsApplied, "nvidia.com/gpu-xid-error", "NoSchedule")
+	beforeLabels := getCounterVecValue(t, metrics.LabelsApplied, "nvidia.com/gpu-fault")
 	beforeCordons := getCounterValue(t, metrics.CordonsApplied)
 	beforeRulesetPassed := getCounterVecValue(t, metrics.RulesetEvaluations, "gpu-xid-critical-errors", metrics.StatusPassed)
 
@@ -747,6 +774,9 @@ func TestE2E_BasicQuarantineAndUnquarantine(t *testing.T) {
 	}
 	verifyAppliedTaintsAnnotation(t, node, expectedTaints)
 	verifyNodeTaintsMatch(t, node, expectedTaints)
+	expectedLabels := []config.Label{{Key: "nvidia.com/gpu-fault", Value: "active"}}
+	verifyAppliedLabelsAnnotation(t, node, expectedLabels)
+	assert.Equal(t, "active", node.Labels["nvidia.com/gpu-fault"])
 	assert.Equal(t, "True", node.Annotations[quarantineHealthEventIsCordonedAnnotationKey], "Cordon annotation should be True")
 	assert.Empty(t, node.Annotations[common.QuarantineHealthEventCordonPreExistingAnnotationKey], "CordonPreExisting annotation should not be set")
 	verifyQuarantineLabels(t, node, "gpu-xid-critical-errors", string(statemanager.QuarantinedLabelValue))
@@ -755,6 +785,7 @@ func TestE2E_BasicQuarantineAndUnquarantine(t *testing.T) {
 	afterQuarantined := getCounterVecValue(t, metrics.TotalNodesQuarantined, nodeName)
 	afterGauge := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
 	afterTaints := getCounterVecValue(t, metrics.TaintsApplied, "nvidia.com/gpu-xid-error", "NoSchedule")
+	afterLabels := getCounterVecValue(t, metrics.LabelsApplied, "nvidia.com/gpu-fault")
 	afterCordons := getCounterValue(t, metrics.CordonsApplied)
 	afterRulesetPassed := getCounterVecValue(t, metrics.RulesetEvaluations, "gpu-xid-critical-errors", metrics.StatusPassed)
 
@@ -762,6 +793,7 @@ func TestE2E_BasicQuarantineAndUnquarantine(t *testing.T) {
 	assert.Equal(t, beforeQuarantined+1, afterQuarantined, "TotalNodesQuarantined should increment by 1")
 	assert.Equal(t, float64(1), afterGauge, "CurrentQuarantinedNodes should be 1")
 	assert.GreaterOrEqual(t, afterTaints, beforeTaints+1, "TaintsApplied should increment")
+	assert.GreaterOrEqual(t, afterLabels, beforeLabels+1, "LabelsApplied should increment")
 	assert.GreaterOrEqual(t, afterCordons, beforeCordons+1, "CordonsApplied should increment")
 	assert.GreaterOrEqual(t, afterRulesetPassed, beforeRulesetPassed+1, "RulesetEvaluations with status=passed should increment")
 
@@ -804,21 +836,178 @@ func TestE2E_BasicQuarantineAndUnquarantine(t *testing.T) {
 	assert.Equal(t, 0, fqTaintCount, "FQ taints should be removed")
 	assert.Empty(t, node.Annotations[quarantineHealthEventAnnotationKey], "Quarantine annotation should be removed")
 	assert.Empty(t, node.Annotations[quarantineHealthEventAppliedTaintsAnnotationKey], "Applied taints annotation should be removed")
+	assert.Empty(t, node.Annotations[quarantineHealthEventAppliedLabelsAnnotationKey], "Applied labels annotation should be removed")
 	assert.Empty(t, node.Annotations[quarantineHealthEventIsCordonedAnnotationKey], "Cordoned annotation should be removed")
 	assert.Empty(t, node.Annotations[common.QuarantineHealthEventCordonPreExistingAnnotationKey], "CordonPreExisting annotation should not exist")
+	assert.NotContains(t, node.Labels, "nvidia.com/gpu-fault", "Applied fault label should be removed")
 	verifyUnquarantineLabels(t, node)
 
 	afterUnquarantined := getCounterVecValue(t, metrics.TotalNodesUnquarantined, nodeName)
 	finalGauge := getGaugeVecValue(t, metrics.CurrentQuarantinedNodes, nodeName)
 	afterTaintsRemoved := getCounterVecValue(t, metrics.TaintsRemoved, "nvidia.com/gpu-xid-error", "NoSchedule")
+	afterLabelsRemoved := getCounterVecValue(t, metrics.LabelsRemoved, "nvidia.com/gpu-fault")
 	afterCordonsRemoved := getCounterValue(t, metrics.CordonsRemoved)
 	finalProcessed := getCounterValue(t, metrics.TotalEventsSuccessfullyProcessed)
 
 	assert.GreaterOrEqual(t, afterUnquarantined, beforeQuarantined+1, "TotalNodesUnquarantined should increment")
 	assert.Equal(t, float64(0), finalGauge, "CurrentQuarantinedNodes should be 0 after unquarantine")
 	assert.GreaterOrEqual(t, afterTaintsRemoved, beforeTaints+1, "TaintsRemoved should increment")
+	assert.GreaterOrEqual(t, afterLabelsRemoved, beforeLabels+1, "LabelsRemoved should increment")
 	assert.GreaterOrEqual(t, afterCordonsRemoved, beforeCordons+1, "CordonsRemoved should increment")
 	assert.GreaterOrEqual(t, finalProcessed, beforeProcessed+2, "TotalEventsSuccessfullyProcessed should increment for both events")
+}
+
+func TestE2E_LabelOnlyQuarantineAndUnquarantine(t *testing.T) {
+	ctx, cancel := context.WithTimeout(e2eTestContext, 20*time.Second)
+	defer cancel()
+
+	nodeName := "e2e-label-only-" + generateShortTestID()
+	createE2ETestNode(ctx, t, nodeName, nil, nil, nil, false)
+	defer func() {
+		_ = e2eTestClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
+	}()
+
+	tomlConfig := config.TomlConfig{
+		LabelPrefix: "k8s.nvidia.com/",
+		RuleSets: []config.RuleSet{{
+			Enabled: true,
+			Name:    "label-only",
+			Version: "1",
+			Match: config.Match{Any: []config.Rule{{
+				Kind: "HealthEvent", Expression: "event.checkName == 'LabelOnlyFault'",
+			}}},
+			Label: config.Label{Key: "nvidia.com/gpu-fault", Value: "active"},
+		}},
+	}
+
+	_, mockWatcher, getStatus, _ := setupE2EReconciler(t, ctx, tomlConfig, nil)
+
+	unhealthyID := generateTestID()
+	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(
+		unhealthyID, nodeName, "LabelOnlyFault", false, true,
+		[]*protos.Entity{{EntityType: "GPU", EntityValue: "0"}}, model.StatusInProgress,
+	)}
+
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		return err == nil && node.Labels["nvidia.com/gpu-fault"] == "active"
+	}, eventuallyTimeout, eventuallyPollInterval, "Label-only rule should quarantine the node")
+
+	healthyID := generateTestID()
+	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(
+		healthyID, nodeName, "LabelOnlyFault", true, false,
+		[]*protos.Entity{{EntityType: "GPU", EntityValue: "0"}}, model.StatusInProgress,
+	)}
+
+	require.Eventually(t, func() bool {
+		status := getStatus(healthyID)
+		return status != nil && *status == model.UnQuarantined
+	}, statusCheckTimeout, statusCheckPollInterval, "Label-only recovery should be UnQuarantined")
+
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+		_, hasFaultLabel := node.Labels["nvidia.com/gpu-fault"]
+		_, hasAppliedLabelsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedLabelsAnnotationKey]
+		return !hasFaultLabel && !hasAppliedLabelsAnnotation
+	}, eventuallyTimeout, eventuallyPollInterval, "Label-only recovery should remove the applied label and annotation")
+}
+
+func TestE2E_LabelPriorityPersistsAcrossQuarantineSession(t *testing.T) {
+	ctx, cancel := context.WithTimeout(e2eTestContext, 20*time.Second)
+	defer cancel()
+
+	nodeName := "e2e-label-session-priority-" + generateShortTestID()
+	createE2ETestNode(ctx, t, nodeName, nil, nil, nil, false)
+	defer func() {
+		_ = e2eTestClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
+	}()
+
+	tomlConfig := config.TomlConfig{
+		LabelPrefix: "k8s.nvidia.com/",
+		RuleSets: []config.RuleSet{
+			{
+				Enabled:  true,
+				Name:     "low-priority-label",
+				Version:  "1",
+				Priority: 5,
+				Match: config.Match{Any: []config.Rule{{
+					Kind: "HealthEvent", Expression: "event.checkName == 'LowPriorityFault'",
+				}}},
+				Label: config.Label{Key: "nvidia.com/gpu-fault", Value: "degraded"},
+			},
+			{
+				Enabled:  true,
+				Name:     "high-priority-label",
+				Version:  "1",
+				Priority: 10,
+				Match: config.Match{Any: []config.Rule{{
+					Kind: "HealthEvent", Expression: "event.checkName == 'HighPriorityFault'",
+				}}},
+				Label: config.Label{Key: "nvidia.com/gpu-fault", Value: "critical"},
+			},
+		},
+	}
+
+	_, mockWatcher, getStatus, _ := setupE2EReconciler(t, ctx, tomlConfig, nil)
+
+	lowID := generateTestID()
+	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(
+		lowID, nodeName, "LowPriorityFault", false, true,
+		[]*protos.Entity{{EntityType: "GPU", EntityValue: "0"}}, model.StatusInProgress,
+	)}
+
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		return err == nil && node.Labels["nvidia.com/gpu-fault"] == "degraded"
+	}, eventuallyTimeout, eventuallyPollInterval, "Lower-priority event should establish the session label")
+
+	highID := generateTestID()
+	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(
+		highID, nodeName, "HighPriorityFault", false, true,
+		[]*protos.Entity{{EntityType: "GPU", EntityValue: "1"}}, model.StatusInProgress,
+	)}
+
+	require.Eventually(t, func() bool {
+		status := getStatus(highID)
+		return status != nil && *status == model.AlreadyQuarantined
+	}, statusCheckTimeout, statusCheckPollInterval, "Later event should be processed on the active quarantine session")
+
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil || node.Labels["nvidia.com/gpu-fault"] != "critical" {
+			return false
+		}
+
+		var applied []config.AppliedLabel
+		if err := json.Unmarshal(
+			[]byte(node.Annotations[common.QuarantineHealthEventAppliedLabelsAnnotationKey]), &applied,
+		); err != nil || len(applied) != 1 {
+			return false
+		}
+
+		return applied[0] == (config.AppliedLabel{
+			Key: "nvidia.com/gpu-fault", Value: "critical", Priority: 10, Order: 1,
+		})
+	}, eventuallyTimeout, eventuallyPollInterval, "Higher-priority event should promote the session label and annotation winner")
+
+	laterLowID := generateTestID()
+	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(
+		laterLowID, nodeName, "LowPriorityFault", false, true,
+		[]*protos.Entity{{EntityType: "GPU", EntityValue: "2"}}, model.StatusInProgress,
+	)}
+
+	require.Eventually(t, func() bool {
+		status := getStatus(laterLowID)
+		return status != nil && *status == model.AlreadyQuarantined
+	}, statusCheckTimeout, statusCheckPollInterval, "Later lower-priority event should be processed")
+
+	require.Eventually(t, func() bool {
+		node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		return err == nil && node.Labels["nvidia.com/gpu-fault"] == "critical"
+	}, eventuallyTimeout, eventuallyPollInterval, "Later lower-priority event must not downgrade the session label")
 }
 
 func TestE2E_EntityLevelTracking(t *testing.T) {
@@ -845,6 +1034,7 @@ func TestE2E_EntityLevelTracking(t *testing.T) {
 					},
 				},
 				Taint:  config.Taint{Key: "nvidia.com/gpu-xid-error", Value: "true", Effect: "NoSchedule"},
+				Label:  config.Label{Key: "nvidia.com/gpu-fault", Value: "active"},
 				Cordon: config.Cordon{ShouldCordon: true},
 			},
 		},
@@ -938,6 +1128,8 @@ func TestE2E_EntityLevelTracking(t *testing.T) {
 	t.Log("Verify GPU 1 is still in annotation, GPU 0 is not")
 	node, err = e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 	require.NoError(t, err)
+	assert.Equal(t, "active", node.Labels["nvidia.com/gpu-fault"], "Fault label must remain while GPU 1 is still failing")
+	assert.NotEmpty(t, node.Annotations[common.QuarantineHealthEventAppliedLabelsAnnotationKey])
 	verifyHealthEventInAnnotation(t, node, "GpuXidError", "gpu-health-monitor", "GPU", "GPU", "1")
 	var healthEventsMap healthEventsAnnotation.HealthEventsAnnotationMap
 	err = json.Unmarshal([]byte(node.Annotations[quarantineHealthEventAnnotationKey]), &healthEventsMap)
@@ -975,7 +1167,7 @@ func TestE2E_EntityLevelTracking(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		node, _ := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-		return !node.Spec.Unschedulable
+		return !node.Spec.Unschedulable && node.Labels["nvidia.com/gpu-fault"] == ""
 	}, eventuallyTimeout, eventuallyPollInterval, "Node should be unquarantined")
 }
 
@@ -3585,7 +3777,9 @@ func TestE2E_DryRunMode(t *testing.T) {
 	defer cancel()
 
 	nodeName := "e2e-dryrun-" + generateShortTestID()
-	createE2ETestNode(ctx, t, nodeName, nil, nil, nil, false)
+	createE2ETestNode(ctx, t, nodeName, nil, map[string]string{
+		"nvidia.com/gpu-fault": "pre-existing",
+	}, nil, false)
 	defer func() {
 		_ = e2eTestClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
 	}()
@@ -3604,6 +3798,7 @@ func TestE2E_DryRunMode(t *testing.T) {
 					},
 				},
 				Taint:  config.Taint{Key: "nvidia.com/gpu-xid-error", Value: "true", Effect: "NoSchedule"},
+				Label:  config.Label{Key: "nvidia.com/gpu-fault", Value: "critical"},
 				Cordon: config.Cordon{ShouldCordon: true},
 			},
 		},
@@ -3647,9 +3842,34 @@ func TestE2E_DryRunMode(t *testing.T) {
 		}
 	}
 	assert.Equal(t, 0, fqTaintCount, "Node should NOT have taints applied in dry run mode")
+	assert.Equal(t, "pre-existing", node.Labels["nvidia.com/gpu-fault"],
+		"Dry run should not overwrite a rule label")
 
 	// Annotations ARE added in dry run (only spec changes are skipped)
 	assert.NotEmpty(t, node.Annotations[common.QuarantineHealthEventAnnotationKey], "Annotations are still added in dry run")
+	assert.NotEmpty(t, node.Annotations[common.QuarantineHealthEventAppliedLabelsAnnotationKey],
+		"Intended rule labels should still be recorded for dry-run observability")
+
+	healthyID := generateTestID()
+	mockWatcher.EventsChan <- &TestEvent{Data: createHealthEventBSON(
+		healthyID,
+		nodeName,
+		"GpuXidError",
+		true,
+		false,
+		[]*protos.Entity{{EntityType: "GPU", EntityValue: "0"}},
+		model.StatusInProgress,
+	)}
+
+	require.Eventually(t, func() bool {
+		status := getStatus(healthyID)
+		return status != nil && *status == model.UnQuarantined
+	}, statusCheckTimeout, statusCheckPollInterval, "Dry-run recovery should be processed")
+
+	node, err = e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "pre-existing", node.Labels["nvidia.com/gpu-fault"],
+		"Dry run should not remove a rule label during recovery")
 }
 
 func TestE2E_TaintOnlyThenCordonRule(t *testing.T) {
@@ -4702,6 +4922,7 @@ func TestE2E_StaleAnnotationOnRestart_TaintsAndCordon(t *testing.T) {
 					},
 				},
 				Taint:  config.Taint{Key: "nvidia.com/gpu-xid-error", Value: "true", Effect: "NoSchedule"},
+				Label:  config.Label{Key: "nvidia.com/gpu-fault", Value: "active"},
 				Cordon: config.Cordon{ShouldCordon: true},
 			},
 		},
@@ -4712,8 +4933,10 @@ func TestE2E_StaleAnnotationOnRestart_TaintsAndCordon(t *testing.T) {
 	runReconcilerAndQuarantineNode(t, ctx, nodeName, tomlConfig, func(t *testing.T, node *corev1.Node) bool {
 		hasHealthEvent := node.Annotations[common.QuarantineHealthEventAnnotationKey] != ""
 		hasAppliedTaintsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey] != ""
+		hasAppliedLabelsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedLabelsAnnotationKey] != ""
 		hasCordonAnnotation := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey] == "True"
 		isCordoned := node.Spec.Unschedulable
+		hasFaultLabel := node.Labels["nvidia.com/gpu-fault"] == "active"
 
 		hasFQTaint := false
 		for _, taint := range node.Spec.Taints {
@@ -4725,7 +4948,7 @@ func TestE2E_StaleAnnotationOnRestart_TaintsAndCordon(t *testing.T) {
 
 		t.Logf("Node quarantined check: hasHealthEvent=%v, hasAppliedTaintsAnnotation=%v, hasCordonAnnotation=%v, isCordoned=%v, hasFQTaint=%v",
 			hasHealthEvent, hasAppliedTaintsAnnotation, hasCordonAnnotation, isCordoned, hasFQTaint)
-		return hasHealthEvent && hasAppliedTaintsAnnotation && hasCordonAnnotation && isCordoned && hasFQTaint
+		return hasHealthEvent && hasAppliedTaintsAnnotation && hasAppliedLabelsAnnotation && hasCordonAnnotation && isCordoned && hasFQTaint && hasFaultLabel
 	})
 
 	// Step 2: Manually remove taints and uncordon the node
@@ -4783,8 +5006,10 @@ func TestE2E_StaleAnnotationOnRestart_TaintsAndCordon(t *testing.T) {
 		// Stale annotations should be removed
 		annotationRemoved := node.Annotations[common.QuarantineHealthEventAnnotationKey] == ""
 		appliedTaintsRemoved := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey] == ""
+		appliedLabelsRemoved := node.Annotations[common.QuarantineHealthEventAppliedLabelsAnnotationKey] == ""
 		cordonedAnnotationRemoved := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey] == ""
 		labelRemoved := node.Labels[statemanager.NVSentinelStateLabelKey] == ""
+		faultLabelPreserved := node.Labels["nvidia.com/gpu-fault"] == "active"
 
 		fqTaintCount := 0
 		for _, taint := range node.Spec.Taints {
@@ -4795,8 +5020,10 @@ func TestE2E_StaleAnnotationOnRestart_TaintsAndCordon(t *testing.T) {
 
 		return annotationRemoved &&
 			appliedTaintsRemoved &&
+			appliedLabelsRemoved &&
 			cordonedAnnotationRemoved &&
 			labelRemoved &&
+			faultLabelPreserved &&
 			fqTaintCount == 0 &&
 			!node.Spec.Unschedulable
 	}, eventuallyTimeout, eventuallyPollInterval, "Stale annotations should be cleaned up on restart")
@@ -5202,6 +5429,7 @@ func TestE2ECordonAndTaint_ManualUntaint(t *testing.T) {
 					},
 				},
 				Taint:  config.Taint{Key: "nvidia.com/gpu-xid-error", Value: "true", Effect: "NoSchedule"},
+				Label:  config.Label{Key: "nvidia.com/gpu-fault", Value: "active"},
 				Cordon: config.Cordon{ShouldCordon: true},
 			},
 		},
@@ -5232,6 +5460,8 @@ func TestE2ECordonAndTaint_ManualUntaint(t *testing.T) {
 		}
 		hasHealthEvent := node.Annotations[common.QuarantineHealthEventAnnotationKey] != ""
 		hasAppliedTaintsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey] != ""
+		hasAppliedLabelsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedLabelsAnnotationKey] != ""
+		hasFaultLabel := node.Labels["nvidia.com/gpu-fault"] == "active"
 		isCordoned := node.Spec.Unschedulable
 
 		hasFQTaint := false
@@ -5244,7 +5474,8 @@ func TestE2ECordonAndTaint_ManualUntaint(t *testing.T) {
 
 		t.Logf("Node tainted check: hasHealthEvent=%v, hasAppliedTaintsAnnotation=%v, isCordoned=%v, hasFQTaint=%v",
 			hasHealthEvent, hasAppliedTaintsAnnotation, isCordoned, hasFQTaint)
-		return hasHealthEvent && hasAppliedTaintsAnnotation && isCordoned && hasFQTaint
+		return hasHealthEvent && hasAppliedTaintsAnnotation && hasAppliedLabelsAnnotation &&
+			hasFaultLabel && isCordoned && hasFQTaint
 	}, eventuallyTimeout, eventuallyPollInterval, "Node should be quarantined by FQ")
 
 	// Reconciler and mockWatcher remain running for subsequent test steps
@@ -5282,11 +5513,13 @@ func TestE2ECordonAndTaint_ManualUntaint(t *testing.T) {
 		// FQ annotations should be cleaned up
 		_, hasQuarantineAnnotation := node.Annotations[common.QuarantineHealthEventAnnotationKey]
 		_, hasAppliedTaintsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey]
+		_, hasAppliedLabelsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedLabelsAnnotationKey]
 		_, hasCordonedAnnotation := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey]
 		_, hasCordonPreExistingAnnotation := node.Annotations[common.QuarantineHealthEventCordonPreExistingAnnotationKey]
 
 		// State label should be removed
 		_, hasStateLabel := node.Labels[statemanager.NVSentinelStateLabelKey]
+		hasFaultLabel := node.Labels["nvidia.com/gpu-fault"] == "active"
 
 		// Check that FQ taint is removed (manually removed by test)
 		hasFQTaint := false
@@ -5305,10 +5538,12 @@ func TestE2ECordonAndTaint_ManualUntaint(t *testing.T) {
 		return hasManualUntaintAnnotation &&
 			!hasQuarantineAnnotation &&
 			!hasAppliedTaintsAnnotation &&
+			!hasAppliedLabelsAnnotation &&
 			!hasCordonedAnnotation &&
 			!hasCordonPreExistingAnnotation &&
 			!hasFQTaint && // FQ taint should be removed
 			isCordoned && // node should still be cordoned
+			hasFaultLabel && // manual untaint should preserve rule labels
 			!hasStateLabel
 	}, eventuallyTimeout, eventuallyPollInterval, "Manual untaint should clean up FQ state")
 
@@ -5352,6 +5587,7 @@ func TestE2ECordonAndTaint_ManualUncordon(t *testing.T) {
 					},
 				},
 				Taint:  config.Taint{Key: "nvidia.com/gpu-xid-error", Value: "true", Effect: "NoSchedule"},
+				Label:  config.Label{Key: "nvidia.com/gpu-fault", Value: "active"},
 				Cordon: config.Cordon{ShouldCordon: true},
 			},
 		},
@@ -5382,6 +5618,8 @@ func TestE2ECordonAndTaint_ManualUncordon(t *testing.T) {
 		}
 		hasHealthEvent := node.Annotations[common.QuarantineHealthEventAnnotationKey] != ""
 		hasAppliedTaintsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey] != ""
+		hasAppliedLabelsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedLabelsAnnotationKey] != ""
+		hasFaultLabel := node.Labels["nvidia.com/gpu-fault"] == "active"
 		isCordoned := node.Spec.Unschedulable
 
 		hasFQTaint := false
@@ -5394,7 +5632,8 @@ func TestE2ECordonAndTaint_ManualUncordon(t *testing.T) {
 
 		t.Logf("Node tainted check: hasHealthEvent=%v, hasAppliedTaintsAnnotation=%v, isCordoned=%v, hasFQTaint=%v",
 			hasHealthEvent, hasAppliedTaintsAnnotation, isCordoned, hasFQTaint)
-		return hasHealthEvent && hasAppliedTaintsAnnotation && isCordoned && hasFQTaint
+		return hasHealthEvent && hasAppliedTaintsAnnotation && hasAppliedLabelsAnnotation &&
+			hasFaultLabel && isCordoned && hasFQTaint
 	}, eventuallyTimeout, eventuallyPollInterval, "Node should be quarantined by FQ")
 
 	// Reconciler and mockWatcher remain running for subsequent test steps
@@ -5426,11 +5665,13 @@ func TestE2ECordonAndTaint_ManualUncordon(t *testing.T) {
 		// FQ annotations should be cleaned up
 		_, hasQuarantineAnnotation := node.Annotations[common.QuarantineHealthEventAnnotationKey]
 		_, hasAppliedTaintsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedTaintsAnnotationKey]
+		_, hasAppliedLabelsAnnotation := node.Annotations[common.QuarantineHealthEventAppliedLabelsAnnotationKey]
 		_, hasCordonedAnnotation := node.Annotations[common.QuarantineHealthEventIsCordonedAnnotationKey]
 		_, hasCordonPreExistingAnnotation := node.Annotations[common.QuarantineHealthEventCordonPreExistingAnnotationKey]
 
 		// State label should be removed
 		_, hasStateLabel := node.Labels[statemanager.NVSentinelStateLabelKey]
+		hasFaultLabel := node.Labels["nvidia.com/gpu-fault"] == "active"
 
 		// Check that FQ taint remains (manual uncordon only removes cordon, not taints)
 		hasFQTaint := false
@@ -5447,10 +5688,12 @@ func TestE2ECordonAndTaint_ManualUncordon(t *testing.T) {
 		return hasManualUncordonAnnotation &&
 			!hasQuarantineAnnotation &&
 			!hasAppliedTaintsAnnotation &&
+			!hasAppliedLabelsAnnotation &&
 			!hasCordonedAnnotation &&
 			!hasCordonPreExistingAnnotation &&
 			hasFQTaint && // FQ taint should remain (manual uncordon doesn't remove taints)
 			isUncordoned && // node should be uncordoned
+			hasFaultLabel && // manual uncordon should preserve rule labels
 			!hasStateLabel
 	}, eventuallyTimeout, eventuallyPollInterval, "Manual uncordon should clean up FQ state")
 

--- a/fault-quarantine/pkg/reconciler/rule_label_error_test.go
+++ b/fault-quarantine/pkg/reconciler/rule_label_error_test.go
@@ -44,7 +44,8 @@ func (s *stubRuleSetEvaluator) GetName() string    { return s.name }
 func (s *stubRuleSetEvaluator) GetVersion() string { return "1" }
 func (s *stubRuleSetEvaluator) GetPriority() int   { return 0 }
 
-func TestApplyRuleLabelsForEventContinuesAfterEvaluationError(t *testing.T) {
+// TestApplyRuleLabelsForEvent_EvaluationError_ContinuesToNextEvaluator verifies that later evaluators still apply labels.
+func TestApplyRuleLabelsForEvent_EvaluationError_ContinuesToNextEvaluator(t *testing.T) {
 	ctx, cancel := context.WithTimeout(e2eTestContext, 20*time.Second)
 	defer cancel()
 

--- a/fault-quarantine/pkg/reconciler/rule_label_error_test.go
+++ b/fault-quarantine/pkg/reconciler/rule_label_error_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/nvidia/nvsentinel/data-models/pkg/protos"
+	"github.com/nvidia/nvsentinel/fault-quarantine/pkg/common"
+	"github.com/nvidia/nvsentinel/fault-quarantine/pkg/config"
+	"github.com/nvidia/nvsentinel/fault-quarantine/pkg/evaluator"
+)
+
+type stubRuleSetEvaluator struct {
+	name   string
+	result common.RuleEvaluationResult
+	err    error
+}
+
+func (s *stubRuleSetEvaluator) Evaluate(*protos.HealthEvent) (common.RuleEvaluationResult, error) {
+	return s.result, s.err
+}
+
+func (s *stubRuleSetEvaluator) GetName() string    { return s.name }
+func (s *stubRuleSetEvaluator) GetVersion() string { return "1" }
+func (s *stubRuleSetEvaluator) GetPriority() int   { return 0 }
+
+func TestApplyRuleLabelsForEventContinuesAfterEvaluationError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(e2eTestContext, 20*time.Second)
+	defer cancel()
+
+	nodeName := "rule-label-evaluation-error-" + generateShortTestID()
+	createE2ETestNode(ctx, t, nodeName, nil, nil, nil, false)
+	defer func() {
+		_ = e2eTestClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
+	}()
+
+	r, _, _, _ := setupE2EReconciler(t, ctx, config.TomlConfig{}, nil)
+	rulesets := rulesetsConfig{
+		LabelConfigMap: map[string]*config.Label{
+			"low":  {Key: "nvidia.com/gpu-fault", Value: "degraded"},
+			"high": {Key: "nvidia.com/gpu-fault", Value: "critical"},
+		},
+		RuleSetPriorityMap: map[string]int{"low": 5, "high": 10},
+		RuleSetOrderMap:    map[string]int{"low": 0, "broken": 1, "high": 2},
+	}
+	evaluators := []evaluator.RuleSetEvaluatorIface{
+		&stubRuleSetEvaluator{name: "low", result: common.RuleEvaluationSuccess},
+		&stubRuleSetEvaluator{name: "broken", err: errors.New("evaluation failed")},
+		&stubRuleSetEvaluator{name: "high", result: common.RuleEvaluationSuccess},
+	}
+
+	err := r.applyRuleLabelsForEvent(ctx, &protos.HealthEvent{NodeName: nodeName}, evaluators, rulesets)
+	require.NoError(t, err)
+
+	node, err := e2eTestClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "critical", node.Labels["nvidia.com/gpu-fault"])
+}


### PR DESCRIPTION
  ## Summary

  Add optional Kubernetes label actions to fault-quarantine rulesets.

  When a ruleset matches, fault-quarantine can now:

  - Apply or overwrite the configured node label.
  - Resolve multiple matching rules for the same label key by priority, with configuration order as the tie-breaker.
  - Record managed labels in the `quarantineHealthEventAppliedLabels` node annotation.
  - Keep labels while any tracked health event remains unhealthy.
  - Remove only the recorded labels after all tracked health events recover.
  - Clean up managed labels during manual uncordon, manual untaint, and stale-state recovery.
  - Export metrics for applied and removed labels.

  The Helm chart values, rendered TOML configuration, and fault-quarantine documentation have also been updated.

  ## Type of Change

  - [ ] 🐛 Bug fix
  - [x] ✨ New feature
  - [ ] 💥 Breaking change
  - [x] 📚 Documentation
  - [ ] 🔧 Refactoring
  - [ ] 🔨 Build/CI

  ## Component(s) Affected

  - [ ] Core Services
  - [ ] Documentation/CI
  - [x] Fault Management
  - [ ] Health Monitors
  - [ ] Janitor
  - [ ] Other: __________

  ## Testing

  - [x] Tests pass locally
  - [x] Manual testing completed
  - [x] No breaking changes (or documented)

  Validation performed:

  - `make lint-test`
  - 146 tests passed
  - `golangci-lint`: 0 issues
  - Race-enabled envtest suite passed
  - Helm chart lint passed

  Test coverage includes:

  - Label-only quarantine and recovery.
  - Overwriting an existing label value.
  - Keeping the label while another entity-level fault remains active.
  - Removing the label after the final tracked fault recovers.
  - Priority and configuration-order conflict resolution.
  - Manual and stale-state cleanup behavior.

  ## Checklist

  - [x] Self-review completed
  - [x] Documentation updated (if needed)
  - [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fault Quarantine now supports rule-driven Kubernetes label actions alongside taints/cordons.
  * Rules may set optional `label` (key/value); when multiple rules set the same key, higher `priority` wins (default `0`), with later configuration order breaking ties.
  * Applied labels are persisted on nodes and removed during recovery, unquarantine, and manual/stale remediation.
  * Added Prometheus counters for label application/removal.
* **Documentation**
  * Updated chart values and docs to cover label configuration, priority/overwrite semantics, and cleanup/dry-run behavior.
* **Tests**
  * Added/extended unit and end-to-end coverage for label-only flows, winner selection, applied-label annotation merging/removal, metrics, and restart/manual cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->