### PR TITLE
feat(kom-chart): add customRecommendedAction to policy TOML template

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/configmap.yaml
@@ -50,6 +50,9 @@ data:
         isFatal = {{ .healthEvent.isFatal }}
         message = {{ .healthEvent.message | quote }}
         recommendedAction = {{ .healthEvent.recommendedAction | quote }}
+        {{- if .healthEvent.customRecommendedAction }}
+        customRecommendedAction = {{ .healthEvent.customRecommendedAction | quote }}
+        {{- end }}
         {{- if .healthEvent.errorCode }}
         errorCode = [{{- range $index, $code := .healthEvent.errorCode }}{{- if $index }}, {{ end }}{{ $code | quote }}{{- end }}]
         {{- end }}


### PR DESCRIPTION
## Summary

The kubernetes-object-monitor Helm chart configmap template renders KOM policies into TOML but was missing \`customRecommendedAction\`. This caused KOM to crash at startup with a config validation error when a policy set \`recommendedAction: CUSTOM\` without the accompanying \`customRecommendedAction\` field being present in the rendered TOML.

Adds conditional rendering of \`customRecommendedAction\`, consistent with other optional fields in the template (\`processingStrategy\`, \`quarantineOverrides\`, \`drainOverrides\`).

## Test plan

- [ ] KOM policy with \`recommendedAction: CUSTOM\` and \`customRecommendedAction: REBOOT\` starts without config validation errors
- [ ] KOM policy without \`customRecommendedAction\` (non-CUSTOM actions) still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health event configurations can now include an optional custom recommended action.
  * The custom action is included only when configured, preserving existing behavior otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->