### PR TITLE
feat(nic-health-monitor): detect missing InfiniBand character devices

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/nic-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/nic-health-monitor/values.yaml
@@ -32,12 +32,16 @@ resources:
 #   - InfiniBandStateCheck: Monitors IB port state (UP/DOWN), physical state, device disappearance,
 #       card homogeneity anomalies; auto-excludes management NICs via NUMA topology
 #   - InfiniBandDegradationCheck: Monitors IB counter thresholds (fatal and non-fatal)
+#   - InfiniBandCharDeviceCheck: Detects missing IB character-device nodes (issm/umad/uverbs)
+#       via /sys/class/infiniband_mad and /sys/class/infiniband_verbs — a device whose ports
+#       read ACTIVE/LinkUp but whose /dev/infiniband/* nodes are missing (pods fail to start)
 #   - EthernetStateCheck: Monitors Ethernet/RoCE interface state (operstate), device disappearance,
 #       card homogeneity anomalies; auto-excludes management NICs via NUMA topology
 #   - EthernetDegradationCheck: Monitors Ethernet/RoCE counter thresholds
 enabledChecks:
   - InfiniBandStateCheck
   - InfiniBandDegradationCheck
+  - InfiniBandCharDeviceCheck
   - EthernetStateCheck
   - EthernetDegradationCheck
 

--- a/docs/configuration/nic-health-monitor.md
+++ b/docs/configuration/nic-health-monitor.md
@@ -67,6 +67,7 @@ nic-health-monitor:
   enabledChecks:
     - InfiniBandStateCheck
     - InfiniBandDegradationCheck
+    - InfiniBandCharDeviceCheck
     - EthernetStateCheck
     - EthernetDegradationCheck
 ```
@@ -78,6 +79,9 @@ Polls `/sys/class/infiniband/*/ports/*/state` and `phys_state` every `statePolli
 
 #### InfiniBandDegradationCheck
 Polls InfiniBand hardware counters every 1 second. Emits fatal events when counters like `link_downed`, `rnr_nak_retry_err`, or `excessive_buffer_overrun_errors` increment. Rate-based threshold breaches emit events at the severity configured for each counter — `symbol_error > 10/sec` is non-fatal, `symbol_error_fatal > 120/hour` is fatal. Counter breach state is persisted across pod restarts.
+
+#### InfiniBandCharDeviceCheck
+Verifies that each InfiniBand device's character-device nodes exist: one `uverbs` per device plus one `umad` and one `issm` per InfiniBand-mode port, read from `/sys/class/infiniband_verbs` and `/sys/class/infiniband_mad` (udev creates the `/dev/infiniband/*` nodes from these class entries, so a missing entry means workloads fail with errors like `lstat /dev/infiniband/issm9: no such file or directory` even while the port reads ACTIVE/LinkUp). The expectation is derived per device from its own discovered ports — never from an absolute device count — and `issm` is only expected on InfiniBand-mode ports (RoCE ports legitimately have none). A node missing for 3 consecutive polls emits a fatal `REPLACE_VM` event; the fault latches (persisted across pod restarts and reboots) and clears only when the node is positively observed again. An entirely absent class directory (e.g. `ib_umad` module not loaded) is treated as an uncertain observation and held rather than reported.
 
 #### EthernetStateCheck
 Same as `InfiniBandStateCheck` but for Ethernet/RoCE devices (reads `link_layer = Ethernet`). Monitors `operstate` in addition to `state` and `phys_state`.

--- a/health-monitors/nic-health-monitor/main.go
+++ b/health-monitors/nic-health-monitor/main.go
@@ -56,7 +56,8 @@ var (
 	date    = "unknown"
 
 	checksList = flag.String("checks",
-		"InfiniBandStateCheck,InfiniBandDegradationCheck,EthernetStateCheck,EthernetDegradationCheck",
+		"InfiniBandStateCheck,InfiniBandDegradationCheck,InfiniBandCharDeviceCheck,"+
+			"EthernetStateCheck,EthernetDegradationCheck",
 		"Comma-separated list of checks to enable.")
 	platformConnectorSocket = flag.String("platform-connector-socket", "unix:///var/run/nvsentinel.sock",
 		"Path to the platform-connector UDS socket")
@@ -146,7 +147,8 @@ func run() error {
 		rc.processingStrategy, stateManager, rebooted || scopeChanged, rebooted)
 	if len(enabledChecks) == 0 {
 		return fmt.Errorf("no checks enabled — set --checks to include at least one of: " +
-			"InfiniBandStateCheck, InfiniBandDegradationCheck, EthernetStateCheck, EthernetDegradationCheck")
+			"InfiniBandStateCheck, InfiniBandDegradationCheck, InfiniBandCharDeviceCheck, " +
+			"EthernetStateCheck, EthernetDegradationCheck")
 	}
 
 	nicMonitor := monitor.NewNICHealthMonitor(rc.nodeName, client, *platformConnectorSocket,
@@ -369,41 +371,57 @@ func buildChecks(
 			continue
 		}
 
-		switch c {
-		case checks.InfiniBandStateCheckName:
-			result = append(result, state.NewInfiniBandStateCheck(
-				nodeName, reader, cfg, classifier, processingStrategy,
-				stateManager, stateBaselines,
-			))
-		case checks.InfiniBandDegradationCheckName:
-			if cfg.CounterDetection.Enabled {
-				result = append(result, counter.NewInfiniBandDegradationCheck(
-					nodeName, reader, cfg, classifier, processingStrategy,
-					stateManager, counterBaselines,
-				))
-			} else {
-				slog.Warn("Skipping requested check: counterDetection.enabled is false", "check", c)
-			}
-		case checks.EthernetStateCheckName:
-			result = append(result, state.NewEthernetStateCheck(
-				nodeName, reader, cfg, classifier, processingStrategy,
-				stateManager, stateBaselines,
-			))
-		case checks.EthernetDegradationCheckName:
-			if cfg.CounterDetection.Enabled {
-				result = append(result, counter.NewEthernetDegradationCheck(
-					nodeName, reader, cfg, classifier, processingStrategy,
-					stateManager, counterBaselines,
-				))
-			} else {
-				slog.Warn("Skipping requested check: counterDetection.enabled is false", "check", c)
-			}
-		default:
-			slog.Warn("Unknown check, skipping", "check", c)
+		if chk := buildCheck(c, nodeName, reader, cfg, classifier,
+			processingStrategy, stateManager, stateBaselines, counterBaselines); chk != nil {
+			result = append(result, chk)
 		}
 	}
 
 	return result
+}
+
+// buildCheck instantiates a single check by name, or returns nil when the
+// name is unknown or a counter check is requested while counter detection
+// is disabled.
+func buildCheck(
+	name, nodeName string,
+	reader sysfs.Reader,
+	cfg *config.Config,
+	classifier *topology.Classifier,
+	processingStrategy pb.ProcessingStrategy,
+	stateManager *statefile.Manager,
+	stateBaselines, counterBaselines bool,
+) checks.TransactionalCheck {
+	switch name {
+	case checks.InfiniBandStateCheckName:
+		return state.NewInfiniBandStateCheck(
+			nodeName, reader, cfg, classifier, processingStrategy, stateManager, stateBaselines)
+	case checks.InfiniBandCharDeviceCheckName:
+		return state.NewInfiniBandCharDeviceCheck(
+			nodeName, reader, cfg, classifier, processingStrategy, stateManager, stateBaselines)
+	case checks.EthernetStateCheckName:
+		return state.NewEthernetStateCheck(
+			nodeName, reader, cfg, classifier, processingStrategy, stateManager, stateBaselines)
+	case checks.InfiniBandDegradationCheckName:
+		if !cfg.CounterDetection.Enabled {
+			slog.Warn("Skipping requested check: counterDetection.enabled is false", "check", name)
+			return nil
+		}
+
+		return counter.NewInfiniBandDegradationCheck(
+			nodeName, reader, cfg, classifier, processingStrategy, stateManager, counterBaselines)
+	case checks.EthernetDegradationCheckName:
+		if !cfg.CounterDetection.Enabled {
+			slog.Warn("Skipping requested check: counterDetection.enabled is false", "check", name)
+			return nil
+		}
+
+		return counter.NewEthernetDegradationCheck(
+			nodeName, reader, cfg, classifier, processingStrategy, stateManager, counterBaselines)
+	default:
+		slog.Warn("Unknown check, skipping", "check", name)
+		return nil
+	}
 }
 
 // parseProcessingStrategy maps the string flag to the protobuf enum.

--- a/health-monitors/nic-health-monitor/pkg/checks/state/ibdevnode.go
+++ b/health-monitors/nic-health-monitor/pkg/checks/state/ibdevnode.go
@@ -50,6 +50,15 @@ const (
 	// noPort is the sentinel port used for device-level entries (uverbs),
 	// which are not associated with a specific port.
 	noPort = 0
+
+	// charDevMissThreshold is the number of consecutive polls a character
+	// device must be expected-but-missing before a FATAL is emitted. The
+	// device list and the mad/verbs class directories are read at slightly
+	// different instants, so a driver teardown/reload landing between the
+	// reads can make every node of a device look missing for one poll;
+	// requiring consecutive misses removes that race, mirroring the device
+	// disappearance debounce (deviceMissThreshold).
+	charDevMissThreshold = 3
 )
 
 // charDevKey uniquely identifies an expected or missing character device.
@@ -59,6 +68,21 @@ type charDevKey struct {
 	kind   charDevKind
 	device string
 	port   int
+}
+
+// flagKey renders the persisted statefile key for a charDevKey.
+func (k charDevKey) flagKey() string {
+	return fmt.Sprintf("%s/%s_%d", k.kind, k.device, k.port)
+}
+
+// flagOf converts a charDevKey to its persisted representation.
+func (k charDevKey) flagOf() statefile.MissingCharDeviceFlag {
+	return statefile.MissingCharDeviceFlag{Kind: string(k.kind), Device: k.device, Port: k.port}
+}
+
+// keyOfFlag converts a persisted flag back to a charDevKey.
+func keyOfFlag(f statefile.MissingCharDeviceFlag) charDevKey {
+	return charDevKey{kind: charDevKind(f.Kind), device: f.Device, port: f.Port}
 }
 
 // InfiniBandCharDeviceCheck detects missing InfiniBand character-device
@@ -81,6 +105,14 @@ type charDevKey struct {
 // device that is entirely absent from /sys/class/infiniband is out of
 // scope here — that is the InfiniBandStateCheck's device-disappearance
 // responsibility.
+//
+// Fault handling is latched and debounced: a node must be missing for
+// charDevMissThreshold consecutive polls before the FATAL fires, the
+// resulting latch persists across pod restarts and reboots via
+// pkg/statefile, and it is released only on a positive observation of the
+// node (recovery) or by the baseline clear. A latched key whose device
+// drops out of discovery is HELD, not recovered: absence of the device is
+// not evidence the character device healed.
 type InfiniBandCharDeviceCheck struct {
 	nodeName           string
 	reader             sysfs.Reader
@@ -95,19 +127,38 @@ type InfiniBandCharDeviceCheck struct {
 	// are wiped before current-boot faults are re-asserted.
 	emitHealthyBaselines bool
 
-	// previousMissing is the committed set of currently-missing character
-	// devices; it drives transition (missing↔present) event emission so
-	// steady states do not re-emit every poll. It is in-memory only: a
-	// reboot re-baselines, and a non-reboot pod restart re-discovers the
-	// current state on the first poll.
-	previousMissing map[charDevKey]bool
+	// latched is the committed set of character devices with a
+	// missing-node FATAL outstanding downstream. Seeded from the
+	// persisted statefile latch at construction so a recovery that
+	// happens while the pod is down is still emitted by the next pod.
+	latched map[charDevKey]bool
+
+	// missStreak counts consecutive polls each expected key has been
+	// missing; a FATAL fires when it reaches charDevMissThreshold.
+	// In-memory only: losing it to a restart merely restarts the
+	// debounce, which is the safe direction.
+	missStreak map[charDevKey]int
+
+	// seeded is true once one complete enumeration has succeeded, making
+	// a later incomplete enumeration an error rather than a quiet skip.
+	seeded bool
+
+	// uncertainWarned suppresses the held-poll warning after its first
+	// emission so an IB node without the ib_umad module does not log at
+	// every poll; it resets when a certain observation succeeds.
+	uncertainWarned bool
+
+	// saveFailed keeps a failed statefile Save retrying on subsequent
+	// commits even when nothing else changed.
+	saveFailed bool
 
 	pending *charDevPollCommit
 }
 
 // charDevPollCommit stages a prepared poll until Commit makes it durable.
 type charDevPollCommit struct {
-	missing     map[charDevKey]bool
+	latched     map[charDevKey]bool
+	missStreak  map[charDevKey]int
 	baselineRan bool
 }
 
@@ -131,6 +182,11 @@ func NewInfiniBandCharDeviceCheck(
 		stateManager.SetPendingBaseline(checks.InfiniBandCharDeviceCheckName)
 	}
 
+	latched := make(map[charDevKey]bool)
+	for _, flag := range stateManager.MissingCharDevices() {
+		latched[keyOfFlag(flag)] = true
+	}
+
 	return &InfiniBandCharDeviceCheck{
 		nodeName:             nodeName,
 		reader:               reader,
@@ -139,6 +195,8 @@ func NewInfiniBandCharDeviceCheck(
 		processingStrategy:   processingStrategy,
 		state:                stateManager,
 		emitHealthyBaselines: pendingBaseline,
+		latched:              latched,
+		missStreak:           make(map[charDevKey]int),
 	}
 }
 
@@ -160,7 +218,7 @@ func (c *InfiniBandCharDeviceCheck) Run() ([]*pb.HealthEvent, error) {
 }
 
 // Prepare observes one poll and stages its candidate state without
-// advancing the committed missing-set or persistent state.
+// advancing the committed latch or persistent state.
 func (c *InfiniBandCharDeviceCheck) Prepare() ([]*pb.HealthEvent, error) {
 	c.Discard()
 
@@ -172,7 +230,7 @@ func (c *InfiniBandCharDeviceCheck) Prepare() ([]*pb.HealthEvent, error) {
 	}
 
 	if !result.Complete {
-		if c.previousMissing != nil {
+		if c.seeded {
 			return nil, fmt.Errorf("device discovery incomplete: InfiniBand sysfs tree unavailable")
 		}
 
@@ -199,17 +257,23 @@ func (c *InfiniBandCharDeviceCheck) Prepare() ([]*pb.HealthEvent, error) {
 		// A class directory we need was entirely absent while devices that
 		// should populate it exist: an uncertain observation, not evidence
 		// of mass failure. Hold state (do not stage) so the baseline stays
-		// owed and no spurious FATALs are emitted.
-		slog.Warn("Holding InfiniBand char-device poll: class directory unavailable",
-			"check", c.Name(), "node", c.nodeName)
+		// owed and no spurious FATALs are emitted. Warn once per
+		// transition, not per poll: on a node without the ib_umad module
+		// this state is permanent and would otherwise log every second.
+		if !c.uncertainWarned {
+			c.uncertainWarned = true
+
+			slog.Warn("Holding InfiniBand char-device poll: class directory unavailable",
+				"check", c.Name(), "node", c.nodeName)
+		}
 
 		return nil, nil
 	}
 
-	currentMissing := diffMissing(expected, observed)
-	events := c.buildEvents(currentMissing, baselineRun)
+	c.uncertainWarned = false
 
-	c.pending = &charDevPollCommit{missing: currentMissing, baselineRan: baselineRun}
+	events, nextLatched, nextStreak := c.evaluatePoll(expected, observed, baselineRun)
+	c.pending = &charDevPollCommit{latched: nextLatched, missStreak: nextStreak, baselineRan: baselineRun}
 
 	return events, nil
 }
@@ -222,12 +286,41 @@ func (c *InfiniBandCharDeviceCheck) Commit() {
 
 	pending := c.pending
 	c.pending = nil
-	c.previousMissing = pending.missing
+	c.latched = pending.latched
+	c.missStreak = pending.missStreak
+	c.seeded = true
+
+	flags := make(map[string]statefile.MissingCharDeviceFlag, len(pending.latched))
+	for key := range pending.latched {
+		flags[key.flagKey()] = key.flagOf()
+	}
+
+	changed := c.state.UpdateMissingCharDevices(flags)
 
 	if pending.baselineRan {
 		c.emitHealthyBaselines = false
 		c.state.ClearPendingBaseline(checks.InfiniBandCharDeviceCheckName)
+
+		changed = true
 	}
+
+	// Persist when something changed or a previous Save failed: the
+	// in-memory manager already carries the update, so without the retry
+	// the on-disk state would stay stale until an unrelated change.
+	if !changed && !c.saveFailed {
+		return
+	}
+
+	if err := c.state.Save(); err != nil {
+		c.saveFailed = true
+
+		slog.Warn("Failed to persist state to disk",
+			"check", c.Name(), "path", c.state.Path(), "error", err)
+
+		return
+	}
+
+	c.saveFailed = false
 }
 
 // Discard abandons a prepared poll after check or publication failure.
@@ -235,15 +328,32 @@ func (c *InfiniBandCharDeviceCheck) Discard() {
 	c.pending = nil
 }
 
-// buildEvents turns the current missing-set into HealthEvents. On a
-// baseline run it emits a check-scoped clear (wiping stale prior-boot
-// conditions) followed by a FATAL for every still-missing node. On a
-// normal run it emits a FATAL for each newly-missing node and a healthy
-// recovery for each node that reappeared, staying silent on steady state.
-func (c *InfiniBandCharDeviceCheck) buildEvents(
-	currentMissing map[charDevKey]bool, baselineRun bool,
-) []*pb.HealthEvent {
+// evaluatePoll compares the expected and observed sets and produces this
+// poll's events plus the candidate latch and debounce state.
+//
+// Transitions:
+//   - expected + observed + latched   → recovery event, latch released
+//     (the only path that releases a latch outside a baseline: recovery
+//     requires the node to be positively observed, so a device that
+//     drops out of discovery HOLDS its latch instead of fabricating a
+//     recovery for a fault that never healed).
+//   - expected + missing + unlatched  → debounce; FATAL + latch once the
+//     key has been missing charDevMissThreshold consecutive polls.
+//   - expected + missing + latched    → steady faulted state, silent.
+//   - not expected + latched          → held: no event, latch kept.
+//
+// On a baseline run the check-scoped clear voids every downstream
+// condition, so still-missing latched keys immediately re-assert their
+// FATAL with fresh events, and latches whose keys are no longer expected
+// are dropped with the clear — if their device returns still broken, the
+// debounce re-fatals it within charDevMissThreshold polls.
+func (c *InfiniBandCharDeviceCheck) evaluatePoll(
+	expected expectedCharDevices, observed observedCharDevices, baselineRun bool,
+) ([]*pb.HealthEvent, map[charDevKey]bool, map[charDevKey]int) {
 	var events []*pb.HealthEvent
+
+	nextLatched := make(map[charDevKey]bool)
+	nextStreak := make(map[charDevKey]int)
 
 	if baselineRun {
 		events = append(events, checks.NewBaselineClearEvent(
@@ -251,29 +361,70 @@ func (c *InfiniBandCharDeviceCheck) buildEvents(
 			"InfiniBand character-device check: clearing stale conditions after reboot",
 			c.processingStrategy,
 		))
+	}
 
-		for key := range currentMissing {
-			events = append(events, c.missingEvent(key))
+	for key := range expected.keys {
+		if evt := c.evaluateKey(key, observed.present[key], baselineRun, nextLatched, nextStreak); evt != nil {
+			events = append(events, evt)
 		}
+	}
 
+	// Latched keys not expected this poll (device unreadable, absent, or
+	// without IB ports): hold them — absence is not positive evidence of
+	// recovery. On a baseline run they are dropped instead: the clear has
+	// voided their downstream conditions.
+	if !baselineRun {
+		for key := range c.latched {
+			if _, isExpected := expected.keys[key]; !isExpected {
+				nextLatched[key] = true
+			}
+		}
+	}
+
+	if baselineRun {
 		checks.EnsureClearPrecedesBatch(events)
-
-		return events
 	}
 
-	for key := range currentMissing {
-		if !c.previousMissing[key] {
-			events = append(events, c.missingEvent(key))
+	return events, nextLatched, nextStreak
+}
+
+// evaluateKey applies the transition rules to one expected key, updating
+// the candidate latch/streak maps and returning the event to emit, if any.
+func (c *InfiniBandCharDeviceCheck) evaluateKey(
+	key charDevKey, present, baselineRun bool,
+	nextLatched map[charDevKey]bool, nextStreak map[charDevKey]int,
+) *pb.HealthEvent {
+	if present {
+		if c.latched[key] && !baselineRun {
+			return c.recoveryEvent(key)
 		}
+
+		return nil
 	}
 
-	for key := range c.previousMissing {
-		if !currentMissing[key] {
-			events = append(events, c.recoveryEvent(key))
+	if c.latched[key] {
+		nextLatched[key] = true
+
+		if baselineRun {
+			// The clear just voided this key's condition; re-assert the
+			// confirmed fault immediately rather than re-running the
+			// debounce.
+			return c.missingEvent(key)
 		}
+
+		return nil
 	}
 
-	return events
+	streak := c.missStreak[key] + 1
+	if streak >= charDevMissThreshold {
+		nextLatched[key] = true
+
+		return c.missingEvent(key)
+	}
+
+	nextStreak[key] = streak
+
+	return nil
 }
 
 // expectedCharDevices is the per-device internal-consistency expectation
@@ -461,19 +612,6 @@ func (c *InfiniBandCharDeviceCheck) readVerbsDir(present map[charDevKey]bool) (b
 	return false, nil
 }
 
-// diffMissing returns the expected keys that are absent from the observed set.
-func diffMissing(expected expectedCharDevices, observed observedCharDevices) map[charDevKey]bool {
-	missing := make(map[charDevKey]bool)
-
-	for key := range expected.keys {
-		if !observed.present[key] {
-			missing[key] = true
-		}
-	}
-
-	return missing
-}
-
 // missingEvent builds the FATAL event for a missing character device. A
 // missing node cannot be repaired from inside the workload — it requires
 // host-level driver/udev/reboot intervention and pods hard-fail to start —
@@ -484,10 +622,10 @@ func (c *InfiniBandCharDeviceCheck) missingEvent(key charDevKey) *pb.HealthEvent
 		c.nodeName, c.Name(), key.device, discovery.PortEntityValue(key.port),
 	).Inc()
 
-	return checks.NewHealthEvent(
+	return withCharDevCode(checks.NewHealthEvent(
 		c.nodeName, c.Name(), c.missingMessage(key), c.entitiesFor(key),
 		true, false, pb.RecommendedAction_REPLACE_VM, c.processingStrategy,
-	)
+	), key.kind)
 }
 
 // recoveryEvent builds the healthy event emitted when a previously-missing
@@ -495,10 +633,23 @@ func (c *InfiniBandCharDeviceCheck) missingEvent(key charDevKey) *pb.HealthEvent
 func (c *InfiniBandCharDeviceCheck) recoveryEvent(key charDevKey) *pb.HealthEvent {
 	msg := fmt.Sprintf("InfiniBand character device %s for %s is present again", key.kind, c.entityDesc(key))
 
-	return checks.NewHealthEvent(
+	return withCharDevCode(checks.NewHealthEvent(
 		c.nodeName, c.Name(), msg, c.entitiesFor(key),
 		false, true, pb.RecommendedAction_NONE, c.processingStrategy,
-	)
+	), key.kind)
+}
+
+// withCharDevCode stamps the character-device kind onto an event as its
+// ErrorCode. Downstream consumers scope condition clearing by ErrorCode:
+// without it the issm and umad events for a port share one identity
+// (check name + entities), so a umad recovery would also wipe a still-open
+// issm condition — and since the check reports transitions, the issm fault
+// would never be re-added until reboot. Only the check-scoped baseline
+// clear is deliberately code-less, because it means "clear everything".
+func withCharDevCode(evt *pb.HealthEvent, kind charDevKind) *pb.HealthEvent {
+	evt.ErrorCode = []string{string(kind)}
+
+	return evt
 }
 
 // missingMessage renders the operator-facing description of a missing node.

--- a/health-monitors/nic-health-monitor/pkg/checks/state/ibdevnode.go
+++ b/health-monitors/nic-health-monitor/pkg/checks/state/ibdevnode.go
@@ -1,0 +1,543 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package state
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
+	"github.com/nvidia/nvsentinel/health-monitors/nic-health-monitor/pkg/checks"
+	"github.com/nvidia/nvsentinel/health-monitors/nic-health-monitor/pkg/config"
+	"github.com/nvidia/nvsentinel/health-monitors/nic-health-monitor/pkg/discovery"
+	"github.com/nvidia/nvsentinel/health-monitors/nic-health-monitor/pkg/metrics"
+	"github.com/nvidia/nvsentinel/health-monitors/nic-health-monitor/pkg/statefile"
+	"github.com/nvidia/nvsentinel/health-monitors/nic-health-monitor/pkg/sysfs"
+	"github.com/nvidia/nvsentinel/health-monitors/nic-health-monitor/pkg/topology"
+)
+
+// charDevKind identifies which InfiniBand character-device class an
+// expected/observed entry belongs to.
+type charDevKind string
+
+const (
+	kindIssm   charDevKind = "issm"
+	kindUmad   charDevKind = "umad"
+	kindUverbs charDevKind = "uverbs"
+
+	// abiVersionEntry is the non-device file the kernel places in each
+	// infiniband_mad / infiniband_verbs class directory; it must never be
+	// treated as a character-device node.
+	abiVersionEntry = "abi_version"
+
+	// noPort is the sentinel port used for device-level entries (uverbs),
+	// which are not associated with a specific port.
+	noPort = 0
+)
+
+// charDevKey uniquely identifies an expected or missing character device.
+// device is the IB device name (e.g. "mlx5_0"); port is the IB port for
+// per-port kinds (issm/umad) and noPort for the device-level kind (uverbs).
+type charDevKey struct {
+	kind   charDevKind
+	device string
+	port   int
+}
+
+// InfiniBandCharDeviceCheck detects missing InfiniBand character-device
+// nodes (issm/umad/uverbs) that leave a device's ports ACTIVE/LinkUp yet
+// unusable by RDMA workloads (e.g. a pod failing with
+// "lstat /dev/infiniband/issm9: no such file or directory").
+//
+// udev creates the /dev/infiniband/{issm,umad,uverbs}N nodes from the
+// sysfs class entries under /sys/class/infiniband_mad and
+// /sys/class/infiniband_verbs, so a missing class entry is an exact proxy
+// for a missing /dev node — detectable via passive sysfs reads, no /dev
+// mount required.
+//
+// The check is a per-device internal-consistency test, NOT an absolute
+// expected-count test: for each discovered, in-scope device that exposes
+// at least one InfiniBand-mode port it asserts that the device's own
+// character devices exist (one uverbs per device; one umad and one issm
+// per InfiniBand-mode port). It never assumes a fleet-wide device count,
+// so it cannot false-positive the way an absolute expectation would. A
+// device that is entirely absent from /sys/class/infiniband is out of
+// scope here — that is the InfiniBandStateCheck's device-disappearance
+// responsibility.
+type InfiniBandCharDeviceCheck struct {
+	nodeName           string
+	reader             sysfs.Reader
+	cfg                *config.Config
+	classifier         *topology.Classifier
+	processingStrategy pb.ProcessingStrategy
+	state              *statefile.Manager
+
+	// emitHealthyBaselines requests a check-scoped baseline clear on the
+	// first complete poll after a host reboot (or a still-owed baseline
+	// from a previous pod) so stale FATAL conditions from the prior boot
+	// are wiped before current-boot faults are re-asserted.
+	emitHealthyBaselines bool
+
+	// previousMissing is the committed set of currently-missing character
+	// devices; it drives transition (missing↔present) event emission so
+	// steady states do not re-emit every poll. It is in-memory only: a
+	// reboot re-baselines, and a non-reboot pod restart re-discovers the
+	// current state on the first poll.
+	previousMissing map[charDevKey]bool
+
+	pending *charDevPollCommit
+}
+
+// charDevPollCommit stages a prepared poll until Commit makes it durable.
+type charDevPollCommit struct {
+	missing     map[charDevKey]bool
+	baselineRan bool
+}
+
+var _ checks.TransactionalCheck = (*InfiniBandCharDeviceCheck)(nil)
+
+// NewInfiniBandCharDeviceCheck wires the dependencies for the check. The
+// bootIDChanged flag — typically stateManager.BootIDChanged() right after
+// Load — plus any baseline still owed by a previous pod controls whether
+// the first complete poll emits a check-scoped baseline clear.
+func NewInfiniBandCharDeviceCheck(
+	nodeName string,
+	reader sysfs.Reader,
+	cfg *config.Config,
+	classifier *topology.Classifier,
+	processingStrategy pb.ProcessingStrategy,
+	stateManager *statefile.Manager,
+	bootIDChanged bool,
+) *InfiniBandCharDeviceCheck {
+	pendingBaseline := bootIDChanged || stateManager.PendingBaseline(checks.InfiniBandCharDeviceCheckName)
+	if pendingBaseline {
+		stateManager.SetPendingBaseline(checks.InfiniBandCharDeviceCheckName)
+	}
+
+	return &InfiniBandCharDeviceCheck{
+		nodeName:             nodeName,
+		reader:               reader,
+		cfg:                  cfg,
+		classifier:           classifier,
+		processingStrategy:   processingStrategy,
+		state:                stateManager,
+		emitHealthyBaselines: pendingBaseline,
+	}
+}
+
+// Name returns the check identifier used by the orchestrator and in events.
+func (c *InfiniBandCharDeviceCheck) Name() string { return checks.InfiniBandCharDeviceCheckName }
+
+// Run executes and commits one poll for direct callers. The production
+// monitor uses Prepare/Commit/Discard so publication succeeds before state
+// advances.
+func (c *InfiniBandCharDeviceCheck) Run() ([]*pb.HealthEvent, error) {
+	events, err := c.Prepare()
+	if err != nil {
+		return nil, err
+	}
+
+	c.Commit()
+
+	return events, nil
+}
+
+// Prepare observes one poll and stages its candidate state without
+// advancing the committed missing-set or persistent state.
+func (c *InfiniBandCharDeviceCheck) Prepare() ([]*pb.HealthEvent, error) {
+	c.Discard()
+
+	result, err := discovery.DiscoverDevicesWithOverride(
+		c.reader, c.cfg.NicExclusionRegex, c.cfg.NicInclusionRegexOverride,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("device discovery failed: %w", err)
+	}
+
+	if !result.Complete {
+		if c.previousMissing != nil {
+			return nil, fmt.Errorf("device discovery incomplete: InfiniBand sysfs tree unavailable")
+		}
+
+		// Nodes without an InfiniBand tree stay quiet until one complete
+		// enumeration succeeds.
+		return nil, nil
+	}
+
+	expected := buildExpectedCharDevices(result.Devices, c.classifier)
+	metrics.DevicesDiscovered.WithLabelValues(c.nodeName, c.Name()).Set(float64(expected.deviceCount))
+
+	// The baseline reconciliation waits for a complete enumeration with no
+	// unreadable devices: clearing while a device is unreadable would wipe
+	// that device's previous-boot condition with nothing able to re-assert
+	// it. Until then the baseline stays owed.
+	baselineRun := c.emitHealthyBaselines && len(result.UnreadableDevices) == 0
+
+	observed, uncertain, err := c.observeCharDevices(expected)
+	if err != nil {
+		return nil, err
+	}
+
+	if uncertain {
+		// A class directory we need was entirely absent while devices that
+		// should populate it exist: an uncertain observation, not evidence
+		// of mass failure. Hold state (do not stage) so the baseline stays
+		// owed and no spurious FATALs are emitted.
+		slog.Warn("Holding InfiniBand char-device poll: class directory unavailable",
+			"check", c.Name(), "node", c.nodeName)
+
+		return nil, nil
+	}
+
+	currentMissing := diffMissing(expected, observed)
+	events := c.buildEvents(currentMissing, baselineRun)
+
+	c.pending = &charDevPollCommit{missing: currentMissing, baselineRan: baselineRun}
+
+	return events, nil
+}
+
+// Commit installs and persists the most recently prepared state.
+func (c *InfiniBandCharDeviceCheck) Commit() {
+	if c.pending == nil {
+		return
+	}
+
+	pending := c.pending
+	c.pending = nil
+	c.previousMissing = pending.missing
+
+	if pending.baselineRan {
+		c.emitHealthyBaselines = false
+		c.state.ClearPendingBaseline(checks.InfiniBandCharDeviceCheckName)
+	}
+}
+
+// Discard abandons a prepared poll after check or publication failure.
+func (c *InfiniBandCharDeviceCheck) Discard() {
+	c.pending = nil
+}
+
+// buildEvents turns the current missing-set into HealthEvents. On a
+// baseline run it emits a check-scoped clear (wiping stale prior-boot
+// conditions) followed by a FATAL for every still-missing node. On a
+// normal run it emits a FATAL for each newly-missing node and a healthy
+// recovery for each node that reappeared, staying silent on steady state.
+func (c *InfiniBandCharDeviceCheck) buildEvents(
+	currentMissing map[charDevKey]bool, baselineRun bool,
+) []*pb.HealthEvent {
+	var events []*pb.HealthEvent
+
+	if baselineRun {
+		events = append(events, checks.NewBaselineClearEvent(
+			c.nodeName, c.Name(),
+			"InfiniBand character-device check: clearing stale conditions after reboot",
+			c.processingStrategy,
+		))
+
+		for key := range currentMissing {
+			events = append(events, c.missingEvent(key))
+		}
+
+		checks.EnsureClearPrecedesBatch(events)
+
+		return events
+	}
+
+	for key := range currentMissing {
+		if !c.previousMissing[key] {
+			events = append(events, c.missingEvent(key))
+		}
+	}
+
+	for key := range c.previousMissing {
+		if !currentMissing[key] {
+			events = append(events, c.recoveryEvent(key))
+		}
+	}
+
+	return events
+}
+
+// expectedCharDevices is the per-device internal-consistency expectation
+// derived from discovery: the character devices each in-scope device must
+// expose given its InfiniBand-mode ports.
+type expectedCharDevices struct {
+	keys        map[charDevKey]bool
+	needsMad    bool // any issm/umad expected → the mad class dir is required.
+	needsVerbs  bool // any uverbs expected → the verbs class dir is required.
+	deviceCount int
+}
+
+// buildExpectedCharDevices computes, for each eligible device that exposes
+// at least one InfiniBand-mode port: one uverbs (device-level) plus one
+// umad and one issm per InfiniBand-mode port. umad/issm are gated on the
+// InfiniBand link layer because RoCE/Ethernet-mode ports legitimately have
+// no issm node, so expecting them there would false-positive.
+func buildExpectedCharDevices(
+	devices []discovery.IBDevice, classifier *topology.Classifier,
+) expectedCharDevices {
+	exp := expectedCharDevices{keys: make(map[charDevKey]bool)}
+
+	for i := range devices {
+		dev := &devices[i]
+		if !checks.EligibleDevice(dev, classifier) {
+			continue
+		}
+
+		if !hasInfiniBandPort(dev) {
+			continue
+		}
+
+		exp.deviceCount++
+		exp.keys[charDevKey{kind: kindUverbs, device: dev.Name, port: noPort}] = true
+		exp.needsVerbs = true
+
+		for j := range dev.Ports {
+			port := &dev.Ports[j]
+			if !discovery.IsIBPort(port) {
+				continue
+			}
+
+			exp.keys[charDevKey{kind: kindUmad, device: dev.Name, port: port.Port}] = true
+			exp.keys[charDevKey{kind: kindIssm, device: dev.Name, port: port.Port}] = true
+			exp.needsMad = true
+		}
+	}
+
+	return exp
+}
+
+// hasInfiniBandPort reports whether the device exposes at least one
+// InfiniBand-mode port (making it in-scope for this check).
+func hasInfiniBandPort(dev *discovery.IBDevice) bool {
+	for i := range dev.Ports {
+		if discovery.IsIBPort(&dev.Ports[i]) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// observedCharDevices is the set of character devices actually present in
+// the two sysfs class directories, keyed identically to the expected set.
+type observedCharDevices struct {
+	present map[charDevKey]bool
+}
+
+// observeCharDevices reads the mad and verbs class directories and returns
+// the present character devices. uncertain is true when a class directory
+// that expected entries depend on is entirely absent (ErrNotExist): the
+// observation cannot be trusted and the caller must hold rather than emit
+// mass-missing FATALs. A non-ErrNotExist listing error is returned as err.
+func (c *InfiniBandCharDeviceCheck) observeCharDevices(
+	expected expectedCharDevices,
+) (observedCharDevices, bool, error) {
+	observed := observedCharDevices{present: make(map[charDevKey]bool)}
+
+	madUncertain, err := c.readMadDir(observed.present)
+	if err != nil {
+		return observed, false, err
+	}
+
+	verbsUncertain, err := c.readVerbsDir(observed.present)
+	if err != nil {
+		return observed, false, err
+	}
+
+	uncertain := (madUncertain && expected.needsMad) || (verbsUncertain && expected.needsVerbs)
+
+	return observed, uncertain, nil
+}
+
+// readMadDir enumerates /sys/class/infiniband_mad, recording each issm*/umad*
+// entry as present under its (device, port) key. It returns uncertain=true
+// when the directory does not exist.
+func (c *InfiniBandCharDeviceCheck) readMadDir(present map[charDevKey]bool) (bool, error) {
+	base := c.reader.IBMadBasePath()
+
+	entries, err := c.reader.ListDirs(base)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return true, nil
+		}
+
+		return false, fmt.Errorf("failed to list %s: %w", base, err)
+	}
+
+	for _, entry := range entries {
+		var kind charDevKind
+
+		switch {
+		case entry == abiVersionEntry:
+			continue
+		case strings.HasPrefix(entry, string(kindIssm)):
+			kind = kindIssm
+		case strings.HasPrefix(entry, string(kindUmad)):
+			kind = kindUmad
+		default:
+			continue
+		}
+
+		device, port, ok := c.readMadEntry(base, entry)
+		if !ok {
+			continue
+		}
+
+		present[charDevKey{kind: kind, device: device, port: port}] = true
+	}
+
+	return false, nil
+}
+
+// readMadEntry reads the ibdev and port files of a mad class entry. ok is
+// false when either is unreadable (e.g. the abi_version file, or a
+// transient race) so the caller skips it rather than fabricating a key.
+func (c *InfiniBandCharDeviceCheck) readMadEntry(base, entry string) (string, int, bool) {
+	device, err := c.reader.ReadFile(filepath.Join(base, entry, "ibdev"))
+	if err != nil {
+		return "", 0, false
+	}
+
+	portStr, err := c.reader.ReadFile(filepath.Join(base, entry, "port"))
+	if err != nil {
+		return "", 0, false
+	}
+
+	port, err := strconv.Atoi(strings.TrimSpace(portStr))
+	if err != nil {
+		return "", 0, false
+	}
+
+	return strings.TrimSpace(device), port, true
+}
+
+// readVerbsDir enumerates /sys/class/infiniband_verbs, recording each
+// uverbs* entry as present under its device key. It returns uncertain=true
+// when the directory does not exist.
+func (c *InfiniBandCharDeviceCheck) readVerbsDir(present map[charDevKey]bool) (bool, error) {
+	base := c.reader.IBVerbsBasePath()
+
+	entries, err := c.reader.ListDirs(base)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return true, nil
+		}
+
+		return false, fmt.Errorf("failed to list %s: %w", base, err)
+	}
+
+	for _, entry := range entries {
+		if entry == abiVersionEntry || !strings.HasPrefix(entry, string(kindUverbs)) {
+			continue
+		}
+
+		device, err := c.reader.ReadFile(filepath.Join(base, entry, "ibdev"))
+		if err != nil {
+			continue
+		}
+
+		present[charDevKey{kind: kindUverbs, device: strings.TrimSpace(device), port: noPort}] = true
+	}
+
+	return false, nil
+}
+
+// diffMissing returns the expected keys that are absent from the observed set.
+func diffMissing(expected expectedCharDevices, observed observedCharDevices) map[charDevKey]bool {
+	missing := make(map[charDevKey]bool)
+
+	for key := range expected.keys {
+		if !observed.present[key] {
+			missing[key] = true
+		}
+	}
+
+	return missing
+}
+
+// missingEvent builds the FATAL event for a missing character device. A
+// missing node cannot be repaired from inside the workload — it requires
+// host-level driver/udev/reboot intervention and pods hard-fail to start —
+// so it recommends node replacement, matching how the real incident was
+// resolved (spare migration).
+func (c *InfiniBandCharDeviceCheck) missingEvent(key charDevKey) *pb.HealthEvent {
+	metrics.StateCheckErrors.WithLabelValues(
+		c.nodeName, c.Name(), key.device, discovery.PortEntityValue(key.port),
+	).Inc()
+
+	return checks.NewHealthEvent(
+		c.nodeName, c.Name(), c.missingMessage(key), c.entitiesFor(key),
+		true, false, pb.RecommendedAction_REPLACE_VM, c.processingStrategy,
+	)
+}
+
+// recoveryEvent builds the healthy event emitted when a previously-missing
+// character device reappears, so the platform can clear the node condition.
+func (c *InfiniBandCharDeviceCheck) recoveryEvent(key charDevKey) *pb.HealthEvent {
+	msg := fmt.Sprintf("InfiniBand character device %s for %s is present again", key.kind, c.entityDesc(key))
+
+	return checks.NewHealthEvent(
+		c.nodeName, c.Name(), msg, c.entitiesFor(key),
+		false, true, pb.RecommendedAction_NONE, c.processingStrategy,
+	)
+}
+
+// missingMessage renders the operator-facing description of a missing node.
+func (c *InfiniBandCharDeviceCheck) missingMessage(key charDevKey) string {
+	switch key.kind {
+	case kindUverbs:
+		return fmt.Sprintf(
+			"Device %s: verbs character device (uverbs) missing from /sys/class/infiniband_verbs; "+
+				"RDMA workloads cannot open /dev/infiniband/uverbs*", key.device)
+	case kindIssm:
+		return fmt.Sprintf(
+			"Device %s port %d: issm character device missing from /sys/class/infiniband_mad "+
+				"(expected for an InfiniBand-mode port); pods cannot open /dev/infiniband/issm*",
+			key.device, key.port)
+	case kindUmad:
+		return fmt.Sprintf(
+			"Device %s port %d: umad character device missing from /sys/class/infiniband_mad; "+
+				"pods cannot open /dev/infiniband/umad*", key.device, key.port)
+	default:
+		return fmt.Sprintf("Device %s: character device %s missing", key.device, key.kind)
+	}
+}
+
+// entitiesFor returns the entity references for an event: per-port kinds
+// (issm/umad) pinpoint both card and port; the device-level kind (uverbs)
+// references only the card.
+func (c *InfiniBandCharDeviceCheck) entitiesFor(key charDevKey) []*pb.Entity {
+	if key.kind == kindUverbs {
+		return checks.DeviceEntities(key.device)
+	}
+
+	return checks.PortEntities(key.device, key.port)
+}
+
+// entityDesc renders a short human description of the entity for messages.
+func (c *InfiniBandCharDeviceCheck) entityDesc(key charDevKey) string {
+	if key.kind == kindUverbs {
+		return fmt.Sprintf("device %s", key.device)
+	}
+
+	return fmt.Sprintf("device %s port %d", key.device, key.port)
+}

--- a/health-monitors/nic-health-monitor/pkg/checks/state/ibdevnode_fsrepro_test.go
+++ b/health-monitors/nic-health-monitor/pkg/checks/state/ibdevnode_fsrepro_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
+	"github.com/nvidia/nvsentinel/health-monitors/nic-health-monitor/pkg/config"
+	"github.com/nvidia/nvsentinel/health-monitors/nic-health-monitor/pkg/sysfs"
+	"github.com/nvidia/nvsentinel/health-monitors/nic-health-monitor/pkg/topology"
+)
+
+// writeFile creates path (and parents) with the given content.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+// buildRealNodeSysfs materialises, on a real temp filesystem, the exact
+// InfiniBand character-device layout observed on a live Crusoe H100-IB
+// node (cluster slurmwise, node np-a62cfc8a-1, 2026-07-28): one Ethernet
+// management NIC (mlx5_0, no issm) and one InfiniBand compute NIC
+// (mlx5_1, issm present). It returns the ib/net base paths for
+// sysfs.NewReader — the production reader, not the mock. This is the
+// filesystem mirror of ticket #11021's environment.
+func buildRealNodeSysfs(t *testing.T) (ibBase, netBase string) {
+	t.Helper()
+
+	root := t.TempDir()
+	ibBase = filepath.Join(root, "infiniband")
+	madBase := filepath.Join(root, "infiniband_mad")
+	verbsBase := filepath.Join(root, "infiniband_verbs")
+	netBase = filepath.Join(root, "net")
+
+	// mlx5_0 — Ethernet management NIC (has umad/uverbs, no issm).
+	writeFile(t, filepath.Join(ibBase, "mlx5_0", "device", "vendor"), "0x15b3")
+	writeFile(t, filepath.Join(ibBase, "mlx5_0", "ports", "1", "state"), "4: ACTIVE")
+	writeFile(t, filepath.Join(ibBase, "mlx5_0", "ports", "1", "phys_state"), "5: LinkUp")
+	writeFile(t, filepath.Join(ibBase, "mlx5_0", "ports", "1", "link_layer"), "Ethernet")
+
+	// mlx5_1 — InfiniBand compute NIC (issm expected).
+	writeFile(t, filepath.Join(ibBase, "mlx5_1", "device", "vendor"), "0x15b3")
+	writeFile(t, filepath.Join(ibBase, "mlx5_1", "ports", "1", "state"), "4: ACTIVE")
+	writeFile(t, filepath.Join(ibBase, "mlx5_1", "ports", "1", "phys_state"), "5: LinkUp")
+	writeFile(t, filepath.Join(ibBase, "mlx5_1", "ports", "1", "link_layer"), "InfiniBand")
+
+	// infiniband_mad: umad0(mlx5_0/1), umad1(mlx5_1/1), issm1(mlx5_1/1) + abi_version.
+	writeFile(t, filepath.Join(madBase, "abi_version"), "5")
+	writeFile(t, filepath.Join(madBase, "umad0", "ibdev"), "mlx5_0")
+	writeFile(t, filepath.Join(madBase, "umad0", "port"), "1")
+	writeFile(t, filepath.Join(madBase, "umad1", "ibdev"), "mlx5_1")
+	writeFile(t, filepath.Join(madBase, "umad1", "port"), "1")
+	writeFile(t, filepath.Join(madBase, "issm1", "ibdev"), "mlx5_1")
+	writeFile(t, filepath.Join(madBase, "issm1", "port"), "1")
+
+	// infiniband_verbs: uverbs0(mlx5_0), uverbs1(mlx5_1) + abi_version.
+	writeFile(t, filepath.Join(verbsBase, "abi_version"), "1")
+	writeFile(t, filepath.Join(verbsBase, "uverbs0", "ibdev"), "mlx5_0")
+	writeFile(t, filepath.Join(verbsBase, "uverbs1", "ibdev"), "mlx5_1")
+
+	require.NoError(t, os.MkdirAll(netBase, 0o755))
+
+	return ibBase, netBase
+}
+
+// TestIBCharDev_RealNodeLayout_FilesystemRepro drives the check through the
+// production sysfs.Reader against a real on-disk mirror of a live H100-IB
+// node: healthy first (mlx5_0 Ethernet correctly needs no issm, mlx5_1 IB
+// has issm), then reproduces ticket #11021 by removing mlx5_1's issm node.
+func TestIBCharDev_RealNodeLayout_FilesystemRepro(t *testing.T) {
+	t.Parallel()
+
+	ibBase, netBase := buildRealNodeSysfs(t)
+	reader := sysfs.NewReader(ibBase, netBase)
+
+	// Inclusion override keeps the classifier out of it (no gpu_metadata
+	// needed): scope is decided by our own IB-port gate, so mlx5_0
+	// (Ethernet) is still correctly out of scope.
+	cfg := &config.Config{NicInclusionRegexOverride: "mlx5_.*"}
+	classifier := topology.NewOverrideClassifier(reader)
+
+	newCheck := func() *InfiniBandCharDeviceCheck {
+		return NewInfiniBandCharDeviceCheck("np-a62cfc8a-1", reader, cfg, classifier,
+			pb.ProcessingStrategy_EXECUTE_REMEDIATION, freshStateManager(t), false)
+	}
+
+	// Healthy node: every expected char device present → no events. This
+	// also proves the Ethernet mlx5_0 does not trigger a false issm miss.
+	events, err := newCheck().Run()
+	require.NoError(t, err)
+	assert.Empty(t, events, "healthy H100-IB node must emit no events")
+
+	// Reproduce #11021: mlx5_1's issm node is gone (device still present,
+	// port still ACTIVE/LinkUp) — the exact failure the passive port check
+	// misses.
+	require.NoError(t, os.RemoveAll(filepath.Join(ibBase+"_mad", "issm1")))
+
+	events, err = newCheck().Run()
+	require.NoError(t, err)
+	require.Len(t, events, 1, "missing issm on an IB device must produce one fatal event")
+
+	evt := events[0]
+	assert.True(t, evt.IsFatal)
+	assert.Equal(t, pb.RecommendedAction_REPLACE_VM, evt.RecommendedAction)
+	assert.Contains(t, evt.Message, "issm")
+	assert.Contains(t, evt.Message, "mlx5_1")
+	assertPortEntities(t, evt, "mlx5_1", 1)
+}

--- a/health-monitors/nic-health-monitor/pkg/checks/state/ibdevnode_fsrepro_test.go
+++ b/health-monitors/nic-health-monitor/pkg/checks/state/ibdevnode_fsrepro_test.go
@@ -98,30 +98,41 @@ func TestIBCharDev_RealNodeLayout_FilesystemRepro(t *testing.T) {
 	cfg := &config.Config{NicInclusionRegexOverride: "mlx5_.*"}
 	classifier := topology.NewOverrideClassifier(reader)
 
-	newCheck := func() *InfiniBandCharDeviceCheck {
-		return NewInfiniBandCharDeviceCheck("np-a62cfc8a-1", reader, cfg, classifier,
-			pb.ProcessingStrategy_EXECUTE_REMEDIATION, freshStateManager(t), false)
-	}
+	check := NewInfiniBandCharDeviceCheck("np-a62cfc8a-1", reader, cfg, classifier,
+		pb.ProcessingStrategy_EXECUTE_REMEDIATION, freshStateManager(t), false)
 
 	// Healthy node: every expected char device present → no events. This
 	// also proves the Ethernet mlx5_0 does not trigger a false issm miss.
-	events, err := newCheck().Run()
+	events, err := check.Run()
 	require.NoError(t, err)
 	assert.Empty(t, events, "healthy H100-IB node must emit no events")
 
 	// Reproduce #11021: mlx5_1's issm node is gone (device still present,
 	// port still ACTIVE/LinkUp) — the exact failure the passive port check
-	// misses.
+	// misses. The fatal fires once the miss has been confirmed for
+	// charDevMissThreshold consecutive polls.
 	require.NoError(t, os.RemoveAll(filepath.Join(ibBase+"_mad", "issm1")))
 
-	events, err = newCheck().Run()
+	runQuietPolls(t, check, charDevMissThreshold-1)
+
+	events, err = check.Run()
 	require.NoError(t, err)
 	require.Len(t, events, 1, "missing issm on an IB device must produce one fatal event")
 
 	evt := events[0]
 	assert.True(t, evt.IsFatal)
 	assert.Equal(t, pb.RecommendedAction_REPLACE_VM, evt.RecommendedAction)
+	assert.Equal(t, []string{"issm"}, evt.ErrorCode)
 	assert.Contains(t, evt.Message, "issm")
 	assert.Contains(t, evt.Message, "mlx5_1")
 	assertPortEntities(t, evt, "mlx5_1", 1)
+
+	// Restore the node and confirm a positively-observed recovery.
+	writeFile(t, filepath.Join(ibBase+"_mad", "issm1", "ibdev"), "mlx5_1")
+	writeFile(t, filepath.Join(ibBase+"_mad", "issm1", "port"), "1")
+
+	events, err = check.Run()
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.True(t, events[0].IsHealthy, "restored issm must emit a recovery")
 }

--- a/health-monitors/nic-health-monitor/pkg/checks/state/ibdevnode_test.go
+++ b/health-monitors/nic-health-monitor/pkg/checks/state/ibdevnode_test.go
@@ -28,6 +28,7 @@ import (
 	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	"github.com/nvidia/nvsentinel/health-monitors/nic-health-monitor/pkg/checks"
 	"github.com/nvidia/nvsentinel/health-monitors/nic-health-monitor/pkg/config"
+	"github.com/nvidia/nvsentinel/health-monitors/nic-health-monitor/pkg/statefile"
 	"github.com/nvidia/nvsentinel/health-monitors/nic-health-monitor/pkg/sysfs"
 )
 
@@ -157,19 +158,24 @@ func fullCharDevs(node *stubNode) ([]madEntry, []verbsEntry) {
 	return mad, verbs
 }
 
-// singleIBNode returns a stubNode with one compute IB device (mlx5_0)
-// exposing a single ACTIVE/LinkUp InfiniBand port, plus a classifier that
-// keeps it in scope.
-func singleIBNode(t *testing.T) (*stubNode, *charDevFixture) {
-	t.Helper()
-
-	node := newStubNode().addIB("mlx5_0", &stubDevice{
+// singleIBDevice returns the stubDevice used by singleIBNode, so tests
+// that remove/re-add the device between polls can share the definition.
+func singleIBDevice() *stubDevice {
+	return &stubDevice{
 		pciAddress: "0000:47:00.0",
 		numaNode:   0,
 		ports: map[int]stubPort{
 			1: {state: "ACTIVE", physState: "LinkUp", linkLayer: "InfiniBand"},
 		},
-	})
+	}
+}
+
+// singleIBNode returns a stubNode with one compute IB device (mlx5_0)
+// exposing a single ACTIVE/LinkUp InfiniBand port.
+func singleIBNode(t *testing.T) (*stubNode, *charDevFixture) {
+	t.Helper()
+
+	node := newStubNode().addIB("mlx5_0", singleIBDevice())
 	mad, verbs := fullCharDevs(node)
 
 	return node, &charDevFixture{node: node, mad: mad, verbs: verbs}
@@ -180,13 +186,34 @@ func newCharDevCheck(
 ) *InfiniBandCharDeviceCheck {
 	t.Helper()
 
+	return newCharDevCheckWithManager(t, f, reader, freshStateManager(t), bootIDChanged)
+}
+
+func newCharDevCheckWithManager(
+	t *testing.T, f *charDevFixture, reader sysfs.Reader,
+	mgr *statefile.Manager, bootIDChanged bool,
+) *InfiniBandCharDeviceCheck {
+	t.Helper()
+
 	classifier := buildClassifier(t, reader,
 		[]string{"0000:0f:00.0"},
 		map[string][]string{"mlx5_0": {"PIX"}},
 	)
 
 	return NewInfiniBandCharDeviceCheck("node1", reader, &config.Config{},
-		classifier, pb.ProcessingStrategy_EXECUTE_REMEDIATION, freshStateManager(t), bootIDChanged)
+		classifier, pb.ProcessingStrategy_EXECUTE_REMEDIATION, mgr, bootIDChanged)
+}
+
+// runQuietPolls runs the check n times, requiring every poll to emit no
+// events (the debounce window before a fatal fires).
+func runQuietPolls(t *testing.T, check *InfiniBandCharDeviceCheck, n int) {
+	t.Helper()
+
+	for i := 0; i < n; i++ {
+		events, err := check.Run()
+		require.NoError(t, err)
+		assert.Emptyf(t, events, "poll %d of %d should be silent (debounce window)", i+1, n)
+	}
 }
 
 func fatalEvents(events []*pb.HealthEvent) []*pb.HealthEvent {
@@ -213,16 +240,19 @@ func TestIBCharDev_AllPresentHealthy(t *testing.T) {
 	assert.Empty(t, events, "a device with all char devices present must not emit events")
 }
 
-func TestIBCharDev_IssmMissingIsFatal(t *testing.T) {
+func TestIBCharDev_IssmMissingIsFatalAfterDebounce(t *testing.T) {
 	t.Parallel()
 
 	// The production ticket: an ACTIVE/LinkUp InfiniBand port whose issm
 	// character device never materialised, so pods fail with
-	// "lstat /dev/infiniband/issm9: no such file or directory".
+	// "lstat /dev/infiniband/issm9: no such file or directory". The fatal
+	// fires only after charDevMissThreshold consecutive missing polls.
 	_, f := singleIBNode(t)
 	f.mad = dropKind(f.mad, "issm")
 	reader := f.reader()
 	check := newCharDevCheck(t, f, reader, false)
+
+	runQuietPolls(t, check, charDevMissThreshold-1)
 
 	events, err := check.Run()
 	require.NoError(t, err)
@@ -233,8 +263,39 @@ func TestIBCharDev_IssmMissingIsFatal(t *testing.T) {
 	assert.False(t, evt.IsHealthy)
 	assert.Equal(t, pb.RecommendedAction_REPLACE_VM, evt.RecommendedAction)
 	assert.Equal(t, checks.InfiniBandCharDeviceCheckName, evt.CheckName)
+	assert.Equal(t, []string{"issm"}, evt.ErrorCode, "fatal must carry the per-kind error code")
 	assert.Contains(t, evt.Message, "issm")
 	assertPortEntities(t, evt, "mlx5_0", 1)
+
+	// Steady faulted state stays silent.
+	events, err = check.Run()
+	require.NoError(t, err)
+	assert.Empty(t, events, "latched fault must not re-emit")
+}
+
+func TestIBCharDev_OnePollBlipIsSwallowed(t *testing.T) {
+	t.Parallel()
+
+	// A single bad poll (driver teardown between the device-list read and
+	// the class-dir reads) must not fatal: the debounce resets when the
+	// node is observed again.
+	_, f := singleIBNode(t)
+	fullMad := f.mad
+	f.mad = dropKind(f.mad, "issm")
+	reader := f.reader()
+	check := newCharDevCheck(t, f, reader, false)
+
+	events, err := check.Run() // one missing poll — inside the debounce window
+	require.NoError(t, err)
+	assert.Empty(t, events)
+
+	f.mad = fullMad
+
+	for i := 0; i < 2*charDevMissThreshold; i++ {
+		events, err = check.Run()
+		require.NoError(t, err)
+		assert.Empty(t, events, "a one-poll blip must never produce a fatal or recovery")
+	}
 }
 
 func TestIBCharDev_RoCEPortExpectsNoIssm(t *testing.T) {
@@ -258,9 +319,7 @@ func TestIBCharDev_RoCEPortExpectsNoIssm(t *testing.T) {
 	reader := f.reader()
 	check := newCharDevCheck(t, f, reader, false)
 
-	events, err := check.Run()
-	require.NoError(t, err)
-	assert.Empty(t, events, "RoCE-only device must not expect issm")
+	runQuietPolls(t, check, 2*charDevMissThreshold)
 }
 
 func TestIBCharDev_MixedDeviceOnlyIBPortNeedsIssm(t *testing.T) {
@@ -290,9 +349,7 @@ func TestIBCharDev_MixedDeviceOnlyIBPortNeedsIssm(t *testing.T) {
 	reader := f.reader()
 	check := newCharDevCheck(t, f, reader, false)
 
-	events, err := check.Run()
-	require.NoError(t, err)
-	assert.Empty(t, events, "Ethernet port must not require issm on a mixed device")
+	runQuietPolls(t, check, 2*charDevMissThreshold)
 }
 
 func TestIBCharDev_UmadMissingIsFatal(t *testing.T) {
@@ -303,10 +360,13 @@ func TestIBCharDev_UmadMissingIsFatal(t *testing.T) {
 	reader := f.reader()
 	check := newCharDevCheck(t, f, reader, false)
 
+	runQuietPolls(t, check, charDevMissThreshold-1)
+
 	events, err := check.Run()
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 	assert.True(t, events[0].IsFatal)
+	assert.Equal(t, []string{"umad"}, events[0].ErrorCode)
 	assert.Contains(t, events[0].Message, "umad")
 	assertPortEntities(t, events[0], "mlx5_0", 1)
 }
@@ -319,12 +379,15 @@ func TestIBCharDev_UverbsMissingIsFatalWithDeviceEntity(t *testing.T) {
 	reader := f.reader()
 	check := newCharDevCheck(t, f, reader, false)
 
+	runQuietPolls(t, check, charDevMissThreshold-1)
+
 	events, err := check.Run()
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 
 	evt := events[0]
 	assert.True(t, evt.IsFatal)
+	assert.Equal(t, []string{"uverbs"}, evt.ErrorCode)
 	assert.Contains(t, evt.Message, "uverbs")
 	require.Len(t, evt.EntitiesImpacted, 1, "uverbs is a device-level entity")
 	assert.Equal(t, checks.EntityTypeNIC, evt.EntitiesImpacted[0].EntityType)
@@ -340,13 +403,15 @@ func TestIBCharDev_TransitionThenRecoveryThenQuiet(t *testing.T) {
 	reader := f.reader()
 	check := newCharDevCheck(t, f, reader, false)
 
-	// Poll 1: issm missing → one FATAL.
+	runQuietPolls(t, check, charDevMissThreshold-1)
+
+	// Confirmed missing → one FATAL.
 	events, err := check.Run()
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 	assert.True(t, events[0].IsFatal)
 
-	// Poll 2: issm restored → one healthy recovery, no re-emit of the fault.
+	// issm restored → one healthy recovery, no re-emit of the fault.
 	f.mad = fullMad
 	events, err = check.Run()
 	require.NoError(t, err)
@@ -354,12 +419,126 @@ func TestIBCharDev_TransitionThenRecoveryThenQuiet(t *testing.T) {
 	assert.True(t, events[0].IsHealthy)
 	assert.False(t, events[0].IsFatal)
 	assert.Equal(t, pb.RecommendedAction_NONE, events[0].RecommendedAction)
+	assert.Equal(t, []string{"issm"}, events[0].ErrorCode, "recovery must carry the per-kind error code")
 	assertPortEntities(t, events[0], "mlx5_0", 1)
 
-	// Poll 3: steady healthy → silent.
+	// Steady healthy → silent.
 	events, err = check.Run()
 	require.NoError(t, err)
 	assert.Empty(t, events, "steady state must not re-emit")
+}
+
+func TestIBCharDev_DeviceBlipHoldsLatch(t *testing.T) {
+	t.Parallel()
+
+	// The reviewer-reported false-recovery bug: after a fault is latched,
+	// the device momentarily drops out of /sys/class/infiniband (firmware
+	// reset). Its keys leave the expected set — that absence must HOLD the
+	// latch, not emit a "present again" recovery for a fault that never
+	// healed.
+	node, f := singleIBNode(t)
+	f.mad = dropKind(f.mad, "issm")
+	reader := f.reader()
+	check := newCharDevCheck(t, f, reader, false)
+
+	runQuietPolls(t, check, charDevMissThreshold-1)
+
+	events, err := check.Run()
+	require.NoError(t, err)
+	require.Len(t, fatalEvents(events), 1, "fault must latch first")
+
+	// Device disappears from enumeration (discovery still Complete).
+	delete(node.ib, "mlx5_0")
+
+	for i := 0; i < 2; i++ {
+		events, err = check.Run()
+		require.NoError(t, err)
+		assert.Empty(t, events, "device absence must hold the latch, not fabricate a recovery")
+	}
+
+	// Device returns, issm still missing: steady faulted state, silent —
+	// the latch survived the blip.
+	node.ib["mlx5_0"] = singleIBDevice()
+	events, err = check.Run()
+	require.NoError(t, err)
+	assert.Empty(t, events, "still-missing fault must stay latched after the blip, not re-fire")
+
+	// Only a positive observation releases it.
+	f.mad, _ = fullCharDevs(node)
+	events, err = check.Run()
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.True(t, events[0].IsHealthy, "recovery requires positive observation")
+}
+
+func TestIBCharDev_LatchSurvivesPodRestart(t *testing.T) {
+	t.Parallel()
+
+	// The recovery-while-pod-down orphan: a fault is latched, the pod
+	// dies, the char device comes back while no monitor is running. The
+	// next pod must seed the latch from the state file and emit the
+	// recovery, or the REPLACE_VM condition would stay on the node until
+	// the next reboot.
+	mgr, statePath, bootIDPath := newStateManagerForTest(t, "boot-1")
+
+	_, f := singleIBNode(t)
+	f.mad = dropKind(f.mad, "issm")
+	reader := f.reader()
+	check := newCharDevCheckWithManager(t, f, reader, mgr, false)
+
+	runQuietPolls(t, check, charDevMissThreshold-1)
+
+	events, err := check.Run()
+	require.NoError(t, err)
+	require.Len(t, fatalEvents(events), 1)
+
+	// Pod restarts on the same boot; the char device healed while it was
+	// down.
+	f.mad, _ = fullCharDevs(f.node)
+
+	mgr2 := statefile.NewManagerWithPaths(statePath, bootIDPath)
+	require.NoError(t, mgr2.Load())
+	require.False(t, mgr2.BootIDChanged())
+
+	check2 := newCharDevCheckWithManager(t, f, reader, mgr2, false)
+
+	events, err = check2.Run()
+	require.NoError(t, err)
+	require.Len(t, events, 1, "restarted pod must emit the recovery for the persisted latch")
+	assert.True(t, events[0].IsHealthy)
+	assert.Equal(t, []string{"issm"}, events[0].ErrorCode)
+}
+
+func TestIBCharDev_NoDuplicateBaselineAfterRestart(t *testing.T) {
+	t.Parallel()
+
+	// Commit must persist the consumed pending-baseline flag: without the
+	// Save, every pod restart within the same boot would re-emit the
+	// baseline clear.
+	mgr, statePath, bootIDPath := newStateManagerForTest(t, "boot-1")
+
+	_, f := singleIBNode(t)
+	reader := f.reader()
+	check := newCharDevCheckWithManager(t, f, reader, mgr, true)
+
+	events, err := check.Run()
+	require.NoError(t, err)
+	require.Len(t, events, 1, "baseline poll emits the check-scoped clear")
+	assert.True(t, events[0].IsHealthy)
+	assert.Empty(t, events[0].EntitiesImpacted)
+
+	// Same boot, new pod: the persisted flag must be consumed.
+	mgr2 := statefile.NewManagerWithPaths(statePath, bootIDPath)
+	require.NoError(t, mgr2.Load())
+	require.False(t, mgr2.BootIDChanged())
+	assert.False(t, mgr2.PendingBaseline(checks.InfiniBandCharDeviceCheckName),
+		"consumed baseline must be persisted by Commit")
+
+	check2 := newCharDevCheckWithManager(t, f, reader, mgr2, false)
+
+	events, err = check2.Run()
+	require.NoError(t, err)
+	assert.Empty(t, events, "restart on the same boot must not re-emit the baseline clear")
 }
 
 func TestIBCharDev_AbiVersionEntryIgnored(t *testing.T) {
@@ -371,9 +550,7 @@ func TestIBCharDev_AbiVersionEntryIgnored(t *testing.T) {
 	reader := f.reader()
 	check := newCharDevCheck(t, f, reader, false)
 
-	events, err := check.Run()
-	require.NoError(t, err)
-	assert.Empty(t, events, "abi_version must not be treated as a char device")
+	runQuietPolls(t, check, 2*charDevMissThreshold)
 }
 
 func TestIBCharDev_ClassDirAbsentIsUncertain(t *testing.T) {
@@ -387,15 +564,17 @@ func TestIBCharDev_ClassDirAbsentIsUncertain(t *testing.T) {
 	reader := f.reader()
 	check := newCharDevCheck(t, f, reader, false)
 
-	events, err := check.Run()
-	require.NoError(t, err)
-	assert.Empty(t, events, "absent class dir must be treated as uncertain, not mass-missing")
+	runQuietPolls(t, check, 2*charDevMissThreshold)
 
 	// When the directory returns (with issm still missing) the fault is
-	// then reported — proving the earlier poll held rather than latched.
+	// then reported after the debounce — proving the earlier polls held
+	// rather than latched.
 	f.madErr = nil
 	f.mad = dropKind(f.mad, "issm")
-	events, err = check.Run()
+
+	runQuietPolls(t, check, charDevMissThreshold-1)
+
+	events, err := check.Run()
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 	assert.True(t, events[0].IsFatal)
@@ -441,12 +620,12 @@ func TestIBCharDev_IncompleteDiscoveryBail(t *testing.T) {
 	require.Error(t, err, "losing the IB tree after seeding state must error")
 }
 
-func TestIBCharDev_BaselineRunClearsThenReasserts(t *testing.T) {
+func TestIBCharDev_BaselineClearThenDebouncedReassert(t *testing.T) {
 	t.Parallel()
 
-	// A reboot (bootIDChanged=true) with issm still missing: the batch must
-	// lead with a check-scoped clear (empty entities) that wipes stale
-	// prior-boot conditions, followed by the current-boot FATAL.
+	// A reboot (bootIDChanged=true) with issm missing and no prior latch:
+	// the first complete poll emits the check-scoped clear; the fault then
+	// confirms through the normal debounce.
 	_, f := singleIBNode(t)
 	f.mad = dropKind(f.mad, "issm")
 	reader := f.reader()
@@ -454,21 +633,63 @@ func TestIBCharDev_BaselineRunClearsThenReasserts(t *testing.T) {
 
 	events, err := check.Run()
 	require.NoError(t, err)
-	require.Len(t, events, 2)
+	require.Len(t, events, 1, "baseline poll emits only the clear (fault not yet confirmed)")
+	assert.True(t, events[0].IsHealthy)
+	assert.Empty(t, events[0].EntitiesImpacted, "baseline clear is check-scoped (no entities)")
+
+	runQuietPolls(t, check, charDevMissThreshold-2)
+
+	events, err = check.Run()
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.True(t, events[0].IsFatal, "fault confirms through the debounce after the clear")
+}
+
+func TestIBCharDev_BaselineReassertsLatchedFaultImmediately(t *testing.T) {
+	t.Parallel()
+
+	// A fault confirmed before a reboot: the persisted latch survives, so
+	// the baseline poll emits the clear followed immediately by the
+	// re-asserted FATAL (no debounce — the fault was already confirmed).
+	mgr, statePath, bootIDPath := newStateManagerForTest(t, "boot-1")
+
+	_, f := singleIBNode(t)
+	f.mad = dropKind(f.mad, "issm")
+	reader := f.reader()
+	check := newCharDevCheckWithManager(t, f, reader, mgr, false)
+
+	runQuietPolls(t, check, charDevMissThreshold-1)
+
+	events, err := check.Run()
+	require.NoError(t, err)
+	require.Len(t, fatalEvents(events), 1)
+
+	// Reboot: new manager on the same state file sees a new boot ID.
+	require.NoError(t, os.WriteFile(bootIDPath, []byte("boot-2\n"), 0o644))
+
+	mgr2 := statefile.NewManagerWithPaths(statePath, bootIDPath)
+	require.NoError(t, mgr2.Load())
+	require.True(t, mgr2.BootIDChanged())
+
+	check2 := newCharDevCheckWithManager(t, f, reader, mgr2, mgr2.BootIDChanged())
+
+	events, err = check2.Run()
+	require.NoError(t, err)
+	require.Len(t, events, 2, "baseline must emit clear + immediate re-assert of the latched fault")
 
 	clear := events[0]
 	assert.True(t, clear.IsHealthy, "baseline clear must be healthy")
-	assert.Empty(t, clear.EntitiesImpacted, "baseline clear is check-scoped (no entities)")
+	assert.Empty(t, clear.EntitiesImpacted)
 	assert.True(t, clear.GeneratedTimestamp.AsTime().Before(events[1].GeneratedTimestamp.AsTime()),
 		"clear must sort before the fault it precedes")
 
-	assert.Len(t, fatalEvents(events), 1, "the still-missing issm must be re-asserted")
+	require.Len(t, fatalEvents(events), 1)
+	assert.Equal(t, []string{"issm"}, fatalEvents(events)[0].ErrorCode)
 
-	// The baseline is consumed after the first poll: a subsequent poll is a
-	// normal run with no clear.
-	events, err = check.Run()
+	// The baseline is consumed: a subsequent poll is a quiet steady state.
+	events, err = check2.Run()
 	require.NoError(t, err)
-	assert.Empty(t, events, "second poll must be a normal (non-baseline) steady state")
+	assert.Empty(t, events)
 }
 
 func TestIBCharDev_VirtualFunctionSkipped(t *testing.T) {
@@ -491,9 +712,7 @@ func TestIBCharDev_VirtualFunctionSkipped(t *testing.T) {
 	reader := f.reader()
 	check := newCharDevCheck(t, f, reader, false)
 
-	events, err := check.Run()
-	require.NoError(t, err)
-	assert.Empty(t, events, "VFs are excluded from discovery and must not be checked")
+	runQuietPolls(t, check, 2*charDevMissThreshold)
 }
 
 func TestIBCharDev_UnsupportedVendorExcluded(t *testing.T) {
@@ -517,9 +736,7 @@ func TestIBCharDev_UnsupportedVendorExcluded(t *testing.T) {
 	reader := f.reader()
 	check := newCharDevCheck(t, f, reader, false)
 
-	events, err := check.Run()
-	require.NoError(t, err)
-	assert.Empty(t, events, "unsupported vendor must be out of scope")
+	runQuietPolls(t, check, 2*charDevMissThreshold)
 }
 
 // dropKind removes every mad entry whose directory name starts with the

--- a/health-monitors/nic-health-monitor/pkg/checks/state/ibdevnode_test.go
+++ b/health-monitors/nic-health-monitor/pkg/checks/state/ibdevnode_test.go
@@ -1,0 +1,545 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package state
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/nvidia/nvsentinel/data-models/pkg/protos"
+	"github.com/nvidia/nvsentinel/health-monitors/nic-health-monitor/pkg/checks"
+	"github.com/nvidia/nvsentinel/health-monitors/nic-health-monitor/pkg/config"
+	"github.com/nvidia/nvsentinel/health-monitors/nic-health-monitor/pkg/sysfs"
+)
+
+// madEntry / verbsEntry describe one character-device class entry as it
+// appears in /sys/class/infiniband_mad or /sys/class/infiniband_verbs:
+// the directory name (issm3/umad3/uverbs0) plus the ibdev/port it maps to.
+type madEntry struct {
+	name  string
+	ibdev string
+	port  int
+}
+
+type verbsEntry struct {
+	name  string
+	ibdev string
+}
+
+// charDevFixture layers the two InfiniBand character-device class
+// directories on top of a stubNode's sysfs topology. Its fields are read
+// live by the MockReader closures, so a test can mutate mad/verbs between
+// polls to exercise transition and recovery behaviour.
+type charDevFixture struct {
+	node     *stubNode
+	mad      []madEntry
+	verbs    []verbsEntry
+	madErr   error
+	verbsErr error
+	noIBTree bool
+}
+
+func (f *charDevFixture) reader() *sysfs.MockReader {
+	m := f.node.reader()
+	origList := m.ListDirsFunc
+	madBase := m.IBMadBasePath()
+	verbsBase := m.IBVerbsBasePath()
+
+	m.ListDirsFunc = func(path string) ([]string, error) {
+		if f.noIBTree && path == m.IBBasePath() {
+			return nil, os.ErrNotExist
+		}
+
+		switch path {
+		case madBase:
+			if f.madErr != nil {
+				return nil, f.madErr
+			}
+
+			return append([]string{abiVersionEntry}, madNames(f.mad)...), nil
+		case verbsBase:
+			if f.verbsErr != nil {
+				return nil, f.verbsErr
+			}
+
+			return append([]string{abiVersionEntry}, verbsNames(f.verbs)...), nil
+		}
+
+		return origList(path)
+	}
+
+	m.ReadFileFunc = func(path string) (string, error) {
+		for _, e := range f.mad {
+			if path == filepath.Join(madBase, e.name, "ibdev") {
+				return e.ibdev, nil
+			}
+
+			if path == filepath.Join(madBase, e.name, "port") {
+				return strconv.Itoa(e.port), nil
+			}
+		}
+
+		for _, e := range f.verbs {
+			if path == filepath.Join(verbsBase, e.name, "ibdev") {
+				return e.ibdev, nil
+			}
+		}
+
+		return "", nil
+	}
+
+	return m
+}
+
+func madNames(entries []madEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.name)
+	}
+
+	return out
+}
+
+func verbsNames(entries []verbsEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.name)
+	}
+
+	return out
+}
+
+// fullCharDevs returns the complete, correct character-device listing for
+// a node: one uverbs per device, one umad per port (IB or Ethernet), and
+// one issm per InfiniBand-mode port. Tests start from this and remove an
+// entry to model a fault.
+func fullCharDevs(node *stubNode) ([]madEntry, []verbsEntry) {
+	var (
+		mad   []madEntry
+		verbs []verbsEntry
+		i     int
+	)
+
+	for name, d := range node.ib {
+		verbs = append(verbs, verbsEntry{name: fmt.Sprintf("uverbs%d", i), ibdev: name})
+
+		for p, port := range d.ports {
+			i++
+			mad = append(mad, madEntry{name: fmt.Sprintf("umad%d", i), ibdev: name, port: p})
+
+			if strings.EqualFold(port.linkLayer, "InfiniBand") {
+				mad = append(mad, madEntry{name: fmt.Sprintf("issm%d", i), ibdev: name, port: p})
+			}
+		}
+
+		i++
+	}
+
+	return mad, verbs
+}
+
+// singleIBNode returns a stubNode with one compute IB device (mlx5_0)
+// exposing a single ACTIVE/LinkUp InfiniBand port, plus a classifier that
+// keeps it in scope.
+func singleIBNode(t *testing.T) (*stubNode, *charDevFixture) {
+	t.Helper()
+
+	node := newStubNode().addIB("mlx5_0", &stubDevice{
+		pciAddress: "0000:47:00.0",
+		numaNode:   0,
+		ports: map[int]stubPort{
+			1: {state: "ACTIVE", physState: "LinkUp", linkLayer: "InfiniBand"},
+		},
+	})
+	mad, verbs := fullCharDevs(node)
+
+	return node, &charDevFixture{node: node, mad: mad, verbs: verbs}
+}
+
+func newCharDevCheck(
+	t *testing.T, f *charDevFixture, reader sysfs.Reader, bootIDChanged bool,
+) *InfiniBandCharDeviceCheck {
+	t.Helper()
+
+	classifier := buildClassifier(t, reader,
+		[]string{"0000:0f:00.0"},
+		map[string][]string{"mlx5_0": {"PIX"}},
+	)
+
+	return NewInfiniBandCharDeviceCheck("node1", reader, &config.Config{},
+		classifier, pb.ProcessingStrategy_EXECUTE_REMEDIATION, freshStateManager(t), bootIDChanged)
+}
+
+func fatalEvents(events []*pb.HealthEvent) []*pb.HealthEvent {
+	var out []*pb.HealthEvent
+
+	for _, e := range events {
+		if e.IsFatal {
+			out = append(out, e)
+		}
+	}
+
+	return out
+}
+
+func TestIBCharDev_AllPresentHealthy(t *testing.T) {
+	t.Parallel()
+
+	_, f := singleIBNode(t)
+	reader := f.reader()
+	check := newCharDevCheck(t, f, reader, false)
+
+	events, err := check.Run()
+	require.NoError(t, err)
+	assert.Empty(t, events, "a device with all char devices present must not emit events")
+}
+
+func TestIBCharDev_IssmMissingIsFatal(t *testing.T) {
+	t.Parallel()
+
+	// The production ticket: an ACTIVE/LinkUp InfiniBand port whose issm
+	// character device never materialised, so pods fail with
+	// "lstat /dev/infiniband/issm9: no such file or directory".
+	_, f := singleIBNode(t)
+	f.mad = dropKind(f.mad, "issm")
+	reader := f.reader()
+	check := newCharDevCheck(t, f, reader, false)
+
+	events, err := check.Run()
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	evt := events[0]
+	assert.True(t, evt.IsFatal, "missing issm must be fatal")
+	assert.False(t, evt.IsHealthy)
+	assert.Equal(t, pb.RecommendedAction_REPLACE_VM, evt.RecommendedAction)
+	assert.Equal(t, checks.InfiniBandCharDeviceCheckName, evt.CheckName)
+	assert.Contains(t, evt.Message, "issm")
+	assertPortEntities(t, evt, "mlx5_0", 1)
+}
+
+func TestIBCharDev_RoCEPortExpectsNoIssm(t *testing.T) {
+	t.Parallel()
+
+	// A pure-RoCE device (single Ethernet-mode port) has no InfiniBand
+	// port, so it is out of scope entirely — no issm is expected and the
+	// check stays silent even though only umad/uverbs exist.
+	node := newStubNode().addIB("mlx5_0", &stubDevice{
+		pciAddress: "0000:47:00.0",
+		numaNode:   0,
+		ports: map[int]stubPort{
+			1: {state: "ACTIVE", physState: "LinkUp", linkLayer: "Ethernet"},
+		},
+	})
+	f := &charDevFixture{
+		node:  node,
+		mad:   []madEntry{{name: "umad0", ibdev: "mlx5_0", port: 1}},
+		verbs: []verbsEntry{{name: "uverbs0", ibdev: "mlx5_0"}},
+	}
+	reader := f.reader()
+	check := newCharDevCheck(t, f, reader, false)
+
+	events, err := check.Run()
+	require.NoError(t, err)
+	assert.Empty(t, events, "RoCE-only device must not expect issm")
+}
+
+func TestIBCharDev_MixedDeviceOnlyIBPortNeedsIssm(t *testing.T) {
+	t.Parallel()
+
+	// A device with one IB port and one Ethernet port. issm is expected
+	// only for the IB port; the Ethernet port legitimately has umad but no
+	// issm. All expected entries are present, so no event fires — proving
+	// the per-port IB gate does not false-positive on the Ethernet port.
+	node := newStubNode().addIB("mlx5_0", &stubDevice{
+		pciAddress: "0000:47:00.0",
+		numaNode:   0,
+		ports: map[int]stubPort{
+			1: {state: "ACTIVE", physState: "LinkUp", linkLayer: "InfiniBand"},
+			2: {state: "ACTIVE", physState: "LinkUp", linkLayer: "Ethernet"},
+		},
+	})
+	f := &charDevFixture{
+		node: node,
+		mad: []madEntry{
+			{name: "umad0", ibdev: "mlx5_0", port: 1},
+			{name: "issm0", ibdev: "mlx5_0", port: 1},
+			{name: "umad1", ibdev: "mlx5_0", port: 2}, // Ethernet port: umad, no issm.
+		},
+		verbs: []verbsEntry{{name: "uverbs0", ibdev: "mlx5_0"}},
+	}
+	reader := f.reader()
+	check := newCharDevCheck(t, f, reader, false)
+
+	events, err := check.Run()
+	require.NoError(t, err)
+	assert.Empty(t, events, "Ethernet port must not require issm on a mixed device")
+}
+
+func TestIBCharDev_UmadMissingIsFatal(t *testing.T) {
+	t.Parallel()
+
+	_, f := singleIBNode(t)
+	f.mad = dropKind(f.mad, "umad")
+	reader := f.reader()
+	check := newCharDevCheck(t, f, reader, false)
+
+	events, err := check.Run()
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.True(t, events[0].IsFatal)
+	assert.Contains(t, events[0].Message, "umad")
+	assertPortEntities(t, events[0], "mlx5_0", 1)
+}
+
+func TestIBCharDev_UverbsMissingIsFatalWithDeviceEntity(t *testing.T) {
+	t.Parallel()
+
+	_, f := singleIBNode(t)
+	f.verbs = nil // drop the only uverbs entry.
+	reader := f.reader()
+	check := newCharDevCheck(t, f, reader, false)
+
+	events, err := check.Run()
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	evt := events[0]
+	assert.True(t, evt.IsFatal)
+	assert.Contains(t, evt.Message, "uverbs")
+	require.Len(t, evt.EntitiesImpacted, 1, "uverbs is a device-level entity")
+	assert.Equal(t, checks.EntityTypeNIC, evt.EntitiesImpacted[0].EntityType)
+	assert.Equal(t, "mlx5_0", evt.EntitiesImpacted[0].EntityValue)
+}
+
+func TestIBCharDev_TransitionThenRecoveryThenQuiet(t *testing.T) {
+	t.Parallel()
+
+	_, f := singleIBNode(t)
+	fullMad := f.mad
+	f.mad = dropKind(f.mad, "issm")
+	reader := f.reader()
+	check := newCharDevCheck(t, f, reader, false)
+
+	// Poll 1: issm missing → one FATAL.
+	events, err := check.Run()
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.True(t, events[0].IsFatal)
+
+	// Poll 2: issm restored → one healthy recovery, no re-emit of the fault.
+	f.mad = fullMad
+	events, err = check.Run()
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.True(t, events[0].IsHealthy)
+	assert.False(t, events[0].IsFatal)
+	assert.Equal(t, pb.RecommendedAction_NONE, events[0].RecommendedAction)
+	assertPortEntities(t, events[0], "mlx5_0", 1)
+
+	// Poll 3: steady healthy → silent.
+	events, err = check.Run()
+	require.NoError(t, err)
+	assert.Empty(t, events, "steady state must not re-emit")
+}
+
+func TestIBCharDev_AbiVersionEntryIgnored(t *testing.T) {
+	t.Parallel()
+
+	// fullCharDevs plus the abi_version file the fixture always lists must
+	// not be mistaken for a device node.
+	_, f := singleIBNode(t)
+	reader := f.reader()
+	check := newCharDevCheck(t, f, reader, false)
+
+	events, err := check.Run()
+	require.NoError(t, err)
+	assert.Empty(t, events, "abi_version must not be treated as a char device")
+}
+
+func TestIBCharDev_ClassDirAbsentIsUncertain(t *testing.T) {
+	t.Parallel()
+
+	// The whole mad class directory is absent while an IB device exists:
+	// an uncertain observation, not evidence of failure. The check must
+	// hold — emit nothing — rather than fabricate mass-missing FATALs.
+	_, f := singleIBNode(t)
+	f.madErr = os.ErrNotExist
+	reader := f.reader()
+	check := newCharDevCheck(t, f, reader, false)
+
+	events, err := check.Run()
+	require.NoError(t, err)
+	assert.Empty(t, events, "absent class dir must be treated as uncertain, not mass-missing")
+
+	// When the directory returns (with issm still missing) the fault is
+	// then reported — proving the earlier poll held rather than latched.
+	f.madErr = nil
+	f.mad = dropKind(f.mad, "issm")
+	events, err = check.Run()
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.True(t, events[0].IsFatal)
+}
+
+func TestIBCharDev_ClassDirListingErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	// A non-ENOENT error listing the mad directory is a genuine read
+	// failure (not "no IB MAD devices"); it must propagate so the poll is
+	// discarded rather than treated as an empty/uncertain observation.
+	_, f := singleIBNode(t)
+	f.madErr = fmt.Errorf("permission denied")
+	reader := f.reader()
+	check := newCharDevCheck(t, f, reader, false)
+
+	_, err := check.Run()
+	require.Error(t, err, "a non-ENOENT class-dir listing error must propagate")
+}
+
+func TestIBCharDev_IncompleteDiscoveryBail(t *testing.T) {
+	t.Parallel()
+
+	// First poll on a node whose IB tree is absent: stay quiet, no error.
+	_, f := singleIBNode(t)
+	f.noIBTree = true
+	reader := f.reader()
+	check := newCharDevCheck(t, f, reader, false)
+
+	events, err := check.Run()
+	require.NoError(t, err)
+	assert.Empty(t, events)
+
+	// After a complete poll seeds state, a later disappearance of the tree
+	// is an incomplete observation and must error (so the poll is discarded
+	// rather than advancing state on a partial read).
+	f.noIBTree = false
+	_, err = check.Run()
+	require.NoError(t, err)
+
+	f.noIBTree = true
+	_, err = check.Run()
+	require.Error(t, err, "losing the IB tree after seeding state must error")
+}
+
+func TestIBCharDev_BaselineRunClearsThenReasserts(t *testing.T) {
+	t.Parallel()
+
+	// A reboot (bootIDChanged=true) with issm still missing: the batch must
+	// lead with a check-scoped clear (empty entities) that wipes stale
+	// prior-boot conditions, followed by the current-boot FATAL.
+	_, f := singleIBNode(t)
+	f.mad = dropKind(f.mad, "issm")
+	reader := f.reader()
+	check := newCharDevCheck(t, f, reader, true)
+
+	events, err := check.Run()
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+
+	clear := events[0]
+	assert.True(t, clear.IsHealthy, "baseline clear must be healthy")
+	assert.Empty(t, clear.EntitiesImpacted, "baseline clear is check-scoped (no entities)")
+	assert.True(t, clear.GeneratedTimestamp.AsTime().Before(events[1].GeneratedTimestamp.AsTime()),
+		"clear must sort before the fault it precedes")
+
+	assert.Len(t, fatalEvents(events), 1, "the still-missing issm must be re-asserted")
+
+	// The baseline is consumed after the first poll: a subsequent poll is a
+	// normal run with no clear.
+	events, err = check.Run()
+	require.NoError(t, err)
+	assert.Empty(t, events, "second poll must be a normal (non-baseline) steady state")
+}
+
+func TestIBCharDev_VirtualFunctionSkipped(t *testing.T) {
+	t.Parallel()
+
+	// A VF with a missing issm must not fire — discovery excludes VFs.
+	node := newStubNode().addIB("mlx5_0", &stubDevice{
+		pciAddress: "0000:47:00.1",
+		numaNode:   0,
+		isVF:       true,
+		ports: map[int]stubPort{
+			1: {state: "ACTIVE", physState: "LinkUp", linkLayer: "InfiniBand"},
+		},
+	})
+	f := &charDevFixture{
+		node:  node,
+		mad:   []madEntry{{name: "umad0", ibdev: "mlx5_0", port: 1}}, // no issm.
+		verbs: []verbsEntry{{name: "uverbs0", ibdev: "mlx5_0"}},
+	}
+	reader := f.reader()
+	check := newCharDevCheck(t, f, reader, false)
+
+	events, err := check.Run()
+	require.NoError(t, err)
+	assert.Empty(t, events, "VFs are excluded from discovery and must not be checked")
+}
+
+func TestIBCharDev_UnsupportedVendorExcluded(t *testing.T) {
+	t.Parallel()
+
+	// EligibleDevice drops non-Mellanox vendors before any per-device work,
+	// so a missing issm on an unsupported card must not fire.
+	node := newStubNode().addIB("mlx5_0", &stubDevice{
+		pciAddress: "0000:47:00.0",
+		numaNode:   0,
+		vendor:     "0x8086", // Intel — unsupported.
+		ports: map[int]stubPort{
+			1: {state: "ACTIVE", physState: "LinkUp", linkLayer: "InfiniBand"},
+		},
+	})
+	f := &charDevFixture{
+		node:  node,
+		mad:   []madEntry{{name: "umad0", ibdev: "mlx5_0", port: 1}}, // no issm.
+		verbs: []verbsEntry{{name: "uverbs0", ibdev: "mlx5_0"}},
+	}
+	reader := f.reader()
+	check := newCharDevCheck(t, f, reader, false)
+
+	events, err := check.Run()
+	require.NoError(t, err)
+	assert.Empty(t, events, "unsupported vendor must be out of scope")
+}
+
+// dropKind removes every mad entry whose directory name starts with the
+// given kind prefix (e.g. "issm" or "umad").
+func dropKind(entries []madEntry, kind string) []madEntry {
+	out := make([]madEntry, 0, len(entries))
+	for _, e := range entries {
+		if !strings.HasPrefix(e.name, kind) {
+			out = append(out, e)
+		}
+	}
+
+	return out
+}
+
+func assertPortEntities(t *testing.T, evt *pb.HealthEvent, device string, port int) {
+	t.Helper()
+	require.Len(t, evt.EntitiesImpacted, 2)
+	assert.Equal(t, checks.EntityTypeNIC, evt.EntitiesImpacted[0].EntityType)
+	assert.Equal(t, device, evt.EntitiesImpacted[0].EntityValue)
+	assert.Equal(t, checks.EntityTypePort, evt.EntitiesImpacted[1].EntityType)
+	assert.Equal(t, strconv.Itoa(port), evt.EntitiesImpacted[1].EntityValue)
+}

--- a/health-monitors/nic-health-monitor/pkg/checks/state/ibdevnode_test.go
+++ b/health-monitors/nic-health-monitor/pkg/checks/state/ibdevnode_test.go
@@ -509,6 +509,49 @@ func TestIBCharDev_LatchSurvivesPodRestart(t *testing.T) {
 	assert.Equal(t, []string{"issm"}, events[0].ErrorCode)
 }
 
+func TestIBCharDev_LatchSurvivesScopeChange(t *testing.T) {
+	t.Parallel()
+
+	// A discovery-scope change (e.g. enabling the inclusion override)
+	// resets port/device state but must preserve the missing-char-device
+	// latch: the FATAL is still holding a condition downstream, and the
+	// check rebuilds its latch map from the persisted state at
+	// construction.
+	mgr, statePath, bootIDPath := newStateManagerForTest(t, "boot-1")
+
+	_, f := singleIBNode(t)
+	f.mad = dropKind(f.mad, "issm")
+	reader := f.reader()
+	check := newCharDevCheckWithManager(t, f, reader, mgr, false)
+
+	runQuietPolls(t, check, charDevMissThreshold-1)
+
+	events, err := check.Run()
+	require.NoError(t, err)
+	require.Len(t, fatalEvents(events), 1)
+
+	// Reload under a different discovery scope, same boot.
+	mgr2 := statefile.NewManagerWithPaths(statePath, bootIDPath)
+	mgr2.SetScope("incl=mlx5_.*;excl=")
+	require.NoError(t, mgr2.Load())
+	require.True(t, mgr2.ScopeChanged())
+	require.False(t, mgr2.BootIDChanged())
+
+	assert.NotEmpty(t, mgr2.MissingCharDevices(),
+		"scope change must preserve the missing-char-device latch")
+
+	// The node healed while the scope changed: the new pod's check must
+	// still emit the recovery for the preserved latch.
+	f.mad, _ = fullCharDevs(f.node)
+	check2 := newCharDevCheckWithManager(t, f, reader, mgr2, mgr2.BootIDChanged())
+
+	events, err = check2.Run()
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.True(t, events[0].IsHealthy, "preserved latch must release via recovery")
+	assert.Equal(t, []string{"issm"}, events[0].ErrorCode)
+}
+
 func TestIBCharDev_NoDuplicateBaselineAfterRestart(t *testing.T) {
 	t.Parallel()
 

--- a/health-monitors/nic-health-monitor/pkg/checks/types.go
+++ b/health-monitors/nic-health-monitor/pkg/checks/types.go
@@ -27,6 +27,7 @@ const (
 	// Check names match the enabledChecks keys in the Helm values.
 	InfiniBandStateCheckName       = "InfiniBandStateCheck"
 	InfiniBandDegradationCheckName = "InfiniBandDegradationCheck"
+	InfiniBandCharDeviceCheckName  = "InfiniBandCharDeviceCheck"
 	EthernetStateCheckName         = "EthernetStateCheck"
 	EthernetDegradationCheckName   = "EthernetDegradationCheck"
 

--- a/health-monitors/nic-health-monitor/pkg/statefile/statefile.go
+++ b/health-monitors/nic-health-monitor/pkg/statefile/statefile.go
@@ -400,6 +400,7 @@ func (m *Manager) Load() error {
 			AnomalousCards:     loaded.AnomalousCards,
 			DisappearedDevices: loaded.DisappearedDevices,
 			DisappearedPorts:   loaded.DisappearedPorts,
+			MissingCharDevices: loaded.MissingCharDevices,
 			CounterSnapshots:   loaded.CounterSnapshots,
 			BreachFlags:        loaded.BreachFlags,
 			PendingBaselines:   loaded.PendingBaselines,

--- a/health-monitors/nic-health-monitor/pkg/statefile/statefile.go
+++ b/health-monitors/nic-health-monitor/pkg/statefile/statefile.go
@@ -102,6 +102,14 @@ type MonitorState struct {
 	// state and is discarded on boot-ID or discovery-scope changes.
 	DeviceMissCounts map[string]DeviceMissCount `json:"device_miss_counts,omitempty"`
 
+	// MissingCharDevices is the InfiniBandCharDeviceCheck latch: character
+	// devices (issm/umad/uverbs) with a missing-node FATAL outstanding
+	// downstream. Like the disappearance latches it survives restarts and
+	// reboots — an entry means a condition is still held on the node, and
+	// only a positive observation of the node (or the baseline clear)
+	// removes it. Keys are "<kind>/<device>_<port>".
+	MissingCharDevices map[string]MissingCharDeviceFlag `json:"missing_char_devices,omitempty"`
+
 	// Counter detection state — produced by InfiniBandDegradationCheck
 	// and EthernetDegradationCheck. Both maps key on
 	// `<device>:<port>:<counter_name>` so the IB and Ethernet checks
@@ -172,6 +180,15 @@ type DeviceMissCount struct {
 	Device    string `json:"device,omitempty"`
 	LinkLayer string `json:"link_layer,omitempty"`
 	Count     int    `json:"count,omitempty"`
+}
+
+// MissingCharDeviceFlag marks one missing InfiniBand character-device
+// node (issm/umad/uverbs) with a FATAL outstanding downstream. Port is
+// zero for the device-level uverbs kind.
+type MissingCharDeviceFlag struct {
+	Kind   string `json:"kind,omitempty"`
+	Device string `json:"device,omitempty"`
+	Port   int    `json:"port,omitempty"`
 }
 
 // CounterSnapshot stores the value and wall-clock timestamp of a counter
@@ -340,6 +357,7 @@ func (m *Manager) Load() error {
 			AnomalousCards:     loaded.AnomalousCards,
 			DisappearedDevices: stripDeviceBootMarkers(loaded.DisappearedDevices),
 			DisappearedPorts:   stripPortBootMarkers(loaded.DisappearedPorts),
+			MissingCharDevices: loaded.MissingCharDevices,
 		}
 		m.loaded = true
 		m.bootIDChanged = true
@@ -755,6 +773,57 @@ func (m *Manager) UpdateDisappearedPorts(
 	}
 
 	return changed
+}
+
+// MissingCharDevices returns the outstanding missing-character-device
+// latches, keyed as persisted ("<kind>/<device>_<port>").
+func (m *Manager) MissingCharDevices() map[string]MissingCharDeviceFlag {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	out := make(map[string]MissingCharDeviceFlag, len(m.state.MissingCharDevices))
+	for k, v := range m.state.MissingCharDevices {
+		out[k] = v
+	}
+
+	return out
+}
+
+// UpdateMissingCharDevices replaces the persisted missing-character-device
+// latch with the caller's set and reports whether anything changed. The
+// InfiniBandCharDeviceCheck is the map's only owner, so unlike the
+// port-disappearance latch there is no link-layer slicing to preserve.
+func (m *Manager) UpdateMissingCharDevices(flags map[string]MissingCharDeviceFlag) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	changed := len(m.state.MissingCharDevices) != len(flags)
+
+	if !changed {
+		for k, v := range flags {
+			if old, ok := m.state.MissingCharDevices[k]; !ok || old != v {
+				changed = true
+				break
+			}
+		}
+	}
+
+	if !changed {
+		return false
+	}
+
+	if len(flags) == 0 {
+		m.state.MissingCharDevices = nil
+
+		return true
+	}
+
+	m.state.MissingCharDevices = make(map[string]MissingCharDeviceFlag, len(flags))
+	for k, v := range flags {
+		m.state.MissingCharDevices[k] = v
+	}
+
+	return true
 }
 
 // DeviceMissCountsFor returns consecutive enumeration-miss counts for the

--- a/health-monitors/nic-health-monitor/pkg/sysfs/interface.go
+++ b/health-monitors/nic-health-monitor/pkg/sysfs/interface.go
@@ -29,6 +29,14 @@ type Reader interface {
 	// Paths -------------------------------------------------------------
 	IBBasePath() string
 	NetBasePath() string
+	// IBMadBasePath returns the sysfs directory holding the InfiniBand
+	// MAD character-device class entries (issm*/umad*), a sibling of
+	// IBBasePath (e.g. /nvsentinel/sys/class/infiniband_mad).
+	IBMadBasePath() string
+	// IBVerbsBasePath returns the sysfs directory holding the InfiniBand
+	// verbs character-device class entries (uverbs*), a sibling of
+	// IBBasePath (e.g. /nvsentinel/sys/class/infiniband_verbs).
+	IBVerbsBasePath() string
 	IBPortPath(device string, port int) string
 	NetInterfacePath(iface string) string
 

--- a/health-monitors/nic-health-monitor/pkg/sysfs/mock_reader.go
+++ b/health-monitors/nic-health-monitor/pkg/sysfs/mock_reader.go
@@ -19,6 +19,8 @@ package sysfs
 type MockReader struct {
 	IBBase         string
 	NetBase        string
+	IBMadBase      string
+	IBVerbsBase    string
 	IBPortPathFunc func(device string, port int) string
 	NetIfacePathFn func(iface string) string
 	ReadFileFunc   func(path string) (string, error)
@@ -57,6 +59,22 @@ func (m *MockReader) NetBasePath() string {
 	}
 
 	return m.NetBase
+}
+
+func (m *MockReader) IBMadBasePath() string {
+	if m.IBMadBase == "" {
+		return m.IBBasePath() + "_mad"
+	}
+
+	return m.IBMadBase
+}
+
+func (m *MockReader) IBVerbsBasePath() string {
+	if m.IBVerbsBase == "" {
+		return m.IBBasePath() + "_verbs"
+	}
+
+	return m.IBVerbsBase
 }
 
 func (m *MockReader) IBPortPath(device string, port int) string {

--- a/health-monitors/nic-health-monitor/pkg/sysfs/reader.go
+++ b/health-monitors/nic-health-monitor/pkg/sysfs/reader.go
@@ -41,6 +41,14 @@ func NewReader(ibBase, netBase string) Reader {
 func (r *fsReader) IBBasePath() string  { return r.ibBase }
 func (r *fsReader) NetBasePath() string { return r.netBase }
 
+// IBMadBasePath and IBVerbsBasePath derive the sibling MAD/verbs class
+// directories from the IB base. The kernel exposes them alongside
+// /sys/class/infiniband as /sys/class/infiniband_mad and
+// /sys/class/infiniband_verbs, so under a container mount they are
+// simply the IB base with the "_mad"/"_verbs" suffix.
+func (r *fsReader) IBMadBasePath() string   { return r.ibBase + "_mad" }
+func (r *fsReader) IBVerbsBasePath() string { return r.ibBase + "_verbs" }
+
 func (r *fsReader) IBPortPath(device string, port int) string {
 	return filepath.Join(r.ibBase, device, "ports", strconv.Itoa(port))
 }


### PR DESCRIPTION
## Summary

Adds `InfiniBandCharDeviceCheck`, a passive state check for the NIC health
monitor that flags an InfiniBand device whose `/dev/infiniband` character
nodes (issm/umad/uverbs) are missing while its ports still read
`ACTIVE`/`LinkUp` — a failure the existing port-state checks report as
**healthy**, yet RDMA workloads cannot start on the node (pods fail with
`lstat /dev/infiniband/issm9: no such file or directory`).

### Motivation

A GPU node came up with only 8 of ~12 expected `/dev/infiniband/issm*` nodes.
The IB ports were `ACTIVE`/`LinkUp` throughout, so no existing check fired; it
required manual triage and a spare migration. This is distinct from device
disappearance (the device is present in `/sys/class/infiniband`) and from
verbs-level resource exhaustion — it is a missing character-device node.

### How it works

udev creates `/dev/infiniband/{issm,umad,uverbs}N` from the sysfs class entries
under `/sys/class/infiniband_mad` and `/sys/class/infiniband_verbs`, so a
missing class entry is an exact proxy for a missing `/dev` node. Those
directories are already inside the host `/sys` the DaemonSet mounts, so **no
`/dev` mount is required**.

The check is a per-device internal-consistency test, not an absolute
expected-count test (to avoid the false-positive class that motivated #1361 /
#1379 / #1462): for each discovered, in-scope device that exposes at least one
InfiniBand-mode port it expects one `uverbs` per device and one `umad` and one
`issm` per InfiniBand-mode port. `issm`/`umad` are gated on the InfiniBand link
layer because RoCE/Ethernet-mode ports legitimately have no `issm`. A device
entirely absent from `/sys/class/infiniband` stays the `InfiniBandStateCheck`'s
device-disappearance responsibility.

Missing nodes are fatal (`REPLACE_VM`); a healthy recovery event is emitted when
they reappear. An absent class directory is treated as an uncertain observation
and held rather than reported as mass failure. Enabled by default in the Helm
`enabledChecks`.

## Type of Change
- [x] ✨ New feature

## Component(s) Affected
- [x] Health Monitors

## Testing
- [x] Tests pass locally (`go test ./...`, race) and `golangci-lint` clean
- [x] Unit tests cover: issm/umad/uverbs missing (fatal), RoCE port expects no
      issm, mixed IB/Ethernet device, transition→recovery→quiet, `abi_version`
      ignored, absent class dir (uncertain/held), incomplete-discovery bail,
      reboot baseline clear+reassert, VF skipped, unsupported vendor excluded
- [x] Manual testing: validated the sysfs layout on a live H100-IB node
      (`mlx5_0` Ethernet mgmt NIC correctly has no issm; `mlx5_1..8` IB each
      have issm/umad/uverbs with `ibdev`/`port` files), plus a filesystem
      integration test that mirrors that node and reproduces the missing-issm
      fault against the production `sysfs.Reader`
- [x] No breaking changes

## Checklist
- [x] Self-review completed
- [x] Documentation updated (Helm values comment)
- [x] Ready for review

## Notes for reviewers
- The missing-set transition latch is in-memory (a reboot re-baselines; a
  non-reboot pod restart re-discovers current state on the first poll). If you
  prefer restart-durable recovery semantics, I can promote it into
  `statefile.Manager` mirroring the disappeared-port latch.
- `umad`/`issm` are gated to InfiniBand-mode ports; `umad` on Ethernet-mode
  ports of mixed cards is intentionally not required (conservative — avoids any
  RoCE-firmware-variant false positive). Happy to broaden if desired.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `InfiniBandCharDeviceCheck` to detect missing InfiniBand character-device nodes (`issm`, `umad`, `uverbs`) with debounced FATAL alerts and recovery events.
  - Updated the default enabled check set and configuration examples to include `InfiniBandCharDeviceCheck`.
  - Extended monitoring state to persist missing-node latches across restarts and handle baseline/boot changes.
- **Bug Fixes**
  - Prevented false `issm` alerts on mixed Ethernet/InfiniBand systems and improved handling of uncertain discovery.
- **Tests**
  - Added regression coverage for realistic sysfs layouts and latch behavior across scope changes.
- **Documentation**
  - Documented the new `InfiniBandCharDeviceCheck` and its alerting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->