### PR TITLE
fix: harden lifecycle state updates and circuit breaker accounting

### DIFF
--- a/commons/pkg/eventutil/parser.go
+++ b/commons/pkg/eventutil/parser.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/nvidia/nvsentinel/data-models/pkg/model"
+	"github.com/nvidia/nvsentinel/data-models/pkg/protos"
 	"github.com/nvidia/nvsentinel/store-client/pkg/datastore"
 )
 
@@ -50,7 +51,12 @@ func ParseHealthEventFromEvent(event datastore.Event) (model.HealthEventWithStat
 		return healthEventWithStatus, fmt.Errorf("health event is nil after unmarshaling")
 	}
 
-	// Set default value for NodeQuarantined if nil (e.g., for new events)
+	// Malformed or partial documents can omit healtheventstatus entirely.
+	if healthEventWithStatus.HealthEventStatus == nil {
+		healthEventWithStatus.HealthEventStatus = &protos.HealthEventStatus{}
+	}
+
+	// Set default value for NodeQuarantined if empty (e.g., for new events)
 	if healthEventWithStatus.HealthEventStatus.NodeQuarantined == "" {
 		healthEventWithStatus.HealthEventStatus.NodeQuarantined = string(model.StatusNotStarted)
 	}

--- a/commons/pkg/eventutil/parser_test.go
+++ b/commons/pkg/eventutil/parser_test.go
@@ -245,6 +245,27 @@ func TestParseHealthEventFromEvent(t *testing.T) {
 				assert.EqualValues(t, model.StatusNotStarted, result.HealthEventStatus.NodeQuarantined)
 			},
 		},
+		{
+			name: "handle missing healtheventstatus object without panic",
+			event: datastore.Event{
+				"operationType": "insert",
+				"fullDocument": map[string]interface{}{
+					"document": map[string]interface{}{
+						"healthevent": map[string]interface{}{
+							"nodename":       "missing-status-object-node",
+							"checkname":      "GpuXidError",
+							"componentclass": "GPU",
+						},
+					},
+				},
+			},
+			expectError: false,
+			checkResult: func(t *testing.T, result model.HealthEventWithStatus) {
+				assert.Equal(t, "missing-status-object-node", result.HealthEvent.NodeName)
+				require.NotNil(t, result.HealthEventStatus)
+				assert.EqualValues(t, model.StatusNotStarted, result.HealthEventStatus.NodeQuarantined)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/commons/pkg/statemanager/statemanager.go
+++ b/commons/pkg/statemanager/statemanager.go
@@ -241,6 +241,10 @@ func (manager *stateManager) UpdateNVSentinelStateNodeLabel(ctx context.Context,
 			return err
 		}
 
+		if node.Labels == nil {
+			node.Labels = make(map[string]string)
+		}
+
 		currentValue, exists := node.Labels[NVSentinelStateLabelKey]
 
 		if removeStateLabel {

--- a/commons/pkg/statemanager/statemanager_test.go
+++ b/commons/pkg/statemanager/statemanager_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,7 +63,7 @@ func TestUpdateNVSentinelStateNodeLabelWithNilLabelsMap(t *testing.T) {
 		Spec: v1.NodeSpec{},
 	}
 	_, err := clientSet.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	manager := &stateManager{clientSet: clientSet}
 	nodeModified, err := manager.UpdateNVSentinelStateNodeLabel(ctx, testNodeName, QuarantinedLabelValue, false)
@@ -70,7 +71,7 @@ func TestUpdateNVSentinelStateNodeLabelWithNilLabelsMap(t *testing.T) {
 	assert.NoError(t, err)
 
 	updated, err := clientSet.CoreV1().Nodes().Get(ctx, testNodeName, metav1.GetOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, string(QuarantinedLabelValue), updated.Labels[NVSentinelStateLabelKey])
 }
 

--- a/commons/pkg/statemanager/statemanager_test.go
+++ b/commons/pkg/statemanager/statemanager_test.go
@@ -51,6 +51,29 @@ func newTestStateManager(nodeName string, startingNodeLabels map[string]string) 
 	return ctx, &stateManager{clientSet: clientSet}, nil
 }
 
+func TestUpdateNVSentinelStateNodeLabelWithNilLabelsMap(t *testing.T) {
+	ctx := context.Background()
+	clientSet := fake.NewSimpleClientset()
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   testNodeName,
+			Labels: nil,
+		},
+		Spec: v1.NodeSpec{},
+	}
+	_, err := clientSet.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	manager := &stateManager{clientSet: clientSet}
+	nodeModified, err := manager.UpdateNVSentinelStateNodeLabel(ctx, testNodeName, QuarantinedLabelValue, false)
+	assert.True(t, nodeModified)
+	assert.NoError(t, err)
+
+	updated, err := clientSet.CoreV1().Nodes().Get(ctx, testNodeName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, string(QuarantinedLabelValue), updated.Labels[NVSentinelStateLabelKey])
+}
+
 func TestUpdateNVSentinelStateNodeLabelWithGetFailure(t *testing.T) {
 	ctx := context.Background()
 	clientSet := fake.NewSimpleClientset()

--- a/fault-quarantine/pkg/eventwatcher/event_watcher.go
+++ b/fault-quarantine/pkg/eventwatcher/event_watcher.go
@@ -179,7 +179,13 @@ func (w *EventWatcher) processEvent(ctx context.Context, event client.Event) err
 	w.lastProcessedObjectID.StoreLastProcessedObjectID(eventID)
 
 	traceID := tracing.TraceIDFromMetadata(healthEventWithStatus.HealthEvent.GetMetadata())
-	parentSpanID := tracing.ParentSpanID(healthEventWithStatus.HealthEventStatus.SpanIds, tracing.ServicePlatformConnector)
+
+	var spanIDs map[string]string
+	if healthEventWithStatus.HealthEventStatus != nil {
+		spanIDs = healthEventWithStatus.HealthEventStatus.SpanIds
+	}
+
+	parentSpanID := tracing.ParentSpanID(spanIDs, tracing.ServicePlatformConnector)
 
 	// Short-lived span that marks the exact moment fault-quarantine received the
 	// event. It ends immediately so it appears in the trace backend before

--- a/fault-quarantine/pkg/reconciler/reconciler.go
+++ b/fault-quarantine/pkg/reconciler/reconciler.go
@@ -1062,8 +1062,6 @@ func (r *Reconciler) applyQuarantine(
 	ctx, span := tracing.StartSpan(ctx, "fault_quarantine.apply_quarantine")
 	defer span.End()
 
-	r.recordCordonEventInCircuitBreaker(event)
-
 	healthEvents := healthEventsAnnotation.NewHealthEventsAnnotationMap()
 	updated := healthEvents.AddOrUpdateEvent(event.HealthEvent)
 
@@ -1135,6 +1133,10 @@ func (r *Reconciler) applyQuarantine(
 
 		return nil
 	}
+
+	// Record only after a successful quarantine write. Counting earlier false-trips
+	// the breaker on API/annotation failures that never cordoned a node.
+	r.recordCordonEventInCircuitBreaker(event)
 
 	slog.DebugContext(ctx, "QuarantineNodeAndSetAnnotations completed successfully", "node", event.HealthEvent.NodeName)
 

--- a/fault-remediation/pkg/reconciler/reconciler.go
+++ b/fault-remediation/pkg/reconciler/reconciler.go
@@ -316,11 +316,13 @@ func (r *FaultRemediationReconciler) performRemediation(ctx context.Context,
 	defer span.End()
 
 	// Update state to "remediating"
-	_, err := r.Config.StateManager.UpdateNVSentinelStateNodeLabel(ctx,
+	nodeModified, err := r.Config.StateManager.UpdateNVSentinelStateNodeLabel(ctx,
 		healthEventWithStatus.HealthEvent.NodeName,
 		statemanager.RemediatingLabelValue, false)
 	if err != nil {
-		slog.ErrorContext(ctx, "Error updating node label to remediating", "error", err)
+		slog.ErrorContext(ctx, "Error updating node label to remediating",
+			"error", err,
+			"nodeModified", nodeModified)
 		metrics.ProcessingErrors.WithLabelValues("label_update_error", nodeName).Inc()
 
 		tracing.RecordError(span, err)
@@ -329,7 +331,12 @@ func (r *FaultRemediationReconciler) performRemediation(ctx context.Context,
 			attribute.String("fault_remediation.error.message", err.Error()),
 		)
 
-		return "", fmt.Errorf("error updating node label to remediating: %w", err)
+		// Validation errors are returned AFTER a successful label write so callers can
+		// emit metrics while still reflecting reality. Only abort when the label was
+		// not actually updated (same contract as node-drainer / partial recovery).
+		if !nodeModified {
+			return "", fmt.Errorf("error updating node label to remediating: %w", err)
+		}
 	}
 
 	healthEventData := &events.HealthEventData{
@@ -353,12 +360,13 @@ func (r *FaultRemediationReconciler) performRemediation(ctx context.Context,
 		// don't throw error yet so we can update state
 	}
 
-	_, err = r.Config.StateManager.UpdateNVSentinelStateNodeLabel(ctx,
+	nodeModified, err = r.Config.StateManager.UpdateNVSentinelStateNodeLabel(ctx,
 		healthEventWithStatus.HealthEvent.NodeName,
 		remediationLabelValue, false)
 	if err != nil {
 		slog.ErrorContext(ctx, "Error updating node label",
 			"label", remediationLabelValue,
+			"nodeModified", nodeModified,
 			"error", err)
 		metrics.ProcessingErrors.WithLabelValues("label_update_error", nodeName).Inc()
 		tracing.RecordError(span, err)
@@ -367,7 +375,9 @@ func (r *FaultRemediationReconciler) performRemediation(ctx context.Context,
 			attribute.String("fault_remediation.error.message", err.Error()),
 		)
 
-		return "", errors.Join(createMaintenanceResourceError, err)
+		if !nodeModified {
+			return "", errors.Join(createMaintenanceResourceError, err)
+		}
 	}
 
 	if createMaintenanceResourceError != nil {

--- a/fault-remediation/pkg/reconciler/reconciler_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_test.go
@@ -579,7 +579,7 @@ func TestPerformRemediationWithFailure(t *testing.T) {
 	assert.Empty(t, crName)
 }
 
-func TestPerformRemediationContinuesWhenLabelUpdatedDespiteValidationError(t *testing.T) {
+func TestPerformRemediation_LabelUpdatedDespiteValidationError_Continues(t *testing.T) {
 	ctx := context.Background()
 	k8sClient := &MockK8sClient{
 		createMaintenanceResourceFn: func(ctx context.Context, healthEventDoc *events.HealthEventData,
@@ -587,11 +587,11 @@ func TestPerformRemediationContinuesWhenLabelUpdatedDespiteValidationError(t *te
 			return "test-cr-label-validation", nil
 		},
 	}
-	count := 0
+	var requestedStates []statemanager.NVSentinelStateLabelValue
 	stateManager := &statemanager.MockStateManager{
 		UpdateNVSentinelStateNodeLabelFn: func(ctx context.Context, nodeName string,
 			newStateLabelValue statemanager.NVSentinelStateLabelValue, removeStateLabel bool) (bool, error) {
-			count++
+			requestedStates = append(requestedStates, newStateLabelValue)
 			// Simulate unexpected transition validation error AFTER a successful write.
 			return true, fmt.Errorf("unexpected state transition")
 		},
@@ -626,7 +626,10 @@ func TestPerformRemediationContinuesWhenLabelUpdatedDespiteValidationError(t *te
 	crName, err := r.performRemediation(ctx, healthEventDoc, groupConfig)
 	assert.NoError(t, err)
 	assert.Equal(t, "test-cr-label-validation", crName)
-	assert.GreaterOrEqual(t, count, 1)
+	assert.Equal(t, []statemanager.NVSentinelStateLabelValue{
+		statemanager.RemediatingLabelValue,
+		statemanager.RemediationSucceededLabelValue,
+	}, requestedStates)
 }
 
 func TestPerformRemediationWithUpdateNodeStateLabelFailures(t *testing.T) {

--- a/fault-remediation/pkg/reconciler/reconciler_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_test.go
@@ -579,6 +579,56 @@ func TestPerformRemediationWithFailure(t *testing.T) {
 	assert.Empty(t, crName)
 }
 
+func TestPerformRemediationContinuesWhenLabelUpdatedDespiteValidationError(t *testing.T) {
+	ctx := context.Background()
+	k8sClient := &MockK8sClient{
+		createMaintenanceResourceFn: func(ctx context.Context, healthEventDoc *events.HealthEventData,
+			_ *common.EquivalenceGroupConfig) (string, error) {
+			return "test-cr-label-validation", nil
+		},
+	}
+	count := 0
+	stateManager := &statemanager.MockStateManager{
+		UpdateNVSentinelStateNodeLabelFn: func(ctx context.Context, nodeName string,
+			newStateLabelValue statemanager.NVSentinelStateLabelValue, removeStateLabel bool) (bool, error) {
+			count++
+			// Simulate unexpected transition validation error AFTER a successful write.
+			return true, fmt.Errorf("unexpected state transition")
+		},
+	}
+	cfg := ReconcilerConfig{
+		RemediationClient: k8sClient,
+		StateManager:      stateManager,
+		UpdateMaxRetries:  2,
+		UpdateRetryDelay:  1 * time.Microsecond,
+	}
+	healthEvent := events.HealthEventData{
+		HealthEventWithStatus: model.HealthEventWithStatus{
+			CreatedAt: time.Now(),
+			HealthEvent: &protos.HealthEvent{
+				NodeName:          "node1",
+				RecommendedAction: protos.RecommendedAction_RESTART_BM,
+			},
+			HealthEventStatus: &protos.HealthEventStatus{
+				NodeQuarantined:        string(model.Quarantined),
+				UserPodsEvictionStatus: &protos.OperationStatus{Status: string(model.StatusSucceeded)},
+				FaultRemediated:        nil,
+			},
+		},
+	}
+	r := NewFaultRemediationReconciler(nil, nil, nil, cfg, false)
+	healthEventDoc := &events.HealthEventDoc{
+		ID:                    "test-id-123",
+		HealthEventWithStatus: healthEvent.HealthEventWithStatus,
+	}
+	groupConfig := getGroupConfig("restart", nil)
+
+	crName, err := r.performRemediation(ctx, healthEventDoc, groupConfig)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-cr-label-validation", crName)
+	assert.GreaterOrEqual(t, count, 1)
+}
+
 func TestPerformRemediationWithUpdateNodeStateLabelFailures(t *testing.T) {
 	ctx := context.Background()
 	k8sClient := &MockK8sClient{
@@ -590,8 +640,8 @@ func TestPerformRemediationWithUpdateNodeStateLabelFailures(t *testing.T) {
 	stateManager := &statemanager.MockStateManager{
 		UpdateNVSentinelStateNodeLabelFn: func(ctx context.Context, nodeName string,
 			newStateLabelValue statemanager.NVSentinelStateLabelValue, removeStateLabel bool) (bool, error) {
-			// Simulate error but allow the function to continue
-			return true, fmt.Errorf("got an error calling UpdateNVSentinelStateNodeLabel")
+			// Hard failure: label was not written.
+			return false, fmt.Errorf("got an error calling UpdateNVSentinelStateNodeLabel")
 		},
 	}
 	cfg := ReconcilerConfig{
@@ -621,7 +671,6 @@ func TestPerformRemediationWithUpdateNodeStateLabelFailures(t *testing.T) {
 		HealthEventWithStatus: healthEvent.HealthEventWithStatus,
 	}
 	groupConfig := getGroupConfig("restart", nil)
-	// Even with label update errors, remediation should still succeed
 	_, err := r.performRemediation(ctx, healthEventDoc, groupConfig)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
## Summary
- Initialize nil node `Labels` maps in `statemanager` before writes, and initialize missing `HealthEventStatus` in shared event parsing (plus nil-safe span ID access in fault-quarantine) so malformed documents cannot panic the hot path.
- Teach fault-remediation to honor the `nodeModified` contract: continue creating maintenance CRs when a state label was successfully written despite a validation error (aligned with node-drainer / partial recovery).
- Record circuit-breaker cordon events only after a successful quarantine write, so API/annotation failures no longer false-trip the breaker and halt the cluster pipeline.

## Test plan
- [x] `go test ./pkg/statemanager/ ./pkg/eventutil/` in `commons`
- [x] `go test ./pkg/reconciler/ -run 'TestPerformRemediation...'` in `fault-remediation` (with `KUBEBUILDER_ASSETS`)
- [x] `go build` for fault-quarantine reconciler/eventwatcher
- [x] CI green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete health events to prevent processing failures and apply default node status correctly.
  * Prevented errors when node labels are missing during quarantine or remediation.
  * Ensured circuit-breaker records are updated only after successful node quarantine.
  * Improved remediation error handling and validation of node state updates.
  * Added safer tracing behavior for events with incomplete status data.

* **Tests**
  * Added coverage for incomplete health events, missing node labels, and remediation state-update failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->