### PR TITLE
fix: fix UAT Scripts and dcgm embedded-mode prerequisites

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/daemonset-dcgm-3.x.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/daemonset-dcgm-3.x.yaml
@@ -65,6 +65,11 @@ spec:
             - {{ .Values.processingStrategy | quote }}
           securityContext:
             runAsUser: 0
+            {{- if eq (include "gpu-health-monitor.dcgmMode" .) "embedded-mode" }}
+            # Required for NVIDIA container toolkit GPU/driver injection when the
+            # toolkit ignores NVIDIA_VISIBLE_DEVICES for unprivileged containers.
+            privileged: true
+            {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default ((.Values.global).image).tag | default .Chart.AppVersion }}-dcgm-3.x"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:

--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/daemonset-dcgm-4.x.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/daemonset-dcgm-4.x.yaml
@@ -65,6 +65,11 @@ spec:
             - {{ .Values.processingStrategy | quote }}
           securityContext:
             runAsUser: 0
+            {{- if eq (include "gpu-health-monitor.dcgmMode" .) "embedded-mode" }}
+            # Required for NVIDIA container toolkit GPU/driver injection when the
+            # toolkit ignores NVIDIA_VISIBLE_DEVICES for unprivileged containers.
+            privileged: true
+            {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default ((.Values.global).image).tag | default .Chart.AppVersion }}-dcgm-4.x"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:

--- a/docs/configuration/gpu-health-monitor.md
+++ b/docs/configuration/gpu-health-monitor.md
@@ -6,25 +6,35 @@ The GPU Health Monitor module watches GPU health using NVIDIA DCGM (Data Center 
 
 ## DCGM Deployment Modes
 
-DCGM (Data Center GPU Manager) always runs as a DaemonSet with one pod per GPU node. The GPU Health Monitor can connect to DCGM in two modes:
+The GPU Health Monitor supports three DCGM source modes, selected with `global.dcgm.mode`.
 
-### DCGM with Kubernetes Service
+### Operator Service
 
-DCGM DaemonSet exposes a Kubernetes service. GPU Health Monitor pods connect to DCGM on their local node via this service endpoint.
+The GPU Operator runs DCGM as a DaemonSet and exposes it through a Kubernetes service. GPU Health Monitor pods connect to the service endpoint.
 
 **Characteristics:**
 - DCGM runs as a DaemonSet (one pod per GPU node)
 - Kubernetes service provides DNS endpoint for DCGM
 - GPU Health Monitor connects via service DNS name
 
-### DCGM with Host Networking
+### External Hostengine
 
-DCGM DaemonSet uses host networking. GPU Health Monitor pods connect to DCGM via `localhost:5555` on the host network.
+An externally managed hostengine runs on each GPU node. GPU Health Monitor pods use host networking and connect to the configured endpoint, which defaults to `localhost:5555`.
 
 **Characteristics:**
-- DCGM runs as a DaemonSet with `hostNetwork: true`
+- The hostengine lifecycle is managed outside NVSentinel
 - No Kubernetes service needed
-- GPU Health Monitor connects to `localhost:5555`
+- GPU Health Monitor enables host networking automatically
+
+### Embedded Mode
+
+GPU Health Monitor starts an in-process DCGM hostengine and exposes it to pod-local clients on a loopback endpoint.
+
+**Characteristics:**
+- No separate DCGM DaemonSet or service is needed
+- `gpu-health-monitor.runtimeClassName` must name the cluster's NVIDIA RuntimeClass
+- The chart automatically sets `privileged: true` on the GPU Health Monitor container
+- The endpoint must be `localhost`, `127.0.0.1`, or `::1`
 
 ## Configuration Reference
 
@@ -64,70 +74,69 @@ gpu-health-monitor:
 
 ## DCGM Configuration
 
-### DCGM Service Mode
+### Operator Service Mode
 
-Configuration for connecting to DCGM running as a Kubernetes service.
+This is the default mode.
 
 ```yaml
-gpu-health-monitor:
+global:
   dcgm:
-    dcgmK8sServiceEnabled: true
+    mode: operator-service
+    enabled: true
     service:
       endpoint: "nvidia-dcgm.gpu-operator.svc"
       port: 5555
 ```
 
-#### Parameters
-
-##### dcgmK8sServiceEnabled
-Enables connection to DCGM via Kubernetes service. When `true`, uses `service.endpoint` and `service.port`. When `false`, connects to `localhost:5555` (sidecar mode).
-
-##### service.endpoint
-Kubernetes service DNS name for DCGM. Typically the DCGM service deployed by GPU Operator.
-
-##### service.port
-Port where DCGM is listening. Default is `5555`.
-
-#### DCGM Service Examples
-
-##### Example 1: GPU Operator DCGM Service
+To use a service in another namespace, override its endpoint:
 
 ```yaml
-dcgm:
-  dcgmK8sServiceEnabled: true
-  service:
-    endpoint: "nvidia-dcgm.gpu-operator.svc"
-    port: 5555
+global:
+  dcgm:
+    mode: operator-service
+    service:
+      endpoint: "dcgm-service.custom-namespace.svc.cluster.local"
+      port: 5555
 ```
 
-##### Example 2: Custom Namespace DCGM Service
+### External Hostengine Mode
+
+NVSentinel does not deploy the hostengine in this mode. The configured hostengine must already be running and reachable on every selected GPU node.
 
 ```yaml
-dcgm:
-  dcgmK8sServiceEnabled: true
-  service:
-    endpoint: "dcgm-service.custom-namespace.svc.cluster.local"
-    port: 5555
+global:
+  dcgm:
+    mode: external-hostengine
+    externalHostengine:
+      endpoint: localhost
+      port: 5555
 ```
 
-### Host Networking
+GPU Health Monitor enables host networking automatically in this mode.
 
-Enables host network mode for GPU Health Monitor pods.
+### Embedded Mode
+
+```yaml
+global:
+  dcgm:
+    mode: embedded-mode
+    embedded:
+      endpoint: localhost
+      port: 5555
+
+gpu-health-monitor:
+  runtimeClassName: nvidia
+```
+
+`runtimeClassName` is required and must match an NVIDIA RuntimeClass installed in the cluster. The chart automatically sets the GPU Health Monitor container to privileged in embedded mode so the NVIDIA Container Toolkit can provide GPU and driver access; no separate security-context value is required.
+
+### Host Networking Override
+
+`external-hostengine` enables host networking automatically. For other modes, it can be enabled explicitly when required by a custom deployment:
 
 ```yaml
 gpu-health-monitor:
-  useHostNetworking: false
-```
-
-Set to `true` when DCGM is deployed with host networking (`dcgm.dcgmK8sServiceEnabled: false`). In this mode, GPU Health Monitor connects to DCGM via `localhost:5555` on the host network.
-
-#### Example: Host Networking Mode for connecting to DCGM
-
-```yaml
-dcgm:
-  dcgmK8sServiceEnabled: false
-
-useHostNetworking: true
+  useHostNetworking: true
 ```
 
 ## DCGM Health Check Incident Suppression

--- a/docs/designs/044-dcgm-source-modes.md
+++ b/docs/designs/044-dcgm-source-modes.md
@@ -71,7 +71,7 @@ Embedded-mode runs the DCGM hostengine inside GPU health monitor container, so t
 
 - `operator-service` renders the existing service-backed monitor DaemonSets selected by `dcgm.version`.
 - `external-hostengine` renders the regular remote monitor path with host networking and is selected by the existing node `dcgm.version` label.
-- `embedded-mode` renders the regular monitor DaemonSets and is selected by the existing node `dcgm.version` label, just like `external-hostengine`.
+- `embedded-mode` renders the regular monitor DaemonSets and is selected by the existing node `dcgm.version` label, just like `external-hostengine`, and sets `privileged: true` on the monitor container.
 
 In `external-hostengine` and `embedded-mode`, the chart sets `--assume-dcgm-available` on labeler. This tells labeler not to remove an existing valid `dcgm.version` label when no DCGM pod is present, which is the expected topology for an externally managed hostengine or an embedded hostengine selected by node label.
 
@@ -99,6 +99,7 @@ Labeler resolves the expected DCGM version from DCGM pods when they exist, match
 `embedded-mode` runs an in-process embedded DCGM hostengine inside the GPU health monitor process and exposes the same engine on pod-local loopback. It uses the DCGM APIs rather than a separate `nv-hostengine` process.
 
 Runtime behavior:
+
 1. Create the DCGM handle with no IP address (`pydcgm.DcgmHandle(opMode=DCGM_OPERATION_MODE_AUTO)`), which calls `dcgmStartEmbedded` to start the embedded hostengine in-process.
 2. Call `dcgmEngineRun` through the Python bindings to expose that engine on `127.0.0.1:<port>`. GPU health monitor continues using the embedded handle; pod-local tools such as `dcgmi` connect to the loopback listener and therefore operate on the same hostengine cache.
 3. Run the normal health-check loop against the embedded handle.
@@ -106,7 +107,7 @@ Runtime behavior:
 
 This starts DCGM the same way `dcgm-exporter` does in embedded deployments (`dcgm.Init(dcgm.Embedded)`), then follows DCGM's own embedded test utility pattern by calling `dcgmEngineRun` for local client access. The CLI selects it via `--dcgm-mode local-managed`, derived in the chart from `global.dcgm.mode=embedded-mode`.
 
-Because the embedded engine runs in the monitor's own pod, that pod must have GPU and driver access: set `runtimeClassName` to the NVIDIA RuntimeClass so the toolkit injects the GPUs and driver.
+Because the embedded engine runs in the monitor's own pod, that pod must have GPU and driver access: set `runtimeClassName` to the NVIDIA RuntimeClass so the toolkit injects the GPUs and driver. The chart additionally sets `privileged: true` on the monitor container in this mode; on toolkits that ignore `NVIDIA_VISIBLE_DEVICES` for unprivileged containers, privileged is what makes the injection happen at all.
 
 ## Rationale
 

--- a/tests/uat/nvsentinel-debug-pod-template.yaml
+++ b/tests/uat/nvsentinel-debug-pod-template.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: uat-node-debug
+  namespace: nvsentinel
+  labels:
+    app.kubernetes.io/name: uat-node-debug
+spec:
+  nodeName: NODE_NAME
+  runtimeClassName: nvidia
+  restartPolicy: Never
+  tolerations:
+    - operator: Exists
+  containers:
+    - name: nvsentinel-debug
+      # Same base image as the syslog-health-monitor runtime stage. nvidia-smi
+      # is injected by the NVIDIA container toolkit (runtimeClassName +
+      # privileged + NVIDIA_VISIBLE_DEVICES, see ADR-044).
+      image: public.ecr.aws/docker/library/debian:trixie-slim
+      command: ["sleep", "3600"]
+      securityContext:
+        privileged: true
+      env:
+        - name: NVIDIA_VISIBLE_DEVICES
+          value: all
+        - name: NVIDIA_DRIVER_CAPABILITIES
+          value: utility

--- a/tests/uat/nvsentinel-debug-pod-template.yaml
+++ b/tests/uat/nvsentinel-debug-pod-template.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: uat-node-debug
+  generateName: uat-node-debug-
   namespace: nvsentinel
   labels:
     app.kubernetes.io/name: uat-node-debug

--- a/tests/uat/tests.sh
+++ b/tests/uat/tests.sh
@@ -117,6 +117,57 @@ verify_gpu_driver_pod_exists() {
     log "WARN: No running driver pod found on node $node (checked gpu-operator and kube-system namespaces)."
 }
 
+# Resolve the DCGM fault-injection target for the given node. dcgmi faults
+# are always injected from the gpu-health-monitor pod, against the same
+# engine address the monitor itself watches (its --dcgm-addr argument): the
+# pod-local embedded engine, the GPU Operator DCGM service (node-local via
+# internalTrafficPolicy: Local), or an external host engine. Set
+# UAT_DCGM_HOST to override the dcgmi --host value.
+# Sets: DCGM_NS, DCGM_POD, DCGM_HOST
+discover_dcgm_target() {
+    local node=$1
+
+    DCGM_NS=nvsentinel
+    DCGM_POD=$(kubectl get pods -n "$DCGM_NS" -l app.kubernetes.io/name=gpu-health-monitor \
+        --field-selector=status.phase=Running \
+        -o jsonpath="{.items[?(@.spec.nodeName=='$node')].metadata.name}" 2>/dev/null | head -1)
+    if [[ -z "$DCGM_POD" ]]; then
+        error "No running gpu-health-monitor pod on node $node"
+    fi
+
+    local dcgm_addr
+    dcgm_addr=$(kubectl get pod -n "$DCGM_NS" "$DCGM_POD" -o json 2>/dev/null \
+        | jq -r '.spec.containers[0].args // [] | index("--dcgm-addr") as $i | if $i then .[$i + 1] else empty end')
+    DCGM_HOST=${UAT_DCGM_HOST:-${dcgm_addr:-localhost:5555}}
+    log "Using monitor pod for DCGM injection: $DCGM_NS/$DCGM_POD (dcgmi host: $DCGM_HOST)"
+}
+
+# Privileged helper pod for node-level test operations (/dev/kmsg writes,
+# nvidia-smi queries) on the given node, from nvsentinel-debug-pod-template.yaml.
+# Sets: NODE_NS, NODE_POD
+create_node_debug_pod() {
+    local node=$1
+
+    NODE_NS=nvsentinel
+    NODE_POD=uat-node-debug
+    trap 'delete_node_debug_pod' EXIT
+
+    kubectl delete pod -n "$NODE_NS" "$NODE_POD" --ignore-not-found --wait=true >/dev/null
+
+    sed "s|NODE_NAME|$node|" "${SCRIPT_DIR}/nvsentinel-debug-pod-template.yaml" | kubectl apply -f -
+
+    if ! kubectl wait --for=condition=Ready pod -n "$NODE_NS" "$NODE_POD" --timeout=120s >/dev/null; then
+        error "Debug pod $NODE_NS/$NODE_POD did not become Ready on node $node"
+    fi
+    log "Node debug pod running: $NODE_NS/$NODE_POD"
+}
+
+delete_node_debug_pod() {
+    kubectl delete pod -n "${NODE_NS:-nvsentinel}" "${NODE_POD:-uat-node-debug}" --ignore-not-found --wait=false >/dev/null
+    trap - EXIT
+    log "Node debug pod deleted"
+}
+
 
 wait_for_node_condition() {
     local node=$1
@@ -334,14 +385,9 @@ test_gpu_monitoring_dcgm() {
     original_boot_id=$(get_boot_id "$gpu_node")
     log "Original boot ID: $original_boot_id"
 
-    local dcgm_pod
-    dcgm_pod=$(kubectl get pods -n gpu-operator -l app=nvidia-dcgm -o jsonpath="{.items[?(@.spec.nodeName=='$gpu_node')].metadata.name}" | head -1)
+    discover_dcgm_target "$gpu_node"
 
-    if [[ -z "$dcgm_pod" ]]; then
-        error "No DCGM pod found on node $gpu_node"
-    fi
-
-    kubectl exec -n gpu-operator "$dcgm_pod" -- dcgmi test --inject --gpuid 0 -f 240 -v 99999 # power watch error
+    kubectl exec -n "$DCGM_NS" "$DCGM_POD" -- dcgmi test --host "$DCGM_HOST" --inject --gpuid 0 -f 240 -v 99999 # power watch error
 
     log "Waiting for node events to appear..."
     local max_wait=${UAT_EVENT_TIMEOUT:-30}
@@ -368,7 +414,7 @@ test_gpu_monitoring_dcgm() {
     # XID 95 results in DCGM_FR_UNCONTAINED_ERROR which requires a RESTART_VM action.
     # DCGM 4.2.x maps this to DCGM_HEALTH_WATCH_MEM (GpuMemWatch).
     # DCGM 4.4.x+ reclassified it as a "devastating" XID under DCGM_HEALTH_WATCH_ALL (GpuAllWatch).
-    kubectl exec -n gpu-operator "$dcgm_pod" -- dcgmi test --inject --gpuid 0 -f 230 -v 95
+    kubectl exec -n "$DCGM_NS" "$DCGM_POD" -- dcgmi test --host "$DCGM_HOST" --inject --gpuid 0 -f 230 -v 95
 
     wait_for_any_node_condition "$gpu_node" "GpuAllWatch" "GpuMemWatch"
 
@@ -376,7 +422,7 @@ test_gpu_monitoring_dcgm() {
 
     log "Waiting for node to reboot and recover..."
     wait_for_boot_id_change "$gpu_node" "$original_boot_id"
-    
+
     log "Test 1 PASSED ✓"
 }
 
@@ -398,15 +444,10 @@ test_xid_monitoring_syslog() {
     original_boot_id=$(get_boot_id "$gpu_node")
     log "Original boot ID: $original_boot_id"
 
-    local dcgm_pod
-    dcgm_pod=$(kubectl get pods -n gpu-operator -l app=nvidia-dcgm \
-        -o jsonpath="{.items[?(@.spec.nodeName=='$gpu_node')].metadata.name}" | head -1)
-    if [[ -z "$dcgm_pod" ]]; then
-        error "No DCGM pod found on node $gpu_node"
-    fi
+    create_node_debug_pod "$gpu_node"
 
-    log "Injecting XID 79 via /dev/kmsg on pod: gpu-operator/$dcgm_pod"
-    kubectl exec -n "gpu-operator" "$dcgm_pod" -- sh -c 'echo "<3>[6085126.134786] NVRM: Xid (PCI:0002:00:00): 79, pid=1582259, name=nvc:[driver], GPU has fallen off the bus." > /dev/kmsg'
+    log "Injecting XID 79 via /dev/kmsg on pod: $NODE_NS/$NODE_POD"
+    kubectl exec -n "$NODE_NS" "$NODE_POD" -- sh -c 'echo "<3>[6085126.134786] NVRM: Xid (PCI:0002:00:00): 79, pid=1582259, name=nvc:[driver], GPU has fallen off the bus." > /dev/kmsg'
 
     wait_for_node_condition "$gpu_node" "SysLogsXIDError"
 
@@ -414,6 +455,8 @@ test_xid_monitoring_syslog() {
 
     log "Waiting for node to reboot and recover..."
     wait_for_boot_id_change "$gpu_node" "$original_boot_id"
+
+    delete_node_debug_pod
 
     log "Test 2 PASSED ✓"
 }
@@ -446,16 +489,11 @@ test_xid_monitoring_syslog_gpu_reset() {
     initial_boot_id=$(get_boot_id "$gpu_node")
     log "Original boot ID: $initial_boot_id"
 
-    local dcgm_pod
-    dcgm_pod=$(kubectl get pods -n gpu-operator -l app=nvidia-dcgm \
-        -o jsonpath="{.items[?(@.spec.nodeName=='$gpu_node')].metadata.name}" | head -1)
-    if [[ -z "$dcgm_pod" ]]; then
-        error "No DCGM pod found on node $gpu_node"
-    fi
+    create_node_debug_pod "$gpu_node"
 
-    log "Fetching GPU UUID and PCI from nvidia-smi on gpu-operator/$dcgm_pod"
+    log "Fetching GPU UUID and PCI from nvidia-smi on $NODE_NS/$NODE_POD"
 
-    uuid_pci=$(kubectl exec -n "gpu-operator" "$dcgm_pod" -- sh -c "nvidia-smi --query-gpu=uuid,pci.bus_id --format=csv,noheader | head -n 1")
+    uuid_pci=$(kubectl exec -n "$NODE_NS" "$NODE_POD" -- sh -c "nvidia-smi --query-gpu=uuid,pci.bus_id --format=csv,noheader | head -n 1")
 
     if [[ -z "$uuid_pci" ]]; then
         error "No nvidia-smi query output on node $gpu_node"
@@ -468,8 +506,8 @@ test_xid_monitoring_syslog_gpu_reset() {
     fi
     log "Resetting GPU UUID $uuid on PCI $pci"
 
-    log "Injecting XID 119 on GPU $uuid via /dev/kmsg on pod: gpu-operator/$dcgm_pod"
-    kubectl exec -n "gpu-operator" "$dcgm_pod" -- sh -c "echo '<3>[6085126.134786] NVRM: Xid (PCI:$pci): 119, pid=1582259, name=nvc:[driver], Timeout after 6s of waiting for RPC response from GPU1 GSP! Expected function 76 (GSP_RM_CONTROL) (0x20802a02 0x8).' > /dev/kmsg"
+    log "Injecting XID 119 on GPU $uuid via /dev/kmsg on pod: $NODE_NS/$NODE_POD"
+    kubectl exec -n "$NODE_NS" "$NODE_POD" -- sh -c "echo '<3>[6085126.134786] NVRM: Xid (PCI:$pci): 119, pid=1582259, name=nvc:[driver], Timeout after 6s of waiting for RPC response from GPU1 GSP! Expected function 76 (GSP_RM_CONTROL) (0x20802a02 0x8).' > /dev/kmsg"
 
     wait_for_node_condition "$gpu_node" "SysLogsXIDError"
 
@@ -487,6 +525,8 @@ test_xid_monitoring_syslog_gpu_reset() {
         error "Boot ID changed during GPU reset. Original: $initial_boot_id, Final: $final_boot_id"
     fi
     log "Boot ID unchanged: $final_boot_id"
+
+    delete_node_debug_pod
 
     log "Test 3 PASSED ✓"
 }
@@ -510,16 +550,11 @@ test_sxid_monitoring_syslog() {
     log "Original boot ID: $original_boot_id"
 
 
-    local dcgm_pod
-    dcgm_pod=$(kubectl get pods -n gpu-operator -l app=nvidia-dcgm -o jsonpath="{.items[?(@.spec.nodeName=='$gpu_node')].metadata.name}" | head -1)
+    create_node_debug_pod "$gpu_node"
 
-    if [[ -z "$dcgm_pod" ]]; then
-        error "No DCGM pod found on node $gpu_node"
-    fi
-
-    log "Getting NVLink topology from DCGM pod: $dcgm_pod"
+    log "Getting NVLink topology from debug pod: $NODE_POD"
     local nvlink_output
-    nvlink_output=$(kubectl exec -n gpu-operator "$dcgm_pod" -- nvidia-smi nvlink -R 2>/dev/null)
+    nvlink_output=$(kubectl exec -n "$NODE_NS" "$NODE_POD" -- nvidia-smi nvlink -R 2>/dev/null)
 
     if [[ -z "$nvlink_output" ]]; then
         log "Warning: nvidia-smi nvlink not available, using fallback PCI/Link values"
@@ -545,10 +580,10 @@ test_sxid_monitoring_syslog() {
     fi
 
 
-    log "Injecting SXID error messages via /dev/kmsg on pod: gpu-operator/$dcgm_pod"
+    log "Injecting SXID error messages via /dev/kmsg on pod: $NODE_NS/$NODE_POD"
 
     log "  - SXID 28002 (Non-fatal): Therm Warn Deactivated on Link $link_number"
-    kubectl exec -n gpu-operator "$dcgm_pod" -- sh -c "echo '<3>nvidia-nvswitch0: SXid (PCI:${pci_id}): 28002, Non-fatal, Link ${link_number} Therm Warn Deactivated' > /dev/kmsg"
+    kubectl exec -n "$NODE_NS" "$NODE_POD" -- sh -c "echo '<3>nvidia-nvswitch0: SXid (PCI:${pci_id}): 28002, Non-fatal, Link ${link_number} Therm Warn Deactivated' > /dev/kmsg"
 
     local max_wait=${UAT_EVENT_TIMEOUT:-30}
     local waited=0
@@ -571,7 +606,7 @@ test_sxid_monitoring_syslog() {
     log "Node event verified: SysLogsSXIDError ✓"
 
     log "  - SXID 20034 (Fatal): LTSSM Fault Up on Link $link_number"
-    kubectl exec -n gpu-operator "$dcgm_pod" -- sh -c "echo '<3>nvidia-nvswitch3: SXid (PCI:${pci_id}): 20034, Fatal, Link ${link_number} LTSSM Fault Up' > /dev/kmsg"
+    kubectl exec -n "$NODE_NS" "$NODE_POD" -- sh -c "echo '<3>nvidia-nvswitch3: SXid (PCI:${pci_id}): 20034, Fatal, Link ${link_number} LTSSM Fault Up' > /dev/kmsg"
 
     wait_for_node_condition "$gpu_node" "SysLogsSXIDError"
 
@@ -579,6 +614,8 @@ test_sxid_monitoring_syslog() {
 
     log "Waiting for node to reboot and recover..."
     wait_for_boot_id_change "$gpu_node" "$original_boot_id"
+
+    delete_node_debug_pod
 
     log "Test 4 PASSED ✓"
 }

--- a/tests/uat/tests.sh
+++ b/tests/uat/tests.sh
@@ -123,23 +123,23 @@ verify_gpu_driver_pod_exists() {
 # pod-local embedded engine, the GPU Operator DCGM service (node-local via
 # internalTrafficPolicy: Local), or an external host engine. Set
 # UAT_DCGM_HOST to override the dcgmi --host value.
-# Sets: DCGM_NS, DCGM_POD, DCGM_HOST
+# Sets: GPU_HM_NS, GPU_HM_POD, DCGM_HOST
 discover_dcgm_target() {
     local node=$1
 
-    DCGM_NS=nvsentinel
-    DCGM_POD=$(kubectl get pods -n "$DCGM_NS" -l app.kubernetes.io/name=gpu-health-monitor \
+    GPU_HM_NS=nvsentinel
+    GPU_HM_POD=$(kubectl get pods -n "$GPU_HM_NS" -l app.kubernetes.io/name=gpu-health-monitor \
         --field-selector=status.phase=Running \
         -o jsonpath="{.items[?(@.spec.nodeName=='$node')].metadata.name}" 2>/dev/null | head -1)
-    if [[ -z "$DCGM_POD" ]]; then
+    if [[ -z "$GPU_HM_POD" ]]; then
         error "No running gpu-health-monitor pod on node $node"
     fi
 
     local dcgm_addr
-    dcgm_addr=$(kubectl get pod -n "$DCGM_NS" "$DCGM_POD" -o json 2>/dev/null \
+    dcgm_addr=$(kubectl get pod -n "$GPU_HM_NS" "$GPU_HM_POD" -o json 2>/dev/null \
         | jq -r '.spec.containers[0].args // [] | index("--dcgm-addr") as $i | if $i then .[$i + 1] else empty end')
     DCGM_HOST=${UAT_DCGM_HOST:-${dcgm_addr:-localhost:5555}}
-    log "Using monitor pod for DCGM injection: $DCGM_NS/$DCGM_POD (dcgmi host: $DCGM_HOST)"
+    log "Using monitor pod for DCGM injection: $GPU_HM_NS/$GPU_HM_POD (dcgmi host: $DCGM_HOST)"
 }
 
 # Privileged helper pod for node-level test operations (/dev/kmsg writes,
@@ -387,7 +387,7 @@ test_gpu_monitoring_dcgm() {
 
     discover_dcgm_target "$gpu_node"
 
-    kubectl exec -n "$DCGM_NS" "$DCGM_POD" -- dcgmi test --host "$DCGM_HOST" --inject --gpuid 0 -f 240 -v 99999 # power watch error
+    kubectl exec -n "$GPU_HM_NS" "$GPU_HM_POD" -- dcgmi test --host "$DCGM_HOST" --inject --gpuid 0 -f 240 -v 99999 # power watch error
 
     log "Waiting for node events to appear..."
     local max_wait=${UAT_EVENT_TIMEOUT:-30}
@@ -414,7 +414,7 @@ test_gpu_monitoring_dcgm() {
     # XID 95 results in DCGM_FR_UNCONTAINED_ERROR which requires a RESTART_VM action.
     # DCGM 4.2.x maps this to DCGM_HEALTH_WATCH_MEM (GpuMemWatch).
     # DCGM 4.4.x+ reclassified it as a "devastating" XID under DCGM_HEALTH_WATCH_ALL (GpuAllWatch).
-    kubectl exec -n "$DCGM_NS" "$DCGM_POD" -- dcgmi test --host "$DCGM_HOST" --inject --gpuid 0 -f 230 -v 95
+    kubectl exec -n "$GPU_HM_NS" "$GPU_HM_POD" -- dcgmi test --host "$DCGM_HOST" --inject --gpuid 0 -f 230 -v 95
 
     wait_for_any_node_condition "$gpu_node" "GpuAllWatch" "GpuMemWatch"
 
@@ -583,7 +583,7 @@ test_sxid_monitoring_syslog() {
     log "Injecting SXID error messages via /dev/kmsg on pod: $NODE_NS/$NODE_POD"
 
     log "  - SXID 28002 (Non-fatal): Therm Warn Deactivated on Link $link_number"
-    kubectl exec -n "$NODE_NS" "$NODE_POD" -- sh -c "echo '<3>nvidia-nvswitch0: SXid (PCI:${pci_id}): 28002, Non-fatal, Link ${link_number} Therm Warn Deactivated' > /dev/kmsg"
+    kubectl exec -n "$NODE_NS" "$NODE_POD" -- sh -c "echo '<3>[6085126.134786] nvidia-nvswitch0: SXid (PCI:${pci_id}): 28002, Non-fatal, Link ${link_number} Therm Warn Deactivated' > /dev/kmsg"
 
     local max_wait=${UAT_EVENT_TIMEOUT:-30}
     local waited=0
@@ -606,7 +606,7 @@ test_sxid_monitoring_syslog() {
     log "Node event verified: SysLogsSXIDError ✓"
 
     log "  - SXID 20034 (Fatal): LTSSM Fault Up on Link $link_number"
-    kubectl exec -n "$NODE_NS" "$NODE_POD" -- sh -c "echo '<3>nvidia-nvswitch3: SXid (PCI:${pci_id}): 20034, Fatal, Link ${link_number} LTSSM Fault Up' > /dev/kmsg"
+    kubectl exec -n "$NODE_NS" "$NODE_POD" -- sh -c "echo '<3>[6085126.134786] nvidia-nvswitch3: SXid (PCI:${pci_id}): 20034, Fatal, Link ${link_number} LTSSM Fault Up' > /dev/kmsg"
 
     wait_for_node_condition "$gpu_node" "SysLogsSXIDError"
 

--- a/tests/uat/tests.sh
+++ b/tests/uat/tests.sh
@@ -149,12 +149,9 @@ create_node_debug_pod() {
     local node=$1
 
     NODE_NS=nvsentinel
-    NODE_POD=uat-node-debug
+    NODE_POD=$(sed "s|NODE_NAME|$node|" "${SCRIPT_DIR}/nvsentinel-debug-pod-template.yaml" \
+        | kubectl create -f - -o jsonpath='{.metadata.name}')
     trap 'delete_node_debug_pod' EXIT
-
-    kubectl delete pod -n "$NODE_NS" "$NODE_POD" --ignore-not-found --wait=true >/dev/null
-
-    sed "s|NODE_NAME|$node|" "${SCRIPT_DIR}/nvsentinel-debug-pod-template.yaml" | kubectl apply -f -
 
     if ! kubectl wait --for=condition=Ready pod -n "$NODE_NS" "$NODE_POD" --timeout=120s >/dev/null; then
         error "Debug pod $NODE_NS/$NODE_POD did not become Ready on node $node"
@@ -163,7 +160,7 @@ create_node_debug_pod() {
 }
 
 delete_node_debug_pod() {
-    kubectl delete pod -n "${NODE_NS:-nvsentinel}" "${NODE_POD:-uat-node-debug}" --ignore-not-found --wait=false >/dev/null
+    kubectl delete pod -n "${NODE_NS:-nvsentinel}" "$NODE_POD" --ignore-not-found --wait=false >/dev/null
     trap - EXIT
     log "Node debug pod deleted"
 }


### PR DESCRIPTION
## Summary
update gpu-health-monitor embedded DCGM mode helm chart  to make it privileged to find nvidia devices and updates UAT fault injection to work across all supported DCGM modes.

<!-- Brief description of your changes -->
  - Runs DCGM 3.x/4.x health-monitor containers as privileged in embedded mode.
  - Dynamically discovers the monitored DCGM endpoint for fault injection.
  - Adds a privileged NVIDIA debug pod for XID/SXID injection and GPU queries.
  - Updates ADR-044 with the embedded-mode privilege requirement.

Testing in OCI and GCP Environment:-
  - Verified embedded mode runs privileged and local DCGM connectivity.
  -  Ran UAT scripts in all 3 modes to make sure it works fine.
  - Confirmed nonfatal events and fatal condition/cordon behavior across dcgm modes.
  - Verified debug-pod GPU access, /dev/kmsg injection, and cleanup.
  
## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [x] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the GPU health monitor to enable privileged execution only for DCGM embedded mode, improving correct GPU/driver injection behavior.
* **Documentation**
  * Refreshed GPU health monitor guidance with three DCGM source modes and clarified embedded-mode lifecycle and runtime/pod requirements.
* **Tests**
  * Added a UAT node-local debug pod template and updated UAT fault-injection and DCGM test targeting to run from node-local contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->