### PR TITLE
fix(fault-quarantine): don't crash on clusters with no GPU nodes

### DIFF
--- a/fault-quarantine/pkg/breaker/breaker.go
+++ b/fault-quarantine/pkg/breaker/breaker.go
@@ -202,8 +202,9 @@ func (b *slidingWindowBreaker) IsTripped(ctx context.Context) (bool, error) {
 	}
 
 	if totalNodes == 0 {
-		slog.ErrorContext(ctx, "Total nodes is still 0 after all retry attempts - cluster may have no GPU nodes")
-		return false, fmt.Errorf("total nodes is 0 after retries")
+		// No GPU nodes in the cluster; the circuit breaker threshold cannot be reached.
+		// Return not-tripped so event processing continues normally.
+		return false, nil
 	}
 
 	now := time.Now()
@@ -279,7 +280,13 @@ func (b *slidingWindowBreaker) SetCursorMode(ctx context.Context, mode CursorMod
 }
 
 // getTotalNodesWithRetry gets the total number of nodes with retry logic and exponential backoff.
-// This handles NodeInformer cache sync delays that can cause GetTotalNodes to temporarily return 0.
+// getTotalNodesWithRetry gets the total number of GPU nodes from the NodeInformer.
+//
+// When the informer has not yet synced, GetTotalNodes returns a non-nil error; the
+// caller is expected to retry. When the informer has synced but the cluster has no
+// GPU nodes (e.g. a management-only cluster), GetTotalNodes returns (0, nil) — a
+// valid steady state in which the circuit breaker is inactive. In that case this
+// function logs a warning and returns (0, nil) rather than crashing.
 func (b *slidingWindowBreaker) getTotalNodesWithRetry(ctx context.Context) (int, error) {
 	startTime := time.Now()
 
@@ -296,151 +303,31 @@ func (b *slidingWindowBreaker) getTotalNodesWithRetry(ctx context.Context) (int,
 		}
 	}()
 
-	maxRetries, initialDelay, maxDelay := b.getRetryConfig()
-
-	for attempt := 0; attempt <= maxRetries; attempt++ {
-		totalNodes, err := b.cfg.K8sClient.GetTotalNodes(ctx)
-		if err != nil {
-			result = resultError
-			errorType = "api_error"
-
-			return b.handleGetTotalNodesError(err, attempt, maxRetries)
-		}
-
-		if totalNodes > 0 {
-			result = "success"
-
-			metrics.FaultQuarantineGetTotalNodesRetryAttempts.Observe(float64(attempt))
-
-			return b.handleSuccessfulNodeCount(totalNodes, attempt)
-		}
-
-		if attempt == 0 {
-			slog.InfoContext(ctx, "Circuit breaker starting retries: NodeInformer cache may not be synced yet",
-				"maxRetries", maxRetries)
-		}
-
-		if attempt < maxRetries {
-			if err := b.performRetryDelay(ctx, attempt, maxRetries, initialDelay, maxDelay); err != nil {
-				result = resultError
-				errorType = "context_cancelled"
-
-				return 0, fmt.Errorf("context cancelled during GetTotalNodes retry: %w", err)
-			}
-		}
-	}
-
-	// All retries exhausted
-	result = resultError
-	errorType = "zero_nodes"
-
-	return 0, b.logRetriesExhausted(ctx, maxRetries, initialDelay, maxDelay)
-}
-
-// getRetryConfig extracts and validates retry configuration with defaults
-func (b *slidingWindowBreaker) getRetryConfig() (int, time.Duration, time.Duration) {
-	maxRetries := b.cfg.MaxRetries
-	if maxRetries <= 0 {
-		maxRetries = 10 // Default: 10 retries
-	}
-
-	initialDelay := b.cfg.InitialRetryDelay
-	if initialDelay <= 0 {
-		initialDelay = 100 * time.Millisecond // Default: 100ms
-	}
-
-	maxDelay := b.cfg.MaxRetryDelay
-	if maxDelay <= 0 {
-		maxDelay = 5 * time.Second // Default: 5 seconds
-	}
-
-	return maxRetries, initialDelay, maxDelay
-}
-
-// handleGetTotalNodesError handles API errors from GetTotalNodes
-func (b *slidingWindowBreaker) handleGetTotalNodesError(err error, attempt, maxRetries int) (int, error) {
-	slog.Error("GetTotalNodes failed on attempt",
-		"attempt", attempt+1,
-		"maxAttempts", maxRetries+1,
-		"error", err)
-
-	return 0, fmt.Errorf("GetTotalNodes failed: %w", err)
-}
-
-// handleSuccessfulNodeCount handles the success case when nodes > 0
-func (b *slidingWindowBreaker) handleSuccessfulNodeCount(totalNodes, attempt int) (int, error) {
-	if attempt > 0 {
-		slog.Info("Circuit breaker retry successful",
-			"totalNodes", totalNodes,
-			"attempts", attempt+1)
-	}
-
-	return totalNodes, nil
-}
-
-// performRetryDelay calculates and performs the exponential backoff delay
-func (b *slidingWindowBreaker) performRetryDelay(ctx context.Context, attempt, maxRetries int,
-	initialDelay, maxDelay time.Duration) error {
-	delay := b.calculateBackoffDelay(attempt, initialDelay, maxDelay)
-
-	slog.DebugContext(ctx, "Circuit breaker retry; got 0 nodes, retrying (NodeInformer cache may still be syncing)",
-		"attempt", attempt+1,
-		"maxRetries", maxRetries,
-		"delay", delay)
-
-	select {
-	case <-ctx.Done():
-		return fmt.Errorf("context cancelled during retry: %w", ctx.Err())
-	case <-time.After(delay):
-	}
-
-	return nil
-}
-
-// calculateBackoffDelay calculates exponential backoff delay with overflow protection
-func (b *slidingWindowBreaker) calculateBackoffDelay(attempt int,
-	initialDelay, maxDelay time.Duration) time.Duration {
-	if attempt > 30 || attempt < 0 { // Prevent overflow for very large or negative attempts
-		return maxDelay
-	}
-
-	// Safe conversion: attempt is guaranteed to be [0, 30] at this point
-	safeAttempt := uint(attempt)
-	multiplier := int64(1 << safeAttempt) // 2^attempt as integer
-	delay := time.Duration(int64(initialDelay) * multiplier)
-
-	if delay > maxDelay || delay < 0 { // Check for overflow
-		delay = maxDelay
-	}
-
-	return delay
-}
-
-// logRetriesExhausted logs a summary when all retries are exhausted.
-// Returns ErrRetryExhausted wrapped with context for pod restart.
-func (b *slidingWindowBreaker) logRetriesExhausted(ctx context.Context, maxRetries int,
-	initialDelay, maxDelay time.Duration) error {
-	actualNodes, err := b.cfg.K8sClient.GetTotalNodes(ctx)
+	totalNodes, err := b.cfg.K8sClient.GetTotalNodes(ctx)
 	if err != nil {
-		slog.ErrorContext(ctx,
-			"Circuit breaker: All retry attempts exhausted; failed to get node count from Kubernetes API; pod will restart",
-			"maxRetries", maxRetries,
-			"error", err,
-			"initialDelay", initialDelay,
-			"totalClusterNodes", actualNodes,
-			"maxDelay", maxDelay)
+		result = resultError
+		errorType = "api_error"
 
-		return fmt.Errorf("%w: failed to get node count: %w", ErrRetryExhausted, err)
+		slog.ErrorContext(ctx, "GetTotalNodes failed", "error", err)
+
+		return 0, fmt.Errorf("GetTotalNodes failed: %w", err)
 	}
 
-	slog.ErrorContext(ctx, "Circuit breaker: All retry attempts exhausted",
-		"maxRetries", maxRetries,
-		"actualNodes", actualNodes,
-		"initialDelay", initialDelay,
-		"maxDelay", maxDelay,
-		"message",
-		"Found total nodes but GetTotalNodes still returning 0. NodeInformer cache sync issues. Pod will restart.")
+	if totalNodes > 0 {
+		result = "success"
 
-	return fmt.Errorf("%w: NodeInformer cache sync failed after %d retries (actualNodes=%d but GetTotalNodes returning 0)",
-		ErrRetryExhausted, maxRetries, actualNodes)
+		metrics.FaultQuarantineGetTotalNodesRetryAttempts.Observe(0)
+
+		return totalNodes, nil
+	}
+
+	// (0, nil): NodeInformer has synced but the cluster has no GPU nodes matching the
+	// configured label. The circuit breaker denominator is 0 so the threshold can
+	// never be reached — the breaker is effectively inactive. Log a warning and
+	// proceed; do not crash.
+	slog.WarnContext(ctx, "No GPU nodes found in cluster; circuit breaker will be inactive")
+
+	result = "success"
+
+	return 0, nil
 }


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #1482, which changed the circuit breaker to count only `nvidia.com/gpu.present=true` nodes as its denominator. On clusters with no GPU workers (management, monitoring, dev clusters without GPUs), `GetTotalNodes()` returns `(0, nil)` after the NodeInformer has synced — the correct, stable answer.

The previous retry loop treated `(0, nil)` as a possible informer cache race and retried up to 10 times before crashing with `ErrRetryExhausted`. This was wrong: `GetNodeCounts()` returns a **non-nil error** when the informer hasn't synced yet, so `(0, nil)` exclusively means "synced, genuinely 0 GPU nodes." The retry loop was never meaningful for this case and always ended in a crash on GPU-less clusters.

## Root cause (pinpointed)

`getTotalNodesWithRetry` in `breaker.go` assumed `(0, nil)` could mean "cache not yet synced." After #1482, `(0, nil)` means "no GPU nodes" and the retry loop fires pointlessly 10 times then crashes.

Additionally, `IsTripped` returned a non-nil error when `totalNodes == 0`, which caused `checkCircuitBreakerAtStartup` to block indefinitely on `<-ctx.Done()` — a hung process rather than a clean failure.

## Changes

- **`getTotalNodesWithRetry`**: return `(0, nil)` immediately when `GetTotalNodes` returns `(0, nil)`, with a warning log that the breaker will be inactive. Remove the now-dead retry loop, delay helpers (`performRetryDelay`, `calculateBackoffDelay`), and `logRetriesExhausted`.
- **`IsTripped`**: return `(false, nil)` when `totalNodes == 0` — the circuit breaker threshold can never be reached with 0 GPU nodes.

## Test plan

- [ ] fault-quarantine starts successfully on a cluster with no `nvidia.com/gpu.present=true` nodes
- [ ] Logs show warning: "No GPU nodes found in cluster; circuit breaker will be inactive"
- [ ] fault-quarantine continues to trip correctly on GPU clusters when threshold is exceeded
- [ ] Existing CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event processing now continues normally when Kubernetes reports zero GPU nodes.
  * The circuit breaker no longer treats an empty GPU-node pool as an error.
  * Improved handling and logging of GPU-node status and API errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->