### PR TITLE
fix: prevent stale replay from leaving remediation-failed label

### DIFF
--- a/commons/pkg/statemanager/statemanager.go
+++ b/commons/pkg/statemanager/statemanager.go
@@ -217,6 +217,8 @@ allows canceled drains and healthy events to remove labels from any state withou
 type StateManager interface {
 	UpdateNVSentinelStateNodeLabel(ctx context.Context, nodeName string,
 		newStateLabelValue NVSentinelStateLabelValue, removeStateLabel bool) (bool, error)
+	RemoveNVSentinelStateNodeLabelIfMatch(ctx context.Context, nodeName string,
+		expectedValues ...NVSentinelStateLabelValue) (bool, error)
 }
 
 type stateManager struct {
@@ -305,6 +307,64 @@ func (manager *stateManager) UpdateNVSentinelStateNodeLabel(ctx context.Context,
 		if validationErr != nil {
 			return validationErr
 		}
+
+		return nil
+	})
+
+	return nodeModified, err
+}
+
+// RemoveNVSentinelStateNodeLabelIfMatch atomically removes the state label only when its latest
+// value is one of expectedValues. The ownership check and deletion share the same conflict-retried
+// read/update loop, so a concurrent writer cannot have its newer state removed.
+func (manager *stateManager) RemoveNVSentinelStateNodeLabelIfMatch(
+	ctx context.Context,
+	nodeName string,
+	expectedValues ...NVSentinelStateLabelValue,
+) (bool, error) {
+	expected := make(map[string]struct{}, len(expectedValues))
+	for _, value := range expectedValues {
+		expected[string(value)] = struct{}{}
+	}
+
+	nodeModified := false
+
+	err := retry.OnError(retry.DefaultRetry, errors.IsConflict, func() error {
+		node, err := manager.clientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		currentValue, exists := node.Labels[NVSentinelStateLabelKey]
+		if !exists {
+			slog.Info("Label already absent",
+				"node", nodeName,
+				"label", NVSentinelStateLabelKey)
+
+			return nil
+		}
+
+		if _, matches := expected[currentValue]; !matches {
+			slog.Info("Skipping conditional label removal because the current value is not owned",
+				"node", nodeName,
+				"label", NVSentinelStateLabelKey,
+				"value", currentValue)
+
+			return nil
+		}
+
+		delete(node.Labels, NVSentinelStateLabelKey)
+
+		if _, err = manager.clientSet.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("failed to update node %s to conditionally remove label: %w", nodeName, err)
+		}
+
+		nodeModified = true
+
+		slog.Info("Label conditionally removed successfully for node",
+			"label", NVSentinelStateLabelKey,
+			"previousValue", currentValue,
+			"node", nodeName)
 
 		return nil
 	})

--- a/commons/pkg/statemanager/statemanager_test.go
+++ b/commons/pkg/statemanager/statemanager_test.go
@@ -165,6 +165,92 @@ func TestUpdateNVSentinelStateNodeLabelWithLabelAlreadyRemoved(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestRemoveNVSentinelStateNodeLabelIfMatch_MatchingValue_RemovesLabel(t *testing.T) {
+	ctx, manager, err := newTestStateManager(testNodeName, map[string]string{
+		NVSentinelStateLabelKey: string(RemediationFailedLabelValue),
+	})
+	assert.NoError(t, err)
+
+	nodeModified, err := manager.RemoveNVSentinelStateNodeLabelIfMatch(
+		ctx,
+		testNodeName,
+		RemediatingLabelValue,
+		RemediationSucceededLabelValue,
+		RemediationFailedLabelValue,
+	)
+
+	assert.True(t, nodeModified)
+	assert.NoError(t, err)
+	node, err := manager.clientSet.CoreV1().Nodes().Get(ctx, testNodeName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.NotContains(t, node.Labels, NVSentinelStateLabelKey)
+}
+
+func TestRemoveNVSentinelStateNodeLabelIfMatch_NewerNonMatchingValue_PreservesLabel(t *testing.T) {
+	ctx, manager, err := newTestStateManager(testNodeName, map[string]string{
+		NVSentinelStateLabelKey: string(QuarantinedLabelValue),
+	})
+	assert.NoError(t, err)
+
+	nodeModified, err := manager.RemoveNVSentinelStateNodeLabelIfMatch(
+		ctx,
+		testNodeName,
+		RemediatingLabelValue,
+		RemediationSucceededLabelValue,
+		RemediationFailedLabelValue,
+	)
+
+	assert.False(t, nodeModified)
+	assert.NoError(t, err)
+	node, err := manager.clientSet.CoreV1().Nodes().Get(ctx, testNodeName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, string(QuarantinedLabelValue), node.Labels[NVSentinelStateLabelKey])
+}
+
+func TestRemoveNVSentinelStateNodeLabelIfMatch_ConcurrentNewerValue_PreservesLabelAfterConflict(t *testing.T) {
+	ctx, manager, err := newTestStateManager(testNodeName, map[string]string{
+		NVSentinelStateLabelKey: string(RemediationFailedLabelValue),
+	})
+	assert.NoError(t, err)
+
+	clientSet := manager.clientSet.(*fake.Clientset)
+	updateCalls := 0
+	clientSet.Fake.PrependReactor("update", "nodes", func(ktesting.Action) (bool, runtime.Object, error) {
+		updateCalls++
+		newerNode := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testNodeName,
+				Labels: map[string]string{
+					NVSentinelStateLabelKey: string(QuarantinedLabelValue),
+				},
+			},
+		}
+		err := clientSet.Tracker().Update(v1.SchemeGroupVersion.WithResource("nodes"), newerNode, "")
+		assert.NoError(t, err)
+
+		return true, nil, errors.NewConflict(
+			schema.GroupResource{Group: "", Resource: "nodes"},
+			testNodeName,
+			fmt.Errorf("simulated concurrent label update"),
+		)
+	})
+
+	nodeModified, err := manager.RemoveNVSentinelStateNodeLabelIfMatch(
+		ctx,
+		testNodeName,
+		RemediatingLabelValue,
+		RemediationSucceededLabelValue,
+		RemediationFailedLabelValue,
+	)
+
+	assert.False(t, nodeModified)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, updateCalls, "retry should observe the newer non-matching value and skip deletion")
+	node, err := manager.clientSet.CoreV1().Nodes().Get(ctx, testNodeName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, string(QuarantinedLabelValue), node.Labels[NVSentinelStateLabelKey])
+}
+
 // Test that label removal from any state doesn't trigger validation errors.
 // This is important for canceled drains: quarantined -> draining -> label removed (healthy event).
 func TestLabelRemovalFromAnyStateDoesNotTriggerValidation(t *testing.T) {

--- a/commons/pkg/statemanager/statemanagermock.go
+++ b/commons/pkg/statemanager/statemanagermock.go
@@ -23,9 +23,23 @@ import (
 type MockStateManager struct {
 	UpdateNVSentinelStateNodeLabelFn func(ctx context.Context, nodeName string,
 		newStateLabelValue NVSentinelStateLabelValue, removeStateLabel bool) (bool, error)
+	RemoveNVSentinelStateNodeLabelIfMatchFn func(ctx context.Context, nodeName string,
+		expectedValues ...NVSentinelStateLabelValue) (bool, error)
 }
 
 func (manager *MockStateManager) UpdateNVSentinelStateNodeLabel(ctx context.Context, nodeName string,
 	newStateLabelValue NVSentinelStateLabelValue, removeStateLabel bool) (bool, error) {
 	return manager.UpdateNVSentinelStateNodeLabelFn(ctx, nodeName, newStateLabelValue, removeStateLabel)
+}
+
+func (manager *MockStateManager) RemoveNVSentinelStateNodeLabelIfMatch(
+	ctx context.Context,
+	nodeName string,
+	expectedValues ...NVSentinelStateLabelValue,
+) (bool, error) {
+	if manager.RemoveNVSentinelStateNodeLabelIfMatchFn == nil {
+		return false, nil
+	}
+
+	return manager.RemoveNVSentinelStateNodeLabelIfMatchFn(ctx, nodeName, expectedValues...)
 }

--- a/fault-remediation/main.go
+++ b/fault-remediation/main.go
@@ -227,7 +227,7 @@ const reconcilerCloseTimeout = 30 * time.Second
 func initializeAndWatch(
 	ctx context.Context, params initializer.InitializationParams, mgr ctrl.Manager,
 ) (cleanup func(), err error) {
-	components, err := initializer.InitializeAll(ctx, params, mgr.GetClient())
+	components, err := initializer.InitializeAll(ctx, params, mgr.GetClient(), mgr.GetAPIReader())
 	if err != nil {
 		return nil, fmt.Errorf("initialization failed: %w", err)
 	}

--- a/fault-remediation/pkg/initializer/init.go
+++ b/fault-remediation/pkg/initializer/init.go
@@ -52,6 +52,7 @@ func InitializeAll(
 	ctx context.Context,
 	params InitializationParams,
 	ctrlruntimeClient ctrlruntimeClient.Client,
+	nodeReader ctrlruntimeClient.Reader,
 ) (*Components, error) {
 	slog.Info("Starting fault remediation module initialization")
 
@@ -98,6 +99,7 @@ func InitializeAll(
 		Pipeline:           pipeline,
 		RemediationClient:  remediationClient,
 		StateManager:       stateManager,
+		NodeReader:         nodeReader,
 		EnableLogCollector: params.EnableLogCollector,
 		UpdateMaxRetries:   tomlConfig.UpdateRetry.MaxRetries,
 		UpdateRetryDelay:   time.Duration(tomlConfig.UpdateRetry.RetryDelaySeconds) * time.Second,

--- a/fault-remediation/pkg/reconciler/reconciler.go
+++ b/fault-remediation/pkg/reconciler/reconciler.go
@@ -334,25 +334,14 @@ func (r *FaultRemediationReconciler) nodeHasActiveQuarantine(
 	return active, nil
 }
 
-// readLiveNode uses the API reader in production to bypass the informer cache. Unit tests that
-// construct the reconciler directly can fall back to the annotation manager's node read.
+// readLiveNode uses the API reader to bypass the informer cache.
 func (r *FaultRemediationReconciler) readLiveNode(ctx context.Context, nodeName string) (*corev1.Node, error) {
-	if r.Config.NodeReader != nil {
-		node := &corev1.Node{}
-		if err := r.Config.NodeReader.Get(ctx, client.ObjectKey{Name: nodeName}, node); err != nil {
-			return nil, err
-		}
-
-		return node, nil
+	node := &corev1.Node{}
+	if err := r.Config.NodeReader.Get(ctx, client.ObjectKey{Name: nodeName}, node); err != nil {
+		return nil, fmt.Errorf("failed to read node %s from the API: %w", nodeName, err)
 	}
 
-	if r.annotationManager == nil {
-		return nil, fmt.Errorf("node reader is not configured")
-	}
-
-	_, node, err := r.annotationManager.GetRemediationState(ctx, nodeName)
-
-	return node, err
+	return node, nil
 }
 
 // runLogCollector runs log collector for non-NONE actions if enabled

--- a/fault-remediation/pkg/reconciler/reconciler.go
+++ b/fault-remediation/pkg/reconciler/reconciler.go
@@ -67,6 +67,7 @@ type ReconcilerConfig struct {
 	Pipeline           datastore.Pipeline
 	RemediationClient  remediation.FaultRemediationClientInterface
 	StateManager       statemanager.StateManager
+	NodeReader         client.Reader
 	EnableLogCollector bool
 	UpdateMaxRetries   int
 	UpdateRetryDelay   time.Duration
@@ -251,13 +252,12 @@ func (r *FaultRemediationReconciler) shouldSkipEvent(ctx context.Context,
 	slog.Info("Unsupported recommended action for node",
 		"action", actionName,
 		"node", nodeName)
-	metrics.TotalUnsupportedRemediationActions.WithLabelValues(actionName, nodeName).Inc()
 
 	span.SetAttributes(
 		attribute.String("fault_remediation.skip_reason", "unsupported_action"),
 	)
 
-	activeQuarantine, err := r.nodeHasActiveQuarantine(ctx, nodeName)
+	activeQuarantine, err := r.nodeHasActiveQuarantine(ctx, healthEventWithStatus.HealthEvent)
 	if err != nil {
 		tracing.RecordError(span, err)
 		span.SetAttributes(
@@ -267,6 +267,8 @@ func (r *FaultRemediationReconciler) shouldSkipEvent(ctx context.Context,
 
 		return true, err
 	}
+
+	metrics.TotalUnsupportedRemediationActions.WithLabelValues(actionName, nodeName).Inc()
 
 	if !activeQuarantine {
 		slog.InfoContext(ctx, "Skipping remediation-failed label for node without an active quarantine",
@@ -303,34 +305,54 @@ func (r *FaultRemediationReconciler) shouldSkipEvent(ctx context.Context,
 	return true, nil
 }
 
-// nodeHasActiveQuarantine checks the current node rather than trusting the event's persisted
-// NodeQuarantined status. Change-stream replay can deliver an old remediation-ready event after
-// fault-quarantine has already recovered the node and removed its quarantine annotation.
-func (r *FaultRemediationReconciler) nodeHasActiveQuarantine(ctx context.Context, nodeName string) (bool, error) {
-	if r.annotationManager == nil {
-		return false, fmt.Errorf("annotation manager is not configured")
+// nodeHasActiveQuarantine checks the current node rather than trusting persisted event status.
+// It requires the same failure to remain in the live quarantine annotation so an event from an
+// older quarantine session cannot affect a newer, unrelated session.
+func (r *FaultRemediationReconciler) nodeHasActiveQuarantine(
+	ctx context.Context,
+	healthEvent *protos.HealthEvent,
+) (bool, error) {
+	if healthEvent == nil {
+		return false, fmt.Errorf("health event is nil")
 	}
 
-	_, node, err := r.annotationManager.GetRemediationState(ctx, nodeName)
+	node, err := r.readLiveNode(ctx, healthEvent.NodeName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return false, nil
 		}
 
-		return false, fmt.Errorf("failed to get live node state for %s: %w", nodeName, err)
+		return false, fmt.Errorf("failed to get live node state for %s: %w", healthEvent.NodeName, err)
 	}
 
-	var annotations map[string]string
-	if node != nil {
-		annotations = node.GetAnnotations()
-	}
-
-	activeEvents, err := activeQuarantineEvents(annotations)
+	active, err := activeQuarantineContainsEvent(node.GetAnnotations(), healthEvent)
 	if err != nil {
-		return false, fmt.Errorf("failed to read active quarantine events for node %s: %w", nodeName, err)
+		return false, fmt.Errorf(
+			"failed to read active quarantine events for node %s: %w", healthEvent.NodeName, err)
 	}
 
-	return len(activeEvents) > 0, nil
+	return active, nil
+}
+
+// readLiveNode uses the API reader in production to bypass the informer cache. Unit tests that
+// construct the reconciler directly can fall back to the annotation manager's node read.
+func (r *FaultRemediationReconciler) readLiveNode(ctx context.Context, nodeName string) (*corev1.Node, error) {
+	if r.Config.NodeReader != nil {
+		node := &corev1.Node{}
+		if err := r.Config.NodeReader.Get(ctx, client.ObjectKey{Name: nodeName}, node); err != nil {
+			return nil, err
+		}
+
+		return node, nil
+	}
+
+	if r.annotationManager == nil {
+		return nil, fmt.Errorf("node reader is not configured")
+	}
+
+	_, node, err := r.annotationManager.GetRemediationState(ctx, nodeName)
+
+	return node, err
 }
 
 // runLogCollector runs log collector for non-NONE actions if enabled
@@ -454,7 +476,7 @@ func (r *FaultRemediationReconciler) handleCancellationEvent(
 		"node", nodeName,
 		"status", status)
 
-	remediationState, node, err := r.annotationManager.GetRemediationState(ctx, nodeName)
+	remediationState, _, err := r.annotationManager.GetRemediationState(ctx, nodeName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			slog.WarnContext(ctx, "Node no longer exists, marking cancellation event as terminal", "node", nodeName)
@@ -491,7 +513,7 @@ func (r *FaultRemediationReconciler) handleCancellationEvent(
 		return ctrl.Result{}, fmt.Errorf("failed to clear remediation state for node: %w", err)
 	}
 
-	if err := r.clearFaultRemediationNodeLabel(ctx, nodeName, node); err != nil {
+	if err := r.clearFaultRemediationNodeLabel(ctx, nodeName); err != nil {
 		tracing.RecordError(span, err)
 		span.SetAttributes(
 			attribute.String("fault_remediation.error.type", "clear_remediation_label_error"),
@@ -523,30 +545,23 @@ func (r *FaultRemediationReconciler) handleCancellationEvent(
 func (r *FaultRemediationReconciler) clearFaultRemediationNodeLabel(
 	ctx context.Context,
 	nodeName string,
-	node *corev1.Node,
 ) error {
-	label := currentNodeStateLabel(node)
-	if !isFaultRemediationOwnedLabel(label) {
-		return nil
-	}
-
-	_, err := r.Config.StateManager.UpdateNVSentinelStateNodeLabel(ctx, nodeName, "", true)
+	_, err := r.Config.StateManager.RemoveNVSentinelStateNodeLabelIfMatch(
+		ctx,
+		nodeName,
+		statemanager.RemediatingLabelValue,
+		statemanager.RemediationSucceededLabelValue,
+		statemanager.RemediationFailedLabelValue,
+	)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to clear fault-remediation node label",
 			"node", nodeName,
-			"label", label,
 			"error", err)
 
 		return fmt.Errorf("failed to clear fault-remediation label for node %s: %w", nodeName, err)
 	}
 
 	return nil
-}
-
-func isFaultRemediationOwnedLabel(label string) bool {
-	return label == string(statemanager.RemediatingLabelValue) ||
-		label == string(statemanager.RemediationSucceededLabelValue) ||
-		label == string(statemanager.RemediationFailedLabelValue)
 }
 
 func (r *FaultRemediationReconciler) handlePartialRecoveryEvent(
@@ -840,6 +855,38 @@ func activeQuarantineEvents(annotations map[string]string) ([]*protos.HealthEven
 	}
 
 	return activeEvents, nil
+}
+
+// activeQuarantineContainsEvent reports whether the incoming event belongs to the current
+// quarantine session. Event IDs distinguish repeated failures across sessions when available;
+// legacy records without IDs fall back to fault-quarantine's normal event-key matching.
+func activeQuarantineContainsEvent(
+	annotations map[string]string,
+	incomingEvent *protos.HealthEvent,
+) (bool, error) {
+	activeEvents, err := activeQuarantineEvents(annotations)
+	if err != nil {
+		return false, err
+	}
+
+	for _, activeEvent := range activeEvents {
+		if activeEvent.Id != "" && incomingEvent.Id != "" {
+			if activeEvent.Id == incomingEvent.Id {
+				return true, nil
+			}
+
+			continue
+		}
+
+		activeEventMap := fqannotation.NewHealthEventsAnnotationMap()
+		activeEventMap.AddOrUpdateEvent(activeEvent)
+
+		if _, matches := activeEventMap.GetEvent(incomingEvent); matches {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 // unsupportedRemediationAction reports whether an active event needs remediation but has no

--- a/fault-remediation/pkg/reconciler/reconciler.go
+++ b/fault-remediation/pkg/reconciler/reconciler.go
@@ -214,7 +214,9 @@ func (r *FaultRemediationReconciler) completeEventSession(
 }
 
 func (r *FaultRemediationReconciler) shouldSkipEvent(ctx context.Context,
-	healthEventWithStatus model.HealthEventWithStatus, groupConfig *common.EquivalenceGroupConfig) bool {
+	healthEventWithStatus model.HealthEventWithStatus,
+	groupConfig *common.EquivalenceGroupConfig,
+) (bool, error) {
 	action := healthEventWithStatus.HealthEvent.RecommendedAction
 	nodeName := healthEventWithStatus.HealthEvent.NodeName
 
@@ -228,7 +230,7 @@ func (r *FaultRemediationReconciler) shouldSkipEvent(ctx context.Context,
 			attribute.String("fault_remediation.skip_reason", "recommended_action_none"),
 		)
 
-		return true
+		return true, nil
 	}
 
 	if healthEventWithStatus.HealthEventStatus != nil && healthEventWithStatus.HealthEventStatus.FaultRemediated != nil &&
@@ -237,11 +239,11 @@ func (r *FaultRemediationReconciler) shouldSkipEvent(ctx context.Context,
 			attribute.String("fault_remediation.skip_reason", "already_remediated"),
 		)
 
-		return true
+		return true, nil
 	}
 
 	if groupConfig != nil {
-		return false
+		return false, nil
 	}
 
 	// Unsupported action detected
@@ -255,12 +257,35 @@ func (r *FaultRemediationReconciler) shouldSkipEvent(ctx context.Context,
 		attribute.String("fault_remediation.skip_reason", "unsupported_action"),
 	)
 
-	_, err := r.Config.StateManager.UpdateNVSentinelStateNodeLabel(ctx,
+	activeQuarantine, err := r.nodeHasActiveQuarantine(ctx, nodeName)
+	if err != nil {
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("fault_remediation.error.type", "quarantine_state_check_error"),
+			attribute.String("fault_remediation.error.message", err.Error()),
+		)
+
+		return true, err
+	}
+
+	if !activeQuarantine {
+		slog.InfoContext(ctx, "Skipping remediation-failed label for node without an active quarantine",
+			"action", actionName,
+			"node", nodeName)
+		span.SetAttributes(
+			attribute.String("fault_remediation.skip_reason", "unsupported_action_stale_event"),
+		)
+
+		return true, nil
+	}
+
+	nodeModified, err := r.Config.StateManager.UpdateNVSentinelStateNodeLabel(ctx,
 		healthEventWithStatus.HealthEvent.NodeName,
 		statemanager.RemediationFailedLabelValue, false)
 	if err != nil {
 		slog.ErrorContext(ctx, "Error updating node label",
 			"label", statemanager.RemediationFailedLabelValue,
+			"nodeModified", nodeModified,
 			"error", err)
 		tracing.RecordError(span, err)
 		span.SetAttributes(
@@ -269,9 +294,43 @@ func (r *FaultRemediationReconciler) shouldSkipEvent(ctx context.Context,
 		)
 		metrics.ProcessingErrors.WithLabelValues("label_update_error",
 			healthEventWithStatus.HealthEvent.NodeName).Inc()
+
+		if !nodeModified {
+			return true, fmt.Errorf("failed to label unsupported remediation action for node %s: %w", nodeName, err)
+		}
 	}
 
-	return true
+	return true, nil
+}
+
+// nodeHasActiveQuarantine checks the current node rather than trusting the event's persisted
+// NodeQuarantined status. Change-stream replay can deliver an old remediation-ready event after
+// fault-quarantine has already recovered the node and removed its quarantine annotation.
+func (r *FaultRemediationReconciler) nodeHasActiveQuarantine(ctx context.Context, nodeName string) (bool, error) {
+	if r.annotationManager == nil {
+		return false, fmt.Errorf("annotation manager is not configured")
+	}
+
+	_, node, err := r.annotationManager.GetRemediationState(ctx, nodeName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("failed to get live node state for %s: %w", nodeName, err)
+	}
+
+	var annotations map[string]string
+	if node != nil {
+		annotations = node.GetAnnotations()
+	}
+
+	activeEvents, err := activeQuarantineEvents(annotations)
+	if err != nil {
+		return false, fmt.Errorf("failed to read active quarantine events for node %s: %w", nodeName, err)
+	}
+
+	return len(activeEvents) > 0, nil
 }
 
 // runLogCollector runs log collector for non-NONE actions if enabled
@@ -395,7 +454,7 @@ func (r *FaultRemediationReconciler) handleCancellationEvent(
 		"node", nodeName,
 		"status", status)
 
-	remediationState, _, err := r.annotationManager.GetRemediationState(ctx, nodeName)
+	remediationState, node, err := r.annotationManager.GetRemediationState(ctx, nodeName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			slog.WarnContext(ctx, "Node no longer exists, marking cancellation event as terminal", "node", nodeName)
@@ -432,6 +491,16 @@ func (r *FaultRemediationReconciler) handleCancellationEvent(
 		return ctrl.Result{}, fmt.Errorf("failed to clear remediation state for node: %w", err)
 	}
 
+	if err := r.clearFaultRemediationNodeLabel(ctx, nodeName, node); err != nil {
+		tracing.RecordError(span, err)
+		span.SetAttributes(
+			attribute.String("fault_remediation.error.type", "clear_remediation_label_error"),
+			attribute.String("fault_remediation.error.message", err.Error()),
+		)
+
+		return ctrl.Result{}, err
+	}
+
 	if err := r.updateNodeRemediatedStatus(ctx, healthEventStore, eventWithToken, true); err != nil {
 		slog.ErrorContext(ctx, "Failed to write completion marker for cancellation event",
 			"node", nodeName,
@@ -446,6 +515,38 @@ func (r *FaultRemediationReconciler) handleCancellationEvent(
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// clearFaultRemediationNodeLabel removes terminal or in-progress labels owned by this controller.
+// It deliberately leaves quarantine and drain labels alone because those belong to other
+// controllers and may represent a newer quarantine session.
+func (r *FaultRemediationReconciler) clearFaultRemediationNodeLabel(
+	ctx context.Context,
+	nodeName string,
+	node *corev1.Node,
+) error {
+	label := currentNodeStateLabel(node)
+	if !isFaultRemediationOwnedLabel(label) {
+		return nil
+	}
+
+	_, err := r.Config.StateManager.UpdateNVSentinelStateNodeLabel(ctx, nodeName, "", true)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to clear fault-remediation node label",
+			"node", nodeName,
+			"label", label,
+			"error", err)
+
+		return fmt.Errorf("failed to clear fault-remediation label for node %s: %w", nodeName, err)
+	}
+
+	return nil
+}
+
+func isFaultRemediationOwnedLabel(label string) bool {
+	return label == string(statemanager.RemediatingLabelValue) ||
+		label == string(statemanager.RemediationSucceededLabelValue) ||
+		label == string(statemanager.RemediationFailedLabelValue)
 }
 
 func (r *FaultRemediationReconciler) handlePartialRecoveryEvent(
@@ -884,7 +985,12 @@ func (r *FaultRemediationReconciler) trySkipEvent(
 	healthEventStore datastore.HealthEventStore,
 	nodeName string,
 ) (ctrl.Result, error, bool) {
-	if !r.shouldSkipEvent(ctx, healthEventWithStatus.HealthEventWithStatus, groupConfig) {
+	shouldSkip, err := r.shouldSkipEvent(ctx, healthEventWithStatus.HealthEventWithStatus, groupConfig)
+	if err != nil {
+		return ctrl.Result{}, err, true
+	}
+
+	if !shouldSkip {
 		return ctrl.Result{}, nil, false
 	}
 

--- a/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
@@ -240,16 +240,17 @@ func (m *MockHealthEventStore) UpdateSpanID(ctx context.Context, id string, serv
 }
 
 var (
-	ctrlRuntimeClient client.Client
-	testClient        *kubernetes.Clientset
-	testDynamic       dynamic.Interface
-	testContext       context.Context
-	testCancelFunc    context.CancelFunc
-	testEnv           *envtest.Environment
-	testRestConfig    *rest.Config
-	mockWatcher       *MockChangeStreamWatcher
-	mockStore         *MockHealthEventStore
-	reconciler        *FaultRemediationReconciler
+	ctrlRuntimeClient    client.Client
+	ctrlRuntimeAPIReader client.Reader
+	testClient           *kubernetes.Clientset
+	testDynamic          dynamic.Interface
+	testContext          context.Context
+	testCancelFunc       context.CancelFunc
+	testEnv              *envtest.Environment
+	testRestConfig       *rest.Config
+	mockWatcher          *MockChangeStreamWatcher
+	mockStore            *MockHealthEventStore
+	reconciler           *FaultRemediationReconciler
 )
 
 func TestMain(m *testing.M) {
@@ -290,6 +291,7 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	ctrlRuntimeClient = mgr.GetClient()
+	ctrlRuntimeAPIReader = mgr.GetAPIReader()
 
 	remediationClient, err := createTestRemediationClient(false, restartRemediationActions)
 	if err != nil {
@@ -299,6 +301,7 @@ func TestMain(m *testing.M) {
 	cfg := ReconcilerConfig{
 		RemediationClient: remediationClient,
 		StateManager:      statemanager.NewStateManager(testClient),
+		NodeReader:        ctrlRuntimeAPIReader,
 		UpdateMaxRetries:  3,
 		UpdateRetryDelay:  100 * time.Millisecond,
 	}
@@ -704,6 +707,7 @@ func TestEventSequenceWithAnnotations_Integration(t *testing.T) {
 	cfg := ReconcilerConfig{
 		RemediationClient: remediationClient,
 		StateManager:      stateManager,
+		NodeReader:        ctrlRuntimeAPIReader,
 		UpdateMaxRetries:  3,
 		UpdateRetryDelay:  100 * time.Millisecond,
 	}
@@ -850,6 +854,7 @@ func TestEventSequenceWithSupersedingGroup(t *testing.T) {
 	cfg := ReconcilerConfig{
 		RemediationClient: remediationClient,
 		StateManager:      stateManager,
+		NodeReader:        ctrlRuntimeAPIReader,
 		UpdateMaxRetries:  3,
 		UpdateRetryDelay:  100 * time.Millisecond,
 	}
@@ -1112,28 +1117,33 @@ func TestEventSequenceWithSupersedingGroup(t *testing.T) {
 
 	// Event 9: COMPONENT_RESET missing GPU_UUID should result in a nvsentinel-state label having value remediation-failed.
 	// Model the active fault-quarantine state that permits fault-remediation to write a terminal label.
+	activeUnsupportedEvent := &protos.HealthEvent{
+		Id:                "event-9",
+		Version:           1,
+		Agent:             "test-agent",
+		ComponentClass:    "GPU",
+		CheckName:         "test-check",
+		IsFatal:           true,
+		RecommendedAction: protos.RecommendedAction_COMPONENT_RESET,
+		NodeName:          nodeName,
+	}
 	node, err = testClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 	require.NoError(t, err)
 	if node.Annotations == nil {
 		node.Annotations = make(map[string]string)
 	}
-	for key, value := range quarantineAnnotationForTest(t,
-		testAnnotationHealthEvent("event-9", nodeName, protos.RecommendedAction_COMPONENT_RESET, "GPU-test")) {
+	for key, value := range quarantineAnnotationForTest(t, activeUnsupportedEvent) {
 		node.Annotations[key] = value
 	}
 	_, err = testClient.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
 	require.NoError(t, err)
-	require.Eventually(t, func() bool {
-		active, err := r.nodeHasActiveQuarantine(ctx, nodeName)
-		return err == nil && active
-	}, 5*time.Second, 100*time.Millisecond, "Expected active quarantine annotation to reach informer cache")
+	active, err := r.nodeHasActiveQuarantine(ctx, activeUnsupportedEvent)
+	require.NoError(t, err)
+	require.True(t, active)
 
 	_, _ = stateManager.UpdateNVSentinelStateNodeLabel(ctx, nodeName, statemanager.DrainSucceededLabelValue, false)
 	event9 := model.HealthEventWithStatus{
-		HealthEvent: &protos.HealthEvent{
-			NodeName:          nodeName,
-			RecommendedAction: protos.RecommendedAction_COMPONENT_RESET,
-		},
+		HealthEvent: activeUnsupportedEvent,
 	}
 	groupConfig, err = common.GetGroupConfigForEvent(cfg.RemediationClient.GetConfig().RemediationActions,
 		event9.HealthEvent)

--- a/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
@@ -1347,6 +1347,7 @@ func TestFullReconcilerWithMockedMongoDB_E2E(t *testing.T) {
 		cfg := ReconcilerConfig{
 			RemediationClient: remediationClient,
 			StateManager:      statemanager.NewStateManager(testClient),
+			NodeReader:        ctrlRuntimeAPIReader,
 			UpdateMaxRetries:  3,
 			UpdateRetryDelay:  100 * time.Millisecond,
 		}

--- a/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
@@ -910,7 +910,8 @@ func TestEventSequenceWithSupersedingGroup(t *testing.T) {
 	groupConfig, err = common.GetGroupConfigForEvent(cfg.RemediationClient.GetConfig().RemediationActions,
 		event2.HealthEvent)
 	assert.NoError(t, err)
-	shouldSkip := r.shouldSkipEvent(ctx, event2, groupConfig)
+	shouldSkip, err := r.shouldSkipEvent(ctx, event2, groupConfig)
+	assert.NoError(t, err)
 	assert.False(t, shouldSkip, "Shouldn't valid health event")
 	shouldCreate, existingCR, _, err := r.checkExistingCRStatus(ctx, event2.HealthEvent, time.Now(), groupConfig)
 	assert.NoError(t, err)
@@ -1110,6 +1111,23 @@ func TestEventSequenceWithSupersedingGroup(t *testing.T) {
 	}, 5*time.Second, 100*time.Millisecond, "Expected CR-2 group to be removed and CR-3 group to remain")
 
 	// Event 9: COMPONENT_RESET missing GPU_UUID should result in a nvsentinel-state label having value remediation-failed.
+	// Model the active fault-quarantine state that permits fault-remediation to write a terminal label.
+	node, err = testClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	require.NoError(t, err)
+	if node.Annotations == nil {
+		node.Annotations = make(map[string]string)
+	}
+	for key, value := range quarantineAnnotationForTest(t,
+		testAnnotationHealthEvent("event-9", nodeName, protos.RecommendedAction_COMPONENT_RESET, "GPU-test")) {
+		node.Annotations[key] = value
+	}
+	_, err = testClient.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		active, err := r.nodeHasActiveQuarantine(ctx, nodeName)
+		return err == nil && active
+	}, 5*time.Second, 100*time.Millisecond, "Expected active quarantine annotation to reach informer cache")
+
 	_, _ = stateManager.UpdateNVSentinelStateNodeLabel(ctx, nodeName, statemanager.DrainSucceededLabelValue, false)
 	event9 := model.HealthEventWithStatus{
 		HealthEvent: &protos.HealthEvent{
@@ -1121,7 +1139,8 @@ func TestEventSequenceWithSupersedingGroup(t *testing.T) {
 		event9.HealthEvent)
 	assert.Error(t, err)
 	assert.Nil(t, groupConfig)
-	shouldSkip = r.shouldSkipEvent(ctx, event9, groupConfig)
+	shouldSkip, err = r.shouldSkipEvent(ctx, event9, groupConfig)
+	assert.NoError(t, err)
 	assert.True(t, shouldSkip, "Should skip invalid health event")
 
 	node, err = testClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
@@ -1339,7 +1358,8 @@ func TestFullReconcilerWithMockedMongoDB_E2E(t *testing.T) {
 			healthEvent.HealthEvent)
 		assert.NoError(t, err)
 
-		shouldSkip := reconcilerInstance.shouldSkipEvent(ctx, healthEvent, groupConfig)
+		shouldSkip, err := reconcilerInstance.shouldSkipEvent(ctx, healthEvent, groupConfig)
+		assert.NoError(t, err)
 		assert.True(t, shouldSkip, "Should skip unsupported action")
 
 		afterUnsupported := getCounterVecValue(t, metrics.TotalUnsupportedRemediationActions, "UNKNOWN", nodeName)

--- a/fault-remediation/pkg/reconciler/reconciler_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/nvidia/nvsentinel/commons/pkg/statemanager"
 	"github.com/nvidia/nvsentinel/data-models/pkg/model"
@@ -51,6 +52,27 @@ type MockK8sClient struct {
 	runLogCollectorJobFn      func(ctx context.Context, nodeName string) (ctrl.Result, error)
 	annotationManagerOverride annotation.NodeAnnotationManagerInterface
 	mockStatusChecker         *mockStatusChecker
+}
+
+type MockNodeReader struct {
+	getFn func(ctx context.Context, key ctrlclient.ObjectKey, obj ctrlclient.Object) error
+}
+
+func (m *MockNodeReader) Get(
+	ctx context.Context,
+	key ctrlclient.ObjectKey,
+	obj ctrlclient.Object,
+	_ ...ctrlclient.GetOption,
+) error {
+	return m.getFn(ctx, key, obj)
+}
+
+func (m *MockNodeReader) List(
+	context.Context,
+	ctrlclient.ObjectList,
+	...ctrlclient.ListOption,
+) error {
+	return nil
 }
 
 func (m *MockK8sClient) CreateMaintenanceResource(ctx context.Context, healthEventData *events.HealthEventData, groupConfig *common.EquivalenceGroupConfig) (string, error) {
@@ -449,11 +471,8 @@ func TestPerformRemediationWithUnsupportedAction(t *testing.T) {
 	}
 	healthEvent := events.HealthEventData{
 		HealthEventWithStatus: model.HealthEventWithStatus{
-			CreatedAt: time.Now(),
-			HealthEvent: &protos.HealthEvent{
-				NodeName:          "node1",
-				RecommendedAction: protos.RecommendedAction_UNKNOWN,
-			},
+			CreatedAt:   time.Now(),
+			HealthEvent: activeEvent,
 			HealthEventStatus: &protos.HealthEventStatus{
 				NodeQuarantined:        string(model.Quarantined),
 				UserPodsEvictionStatus: &protos.OperationStatus{Status: string(model.StatusSucceeded)},
@@ -1315,10 +1334,7 @@ func TestUnsupportedActionSkipMarksEventTerminal(t *testing.T) {
 	healthEventDoc := &events.HealthEventDoc{
 		ID: eventID,
 		HealthEventWithStatus: model.HealthEventWithStatus{
-			HealthEvent: &protos.HealthEvent{
-				NodeName:          nodeName,
-				RecommendedAction: protos.RecommendedAction_CONTACT_SUPPORT,
-			},
+			HealthEvent:       activeEvent,
 			HealthEventStatus: &protos.HealthEventStatus{},
 		},
 	}
@@ -1335,7 +1351,7 @@ func TestUnsupportedActionSkipMarksEventTerminal(t *testing.T) {
 	assert.Equal(t, 1, markProcessedCount)
 }
 
-func TestUnsupportedActionReplayDoesNotLabelUnquarantinedNode(t *testing.T) {
+func TestTrySkipEvent_UnsupportedReplayWithoutLiveQuarantine_MarksTerminalWithoutStateLabel(t *testing.T) {
 	ctx := context.Background()
 	nodeName := "recovered-node"
 	eventID := "stale-unsupported-event"
@@ -1397,7 +1413,169 @@ func TestUnsupportedActionReplayDoesNotLabelUnquarantinedNode(t *testing.T) {
 	assert.Equal(t, 1, markProcessedCount)
 }
 
-func TestCancellationEventClearsOnlyFaultRemediationOwnedLabels(t *testing.T) {
+func TestNodeHasActiveQuarantine_APIReaderHasMatchingEvent_ReturnsTrueWithoutCacheSync(t *testing.T) {
+	nodeName := "test-node"
+	activeEvent := testAnnotationHealthEvent(
+		"active-event", nodeName, protos.RecommendedAction_CONTACT_SUPPORT, "GPU-test")
+	liveNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        nodeName,
+			Annotations: quarantineAnnotationForTest(t, activeEvent),
+		},
+	}
+	mockAnnotationManager := &MockNodeAnnotationManager{
+		getRemediationStateErr: errors.New("cache should not be read"),
+	}
+	mockK8sClient := &MockK8sClient{
+		annotationManagerOverride: mockAnnotationManager,
+	}
+	cfg := ReconcilerConfig{
+		RemediationClient: mockK8sClient,
+		NodeReader: &MockNodeReader{
+			getFn: func(_ context.Context, key ctrlclient.ObjectKey, obj ctrlclient.Object) error {
+				assert.Equal(t, nodeName, key.Name)
+				*obj.(*corev1.Node) = *liveNode.DeepCopy()
+
+				return nil
+			},
+		},
+	}
+	r := NewFaultRemediationReconciler(nil, nil, nil, cfg, false)
+
+	active, err := r.nodeHasActiveQuarantine(t.Context(), activeEvent)
+
+	assert.NoError(t, err)
+	assert.True(t, active)
+}
+
+func TestTrySkipEvent_UnsupportedReplayDuringNewQuarantine_MarksTerminalWithoutStateLabel(t *testing.T) {
+	ctx := context.Background()
+	nodeName := "requarantined-node"
+	staleEventID := "old-session-event"
+	newSessionEvent := testAnnotationHealthEvent(
+		"new-session-event", nodeName, protos.RecommendedAction_RESTART_BM, "GPU-test")
+	staleEvent := testAnnotationHealthEvent(
+		staleEventID, nodeName, protos.RecommendedAction_CONTACT_SUPPORT, "GPU-test")
+	labelUpdateCalled := false
+	statusUpdated := false
+
+	mockK8sClient := &MockK8sClient{
+		annotationManagerOverride: &MockNodeAnnotationManager{
+			nodeAnnotations: quarantineAnnotationForTest(t, newSessionEvent),
+		},
+	}
+	cfg := ReconcilerConfig{
+		RemediationClient: mockK8sClient,
+		StateManager: &statemanager.MockStateManager{
+			UpdateNVSentinelStateNodeLabelFn: func(context.Context, string,
+				statemanager.NVSentinelStateLabelValue, bool) (bool, error) {
+				labelUpdateCalled = true
+
+				return true, nil
+			},
+		},
+	}
+	r := NewFaultRemediationReconciler(nil, nil, nil, cfg, false)
+	mockWatcher := &MockChangeStreamWatcher{}
+	mockStore := &MockHealthEventStore{
+		UpdateHealthEventStatusFn: func(_ context.Context, id string, status datastore.HealthEventStatus) error {
+			assert.Equal(t, staleEventID, id)
+			assert.NotNil(t, status.FaultRemediated)
+			assert.False(t, *status.FaultRemediated)
+			statusUpdated = true
+
+			return nil
+		},
+	}
+	healthEventDoc := &events.HealthEventDoc{
+		ID: staleEventID,
+		HealthEventWithStatus: model.HealthEventWithStatus{
+			HealthEvent: staleEvent,
+			HealthEventStatus: &protos.HealthEventStatus{
+				NodeQuarantined: string(model.Quarantined),
+			},
+		},
+	}
+	eventWithToken := datastore.EventWithToken{
+		Event:       testRawHealthEvent(staleEventID, nodeName, protos.RecommendedAction_CONTACT_SUPPORT),
+		ResumeToken: []byte("resume-token"),
+	}
+
+	_, err, done := r.trySkipEvent(
+		ctx, healthEventDoc, nil, eventWithToken, mockWatcher, mockStore, nodeName)
+
+	assert.True(t, done)
+	assert.NoError(t, err)
+	assert.False(t, labelUpdateCalled,
+		"an event from an older session must not affect a newer quarantine with a different event ID")
+	assert.True(t, statusUpdated)
+	_, markProcessedCount, _, _ := mockWatcher.GetCallCounts()
+	assert.Equal(t, 1, markProcessedCount)
+}
+
+func TestTrySkipEvent_LiveNodeReadFails_ReturnsErrorWithoutFinalizingEvent(t *testing.T) {
+	ctx := context.Background()
+	nodeName := "test-node"
+	eventID := "unsupported-event"
+	liveReadErr := errors.New("live API read failed")
+	labelUpdateCalled := false
+	statusUpdated := false
+	unsupportedEvent := testAnnotationHealthEvent(
+		eventID, nodeName, protos.RecommendedAction_CONTACT_SUPPORT, "GPU-test")
+
+	mockK8sClient := &MockK8sClient{
+		annotationManagerOverride: &MockNodeAnnotationManager{
+			nodeAnnotations: quarantineAnnotationForTest(t, unsupportedEvent),
+		},
+	}
+	cfg := ReconcilerConfig{
+		RemediationClient: mockK8sClient,
+		NodeReader: &MockNodeReader{
+			getFn: func(context.Context, ctrlclient.ObjectKey, ctrlclient.Object) error {
+				return liveReadErr
+			},
+		},
+		StateManager: &statemanager.MockStateManager{
+			UpdateNVSentinelStateNodeLabelFn: func(context.Context, string,
+				statemanager.NVSentinelStateLabelValue, bool) (bool, error) {
+				labelUpdateCalled = true
+
+				return true, nil
+			},
+		},
+	}
+	r := NewFaultRemediationReconciler(nil, nil, nil, cfg, false)
+	mockWatcher := &MockChangeStreamWatcher{}
+	mockStore := &MockHealthEventStore{
+		UpdateHealthEventStatusFn: func(context.Context, string, datastore.HealthEventStatus) error {
+			statusUpdated = true
+
+			return nil
+		},
+	}
+	healthEventDoc := &events.HealthEventDoc{
+		ID: eventID,
+		HealthEventWithStatus: model.HealthEventWithStatus{
+			HealthEvent: unsupportedEvent,
+		},
+	}
+	eventWithToken := datastore.EventWithToken{
+		Event:       testRawHealthEvent(eventID, nodeName, protos.RecommendedAction_CONTACT_SUPPORT),
+		ResumeToken: []byte("resume-token"),
+	}
+
+	_, err, done := r.trySkipEvent(
+		ctx, healthEventDoc, nil, eventWithToken, mockWatcher, mockStore, nodeName)
+
+	assert.True(t, done)
+	assert.ErrorIs(t, err, liveReadErr)
+	assert.False(t, labelUpdateCalled)
+	assert.False(t, statusUpdated)
+	_, markProcessedCount, _, _ := mockWatcher.GetCallCounts()
+	assert.Equal(t, 0, markProcessedCount)
+}
+
+func TestHandleCancellationEvent_StateLabelOwnership_ClearsOnlyFaultRemediationLabels(t *testing.T) {
 	tests := []struct {
 		name          string
 		label         string
@@ -1434,7 +1612,8 @@ func TestCancellationEventClearsOnlyFaultRemediationOwnedLabels(t *testing.T) {
 			ctx := context.Background()
 			nodeName := "test-node"
 			eventID := "cancellation-event"
-			removeCalls := 0
+			conditionalRemoveCalls := 0
+			labelRemoved := false
 			nodeLabels := map[string]string{}
 			if tt.label != "" {
 				nodeLabels[statemanager.NVSentinelStateLabelKey] = tt.label
@@ -1449,14 +1628,19 @@ func TestCancellationEventClearsOnlyFaultRemediationOwnedLabels(t *testing.T) {
 			cfg := ReconcilerConfig{
 				RemediationClient: mockK8sClient,
 				StateManager: &statemanager.MockStateManager{
-					UpdateNVSentinelStateNodeLabelFn: func(_ context.Context, gotNodeName string,
-						newState statemanager.NVSentinelStateLabelValue, remove bool) (bool, error) {
-						removeCalls++
+					RemoveNVSentinelStateNodeLabelIfMatchFn: func(_ context.Context, gotNodeName string,
+						expectedValues ...statemanager.NVSentinelStateLabelValue) (bool, error) {
+						conditionalRemoveCalls++
 						assert.Equal(t, nodeName, gotNodeName)
-						assert.Empty(t, newState)
-						assert.True(t, remove)
+						assert.ElementsMatch(t, []statemanager.NVSentinelStateLabelValue{
+							statemanager.RemediatingLabelValue,
+							statemanager.RemediationSucceededLabelValue,
+							statemanager.RemediationFailedLabelValue,
+						}, expectedValues)
 
-						return true, nil
+						labelRemoved = tt.expectRemoval
+
+						return labelRemoved, nil
 					},
 				},
 			}
@@ -1482,11 +1666,8 @@ func TestCancellationEventClearsOnlyFaultRemediationOwnedLabels(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.True(t, result.IsZero())
-			if tt.expectRemoval {
-				assert.Equal(t, 1, removeCalls)
-			} else {
-				assert.Equal(t, 0, removeCalls)
-			}
+			assert.Equal(t, 1, conditionalRemoveCalls)
+			assert.Equal(t, tt.expectRemoval, labelRemoved)
 			_, markProcessedCount, _, _ := mockWatcher.GetCallCounts()
 			assert.Equal(t, 1, markProcessedCount)
 		})

--- a/fault-remediation/pkg/reconciler/reconciler_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_test.go
@@ -415,11 +415,16 @@ func TestHandleEvent(t *testing.T) {
 }
 
 func TestPerformRemediationWithUnsupportedAction(t *testing.T) {
+	activeEvent := testAnnotationHealthEvent(
+		"unsupported-event", "node1", protos.RecommendedAction_UNKNOWN, "GPU-test")
 	k8sClient := &MockK8sClient{
 		createMaintenanceResourceFn: func(ctx context.Context, healthEventDoc *events.HealthEventData,
 			groupConfig *common.EquivalenceGroupConfig) (string, error) {
 			t.Errorf("CreateMaintenanceResource should not be called on an unsupported action")
 			return "", fmt.Errorf("test error")
+		},
+		annotationManagerOverride: &MockNodeAnnotationManager{
+			nodeAnnotations: quarantineAnnotationForTest(t, activeEvent),
 		},
 	}
 	count := 0
@@ -459,7 +464,9 @@ func TestPerformRemediationWithUnsupportedAction(t *testing.T) {
 	r := NewFaultRemediationReconciler(nil, nil, nil, cfg, false)
 
 	// shouldSkipEvent should return true for UNKNOWN action
-	assert.True(t, r.shouldSkipEvent(t.Context(), healthEvent.HealthEventWithStatus, nil))
+	shouldSkip, err := r.shouldSkipEvent(t.Context(), healthEvent.HealthEventWithStatus, nil)
+	assert.NoError(t, err)
+	assert.True(t, shouldSkip)
 }
 
 func TestPerformRemediationWithSuccess(t *testing.T) {
@@ -627,10 +634,15 @@ func TestPerformRemediationWithUpdateNodeStateLabelFailures(t *testing.T) {
 }
 
 func TestShouldSkipEvent(t *testing.T) {
+	activeEvent := testAnnotationHealthEvent(
+		"unsupported-event", "test-node", protos.RecommendedAction_CONTACT_SUPPORT, "GPU-test")
 	mockK8sClient := &MockK8sClient{
 		createMaintenanceResourceFn: func(ctx context.Context, healthEventDoc *events.HealthEventData,
 			_ *common.EquivalenceGroupConfig) (string, error) {
 			return "test-cr", nil
+		},
+		annotationManagerOverride: &MockNodeAnnotationManager{
+			nodeAnnotations: quarantineAnnotationForTest(t, activeEvent),
 		},
 	}
 	stateManager := &statemanager.MockStateManager{
@@ -695,7 +707,8 @@ func TestShouldSkipEvent(t *testing.T) {
 				HealthEvent: healthEvent,
 			}
 
-			result := r.shouldSkipEvent(t.Context(), healthEventWithStatus, tt.groupConfig)
+			result, err := r.shouldSkipEvent(t.Context(), healthEventWithStatus, tt.groupConfig)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.shouldSkip, result, tt.description)
 		})
 	}
@@ -711,7 +724,8 @@ func TestShouldSkipEvent(t *testing.T) {
 		}
 		groupConfig := getGroupConfig("disk-replace", nil)
 
-		result := r.shouldSkipEvent(t.Context(), healthEventWithStatus, groupConfig)
+		result, err := r.shouldSkipEvent(t.Context(), healthEventWithStatus, groupConfig)
+		assert.NoError(t, err)
 		assert.False(t, result, "Custom actions with a matching group config should not be skipped")
 	})
 
@@ -725,7 +739,8 @@ func TestShouldSkipEvent(t *testing.T) {
 			HealthEvent: healthEvent,
 		}
 
-		result := r.shouldSkipEvent(t.Context(), healthEventWithStatus, nil)
+		result, err := r.shouldSkipEvent(t.Context(), healthEventWithStatus, nil)
+		assert.NoError(t, err)
 		assert.True(t, result, "Custom actions without a matching group config should be skipped")
 	})
 }
@@ -767,7 +782,9 @@ func TestRunLogCollectorOnNoneActionWhenEnabled(t *testing.T) {
 		_, _ = r.Config.RemediationClient.RunLogCollectorJob(ctx, event.HealthEvent.NodeName, "")
 	}
 	groupConfig := getGroupConfig("restart", nil)
-	assert.True(t, r.shouldSkipEvent(t.Context(), event, groupConfig))
+	shouldSkip, err := r.shouldSkipEvent(t.Context(), event, groupConfig)
+	assert.NoError(t, err)
+	assert.True(t, shouldSkip)
 	assert.True(t, called, "log collector job should be invoked when enabled for NONE action")
 }
 
@@ -902,7 +919,9 @@ func TestLogCollectorDisabled(t *testing.T) {
 		_, _ = r.Config.RemediationClient.RunLogCollectorJob(ctx, event.HealthEvent.NodeName, "")
 	}
 	groupConfig := getGroupConfig("restart", nil)
-	assert.True(t, r.shouldSkipEvent(t.Context(), event, groupConfig))
+	shouldSkip, err := r.shouldSkipEvent(t.Context(), event, groupConfig)
+	assert.NoError(t, err)
+	assert.True(t, shouldSkip)
 	assert.False(t, logCollectorCalled, "log collector job should NOT be invoked when disabled")
 }
 
@@ -1265,7 +1284,13 @@ func TestUnsupportedActionSkipMarksEventTerminal(t *testing.T) {
 	// CONTACT_SUPPORT is not configured as a maintenance action for FR. That is an
 	// intentional skip, but it still needs a durable terminal status; otherwise cold
 	// start will keep replaying the same unsupported event because faultremediated is nil.
-	mockK8sClient := &MockK8sClient{}
+	activeEvent := testAnnotationHealthEvent(
+		eventID, nodeName, protos.RecommendedAction_CONTACT_SUPPORT, "GPU-test")
+	mockK8sClient := &MockK8sClient{
+		annotationManagerOverride: &MockNodeAnnotationManager{
+			nodeAnnotations: quarantineAnnotationForTest(t, activeEvent),
+		},
+	}
 	cfg := ReconcilerConfig{
 		RemediationClient: mockK8sClient,
 		StateManager: &statemanager.MockStateManager{
@@ -1308,6 +1333,164 @@ func TestUnsupportedActionSkipMarksEventTerminal(t *testing.T) {
 	assert.True(t, updated)
 	_, markProcessedCount, _, _ := mockWatcher.GetCallCounts()
 	assert.Equal(t, 1, markProcessedCount)
+}
+
+func TestUnsupportedActionReplayDoesNotLabelUnquarantinedNode(t *testing.T) {
+	ctx := context.Background()
+	nodeName := "recovered-node"
+	eventID := "stale-unsupported-event"
+	labelUpdateCalled := false
+	statusUpdated := false
+
+	mockK8sClient := &MockK8sClient{
+		annotationManagerOverride: &MockNodeAnnotationManager{},
+	}
+	cfg := ReconcilerConfig{
+		RemediationClient: mockK8sClient,
+		StateManager: &statemanager.MockStateManager{
+			UpdateNVSentinelStateNodeLabelFn: func(context.Context, string,
+				statemanager.NVSentinelStateLabelValue, bool) (bool, error) {
+				labelUpdateCalled = true
+
+				return true, nil
+			},
+		},
+	}
+	r := NewFaultRemediationReconciler(nil, nil, nil, cfg, false)
+	mockWatcher := &MockChangeStreamWatcher{}
+	mockStore := &MockHealthEventStore{
+		UpdateHealthEventStatusFn: func(_ context.Context, id string, status datastore.HealthEventStatus) error {
+			assert.Equal(t, eventID, id)
+			assert.NotNil(t, status.FaultRemediated)
+			assert.False(t, *status.FaultRemediated)
+			statusUpdated = true
+
+			return nil
+		},
+	}
+	healthEventDoc := &events.HealthEventDoc{
+		ID: eventID,
+		HealthEventWithStatus: model.HealthEventWithStatus{
+			HealthEvent: &protos.HealthEvent{
+				NodeName:          nodeName,
+				RecommendedAction: protos.RecommendedAction_CONTACT_SUPPORT,
+			},
+			HealthEventStatus: &protos.HealthEventStatus{
+				NodeQuarantined: string(model.Quarantined),
+			},
+		},
+	}
+	eventWithToken := datastore.EventWithToken{
+		Event:       testRawHealthEvent(eventID, nodeName, protos.RecommendedAction_CONTACT_SUPPORT),
+		ResumeToken: []byte("resume-token"),
+	}
+
+	_, err, done := r.trySkipEvent(
+		ctx, healthEventDoc, nil, eventWithToken, mockWatcher, mockStore, nodeName)
+
+	assert.True(t, done)
+	assert.NoError(t, err)
+	assert.False(t, labelUpdateCalled,
+		"a persisted quarantine status must not relabel a node whose live quarantine annotation is gone")
+	assert.True(t, statusUpdated, "the stale unsupported event should still be made terminal")
+	_, markProcessedCount, _, _ := mockWatcher.GetCallCounts()
+	assert.Equal(t, 1, markProcessedCount)
+}
+
+func TestCancellationEventClearsOnlyFaultRemediationOwnedLabels(t *testing.T) {
+	tests := []struct {
+		name          string
+		label         string
+		expectRemoval bool
+	}{
+		{
+			name:          "remediating",
+			label:         string(statemanager.RemediatingLabelValue),
+			expectRemoval: true,
+		},
+		{
+			name:          "remediation succeeded",
+			label:         string(statemanager.RemediationSucceededLabelValue),
+			expectRemoval: true,
+		},
+		{
+			name:          "remediation failed",
+			label:         string(statemanager.RemediationFailedLabelValue),
+			expectRemoval: true,
+		},
+		{
+			name:          "drain succeeded belongs to node drainer",
+			label:         string(statemanager.DrainSucceededLabelValue),
+			expectRemoval: false,
+		},
+		{
+			name:          "state label absent",
+			expectRemoval: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			nodeName := "test-node"
+			eventID := "cancellation-event"
+			removeCalls := 0
+			nodeLabels := map[string]string{}
+			if tt.label != "" {
+				nodeLabels[statemanager.NVSentinelStateLabelKey] = tt.label
+			}
+
+			mockAnnotationManager := &MockNodeAnnotationManager{
+				nodeLabels: nodeLabels,
+			}
+			mockK8sClient := &MockK8sClient{
+				annotationManagerOverride: mockAnnotationManager,
+			}
+			cfg := ReconcilerConfig{
+				RemediationClient: mockK8sClient,
+				StateManager: &statemanager.MockStateManager{
+					UpdateNVSentinelStateNodeLabelFn: func(_ context.Context, gotNodeName string,
+						newState statemanager.NVSentinelStateLabelValue, remove bool) (bool, error) {
+						removeCalls++
+						assert.Equal(t, nodeName, gotNodeName)
+						assert.Empty(t, newState)
+						assert.True(t, remove)
+
+						return true, nil
+					},
+				},
+			}
+			mockStore := &MockHealthEventStore{
+				UpdateHealthEventStatusFn: func(_ context.Context, id string,
+					status datastore.HealthEventStatus) error {
+					assert.Equal(t, eventID, id)
+					assert.NotNil(t, status.FaultRemediated)
+					assert.True(t, *status.FaultRemediated)
+
+					return nil
+				},
+			}
+			mockWatcher := &MockChangeStreamWatcher{}
+			r := NewFaultRemediationReconciler(nil, mockWatcher, mockStore, cfg, false)
+			eventWithToken := datastore.EventWithToken{
+				Event:       testRawHealthEvent(eventID, nodeName, protos.RecommendedAction_CONTACT_SUPPORT),
+				ResumeToken: []byte("resume-token"),
+			}
+
+			result, err := r.handleCancellationEvent(
+				ctx, nodeName, model.UnQuarantined, mockWatcher, eventWithToken, mockStore)
+
+			assert.NoError(t, err)
+			assert.True(t, result.IsZero())
+			if tt.expectRemoval {
+				assert.Equal(t, 1, removeCalls)
+			} else {
+				assert.Equal(t, 0, removeCalls)
+			}
+			_, markProcessedCount, _, _ := mockWatcher.GetCallCounts()
+			assert.Equal(t, 1, markProcessedCount)
+		})
+	}
 }
 
 func TestPartialRecoveryRecomputesLabelToRemediationSucceeded(t *testing.T) {

--- a/fault-remediation/pkg/reconciler/reconciler_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_test.go
@@ -58,6 +58,18 @@ type MockNodeReader struct {
 	getFn func(ctx context.Context, key ctrlclient.ObjectKey, obj ctrlclient.Object) error
 }
 
+func newMockNodeReader(annotations map[string]string) *MockNodeReader {
+	return &MockNodeReader{
+		getFn: func(_ context.Context, key ctrlclient.ObjectKey, obj ctrlclient.Object) error {
+			node := obj.(*corev1.Node)
+			node.Name = key.Name
+			node.Annotations = annotations
+
+			return nil
+		},
+	}
+}
+
 func (m *MockNodeReader) Get(
 	ctx context.Context,
 	key ctrlclient.ObjectKey,
@@ -466,6 +478,7 @@ func TestPerformRemediationWithUnsupportedAction(t *testing.T) {
 	cfg := ReconcilerConfig{
 		RemediationClient: k8sClient,
 		StateManager:      stateManager,
+		NodeReader:        newMockNodeReader(quarantineAnnotationForTest(t, activeEvent)),
 		UpdateMaxRetries:  2,
 		UpdateRetryDelay:  1 * time.Microsecond,
 	}
@@ -653,15 +666,10 @@ func TestPerformRemediationWithUpdateNodeStateLabelFailures(t *testing.T) {
 }
 
 func TestShouldSkipEvent(t *testing.T) {
-	activeEvent := testAnnotationHealthEvent(
-		"unsupported-event", "test-node", protos.RecommendedAction_CONTACT_SUPPORT, "GPU-test")
 	mockK8sClient := &MockK8sClient{
 		createMaintenanceResourceFn: func(ctx context.Context, healthEventDoc *events.HealthEventData,
 			_ *common.EquivalenceGroupConfig) (string, error) {
 			return "test-cr", nil
-		},
-		annotationManagerOverride: &MockNodeAnnotationManager{
-			nodeAnnotations: quarantineAnnotationForTest(t, activeEvent),
 		},
 	}
 	stateManager := &statemanager.MockStateManager{
@@ -671,7 +679,11 @@ func TestShouldSkipEvent(t *testing.T) {
 		},
 	}
 
-	cfg := ReconcilerConfig{RemediationClient: mockK8sClient, StateManager: stateManager}
+	cfg := ReconcilerConfig{
+		RemediationClient: mockK8sClient,
+		StateManager:      stateManager,
+		NodeReader:        newMockNodeReader(nil),
+	}
 	r := NewFaultRemediationReconciler(nil, nil, nil, cfg, false)
 
 	tests := []struct {
@@ -1318,6 +1330,7 @@ func TestUnsupportedActionSkipMarksEventTerminal(t *testing.T) {
 				return true, nil
 			},
 		},
+		NodeReader: newMockNodeReader(quarantineAnnotationForTest(t, activeEvent)),
 	}
 	r := NewFaultRemediationReconciler(nil, nil, nil, cfg, false)
 	mockWatcher := &MockChangeStreamWatcher{}
@@ -1371,6 +1384,7 @@ func TestTrySkipEvent_UnsupportedReplayWithoutLiveQuarantine_MarksTerminalWithou
 				return true, nil
 			},
 		},
+		NodeReader: newMockNodeReader(nil),
 	}
 	r := NewFaultRemediationReconciler(nil, nil, nil, cfg, false)
 	mockWatcher := &MockChangeStreamWatcher{}
@@ -1474,6 +1488,7 @@ func TestTrySkipEvent_UnsupportedReplayDuringNewQuarantine_MarksTerminalWithoutS
 				return true, nil
 			},
 		},
+		NodeReader: newMockNodeReader(quarantineAnnotationForTest(t, newSessionEvent)),
 	}
 	r := NewFaultRemediationReconciler(nil, nil, nil, cfg, false)
 	mockWatcher := &MockChangeStreamWatcher{}
@@ -1569,6 +1584,7 @@ func TestTrySkipEvent_LiveNodeReadFails_ReturnsErrorWithoutFinalizingEvent(t *te
 
 	assert.True(t, done)
 	assert.ErrorIs(t, err, liveReadErr)
+	assert.ErrorContains(t, err, "failed to read node test-node from the API")
 	assert.False(t, labelUpdateCalled)
 	assert.False(t, statusUpdated)
 	_, markProcessedCount, _, _ := mockWatcher.GetCallCounts()


### PR DESCRIPTION
## Summary

Fixes #1534 by preventing replayed fault-remediation events from leaving a stale `remediation-failed` label on a recovered node.

When fault-remediation resumed a change stream, it could process an old remediation-ready event after the node had already recovered. If the event contained an unsupported action such as `CONTACT_SUPPORT`, fault-remediation trusted the historical event status and applied:

```text
dgxc.nvidia.com/nvsentinel-state=remediation-failed
```

A later replayed `UnQuarantined` or `Cancelled` event cleared the remediation annotation but did not remove the state label, leaving the healthy node incorrectly marked as failed.

## Changes

### Validate the current quarantine session

Before applying `remediation-failed` for an unsupported action, fault-remediation now reads the node through the uncached API reader and verifies that the incoming event belongs to the node’s current active quarantine.

The persisted `NodeQuarantined` value on a replayed event is no longer sufficient. A stale event also cannot match an unrelated, newer quarantine session.

If no matching active quarantine exists:

- `remediation-failed` is not applied
- the unsupported event is marked terminal with `FaultRemediated=false`
- the change-stream resume token is advanced
- no remediation CR is created

Errors reading the live node are returned so the event can be retried instead of being incorrectly finalized.

### Clear fault-remediation labels during cancellation

Processing an `UnQuarantined` or `Cancelled` event now conditionally removes state labels owned by fault-remediation:

- `remediating`
- `remediation-succeeded`
- `remediation-failed`

The label check and removal use the latest node state within the conflict-retry loop. If another controller has applied a newer quarantine or drain state, that label is preserved.

The cancellation event is marked complete only after the remediation annotation and applicable fault-remediation label have been cleared successfully.

## Test changes

### Stale unsupported-action replay

Added `TestTrySkipEvent_UnsupportedReplayWithoutLiveQuarantine_MarksTerminalWithoutStateLabel`.

The test reproduces a replayed unsupported action whose historical event reports the node as quarantined while the live node has no active quarantine. It verifies that:

- `remediation-failed` is not applied
- no remediation CR is created
- the event receives `FaultRemediated=false`
- the resume token is advanced

### Newer quarantine-session protection

Added `TestTrySkipEvent_UnsupportedReplayDuringNewQuarantine_MarksTerminalWithoutStateLabel`.

The test verifies that a stale event cannot use an unrelated, newer quarantine session to apply `remediation-failed`.

### Uncached live-state validation

Added `TestNodeHasActiveQuarantine_APIReaderHasMatchingEvent_ReturnsTrueWithoutCacheSync`.

The test verifies that quarantine validation uses the uncached API reader and does not depend on informer-cache synchronization.

### Live-state read failures

Added `TestTrySkipEvent_LiveNodeReadFails_ReturnsErrorWithoutFinalizingEvent`.

The test verifies that live-node read failures are returned for retry without:

- finalizing the event
- advancing the resume token
- applying a state label
- creating a remediation CR

### Cancellation cleanup

Added `TestHandleCancellationEvent_StateLabelOwnership_ClearsOnlyFaultRemediationLabels` with coverage for:

- `remediating`
- `remediation-succeeded`
- `remediation-failed`
- `drain-succeeded`
- no state label

The test verifies that cancellation removes fault-remediation-owned labels while preserving labels owned by other controllers.

### Atomic state-label cleanup

Added state-manager tests covering:

- removal when the current state label matches an expected fault-remediation value
- preservation of a newer nonmatching state label
- conflict retries preserving a concurrently applied controller state

### Envtest updates

Updated the end-to-end event sequence to model an active matching fault-quarantine annotation before expecting an unsupported event to apply `remediation-failed`.

## Validation

```text
cd fault-remediation && go test ./...
cd commons && go test ./...
```

All fault-remediation and commons tests pass.


## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added production “live node” quarantine state reads to make skip/retry decisions based on the node’s current status.

* **Bug Fixes**
  * Updated remediation skip logic to retry when live quarantine state checks fail, preventing incorrect terminal handling.
  * Improved cancellation cleanup to remove only fault-remediation-owned NV Sentinel state labels when they match the expected value.
  * Enhanced quarantined-event matching to better handle legacy records.

* **Tests**
  * Expanded unit and e2e coverage for live quarantine detection, replay/cancellation label ownership, and error/retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->