### PR TITLE
fix: propagate per-event MongoDB resume tokens

### DIFF
--- a/store-client/pkg/client/mongodb_client.go
+++ b/store-client/pkg/client/mongodb_client.go
@@ -133,7 +133,7 @@ func (e *mongoEvent) GetNodeName() (string, error) {
 
 func (e *mongoEvent) GetResumeToken() []byte {
 	// Extract the resume token that was captured when the event was received
-	// This token is added by the ChangeStreamWatcher in processChangeStreamEvent
+	// This token is added by the ChangeStreamWatcher in processNextEvent
 	token, ok := e.rawEvent["_resumeToken"]
 	if !ok {
 		// If no token was found, return empty (caller will fall back to cursor position)
@@ -143,6 +143,8 @@ func (e *mongoEvent) GetResumeToken() []byte {
 	// MongoDB resume tokens can be various types (Binary, string, etc.)
 	// Try to extract as byte array
 	switch v := token.(type) {
+	case bson.Raw:
+		return v
 	case []byte:
 		return v
 	case primitive.Binary:

--- a/store-client/pkg/client/mongodb_event_test.go
+++ b/store-client/pkg/client/mongodb_event_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+
+	mongoWatcher "github.com/nvidia/nvsentinel/store-client/pkg/datastore/providers/mongodb/watcher"
+)
+
+func TestMongoEvent_GetResumeToken(t *testing.T) {
+	tokenBytes, err := bson.Marshal(bson.D{{Key: "_data", Value: "8264ABCDEF"}})
+	require.NoError(t, err)
+
+	t.Run("returns bson.Raw token injected by the watcher", func(t *testing.T) {
+		e := &mongoEvent{rawEvent: mongoWatcher.Event{
+			"_resumeToken": bson.Raw(tokenBytes),
+		}}
+
+		assert.Equal(t, tokenBytes, e.GetResumeToken())
+	})
+
+	t.Run("returns plain byte slice token", func(t *testing.T) {
+		e := &mongoEvent{rawEvent: mongoWatcher.Event{
+			"_resumeToken": tokenBytes,
+		}}
+
+		assert.Equal(t, tokenBytes, e.GetResumeToken())
+	})
+
+	t.Run("returns empty token when field is missing", func(t *testing.T) {
+		e := &mongoEvent{rawEvent: mongoWatcher.Event{
+			"operationType": "insert",
+		}}
+
+		assert.Empty(t, e.GetResumeToken())
+	})
+}

--- a/store-client/pkg/datastore/providers/mongodb/adapter.go
+++ b/store-client/pkg/datastore/providers/mongodb/adapter.go
@@ -234,10 +234,14 @@ func (a *AdaptedChangeStreamWatcher) Events() <-chan datastore.EventWithToken {
 					continue
 				}
 
-				// Create EventWithToken
+				// Create EventWithToken carrying the per-event resume token so
+				// consumers (e.g. fault-remediation's safeMarkProcessed) can
+				// checkpoint exactly at the event they processed. Events that
+				// carry no token (e.g. synthesized cold-start events) yield an
+				// empty slice, which consumers treat as "do not checkpoint".
 				eventWithToken := datastore.EventWithToken{
 					Event:       eventMap,
-					ResumeToken: []byte(""), // We'll need to extract the resume token properly
+					ResumeToken: event.GetResumeToken(),
 				}
 
 				a.eventChan <- eventWithToken

--- a/store-client/pkg/datastore/providers/mongodb/adapter_test.go
+++ b/store-client/pkg/datastore/providers/mongodb/adapter_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodb
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nvidia/nvsentinel/store-client/pkg/client"
+)
+
+// fakeClientEvent implements client.Event for adapter tests.
+type fakeClientEvent struct {
+	doc   map[string]interface{}
+	token []byte
+}
+
+func (f *fakeClientEvent) GetDocumentID() (string, error) { return "doc-id", nil }
+func (f *fakeClientEvent) GetRecordUUID() (string, error) { return "doc-id", nil }
+func (f *fakeClientEvent) GetNodeName() (string, error)   { return "node", nil }
+func (f *fakeClientEvent) GetResumeToken() []byte         { return f.token }
+
+func (f *fakeClientEvent) UnmarshalDocument(v interface{}) error {
+	target, ok := v.(*map[string]interface{})
+	if !ok {
+		return fmt.Errorf("unsupported target type %T", v)
+	}
+
+	*target = f.doc
+
+	return nil
+}
+
+// fakeClientWatcher implements client.ChangeStreamWatcher for adapter tests.
+type fakeClientWatcher struct {
+	events chan client.Event
+	marked [][]byte
+}
+
+func (f *fakeClientWatcher) Start(ctx context.Context)       {}
+func (f *fakeClientWatcher) Events() <-chan client.Event     { return f.events }
+func (f *fakeClientWatcher) Close(ctx context.Context) error { return nil }
+
+func (f *fakeClientWatcher) MarkProcessed(ctx context.Context, token []byte) error {
+	f.marked = append(f.marked, token)
+	return nil
+}
+
+func TestAdaptedChangeStreamWatcher_EventsCarryResumeToken(t *testing.T) {
+	token := []byte("per-event-resume-token")
+	doc := map[string]interface{}{"_id": "abc123", "healthevent": map[string]interface{}{"nodename": "node-1"}}
+
+	watcher := &fakeClientWatcher{events: make(chan client.Event, 1)}
+	watcher.events <- &fakeClientEvent{doc: doc, token: token}
+	close(watcher.events)
+
+	adapted := NewAdaptedChangeStreamWatcher(watcher)
+
+	select {
+	case eventWithToken, ok := <-adapted.Events():
+		require.True(t, ok, "expected an adapted event before channel close")
+		assert.Equal(t, token, eventWithToken.ResumeToken,
+			"adapter must propagate the per-event resume token so consumers can checkpoint")
+		assert.Equal(t, doc, map[string]interface{}(eventWithToken.Event))
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for adapted event")
+	}
+}
+
+func TestAdaptedChangeStreamWatcher_MarkProcessedDelegatesToken(t *testing.T) {
+	token := []byte("token-to-persist")
+	watcher := &fakeClientWatcher{events: make(chan client.Event)}
+
+	adapted := NewAdaptedChangeStreamWatcher(watcher)
+
+	require.NoError(t, adapted.MarkProcessed(context.Background(), token))
+	require.Len(t, watcher.marked, 1)
+	assert.Equal(t, token, watcher.marked[0])
+}

--- a/store-client/pkg/datastore/providers/mongodb/watcher/watch_store.go
+++ b/store-client/pkg/datastore/providers/mongodb/watcher/watch_store.go
@@ -441,6 +441,17 @@ func (w *ChangeStreamWatcher) processNextEvent(ctx context.Context) {
 		return
 	}
 
+	// Attach this event's resume token (read via mongoEvent.GetResumeToken) so
+	// consumers can checkpoint exactly at the event they processed. The change
+	// stream cursor keeps advancing while consumers work, so checkpointing the
+	// cursor position instead could skip events that were never processed.
+	// The driver-owned bson.Raw aliases the current batch's pooled response
+	// buffer, which is recycled once the event loop calls Next() again — clone
+	// it so the token stays valid after the channel handoff.
+	if token := w.changeStream.ResumeToken(); len(token) > 0 {
+		event["_resumeToken"] = bson.Raw(append([]byte(nil), token...))
+	}
+
 	genericEvent := Event(event)
 
 	select {
@@ -495,8 +506,17 @@ func (w *ChangeStreamWatcher) MarkProcessed(ctx context.Context, token []byte) e
 
 		slog.Debug("Using change stream resume token", "client", w.clientName)
 	} else {
-		// Use the provided token
-		resumeTokenToStore = token
+		// Use the provided per-event token. Tokens originate from the change
+		// stream as raw BSON documents ({"_data": ...}), so store them as a
+		// document — the same shape SetResumeAfter expects when the token is
+		// read back on startup. Storing the plain byte slice would write a
+		// BSON binary value that fails to decode into TokenDoc.ResumeToken.
+		raw := bson.Raw(token)
+		if err := raw.Validate(); err != nil {
+			return fmt.Errorf("invalid resume token for client %s: %w", w.clientName, err)
+		}
+
+		resumeTokenToStore = raw
 
 		slog.Debug("Using provided resume token", "client", w.clientName)
 	}

--- a/store-client/pkg/datastore/providers/mongodb/watcher/watch_store_test.go
+++ b/store-client/pkg/datastore/providers/mongodb/watcher/watch_store_test.go
@@ -179,6 +179,23 @@ func TestChangeStreamWatcher_Start(t *testing.T) {
 		}
 
 		require.Len(t, receivedEvents, 2)
+
+		// Each event must carry its own resume token (its change stream _id)
+		// so consumers can checkpoint exactly at the event they processed.
+		for i, expectedID := range []bson.D{
+			{{Key: "ts", Value: int64(1)}, {Key: "t", Value: int32(1)}},
+			{{Key: "ts", Value: int64(2)}, {Key: "t", Value: int32(2)}},
+		} {
+			token, ok := receivedEvents[i]["_resumeToken"].(bson.Raw)
+			require.True(t, ok, "event %d should carry a bson.Raw _resumeToken", i)
+
+			expectedToken, err := bson.Marshal(expectedID)
+			require.NoError(t, err)
+			require.Equal(t, bson.Raw(expectedToken), token, "event %d resume token should match its _id", i)
+
+			delete(receivedEvents[i], "_resumeToken")
+		}
+
 		require.EqualValues(t, bson.M{
 			"operationType": "insert",
 			"documentKey":   bson.M{"id": int32(1)},
@@ -194,6 +211,83 @@ func TestChangeStreamWatcher_Start(t *testing.T) {
 		watcher.client = nil
 		err = watcher.Close(ctx)
 		require.NoError(t, err)
+	})
+
+	mt.Run("resume tokens remain valid across batch boundaries", func(mt *mtest.T) {
+		// Regression test: the injected _resumeToken must be a copy. The
+		// driver's ResumeToken() aliases the current batch's pooled response
+		// buffer, so a token captured for event N must stay intact after the
+		// watcher fetches the next batch (which recycles that buffer).
+		id1 := bson.D{{Key: "ts", Value: int64(10)}, {Key: "t", Value: int32(1)}}
+		id2 := bson.D{{Key: "ts", Value: int64(20)}, {Key: "t", Value: int32(2)}}
+
+		event1 := bson.D{
+			{Key: "operationType", Value: "insert"},
+			{Key: "documentKey", Value: bson.D{{Key: "id", Value: int32(1)}}},
+			{Key: "_id", Value: id1},
+		}
+		event2 := bson.D{
+			{Key: "operationType", Value: "insert"},
+			{Key: "documentKey", Value: bson.D{{Key: "id", Value: int32(2)}}},
+			{Key: "_id", Value: id2},
+		}
+
+		mt.AddMockResponses(
+			mtest.CreateCursorResponse(1, "testdb.testcollection", mtest.FirstBatch),
+			mtest.CreateCursorResponse(1, "testdb.testcollection", mtest.NextBatch, event1),
+			mtest.CreateCursorResponse(0, "testdb.testcollection", mtest.NextBatch, event2),
+		)
+
+		coll := mt.Client.Database("testdb").Collection("testcollection")
+		changeStream, err := coll.Watch(context.Background(), mongo.Pipeline{})
+		require.NoError(mt, err)
+
+		watcher := &ChangeStreamWatcher{
+			client:       mt.Client,
+			changeStream: changeStream,
+			// Unbuffered so the watcher can only fetch the next batch after
+			// the test has received the previous event.
+			eventChannel: make(chan Event),
+			clientName:   "testclient-token-lifetime",
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		watcher.Start(ctx)
+
+		receive := func() Event {
+			select {
+			case ev := <-watcher.Events():
+				return ev
+			case <-time.After(2 * time.Second):
+				t.Fatal("timeout waiting for event")
+				return nil
+			}
+		}
+
+		first := receive()
+		firstToken, ok := first["_resumeToken"].(bson.Raw)
+		require.True(t, ok, "first event should carry a bson.Raw _resumeToken")
+
+		// Receiving the second event guarantees the watcher advanced to the
+		// next batch, after which the first batch's buffer may be recycled.
+		second := receive()
+		secondToken, ok := second["_resumeToken"].(bson.Raw)
+		require.True(t, ok, "second event should carry a bson.Raw _resumeToken")
+
+		expectedFirst, err := bson.Marshal(id1)
+		require.NoError(t, err)
+		expectedSecond, err := bson.Marshal(id2)
+		require.NoError(t, err)
+
+		require.Equal(t, bson.Raw(expectedFirst), firstToken,
+			"first event's token must remain intact after the stream advanced to the next batch")
+		require.Equal(t, bson.Raw(expectedSecond), secondToken)
+
+		// Set client to nil before Close() - mtest manages client lifecycle
+		watcher.client = nil
+		require.NoError(t, watcher.Close(ctx))
 	})
 
 	mt.Run("Start exits goroutine on change stream error", func(mt *mtest.T) {
@@ -521,6 +615,79 @@ func TestChangeStreamWatcher_MarkProcessed(t *testing.T) {
 		err = watcher.Close(closeCtx)
 		require.NoError(t, err)
 
+	})
+
+	mt.Run("MarkProcessed stores provided per-event token as document", func(mt *mtest.T) {
+		// mock the UpdateOne response for storing the resume token
+		mt.AddMockResponses(mtest.CreateSuccessResponse())
+
+		resumeTokenCol := mt.Client.Database("tokendb").Collection("tokencollection")
+
+		// No change stream: the provided-token path must not consult the
+		// change stream cursor at all.
+		watcher := &ChangeStreamWatcher{
+			client:                    mt.Client,
+			resumeTokenCol:            resumeTokenCol,
+			clientName:                "testclient-provided-token",
+			resumeTokenUpdateTimeout:  5 * time.Second,
+			resumeTokenUpdateInterval: 1 * time.Second,
+		}
+
+		tokenBytes, err := bson.Marshal(resumeToken)
+		require.NoError(mt, err)
+
+		err = watcher.MarkProcessed(context.Background(), tokenBytes)
+		require.NoError(t, err)
+
+		// Verify the token was stored as a BSON document (the shape
+		// SetResumeAfter expects on restart), not as a binary blob.
+		startedEvents := mt.GetAllStartedEvents()
+		updateCommands := 0
+		for _, startedEvent := range startedEvents {
+			if startedEvent.CommandName == "update" {
+				updateCommands++
+
+				var cmdMap bson.M
+				require.NoError(t, bson.Unmarshal(startedEvent.Command, &cmdMap))
+
+				updates := cmdMap["updates"].(bson.A)
+				update0 := updates[0].(bson.M)
+
+				filter := update0["q"].(bson.M)
+				update := update0["u"].(bson.M)
+
+				require.EqualValues(t, bson.M{"clientName": "testclient-provided-token"}, filter)
+				expectedUpdate := bson.M{"$set": bson.M{"resumeToken": bson.M{"ts": int64(1), "t": int32(1)}}}
+				require.EqualValues(t, expectedUpdate, update)
+			}
+		}
+		require.Equal(t, 1, updateCommands, "Expected exactly one update command")
+
+		mt.ClearEvents()
+	})
+
+	mt.Run("MarkProcessed rejects invalid provided token", func(mt *mtest.T) {
+		resumeTokenCol := mt.Client.Database("tokendb").Collection("tokencollection")
+
+		watcher := &ChangeStreamWatcher{
+			client:                    mt.Client,
+			resumeTokenCol:            resumeTokenCol,
+			clientName:                "testclient-invalid-token",
+			resumeTokenUpdateTimeout:  5 * time.Second,
+			resumeTokenUpdateInterval: 1 * time.Second,
+		}
+
+		err := watcher.MarkProcessed(context.Background(), []byte("not-a-bson-document"))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid resume token")
+
+		// No update command should have been issued
+		for _, startedEvent := range mt.GetAllStartedEvents() {
+			require.NotEqual(t, "update", startedEvent.CommandName,
+				"no update command should be issued for an invalid token")
+		}
+
+		mt.ClearEvents()
 	})
 }
 

--- a/tests/fault_remediation_resume_token_test.go
+++ b/tests/fault_remediation_resume_token_test.go
@@ -1,0 +1,156 @@
+//go:build amd64_group && mongodb
+// +build amd64_group,mongodb
+
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"tests/helpers"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+// NOTE: This test reads the MongoDB ResumeTokens collection directly via mongosh
+// (see helpers/mongodb.go). Direct MongoDB access is normally discouraged in E2E
+// tests, but the change-stream checkpoint IS a MongoDB artifact with no
+// application-level API — asserting on it requires reading the collection.
+// The test is read-only with respect to ResumeTokens.
+
+// TestFaultRemediationResumeTokenAdvances verifies that fault-remediation
+// persists its MongoDB change-stream checkpoint after processing live events.
+//
+// Background (GitHub issue #1513): the MongoDB datastore adapter dropped the
+// per-event resume token (hardcoded it to empty), and fault-remediation's
+// safeMarkProcessed intentionally skips empty tokens (they normally mark
+// synthesized cold-start events). As a result the fault-remediation checkpoint
+// never advanced: every restart replayed the entire event history since the
+// stored token (OOM/CrashLoopBackOff under large backlogs), and fresh installs
+// never wrote a token at all, silently losing events that arrived while the
+// pod was down.
+//
+// This test drives a live health event through the full pipeline
+// (quarantine → drain → remediation CR) and asserts the fault-remediation
+// resume token document was created/advanced as a result:
+//
+//  1. Record the current fault-remediation resume token document (may be absent)
+//  2. Trigger the standard remediation flow on a test node
+//  3. Wait for the RebootNode CR to be created and completed — proof that
+//     fault-remediation processed a live change-stream event
+//  4. Assert the resume token document now exists and differs from step 1
+//
+// On a build without the fix the token document never changes (and on a fresh
+// install never appears), so step 4 times out and the test fails.
+func TestFaultRemediationResumeTokenAdvances(t *testing.T) {
+	feature := features.New("TestFaultRemediationResumeTokenAdvances").
+		WithLabel("suite", "fault-remediation-resume-token")
+
+	var (
+		testCtx     *helpers.QuarantineTestContext
+		mongoPod    string
+		tokenBefore string
+	)
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		require.NoError(t, err)
+
+		t.Log("Finding MongoDB pod")
+		mongoPod = helpers.GetMongoDBPrimaryPodName(ctx, t, client)
+		t.Logf("Using MongoDB pod: %s", mongoPod)
+
+		// On small clusters a single quarantined node can exceed the default
+		// circuit breaker percentage, and a TRIPPED breaker halts
+		// fault-quarantine event dequeuing entirely — no quarantine, no
+		// remediation, no test. Raise the threshold to 100% for the duration
+		// of the test (the ConfigMap is backed up and restored in Teardown)
+		// and reset any TRIPPED state left behind by earlier quarantine tests.
+		var newCtx context.Context
+		newCtx, testCtx, _ = helpers.SetupQuarantineTestWithOptions(ctx, t, c, "", &helpers.QuarantineSetupOptions{
+			CircuitBreakerPercentage: 100,
+			CircuitBreakerDuration:   "5m",
+			CircuitBreakerState:      "CLOSED",
+			CircuitBreakerCursorMode: "RESUME",
+		})
+		t.Logf("Selected test node: %s", testCtx.NodeName)
+
+		// Make the node visible to TeardownFaultRemediation so it can clean
+		// remediation labels/annotations and RebootNode CRs.
+		newCtx = context.WithValue(newCtx, helpers.FRKeyNodeName, testCtx.NodeName)
+
+		t.Log("Cleaning up existing rebootnode CRs")
+		require.NoError(t, helpers.DeleteAllCRs(newCtx, t, client, helpers.RebootNodeGVK))
+
+		// Record the checkpoint BEFORE driving any events so the assertion
+		// can require it to advance (mere existence is not enough — a token
+		// written by an earlier run must not satisfy this test).
+		restConfig := client.RESTConfig()
+		tokenBefore = helpers.GetResumeTokenDoc(newCtx, t, restConfig, client, mongoPod, "fault-remediation")
+		t.Logf("fault-remediation resume token before test: %s", tokenBefore)
+
+		return newCtx
+	})
+
+	feature.Assess("resume token advances after fault-remediation processes a live event",
+		func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+			client, err := c.NewClient()
+			require.NoError(t, err)
+			restConfig := client.RESTConfig()
+
+			// Drive a live event through quarantine → drain → remediation.
+			helpers.TriggerFullRemediationFlow(ctx, t, client, testCtx.NodeName, 15)
+
+			// A completed CR proves fault-remediation consumed a live
+			// change-stream event (the quarantined-and-drained update).
+			cr := helpers.WaitForCR(ctx, t, client, testCtx.NodeName, helpers.RebootNodeGVK)
+			t.Logf("Remediation CR created and completed: %s", cr.GetName())
+
+			// The checkpoint is upserted right after each processed event;
+			// give it a generous window to absorb mongosh exec latency.
+			var tokenAfter string
+			require.Eventually(t, func() bool {
+				tokenAfter = helpers.GetResumeTokenDoc(ctx, t, restConfig, client, mongoPod, "fault-remediation")
+				return !strings.Contains(tokenAfter, "NOT_FOUND") && tokenAfter != tokenBefore
+			}, 2*time.Minute, 5*time.Second,
+				"fault-remediation must persist its change-stream checkpoint after processing "+
+					"a live event (GitHub issue #1513: resume token dropped → replay/OOM on restart). "+
+					"Token before: %s", tokenBefore)
+
+			t.Logf("fault-remediation resume token after test: %s", tokenAfter)
+			t.Log("Resume token advanced — checkpoint persistence verified")
+
+			return ctx
+		})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		// Clears the fault (healthy event), removes remediation labels and
+		// annotations from the node, and deletes RebootNode CRs.
+		ctx = helpers.TeardownFaultRemediation(ctx, t, c)
+
+		// Waits for the node to be fully clean, restores the original
+		// fault-quarantine ConfigMap (default breaker percentage), and
+		// restarts fault-quarantine to pick it up.
+		return helpers.TeardownQuarantineTest(ctx, t, c)
+	})
+
+	testEnv.Test(t, feature.Feature())
+}

--- a/tests/fault_remediation_resume_token_test.go
+++ b/tests/fault_remediation_resume_token_test.go
@@ -19,6 +19,7 @@ package tests
 
 import (
 	"context"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -105,6 +106,9 @@ func TestFaultRemediationResumeTokenAdvances(t *testing.T) {
 		// written by an earlier run must not satisfy this test).
 		restConfig := client.RESTConfig()
 		tokenBefore = helpers.GetResumeTokenDoc(newCtx, t, restConfig, client, mongoPod, "fault-remediation")
+		require.True(t,
+			strings.Contains(tokenBefore, "NOT_FOUND") || resumeTokenData(tokenBefore) != "",
+			"unexpected ResumeTokens read for fault-remediation: %s", tokenBefore)
 		t.Logf("fault-remediation resume token before test: %s", tokenBefore)
 
 		return newCtx
@@ -126,10 +130,19 @@ func TestFaultRemediationResumeTokenAdvances(t *testing.T) {
 
 			// The checkpoint is upserted right after each processed event;
 			// give it a generous window to absorb mongosh exec latency.
+			// Compare the extracted _data payloads rather than raw mongosh
+			// output so transient stdout noise (warnings, partial reads)
+			// can never satisfy the "token advanced" predicate: anything
+			// that is not a well-formed token document parses to "" and the
+			// poll simply retries.
+			dataBefore := resumeTokenData(tokenBefore)
+
 			var tokenAfter string
 			require.Eventually(t, func() bool {
 				tokenAfter = helpers.GetResumeTokenDoc(ctx, t, restConfig, client, mongoPod, "fault-remediation")
-				return !strings.Contains(tokenAfter, "NOT_FOUND") && tokenAfter != tokenBefore
+				dataAfter := resumeTokenData(tokenAfter)
+
+				return dataAfter != "" && dataAfter != dataBefore
 			}, 2*time.Minute, 5*time.Second,
 				"fault-remediation must persist its change-stream checkpoint after processing "+
 					"a live event (GitHub issue #1513: resume token dropped → replay/OOM on restart). "+
@@ -153,4 +166,20 @@ func TestFaultRemediationResumeTokenAdvances(t *testing.T) {
 	})
 
 	testEnv.Test(t, feature.Feature())
+}
+
+// resumeTokenDataRe matches the _data hex payload in a printjson'd resume
+// token document, e.g. `resumeToken: { _data: '826A69...' }`.
+var resumeTokenDataRe = regexp.MustCompile(`_data:\s*['"]([0-9A-Fa-f]+)['"]`)
+
+// resumeTokenData extracts the resume token's _data payload from mongosh
+// output. Returns "" for NOT_FOUND, empty, or malformed output so callers
+// can treat only well-formed token documents as comparable.
+func resumeTokenData(doc string) string {
+	match := resumeTokenDataRe.FindStringSubmatch(doc)
+	if match == nil {
+		return ""
+	}
+
+	return match[1]
 }


### PR DESCRIPTION
## Summary

Fixes #1513.

MongoDB change-stream events were delivered without their per-event resume tokens. `AdaptedChangeStreamWatcher.Events()` therefore passed an empty token to fault-remediation, causing `safeMarkProcessed()` to skip checkpoint persistence entirely.

As a result, fault-remediation repeatedly replayed the same events after restarting. Large replay backlogs could fill the controller workqueue and cause OOM CrashLoops.

This change propagates each MongoDB event’s resume token through the store-client stack and persists it in the BSON document format expected by `SetResumeAfter`.

## Changes

### Propagate per-event resume tokens

- Capture the MongoDB driver’s resume token immediately after decoding each change-stream event
- Clone the driver-owned `bson.Raw` so it remains valid after the cursor advances
- Attach the token as the internal `_resumeToken` field
- Add `bson.Raw` handling to `mongoEvent.GetResumeToken()`
- Propagate the token through `AdaptedChangeStreamWatcher.Events()`

The internal `_resumeToken` field does not become part of the delivered health-event document; consumers continue receiving the extracted `fullDocument`.

### Persist tokens in the correct BSON shape

Provided tokens are validated as raw BSON documents and stored as embedded documents rather than BSON binary values.

This matches:

- the existing cursor-fallback storage format
- `TokenDoc.ResumeToken`
- the format expected by `SetResumeAfter` during startup

Existing stored MongoDB resume tokens remain compatible.

### Preserve cold-start behavior

Synthesized cold-start events continue to carry an empty token. These events are intentionally excluded from change-stream checkpoint updates so they cannot advance the cursor past unprocessed live events.

### Add regression coverage

Added tests covering:

- extraction of injected `bson.Raw` resume tokens
- propagation through the MongoDB datastore adapter
- preservation of tokens after the change stream advances
- persistence of provided tokens as BSON documents
- rejection of invalid resume-token data without a database write
- end-to-end: `TestFaultRemediationResumeTokenAdvances` (`tests/fault_remediation_resume_token_test.go`) drives a live fault through quarantine → drain → remediation on a real cluster and asserts the fault-remediation resume-token document advances

## Operational Notes

On an installation already affected by #1513, the first restart after upgrading may replay events from the previously frozen checkpoint once. Checkpoint persistence now advances during that replay, so subsequent restarts resume after the last processed event.

PostgreSQL uses a separate provider implementation and is unchanged.

## Validation

### Unit / module tests

- Full `store-client` test suite passes (including `-race` on the changed packages)
- Downstream fault-remediation, fault-quarantine, node-drainer, event-exporter, and health-events-analyzer tests pass

### End-to-end verification (kind + Tilt, MongoDB backend)

Added `TestFaultRemediationResumeTokenAdvances` (build tags `amd64_group && mongodb`): sends a fatal health event, waits for the full quarantine -> drain -> RebootNode CR flow to complete, and asserts the stored `fault-remediation` resume token advanced.

Verified in both directions on a local kind cluster (Tilt, 5 KWOK GPU nodes):

| Build deployed | Result |
|---|---|
| This PR | PASS — RebootNode CR completed, resume token advanced |
| Parent `e28f6ce4` (pre-fix) | FAIL — CR completed but the stored token never changed (the #1513 defect: events processed, checkpoint frozen) |
| This PR (restored) | PASS |

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Resume tokens are now correctly extracted and preserved per MongoDB change-stream event.
  * Resume tokens remain intact and valid across batch boundaries.
  * Processed resume tokens are stored in the proper BSON format for checkpointing.
  * Invalid resume tokens are rejected, preventing incorrect checkpoint updates.

* **Tests**
  * Added unit tests for resume-token extraction, event propagation, adapter behavior, and MarkProcessed handling.
  * Added an E2E test to verify resume-token advancement after fault remediation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->