### PR TITLE
fix: correct PG pipeline matching and exporter resume safety

### DIFF
--- a/event-exporter/pkg/exporter/worker_pool.go
+++ b/event-exporter/pkg/exporter/worker_pool.go
@@ -72,6 +72,9 @@ type workerPool struct {
 
 	dispatchCh chan workItem
 	resultCh   chan workResult
+
+	// onResult is an optional test hook invoked for every emitted work result.
+	onResult func(workResult)
 }
 
 func newWorkerPool(
@@ -134,22 +137,23 @@ func (wp *workerPool) worker(ctx context.Context) {
 	for item := range wp.dispatchCh {
 		// Always emit a result for dequeued items so the token writer can observe
 		// cancellation/failure for every sequence and avoid silently dropping work.
-		if err := ctx.Err(); err != nil {
-			wp.resultCh <- workResult{
-				seq:         item.seq,
-				resumeToken: item.resumeToken,
-				err:         err,
-			}
-
-			continue
+		var err error
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			err = ctxErr
+		} else {
+			err = wp.process(ctx, item.event)
 		}
 
-		err := wp.process(ctx, item.event)
-		wp.resultCh <- workResult{
+		result := workResult{
 			seq:         item.seq,
 			resumeToken: item.resumeToken,
 			err:         err,
 		}
+		if wp.onResult != nil {
+			wp.onResult(result)
+		}
+
+		wp.resultCh <- result
 	}
 }
 

--- a/event-exporter/pkg/exporter/worker_pool.go
+++ b/event-exporter/pkg/exporter/worker_pool.go
@@ -132,8 +132,16 @@ func (wp *workerPool) closeDispatch() {
 // worker picks items from dispatchCh and processes them.
 func (wp *workerPool) worker(ctx context.Context) {
 	for item := range wp.dispatchCh {
-		if ctx.Err() != nil {
-			return
+		// Always emit a result for dequeued items so the token writer can observe
+		// cancellation/failure for every sequence and avoid silently dropping work.
+		if err := ctx.Err(); err != nil {
+			wp.resultCh <- workResult{
+				seq:         item.seq,
+				resumeToken: item.resumeToken,
+				err:         err,
+			}
+
+			continue
 		}
 
 		err := wp.process(ctx, item.event)
@@ -147,13 +155,23 @@ func (wp *workerPool) worker(ctx context.Context) {
 
 // tokenWriter collects results from workers and advances the resume token in order.
 // Returns the first fatal error (a worker failed to process after all retries).
+// After a fatal error it cancels the pool and drains remaining results so workers
+// that still emit cancelled/failed outcomes do not block forever on resultCh.
 func (wp *workerPool) tokenWriter(ctx context.Context) error {
 	tracker := newSequenceTracker()
 
+	var fatalErr error
+
 	for result := range wp.resultCh {
+		if fatalErr != nil {
+			continue
+		}
+
 		if result.err != nil {
 			wp.cancel()
-			return fmt.Errorf("process failed for seq %d: %w", result.seq, result.err)
+			fatalErr = fmt.Errorf("process failed for seq %d: %w", result.seq, result.err)
+
+			continue
 		}
 
 		token := tracker.markCompleted(result.seq, result.resumeToken)
@@ -164,8 +182,9 @@ func (wp *workerPool) tokenWriter(ctx context.Context) error {
 		if err := wp.source.MarkProcessed(ctx, token); err != nil {
 			slog.ErrorContext(ctx, "Failed to mark processed", "error", err)
 			wp.cancel()
+			fatalErr = fmt.Errorf("mark processed: %w", err)
 
-			return fmt.Errorf("mark processed: %w", err)
+			continue
 		}
 
 		metrics.ResumeTokenUpdateTimestamp.SetToCurrentTime()
@@ -175,5 +194,5 @@ func (wp *workerPool) tokenWriter(ctx context.Context) error {
 			"pendingOutOfOrder", tracker.pending())
 	}
 
-	return nil
+	return fatalErr
 }

--- a/event-exporter/pkg/exporter/worker_pool_test.go
+++ b/event-exporter/pkg/exporter/worker_pool_test.go
@@ -264,18 +264,32 @@ func TestWorkerPool_CancelEmitsResultsForDequeuedItems(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	const numEvents = 4
+
 	pool := newWorkerPool(2, process, src, cancel)
 
-	go func() {
-		for i := uint64(1); i <= 4; i++ {
-			pool.dispatch(ctx, workItem{
-				seq:         i,
-				resumeToken: []byte(fmt.Sprintf("tok-%d", i)),
-			})
-		}
+	var (
+		resultsMu sync.Mutex
+		results   = make(map[uint64]error, numEvents)
+	)
 
-		pool.closeDispatch()
-	}()
+	pool.onResult = func(r workResult) {
+		resultsMu.Lock()
+		results[r.seq] = r.err
+		resultsMu.Unlock()
+	}
+
+	// Enqueue all work before starting workers so cancel cannot race with dispatch.
+	for i := uint64(1); i <= numEvents; i++ {
+		if !pool.dispatch(ctx, workItem{
+			seq:         i,
+			resumeToken: []byte(fmt.Sprintf("tok-%d", i)),
+		}) {
+			t.Fatalf("failed to dispatch seq %d", i)
+		}
+	}
+
+	pool.closeDispatch()
 
 	done := make(chan error, 1)
 
@@ -298,5 +312,18 @@ func TestWorkerPool_CancelEmitsResultsForDequeuedItems(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("run() hung after cancel; dequeued items likely dropped without results")
+	}
+
+	resultsMu.Lock()
+	defer resultsMu.Unlock()
+
+	if len(results) != numEvents {
+		t.Fatalf("emitted results for %d sequences, want %d (got %#v)", len(results), numEvents, results)
+	}
+
+	for seq := uint64(1); seq <= numEvents; seq++ {
+		if _, ok := results[seq]; !ok {
+			t.Fatalf("missing result for dequeued seq %d", seq)
+		}
 	}
 }

--- a/event-exporter/pkg/exporter/worker_pool_test.go
+++ b/event-exporter/pkg/exporter/worker_pool_test.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/nvidia/nvsentinel/store-client/pkg/client"
 )
@@ -233,5 +234,69 @@ func TestWorkerPool_MarkProcessedError(t *testing.T) {
 
 	if !errors.Is(err, errStore) {
 		t.Fatalf("expected wrapped errStore, got: %v", err)
+	}
+}
+
+// TestWorkerPool_CancelEmitsResultsForDequeuedItems verifies that workers report
+// a result for every dequeued sequence after cancellation instead of silently
+// dropping in-flight work (which would advance resume incorrectly / hang).
+func TestWorkerPool_CancelEmitsResultsForDequeuedItems(t *testing.T) {
+	src := &mockSource{}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	var processCount atomic.Int32
+
+	process := func(ctx context.Context, _ client.Event) error {
+		if processCount.Add(1) == 1 {
+			close(started)
+			<-release
+
+			return errors.New("fatal worker failure")
+		}
+
+		<-ctx.Done()
+
+		return ctx.Err()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pool := newWorkerPool(2, process, src, cancel)
+
+	go func() {
+		for i := uint64(1); i <= 4; i++ {
+			pool.dispatch(ctx, workItem{
+				seq:         i,
+				resumeToken: []byte(fmt.Sprintf("tok-%d", i)),
+			})
+		}
+
+		pool.closeDispatch()
+	}()
+
+	done := make(chan error, 1)
+
+	go func() {
+		done <- pool.run(ctx)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first worker to start")
+	}
+
+	close(release)
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected fatal error from run(), got nil")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("run() hung after cancel; dequeued items likely dropped without results")
 	}
 }

--- a/store-client/pkg/datastore/providers/postgresql/changestream.go
+++ b/store-client/pkg/datastore/providers/postgresql/changestream.go
@@ -1091,6 +1091,17 @@ func (w *PostgreSQLChangeStreamWatcher) sendEventsToChannel(
 		}
 	}
 
+	// Filtered-only batches never reach MarkProcessed, so persist the advanced
+	// in-memory position here to avoid replaying large filtered ranges on restart.
+	if filteredCount > 0 && sentCount == 0 {
+		if err := w.persistCurrentResumePosition(ctx); err != nil {
+			slog.Warn("Failed to persist resume position after filtered-only batch",
+				"client", w.clientName,
+				"filtered", filteredCount,
+				"error", err)
+		}
+	}
+
 	if len(events) > 0 {
 		if w.pipelineFilter != nil {
 			slog.Debug("Sent filtered change events",
@@ -1138,6 +1149,20 @@ func (w *PostgreSQLChangeStreamWatcher) advancePosition(event datastore.EventWit
 	slog.Debug("Advanced position before filtering", "client", w.clientName, "eventID", eventID)
 
 	return eventID
+}
+
+// persistCurrentResumePosition writes the in-memory lastEventID/lastTimestamp bookmark.
+func (w *PostgreSQLChangeStreamWatcher) persistCurrentResumePosition(ctx context.Context) error {
+	w.mu.RLock()
+	eventID := w.lastEventID
+	timestamp := w.lastTimestamp
+	w.mu.RUnlock()
+
+	if eventID <= 0 {
+		return nil
+	}
+
+	return w.saveResumePosition(ctx, timestamp, eventID)
 }
 
 func (w *PostgreSQLChangeStreamWatcher) hasRecentlySeenEventID(eventID int64) bool {

--- a/store-client/pkg/datastore/providers/postgresql/changestream.go
+++ b/store-client/pkg/datastore/providers/postgresql/changestream.go
@@ -1095,10 +1095,7 @@ func (w *PostgreSQLChangeStreamWatcher) sendEventsToChannel(
 	// in-memory position here to avoid replaying large filtered ranges on restart.
 	if filteredCount > 0 && sentCount == 0 {
 		if err := w.persistCurrentResumePosition(ctx); err != nil {
-			slog.Warn("Failed to persist resume position after filtered-only batch",
-				"client", w.clientName,
-				"filtered", filteredCount,
-				"error", err)
+			return fmt.Errorf("persist resume position after filtered-only batch: %w", err)
 		}
 	}
 

--- a/store-client/pkg/datastore/providers/postgresql/changestream_resume_token_test.go
+++ b/store-client/pkg/datastore/providers/postgresql/changestream_resume_token_test.go
@@ -182,6 +182,11 @@ func TestResumeTokenAdvancedEvenForFilteredEvents(t *testing.T) {
 		},
 	}
 
+	// Filtered-only batches persist the advanced resume bookmark.
+	mock.ExpectExec("INSERT INTO resume_tokens").
+		WithArgs(clientName, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
 	// Send events through pipeline filter
 	err = watcher.sendEventsToChannel(ctx, events)
 	require.NoError(t, err)
@@ -549,6 +554,11 @@ func TestMultipleFilteredEventsAdvancePosition(t *testing.T) {
 			ResumeToken: []byte(eventIDStr),
 		}
 	}
+
+	// Filtered-only batch must persist the advanced bookmark.
+	mock.ExpectExec("INSERT INTO resume_tokens").
+		WithArgs(clientName, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	// Send all 11 events through the filter
 	err = watcher.sendEventsToChannel(ctx, events)

--- a/store-client/pkg/datastore/providers/postgresql/database_client.go
+++ b/store-client/pkg/datastore/providers/postgresql/database_client.go
@@ -1043,10 +1043,10 @@ func (c *PostgreSQLDatabaseClient) NewChangeStreamWatcher(
 		// Create application-side filter as fallback
 		pipelineFilter, err := NewPipelineFilter(pipeline)
 		if err != nil {
-			slog.Warn("Failed to create pipeline filter", "error", err)
-		} else {
-			watcher.pipelineFilter = pipelineFilter
+			return nil, fmt.Errorf("failed to create pipeline filter: %w", err)
 		}
+
+		watcher.pipelineFilter = pipelineFilter
 	}
 
 	// Return the adapter that implements client.ChangeStreamWatcher

--- a/store-client/pkg/datastore/providers/postgresql/datastore.go
+++ b/store-client/pkg/datastore/providers/postgresql/datastore.go
@@ -153,7 +153,10 @@ func (p *PostgreSQLDataStore) NewChangeStreamWatcher(
 		return nil, fmt.Errorf("failed to reset change stream resume token on startup: %w", err)
 	}
 
-	pipelineFilter := buildPipelineFilter(pipeline, tableName, clientName)
+	pipelineFilter, err := buildPipelineFilter(pipeline, tableName, clientName)
+	if err != nil {
+		return nil, err
+	}
 
 	// Convert PascalCase table name to snake_case for PostgreSQL compatibility
 	snakeCaseTableName := toSnakeCase(tableName)
@@ -208,20 +211,17 @@ func parseWatcherConfig(config interface{}) (string, string, interface{}, error)
 // buildPipelineFilter creates a two-layer pipeline filter for optimal performance:
 // 1. Server-side: SQL WHERE clause (built from raw pipeline in fetchNewChanges)
 // 2. Application-side: PipelineFilter (handles edge cases SQL can't express)
-func buildPipelineFilter(pipeline interface{}, tableName, clientName string) *PipelineFilter {
+// Returns an error when a pipeline was provided but could not be parsed, so callers
+// never silently open the filter to match everything.
+func buildPipelineFilter(pipeline interface{}, tableName, clientName string) (*PipelineFilter, error) {
 	if pipeline == nil {
-		return nil
+		return nil, nil
 	}
 
 	filter, err := NewPipelineFilter(pipeline)
 	if err != nil {
-		slog.Warn("Failed to parse MongoDB pipeline for PostgreSQL filtering",
-			"error", err,
-			"tableName", tableName,
-			"clientName", clientName,
-			"action", "all events will be returned without filtering")
-
-		return nil
+		return nil, fmt.Errorf("failed to parse MongoDB pipeline for PostgreSQL filtering (table=%s client=%s): %w",
+			tableName, clientName, err)
 	}
 
 	if filter != nil {
@@ -231,7 +231,7 @@ func buildPipelineFilter(pipeline interface{}, tableName, clientName string) *Pi
 			"stages", len(filter.stages))
 	}
 
-	return filter
+	return filter, nil
 }
 
 // --- Backward Compatibility Methods for MongoDB-style Type Assertions ---

--- a/store-client/pkg/datastore/providers/postgresql/pipeline_filter.go
+++ b/store-client/pkg/datastore/providers/postgresql/pipeline_filter.go
@@ -60,19 +60,16 @@ func NewPipelineFilter(pipeline interface{}) (*PipelineFilter, error) {
 		return nil, fmt.Errorf("unsupported pipeline type: %T", pipeline)
 	}
 
-	// Process each stage
+	// Process each stage. Fail closed on unparseable stages so a broken pipeline
+	// never silently degrades into an open (match-everything) filter.
 	for _, stage := range stageList {
 		if err := filter.parseStage(stage); err != nil {
-			slog.Warn("Failed to parse pipeline stage, skipping",
-				"error", err,
-				"stage", fmt.Sprintf("%T", stage))
-
-			continue
+			return nil, fmt.Errorf("failed to parse pipeline stage: %w", err)
 		}
 	}
 
 	if len(filter.stages) == 0 {
-		return nil, nil // No valid stages, return nil filter
+		return nil, nil // Empty pipeline, return nil filter
 	}
 
 	return filter, nil
@@ -306,26 +303,38 @@ func (f *PipelineFilter) matchesMapValue(actualValue interface{}, expectedMap ma
 	return true
 }
 
-// matchesOperators processes MongoDB operator expressions
+// matchesOperators processes MongoDB operator expressions.
+// All operators in the map must match (logical AND), matching MongoDB semantics
+// for expressions like {"$gte": 5, "$lte": 10}.
 func (f *PipelineFilter) matchesOperators(actualValue interface{}, operators map[string]interface{}) bool {
+	if len(operators) == 0 {
+		return true
+	}
+
 	for op, opValue := range operators {
+		var matched bool
+
 		switch op {
 		case opIn:
-			return f.matchesIn(actualValue, opValue)
+			matched = f.matchesIn(actualValue, opValue)
 		case opNe:
-			return !f.matchesEqual(actualValue, opValue)
+			matched = !f.matchesEqual(actualValue, opValue)
 		case opEq:
-			return f.matchesEqual(actualValue, opValue)
+			matched = f.matchesEqual(actualValue, opValue)
 		case opGt:
-			return f.matchesGreaterThan(actualValue, opValue)
+			matched = f.matchesGreaterThan(actualValue, opValue)
 		case opGte:
-			return f.matchesGreaterThanOrEqual(actualValue, opValue)
+			matched = f.matchesGreaterThanOrEqual(actualValue, opValue)
 		case opLt:
-			return f.matchesLessThan(actualValue, opValue)
+			matched = f.matchesLessThan(actualValue, opValue)
 		case opLte:
-			return f.matchesLessThanOrEqual(actualValue, opValue)
+			matched = f.matchesLessThanOrEqual(actualValue, opValue)
 		default:
 			slog.Warn("Unsupported operator", "operator", op)
+			return false
+		}
+
+		if !matched {
 			return false
 		}
 	}

--- a/store-client/pkg/datastore/providers/postgresql/pipeline_filter_test.go
+++ b/store-client/pkg/datastore/providers/postgresql/pipeline_filter_test.go
@@ -406,3 +406,64 @@ func TestMatchesEvent_RealWorldHealthEventsAnalyzer(t *testing.T) {
 		})
 	}
 }
+
+func TestMatchesOperators_RequiresAllOperators(t *testing.T) {
+	pipeline := []interface{}{
+		map[string]interface{}{
+			"$match": map[string]interface{}{
+				"fullDocument.count": map[string]interface{}{
+					"$gte": 5,
+					"$lte":  10,
+				},
+			},
+		},
+	}
+
+	filter, err := NewPipelineFilter(pipeline)
+	if err != nil {
+		t.Fatalf("NewPipelineFilter() error = %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		count    int
+		expected bool
+	}{
+		{name: "inside range", count: 7, expected: true},
+		{name: "below range", count: 4, expected: false},
+		{name: "above range", count: 11, expected: false},
+		{name: "lower bound", count: 5, expected: true},
+		{name: "upper bound", count: 10, expected: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := datastore.EventWithToken{
+				Event: map[string]interface{}{
+					"fullDocument": map[string]interface{}{
+						"count": tt.count,
+					},
+				},
+			}
+
+			if got := filter.MatchesEvent(event); got != tt.expected {
+				t.Fatalf("MatchesEvent(count=%d) = %v, want %v", tt.count, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewPipelineFilter_FailsClosedOnUnparseableStage(t *testing.T) {
+	pipeline := []interface{}{
+		"not-a-stage-map",
+	}
+
+	filter, err := NewPipelineFilter(pipeline)
+	if err == nil {
+		t.Fatal("expected error for unparseable pipeline stage, got nil")
+	}
+
+	if filter != nil {
+		t.Fatalf("expected nil filter on parse failure, got %#v", filter)
+	}
+}

--- a/store-client/pkg/datastore/providers/postgresql/watcher_factory.go
+++ b/store-client/pkg/datastore/providers/postgresql/watcher_factory.go
@@ -74,7 +74,9 @@ func (f *PostgreSQLWatcherFactory) CreateChangeStreamWatcher(
 		ModeHybrid,
 	)
 
-	f.applyPipelineFilter(changeStreamWatcher, config.Pipeline, tableName)
+	if err := f.applyPipelineFilter(changeStreamWatcher, config.Pipeline, tableName); err != nil {
+		return nil, err
+	}
 
 	return NewPostgreSQLChangeStreamWatcherWithUnwrap(changeStreamWatcher, resumeControlDecision), nil
 }
@@ -84,9 +86,9 @@ func (f *PostgreSQLWatcherFactory) applyPipelineFilter(
 	w *PostgreSQLChangeStreamWatcher,
 	pipeline datastore.Pipeline,
 	tableName string,
-) {
+) error {
 	if len(pipeline) == 0 {
-		return
+		return nil
 	}
 
 	slog.Info("PostgreSQL: Setting up two-layer filtering (server-side SQL + application-side fallback)",
@@ -97,16 +99,14 @@ func (f *PostgreSQLWatcherFactory) applyPipelineFilter(
 
 	pipelineFilter, err := NewPipelineFilter(pipeline)
 	if err != nil {
-		slog.Warn("Failed to create application-side pipeline filter",
-			"error", err,
-			"tableName", tableName)
-
-		return
+		return fmt.Errorf("failed to create application-side pipeline filter for %s: %w", tableName, err)
 	}
 
 	if pipelineFilter != nil {
 		w.pipelineFilter = pipelineFilter
 	}
+
+	return nil
 }
 
 // SupportedProvider returns the provider this factory supports


### PR DESCRIPTION
## Summary
- Fix PostgreSQL `matchesOperators` to AND all MongoDB operators (e.g. `$gte` + `$lte`) instead of returning after the first map entry, matching MongoDB semantics.
- Fail closed when a provided pipeline stage cannot be parsed, so watchers never silently degrade into match-everything filters.
- Persist resume bookmarks after filtered-only batches, and make event-exporter workers always emit results for dequeued items after cancel (with token-writer drain) so in-flight sequences are not silently dropped.

## Test plan
- [x] `go test ./pkg/datastore/providers/postgresql/ -run 'TestMatchesOperators|TestNewPipelineFilter_FailsClosed|TestResumeTokenAdvanced|TestMultipleFiltered|TestMixedFiltered'`
- [x] `go test ./pkg/exporter/ -run 'TestWorkerPool_'` in `event-exporter`
- [x] CI green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved event export reliability during cancellation, preventing hangs and preserving progress safely.
  - Resume positions now persist even when an entire event batch is filtered out.
  - Invalid change-stream filters now fail clearly instead of silently allowing unintended events.
  - Filter conditions now correctly require all specified operators to match.

- **Tests**
  - Added coverage for cancellation handling, filtered-batch resume persistence, invalid filters, and combined filter conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->