### PR TITLE
fix: retry events received while an equivalent maintenance CR is in progress

### DIFF
--- a/commons/pkg/statemanager/statemanager.go
+++ b/commons/pkg/statemanager/statemanager.go
@@ -403,9 +403,13 @@ func validateStateTransition(nodeName, currentValue string, exists bool, targetS
 		// remediation-succeeded and remediation-failed are terminal for a single failure, but a
 		// partial recovery (a tracked failure clears while the node stays quarantined) lets
 		// fault-remediation recompute the node label from the remaining active failures, which can
-		// move between the two terminal remediation outcomes.
-		RemediationSucceededLabelValue: {RemediationFailedLabelValue},
-		RemediationFailedLabelValue:    {RemediationSucceededLabelValue},
+		// move between the two terminal remediation outcomes. Both states can also return to
+		// remediating: a new remediation-ready event can arrive after an equivalent maintenance CR
+		// completed (for example a post-reboot fault while the node is still quarantined), and a
+		// failed CR is retried with a new CR, so fault-remediation legitimately starts another
+		// remediation cycle within the same quarantine session.
+		RemediationSucceededLabelValue: {RemediationFailedLabelValue, RemediatingLabelValue},
+		RemediationFailedLabelValue:    {RemediationSucceededLabelValue, RemediatingLabelValue},
 	}
 
 	currentState := NVSentinelStateLabelValue(currentValue)

--- a/commons/pkg/statemanager/statemanager.go
+++ b/commons/pkg/statemanager/statemanager.go
@@ -70,7 +70,8 @@
 //   - [NO LABEL]: No nvsentinel-state label present (healthy node)
 //   - [TERMINAL]: Terminal states with no forward transitions
 //   - remediation-succeeded and remediation-failed are terminal for a single failure, but
-//     fault-remediation may recompute between them on a partial recovery (see below)
+//     fault-remediation may recompute between them on a partial recovery, and either may
+//     return to remediating when a new remediation cycle starts (see below)
 //   - All state names match the dgxc.nvidia.com/nvsentinel-state label values
 //   - Label removal (removeStateLabel=true) bypasses all validation
 //
@@ -98,6 +99,12 @@
 //	  remediation-succeeded → remediation-failed (fault-remediation: a remaining active failure is
 //	                                              unsupported or failed remediation)
 //
+//	Re-remediation (a new remediation cycle starts while the node stays quarantined):
+//	  remediation-succeeded → remediating (fault-remediation: a new remediation-ready event
+//	                                       arrived after the previous maintenance CR completed,
+//	                                       e.g. a post-reboot fault)
+//	  remediation-failed → remediating    (fault-remediation: a failed CR is retried with a new CR)
+//
 //	Label Removal (from ANY state):
 //	  * → (no label)               (removeStateLabel=true - supports canceled drains)
 //
@@ -115,8 +122,10 @@
 //	Invalid Transitions:
 //	  drain-succeeded → drain-failed           (cannot reverse drain result)
 //	  drain-failed → remediating               (terminal state - no remediation)
-//	  remediation-succeeded → * (except remediation-failed via partial-recovery recompute)
-//	  remediation-failed → * (except remediation-succeeded via partial-recovery recompute)
+//	  remediation-succeeded → * (except remediation-failed via partial-recovery recompute
+//	                             and remediating via re-remediation)
+//	  remediation-failed → * (except remediation-succeeded via partial-recovery recompute
+//	                          and remediating via re-remediation)
 //
 // # Example Sequences
 //
@@ -150,11 +159,13 @@
 // drain-failed has no valid forward transitions (only label removal):
 //   - drain-failed: Remediation doesn't process failed drains
 //
-// remediation-succeeded and remediation-failed are terminal for a single failure. The only
-// forward transition allowed is between the two of them, when fault-remediation recomputes the
-// node label from the remaining active failures during a partial recovery:
-//   - remediation-succeeded: Success state (may be recomputed to remediation-failed)
-//   - remediation-failed: Failure state (may be recomputed to remediation-succeeded)
+// remediation-succeeded and remediation-failed are terminal for a single failure. Two forward
+// transitions are allowed: between the two of them, when fault-remediation recomputes the node
+// label from the remaining active failures during a partial recovery, and back to remediating,
+// when fault-remediation starts a new remediation cycle (a remediation-ready event arrived after
+// the previous maintenance CR completed, or a failed CR is retried with a new CR):
+//   - remediation-succeeded: Success state (may be recomputed or re-enter remediating)
+//   - remediation-failed: Failure state (may be recomputed or re-enter remediating)
 package statemanager
 
 import (

--- a/commons/pkg/statemanager/statemanager_test.go
+++ b/commons/pkg/statemanager/statemanager_test.go
@@ -307,6 +307,11 @@ func TestStateTransitionValidProgression(t *testing.T) {
 		// Partial-recovery recompute between terminal remediation outcomes (fault-remediation)
 		{"RemediationFailed to RemediationSucceeded", string(RemediationFailedLabelValue), RemediationSucceededLabelValue, true, false},
 		{"RemediationSucceeded to RemediationFailed", string(RemediationSucceededLabelValue), RemediationFailedLabelValue, true, false},
+		// A new remediation cycle can start after a terminal remediation outcome while the node
+		// stays quarantined: a post-session event creates a new CR after the previous CR
+		// completed (issue #1536), and a failed CR is retried with a new CR (fault-remediation).
+		{"RemediationSucceeded to Remediating", string(RemediationSucceededLabelValue), RemediatingLabelValue, true, false},
+		{"RemediationFailed to Remediating", string(RemediationFailedLabelValue), RemediatingLabelValue, true, false},
 
 		// Unexpected progressions (return error but label is still updated)
 		// This allows callers to emit error metrics while labels reflect reality

--- a/fault-remediation/pkg/metrics/metrics.go
+++ b/fault-remediation/pkg/metrics/metrics.go
@@ -24,6 +24,7 @@ import (
 const (
 	CRStatusCreated = "created"
 	CRStatusSkipped = "skipped"
+	CRStatusWaiting = "waiting"
 )
 
 var (

--- a/fault-remediation/pkg/reconciler/reconciler.go
+++ b/fault-remediation/pkg/reconciler/reconciler.go
@@ -59,6 +59,10 @@ import (
 
 const (
 	coldStartBatchSize = 1000
+
+	// defaultInProgressRequeueDelay is how often an event held behind an equivalent
+	// in-progress maintenance CR is re-evaluated for a terminal CR state.
+	defaultInProgressRequeueDelay = 30 * time.Second
 )
 
 type ReconcilerConfig struct {
@@ -73,6 +77,9 @@ type ReconcilerConfig struct {
 	UpdateRetryDelay   time.Duration
 	StartFresh         bool
 	ColdStartAfterTime time.Time
+	// InProgressRequeueDelay overrides how often events held behind an in-progress
+	// maintenance CR are re-evaluated. Zero uses defaultInProgressRequeueDelay.
+	InProgressRequeueDelay time.Duration
 }
 
 // FaultRemediationReconciler reconciles health events from a datastore change stream
@@ -719,10 +726,10 @@ func (r *FaultRemediationReconciler) recomputePartialRecoveryNodeLabel(
 // remediated.
 //
 // Success is taken from the event's own FaultRemediated=true status when present. When it is nil,
-// the event may have been skipped behind an equivalent maintenance CR (handleExistingCRSkip
-// advances the resume token without writing FaultRemediated and does not requeue, so the flag can
-// stay nil). In that case we consult the actual covering-CR status: an in-progress or succeeded CR
-// means the node is being/has been remediated, matching the normal flow that sets
+// the event may still be waiting behind an equivalent maintenance CR (handleExistingCRInProgress
+// requeues the event without writing FaultRemediated until the CR reaches a terminal state, so the
+// flag can stay nil). In that case we consult the actual covering-CR status: an in-progress or
+// succeeded CR means the node is being/has been remediated, matching the normal flow that sets
 // remediation-succeeded on CR creation.
 func (r *FaultRemediationReconciler) activeEventForcesRemediationFailed(
 	ctx context.Context,
@@ -933,6 +940,55 @@ func findHealthEventStatusByID(
 	return &events[0].HealthEventStatus, nil
 }
 
+// eventResolvedInStore reports whether the event no longer needs remediation according to
+// its current datastore record:
+//   - faultremediated=true: the event was remediated elsewhere.
+//   - The record's quarantine status is UnQuarantined/Cancelled: the session ended and the
+//     cancellation flow owns the event's terminal status.
+//   - faultremediated=false while the event is no longer part of the node's live quarantine
+//     annotation: a durable terminal record written by cancellation cleanup
+//     (closeStaleEquivalentEvents). With a still-active quarantine, false only means the
+//     last remediation attempt failed and the event must remain retryable.
+//
+// A missing record is treated as unresolved so the normal flow decides what to do with it.
+func (r *FaultRemediationReconciler) eventResolvedInStore(
+	ctx context.Context,
+	healthEventStore datastore.HealthEventStore,
+	healthEvent *protos.HealthEvent,
+	eventID string,
+) (bool, error) {
+	status, err := findHealthEventStatusByID(ctx, healthEventStore, healthEvent.NodeName, eventID)
+	if err != nil {
+		return false, err
+	}
+
+	if status == nil {
+		return false, nil
+	}
+
+	if status.FaultRemediated != nil && *status.FaultRemediated {
+		return true, nil
+	}
+
+	if status.NodeQuarantined != nil {
+		quarantined := string(*status.NodeQuarantined)
+		if quarantined == string(model.UnQuarantined) || quarantined == string(model.Cancelled) {
+			return true, nil
+		}
+	}
+
+	if status.FaultRemediated != nil {
+		activeQuarantine, err := r.nodeHasActiveQuarantine(ctx, healthEvent)
+		if err != nil {
+			return false, err
+		}
+
+		return !activeQuarantine, nil
+	}
+
+	return false, nil
+}
+
 // handleRemediationEvent processes remediation for quarantined nodes
 func (r *FaultRemediationReconciler) handleRemediationEvent(
 	ctx context.Context,
@@ -970,7 +1026,19 @@ func (r *FaultRemediationReconciler) handleRemediationEvent(
 		return res, err
 	}
 
-	shouldCreateCR, existingCR, existingCRRemediated, err := r.checkExistingCRStatus(ctx, healthEvent,
+	// The event carries the status snapshot captured by the change stream (or cold start).
+	// By the time it is acted on — especially after waiting in the workqueue behind an
+	// in-progress CR — another actor may have closed it: a cancellation closes covered
+	// events via closeStaleEquivalentEvents, or the quarantine session may have ended.
+	// Re-read the current status so a stale snapshot cannot start a remediation for a
+	// session that is already over.
+	res, err, done = r.trySkipResolvedEvent(ctx, healthEventStore, eventWithToken, watcherInstance,
+		healthEvent, healthEventWithStatus.ID)
+	if done {
+		return res, err
+	}
+
+	decision, err := r.checkExistingCRStatus(ctx, healthEvent,
 		healthEventWithStatus.CreatedAt, groupConfig)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -991,9 +1059,9 @@ func (r *FaultRemediationReconciler) handleRemediationEvent(
 		return ctrl.Result{}, fmt.Errorf("error checking existing CR status: %w", err)
 	}
 
-	if !shouldCreateCR {
-		return r.handleExistingCRSkip(ctx, eventWithToken, watcherInstance, healthEventStore, nodeName, existingCR,
-			existingCRRemediated)
+	if !decision.shouldCreate {
+		return r.handleEventCoveredByExistingCR(ctx, decision, eventWithToken, watcherInstance, healthEventStore,
+			nodeName)
 	}
 
 	result, err := r.runLogCollectorAndRemediate(ctx, healthEvent, healthEventWithStatus, eventWithToken,
@@ -1046,6 +1114,70 @@ func (r *FaultRemediationReconciler) trySkipEvent(
 	return ctrl.Result{}, nil, true
 }
 
+// trySkipResolvedEvent returns (result, err, true) when the event's current datastore
+// record shows it no longer needs remediation; otherwise (zero, nil, false).
+func (r *FaultRemediationReconciler) trySkipResolvedEvent(
+	ctx context.Context,
+	healthEventStore datastore.HealthEventStore,
+	eventWithToken datastore.EventWithToken,
+	watcherInstance datastore.ChangeStreamWatcher,
+	healthEvent *protos.HealthEvent,
+	eventID string,
+) (ctrl.Result, error, bool) {
+	span := tracing.SpanFromContext(ctx)
+	nodeName := healthEvent.NodeName
+
+	resolved, err := r.eventResolvedInStore(ctx, healthEventStore, healthEvent, eventID)
+	if err != nil {
+		metrics.ProcessingErrors.WithLabelValues("status_recheck_error", nodeName).Inc()
+		slog.ErrorContext(ctx, "Error re-reading event status", "node", nodeName, "error", err)
+
+		span.SetAttributes(
+			attribute.String("fault_remediation.error.type", "status_recheck_error"),
+			attribute.String("fault_remediation.error.message", err.Error()),
+		)
+		tracing.RecordError(span, err)
+
+		return ctrl.Result{}, fmt.Errorf("error re-reading event status: %w", err), true
+	}
+
+	if !resolved {
+		return ctrl.Result{}, nil, false
+	}
+
+	slog.InfoContext(ctx, "Event already resolved in the datastore, skipping",
+		"node", nodeName,
+		"eventID", eventID)
+
+	span.SetAttributes(
+		attribute.String("fault_remediation.skip_reason", "resolved_in_datastore"),
+	)
+
+	metrics.EventsProcessed.WithLabelValues(metrics.CRStatusSkipped, nodeName).Inc()
+
+	result, err := r.markProcessedOrError(ctx, watcherInstance, eventWithToken, nodeName)
+
+	return result, err, true
+}
+
+// handleEventCoveredByExistingCR routes a shouldCreate=false decision: an event behind a
+// still-in-progress CR is requeued, an event covered by a terminal CR is finalized.
+func (r *FaultRemediationReconciler) handleEventCoveredByExistingCR(
+	ctx context.Context,
+	decision existingCRDecision,
+	eventWithToken datastore.EventWithToken,
+	watcherInstance datastore.ChangeStreamWatcher,
+	healthEventStore datastore.HealthEventStore,
+	nodeName string,
+) (ctrl.Result, error) {
+	if decision.inProgress {
+		return r.handleExistingCRInProgress(ctx, nodeName, decision.crName)
+	}
+
+	return r.handleExistingCRSkip(ctx, eventWithToken, watcherInstance, healthEventStore, nodeName, decision.crName,
+		decision.remediated)
+}
+
 func shouldMarkSkippedEventUnsupported(healthEventWithStatus model.HealthEventWithStatus,
 	groupConfig *common.EquivalenceGroupConfig) bool {
 	if healthEventWithStatus.HealthEvent == nil || groupConfig != nil {
@@ -1068,9 +1200,11 @@ func shouldMarkSkippedEventUnsupported(healthEventWithStatus model.HealthEventWi
 // covered by the remediation groups recorded on the node annotation.
 //
 // This runs when FQ sends UnQuarantined/Cancelled. At that point the quarantine
-// session is over, so events skipped behind an equivalent in-progress CR must
+// session is over, so events waiting behind an equivalent in-progress CR must
 // become durable terminal records; otherwise FR cold start can replay them and
-// create duplicate maintenance CRs after the node is schedulable again.
+// create duplicate maintenance CRs after the node is schedulable again. Live
+// requeued events observe these terminal records through the pre-remediation
+// datastore re-check (eventResolvedInStore) and stop requeueing.
 //
 // The cleanup is equivalence-group scoped. It only closes events whose computed
 // remediation group, or a configured superseding group, matches a group from the
@@ -1206,7 +1340,9 @@ func unresolvedRemediationReadyEventsCondition(nodeName string) query.Condition 
 	return query.And(conditions...)
 }
 
-// handleExistingCRSkip logs, records metrics, marks the event processed, and returns.
+// handleExistingCRSkip finalizes an event covered by an equivalent maintenance CR that
+// reached a terminal state: logs, records metrics, writes the remediated status when the
+// completed CR covers the event, marks the event processed, and returns.
 func (r *FaultRemediationReconciler) handleExistingCRSkip(
 	ctx context.Context,
 	eventWithToken datastore.EventWithToken,
@@ -1238,6 +1374,43 @@ func (r *FaultRemediationReconciler) handleExistingCRSkip(
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// handleExistingCRInProgress requeues an event whose equivalence group is covered by a
+// maintenance CR that has not reached a terminal state yet. The event is deliberately
+// neither checkpointed nor finalized: a post-reboot event can arrive while the covering
+// CR is still InProgress, and dropping it here would strand the node with an actionable
+// fault but no remediation (issue #1536). Requeueing re-evaluates the CR until it becomes
+// terminal; evaluateExistingCR then either marks the event remediated (event covered by
+// the completed remediation session) or allows a new CR (post-session event or failed CR).
+func (r *FaultRemediationReconciler) handleExistingCRInProgress(
+	ctx context.Context,
+	nodeName, existingCR string,
+) (ctrl.Result, error) {
+	requeueDelay := r.inProgressRequeueDelay()
+
+	span := tracing.SpanFromContext(ctx)
+	slog.InfoContext(ctx, "Existing CR is still in progress, requeueing event until the CR reaches a terminal state",
+		"node", nodeName,
+		"existingCR", existingCR,
+		"requeueAfter", requeueDelay)
+
+	span.SetAttributes(
+		attribute.String("fault_remediation.skip_reason", "existing_cr_in_progress"),
+		attribute.String("fault_remediation.existing_cr.name", existingCR),
+	)
+
+	metrics.EventsProcessed.WithLabelValues(metrics.CRStatusWaiting, nodeName).Inc()
+
+	return ctrl.Result{RequeueAfter: requeueDelay}, nil
+}
+
+func (r *FaultRemediationReconciler) inProgressRequeueDelay() time.Duration {
+	if r.Config.InProgressRequeueDelay > 0 {
+		return r.Config.InProgressRequeueDelay
+	}
+
+	return defaultInProgressRequeueDelay
 }
 
 // runLogCollectorAndRemediate runs the log collector, then performs remediation and updates status.
@@ -1417,30 +1590,31 @@ func (r *FaultRemediationReconciler) updateNodeRemediatedStatus(
 }
 
 func (r *FaultRemediationReconciler) checkExistingCRStatus(ctx context.Context, healthEvent *protos.HealthEvent,
-	eventCreatedAt time.Time, groupConfig *common.EquivalenceGroupConfig) (bool, string, bool, error) {
+	eventCreatedAt time.Time, groupConfig *common.EquivalenceGroupConfig) (existingCRDecision, error) {
 	nodeName := healthEvent.NodeName
+	allowCreate := existingCRDecision{shouldCreate: true}
 
 	if groupConfig == nil {
-		return true, "", false, nil
+		return allowCreate, nil
 	}
 
 	state, _, err := r.annotationManager.GetRemediationState(ctx, nodeName)
 	if err != nil {
 		slog.ErrorContext(ctx, "Error getting remediation state", "node", nodeName, "error", err)
-		return true, "", false, fmt.Errorf("error getting remediation state: %w", err)
+		return allowCreate, fmt.Errorf("error getting remediation state: %w", err)
 	}
 
 	if state == nil {
 		slog.WarnContext(ctx, "Remediation state is nil for node, allowing CR creation",
 			"node", nodeName)
 
-		return true, "", false, nil
+		return allowCreate, nil
 	}
 
 	statusChecker := r.Config.RemediationClient.GetStatusChecker()
 	if statusChecker == nil {
 		slog.WarnContext(ctx, "Status checker is not available, allowing creation")
-		return true, "", false, nil
+		return allowCreate, nil
 	}
 
 	groupStates := sortedEquivalenceGroupStates(common.FilterEquivalenceGroupStates(groupConfig, state))
@@ -1450,7 +1624,7 @@ func (r *FaultRemediationReconciler) checkExistingCRStatus(ctx context.Context, 
 	for _, groupState := range groupStates {
 		decision := r.evaluateExistingCR(ctx, statusChecker, groupState, eventCreatedAt, nodeName)
 		if !decision.shouldCreate {
-			return false, decision.crName, decision.remediated, nil
+			return decision, nil
 		}
 
 		if decision.removeGroup {
@@ -1461,11 +1635,11 @@ func (r *FaultRemediationReconciler) checkExistingCRStatus(ctx context.Context, 
 
 	if len(groupsToRemove) > 0 {
 		if err := r.annotationManager.RemoveGroupsFromState(ctx, nodeName, groupsToRemove); err != nil {
-			return true, "", false, fmt.Errorf("failed to remove groups from annotation: %w", err)
+			return allowCreate, fmt.Errorf("failed to remove groups from annotation: %w", err)
 		}
 	}
 
-	return true, "", false, nil
+	return allowCreate, nil
 }
 
 type existingCRDecision struct {
@@ -1473,6 +1647,9 @@ type existingCRDecision struct {
 	crName       string
 	remediated   bool
 	removeGroup  bool
+	// inProgress marks a shouldCreate=false decision caused by a covering CR that has
+	// not reached a terminal state yet. Such events must be retried, not finalized.
+	inProgress bool
 }
 
 func (r *FaultRemediationReconciler) evaluateExistingCR(
@@ -1487,9 +1664,10 @@ func (r *FaultRemediationReconciler) evaluateExistingCR(
 
 	switch crState {
 	case crstatus.CRStateInProgress:
-		slog.InfoContext(ctx, "CR exists and is in progress, skipping event", "node", nodeName, "crName", crName)
+		slog.InfoContext(ctx, "CR exists and is in progress, waiting for terminal state",
+			"node", nodeName, "crName", crName)
 
-		return existingCRDecision{shouldCreate: false, crName: crName}
+		return existingCRDecision{shouldCreate: false, crName: crName, inProgress: true}
 	case crstatus.CRStateSucceeded:
 		return r.evaluateSucceededCR(ctx, groupState, eventCreatedAt, nodeName)
 	case crstatus.CRStateNotFound, crstatus.CRStateFailed:

--- a/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_e2e_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -156,8 +157,10 @@ type MockHealthEventStore struct {
 	UpdateHealthEventStatusFn        func(ctx context.Context, id string, status datastore.HealthEventStatus) error
 	FindHealthEventsByQueryFn        func(ctx context.Context, builder datastore.QueryBuilder) ([]datastore.HealthEventWithStatus, error)
 	FindHealthEventsByQueryBatchedFn func(ctx context.Context, builder datastore.QueryBuilder, batchSize int, fn func([]datastore.HealthEventWithStatus) error) error
-	updateCalled                     int
-	findHealthEventsByQueryCalls     int
+	// Counters are written from the controller goroutine and polled by tests, so they
+	// must be atomic to stay race-free.
+	updateCalled                 atomic.Int64
+	findHealthEventsByQueryCalls atomic.Int64
 }
 
 // UpdateHealthEventStatus updates a health event status (mock implementation)
@@ -210,7 +213,7 @@ func (m *MockHealthEventStore) FindLatestEventForNode(ctx context.Context, nodeN
 }
 
 func (m *MockHealthEventStore) FindHealthEventsByQuery(ctx context.Context, builder datastore.QueryBuilder) ([]datastore.HealthEventWithStatus, error) {
-	m.findHealthEventsByQueryCalls++
+	m.findHealthEventsByQueryCalls.Add(1)
 
 	if m.FindHealthEventsByQueryFn != nil {
 		return m.FindHealthEventsByQueryFn(ctx, builder)
@@ -304,14 +307,15 @@ func TestMain(m *testing.M) {
 		NodeReader:        ctrlRuntimeAPIReader,
 		UpdateMaxRetries:  3,
 		UpdateRetryDelay:  100 * time.Millisecond,
+		// Keep requeues fast so tests can observe events waiting behind an
+		// in-progress CR being reconsidered within an Eventually window.
+		InProgressRequeueDelay: 200 * time.Millisecond,
 	}
 
 	// Create mock health event store
-	mockStore = &MockHealthEventStore{
-		updateCalled: 0,
-	}
+	mockStore = &MockHealthEventStore{}
 	mockStore.UpdateHealthEventStatusFn = func(ctx context.Context, id string, status datastore.HealthEventStatus) error {
-		mockStore.updateCalled++
+		mockStore.updateCalled.Add(1)
 		return nil
 	}
 
@@ -503,16 +507,26 @@ func TestCRBasedDeduplication_Integration(t *testing.T) {
 		// Update CR status to InProgress
 		updateRebootNodeStatus(ctx, t, firstCRName, "InProgress")
 
-		// Event 2: Should be skipped
-		shouldCreateCR, existingCR, _, err := r.checkExistingCRStatus(ctx, event1.HealthEventWithStatus.HealthEvent, time.Now(), groupConfig)
+		// Event 2: must wait for the in-progress CR instead of being finalized
+		decision, err := r.checkExistingCRStatus(ctx, event1.HealthEventWithStatus.HealthEvent, time.Now(), groupConfig)
 		assert.NoError(t, err)
-		assert.False(t, shouldCreateCR, "Second event should be skipped")
-		assert.Equal(t, firstCRName, existingCR)
+		assert.False(t, decision.shouldCreate, "Second event should not create a CR yet")
+		assert.True(t, decision.inProgress, "Second event must be requeued while the CR is in progress")
+		assert.Equal(t, firstCRName, decision.crName)
 
 		// Verify annotation still exists and unchanged
 		state, _, err := r.annotationManager.GetRemediationState(ctx, nodeName)
 		require.NoError(t, err)
 		assert.Equal(t, firstCRName, state.EquivalenceGroups["restart"].MaintenanceCR)
+
+		// Once the CR completes, a post-session event (created after the CR) must be
+		// allowed to create a new CR instead of staying stranded (issue #1536).
+		updateRebootNodeStatus(ctx, t, firstCRName, "Succeeded")
+
+		decision, err = r.checkExistingCRStatus(ctx, event1.HealthEventWithStatus.HealthEvent, time.Now(), groupConfig)
+		assert.NoError(t, err)
+		assert.True(t, decision.shouldCreate, "post-session event must be reconsidered after the CR succeeds")
+		assert.False(t, decision.inProgress)
 
 		// Cleanup
 		gvr := schema.GroupVersionResource{
@@ -565,9 +579,9 @@ func TestCRBasedDeduplication_Integration(t *testing.T) {
 		updateRebootNodeStatus(ctx, t, firstCRName, "Failed")
 
 		// Event 2: Should create new CR after cleanup
-		shouldCreateCR, _, _, err := r.checkExistingCRStatus(ctx, event1.HealthEventWithStatus.HealthEvent, time.Now(), groupConfig)
+		decision, err := r.checkExistingCRStatus(ctx, event1.HealthEventWithStatus.HealthEvent, time.Now(), groupConfig)
 		assert.NoError(t, err)
-		assert.True(t, shouldCreateCR, "Should allow retry after CR failed")
+		assert.True(t, decision.shouldCreate, "Should allow retry after CR failed")
 
 		// Verify annotation was cleaned up.
 		// Use Eventually because RemoveGroupsFromState writes to the API server but
@@ -669,10 +683,11 @@ func TestCRBasedDeduplication_Integration(t *testing.T) {
 			event2Health)
 		assert.NoError(t, err)
 
-		shouldCreateCR, existingCR, _, err := r.checkExistingCRStatus(ctx, event2Health, time.Now(), groupConfig2)
+		decision, err := r.checkExistingCRStatus(ctx, event2Health, time.Now(), groupConfig2)
 		assert.NoError(t, err)
-		assert.False(t, shouldCreateCR, "RESTART_BM should be deduplicated with RESTART_VM (same group)")
-		assert.Equal(t, firstCRName, existingCR)
+		assert.False(t, decision.shouldCreate, "RESTART_BM should be deduplicated with RESTART_VM (same group)")
+		assert.True(t, decision.inProgress, "deduplicated event must wait for the in-progress CR")
+		assert.Equal(t, firstCRName, decision.crName)
 
 		// Verify both actions map to same group
 		assert.Equal(t, groupConfig1, groupConfig2, "Both actions should be in same equivalence group")
@@ -755,10 +770,11 @@ func TestEventSequenceWithAnnotations_Integration(t *testing.T) {
 	groupConfig, err = common.GetGroupConfigForEvent(cfg.RemediationClient.GetConfig().RemediationActions,
 		event2)
 	assert.NoError(t, err)
-	shouldCreate, existingCR, _, err := r.checkExistingCRStatus(ctx, event2, time.Now(), groupConfig)
+	decision, err := r.checkExistingCRStatus(ctx, event2, time.Now(), groupConfig)
 	assert.NoError(t, err)
-	assert.False(t, shouldCreate, "RESTART_VM should be skipped (same group as RESTART_BM)")
-	assert.Equal(t, crName1, existingCR)
+	assert.False(t, decision.shouldCreate, "RESTART_VM should be skipped (same group as RESTART_BM)")
+	assert.True(t, decision.inProgress, "RESTART_VM must wait for the in-progress CR")
+	assert.Equal(t, crName1, decision.crName)
 
 	// Verify annotation unchanged
 	state, _, err := r.annotationManager.GetRemediationState(ctx, nodeName)
@@ -775,11 +791,12 @@ func TestEventSequenceWithAnnotations_Integration(t *testing.T) {
 	groupConfig, err = common.GetGroupConfigForEvent(cfg.RemediationClient.GetConfig().RemediationActions,
 		event3)
 	assert.NoError(t, err)
-	shouldCreate, _, remediatedByExistingCR, err := r.checkExistingCRStatus(ctx, event3, time.Now().Add(-time.Minute),
+	decision, err = r.checkExistingCRStatus(ctx, event3, time.Now().Add(-time.Minute),
 		groupConfig)
 	assert.NoError(t, err)
-	assert.False(t, shouldCreate, "RESTART_BM should be skipped (CR succeeded)")
-	assert.True(t, remediatedByExistingCR, "successful existing CR should cover equivalent event")
+	assert.False(t, decision.shouldCreate, "RESTART_BM should be skipped (CR succeeded)")
+	assert.True(t, decision.remediated, "successful existing CR should cover equivalent event")
+	assert.False(t, decision.inProgress)
 
 	// Event 4: CR fails - annotation cleaned, retry allowed
 	updateRebootNodeStatus(ctx, t, crName1, "Failed")
@@ -791,9 +808,9 @@ func TestEventSequenceWithAnnotations_Integration(t *testing.T) {
 	groupConfig, err = common.GetGroupConfigForEvent(cfg.RemediationClient.GetConfig().RemediationActions,
 		event4)
 	assert.NoError(t, err)
-	shouldCreate, _, _, err = r.checkExistingCRStatus(ctx, event4, time.Now(), groupConfig)
+	decision, err = r.checkExistingCRStatus(ctx, event4, time.Now(), groupConfig)
 	assert.NoError(t, err)
-	assert.True(t, shouldCreate, "Should allow retry after failure")
+	assert.True(t, decision.shouldCreate, "Should allow retry after failure")
 
 	// Verify annotation cleaned.
 	// Use Eventually because RemoveGroupsFromState writes to the API server but
@@ -918,10 +935,11 @@ func TestEventSequenceWithSupersedingGroup(t *testing.T) {
 	shouldSkip, err := r.shouldSkipEvent(ctx, event2, groupConfig)
 	assert.NoError(t, err)
 	assert.False(t, shouldSkip, "Shouldn't valid health event")
-	shouldCreate, existingCR, _, err := r.checkExistingCRStatus(ctx, event2.HealthEvent, time.Now(), groupConfig)
+	decision, err := r.checkExistingCRStatus(ctx, event2.HealthEvent, time.Now(), groupConfig)
 	assert.NoError(t, err)
-	assert.False(t, shouldCreate, "COMPONENT_RESET should be skipped (same group as RESTART_BM)")
-	assert.Equal(t, crName1, existingCR)
+	assert.False(t, decision.shouldCreate, "COMPONENT_RESET should be skipped (same group as RESTART_BM)")
+	assert.True(t, decision.inProgress, "COMPONENT_RESET must wait for the in-progress superseding CR")
+	assert.Equal(t, crName1, decision.crName)
 
 	// Verify annotation unchanged
 	state, _, err := r.annotationManager.GetRemediationState(ctx, nodeName)
@@ -945,11 +963,12 @@ func TestEventSequenceWithSupersedingGroup(t *testing.T) {
 	groupConfig, err = common.GetGroupConfigForEvent(cfg.RemediationClient.GetConfig().RemediationActions,
 		event3)
 	assert.NoError(t, err)
-	shouldCreate, _, remediatedByExistingCR, err := r.checkExistingCRStatus(ctx, event3, time.Now().Add(-time.Minute),
+	decision, err = r.checkExistingCRStatus(ctx, event3, time.Now().Add(-time.Minute),
 		groupConfig)
 	assert.NoError(t, err)
-	assert.False(t, shouldCreate, "COMPONENT_RESET should be skipped (superseding CR succeeded)")
-	assert.True(t, remediatedByExistingCR, "successful superseding CR should cover reset event")
+	assert.False(t, decision.shouldCreate, "COMPONENT_RESET should be skipped (superseding CR succeeded)")
+	assert.True(t, decision.remediated, "successful superseding CR should cover reset event")
+	assert.False(t, decision.inProgress)
 
 	// Event 4: COMPONENT_RESET in group reset with superseding group restart should be created after CR-1 fails
 	updateRebootNodeStatus(ctx, t, crName1, "Failed")
@@ -967,9 +986,9 @@ func TestEventSequenceWithSupersedingGroup(t *testing.T) {
 	groupConfig, err = common.GetGroupConfigForEvent(cfg.RemediationClient.GetConfig().RemediationActions,
 		event4)
 	assert.NoError(t, err)
-	shouldCreate, _, _, err = r.checkExistingCRStatus(ctx, event4, time.Now(), groupConfig)
+	decision, err = r.checkExistingCRStatus(ctx, event4, time.Now(), groupConfig)
 	assert.NoError(t, err)
-	assert.True(t, shouldCreate, "Should allow retry after failure")
+	assert.True(t, decision.shouldCreate, "Should allow retry after failure")
 
 	// Verify annotation cleaned.
 	// Use Eventually because RemoveGroupsFromState writes to the API server but
@@ -1027,10 +1046,11 @@ func TestEventSequenceWithSupersedingGroup(t *testing.T) {
 	groupConfig, err = common.GetGroupConfigForEvent(cfg.RemediationClient.GetConfig().RemediationActions,
 		event6)
 	assert.NoError(t, err)
-	shouldCreate, existingCR, _, err = r.checkExistingCRStatus(ctx, event6, time.Now(), groupConfig)
+	decision, err = r.checkExistingCRStatus(ctx, event6, time.Now(), groupConfig)
 	assert.NoError(t, err)
-	assert.False(t, shouldCreate, "COMPONENT_RESET should be skipped (same group as previous COMPONENT_RESET)")
-	assert.Equal(t, crName2, existingCR)
+	assert.False(t, decision.shouldCreate, "COMPONENT_RESET should be skipped (same group as previous COMPONENT_RESET)")
+	assert.True(t, decision.inProgress, "COMPONENT_RESET must wait for the in-progress reset CR")
+	assert.Equal(t, crName2, decision.crName)
 
 	// Verify annotation unchanged
 	state, _, err = r.annotationManager.GetRemediationState(ctx, nodeName)
@@ -1057,9 +1077,9 @@ func TestEventSequenceWithSupersedingGroup(t *testing.T) {
 	groupConfig, err = common.GetGroupConfigForEvent(cfg.RemediationClient.GetConfig().RemediationActions,
 		event7.HealthEvent)
 	assert.NoError(t, err)
-	shouldCreate, existingCR, _, err = r.checkExistingCRStatus(ctx, event7.HealthEvent, time.Now(), groupConfig)
+	decision, err = r.checkExistingCRStatus(ctx, event7.HealthEvent, time.Now(), groupConfig)
 	assert.NoError(t, err)
-	assert.True(t, shouldCreate, "COMPONENT_RESET should be allowed (different group as previous COMPONENT_RESET)")
+	assert.True(t, decision.shouldCreate, "COMPONENT_RESET should be allowed (different group as previous COMPONENT_RESET)")
 
 	// Verify annotation unchanged
 	state, _, err = r.annotationManager.GetRemediationState(ctx, nodeName)
@@ -1097,9 +1117,9 @@ func TestEventSequenceWithSupersedingGroup(t *testing.T) {
 	groupConfig, err = common.GetGroupConfigForEvent(cfg.RemediationClient.GetConfig().RemediationActions,
 		event8)
 	assert.NoError(t, err)
-	shouldCreate, existingCR, _, err = r.checkExistingCRStatus(ctx, event8, time.Now(), groupConfig)
+	decision, err = r.checkExistingCRStatus(ctx, event8, time.Now(), groupConfig)
 	assert.NoError(t, err)
-	assert.True(t, shouldCreate, "COMPONENT_RESET should be allowed (same group as previous "+
+	assert.True(t, decision.shouldCreate, "COMPONENT_RESET should be allowed (same group as previous "+
 		"COMPONENT_RESET that completed)")
 
 	// Verify annotation removed for CR-2 but not CR-3.
@@ -1184,7 +1204,7 @@ func TestFullReconcilerWithMockedMongoDB_E2E(t *testing.T) {
 	}
 
 	t.Run("CompleteFlow_WithEventLoop", func(t *testing.T) {
-		mockStore.updateCalled = 0
+		mockStore.updateCalled.Store(0)
 
 		beforeReceived := getCounterValue(t, metrics.TotalEventsReceived)
 		beforeDuration := getHistogramCount(t, metrics.EventHandlingDuration)
@@ -1239,35 +1259,32 @@ func TestFullReconcilerWithMockedMongoDB_E2E(t *testing.T) {
 		}
 		assert.Equal(t, 1, crCount, "Only one CR should exist for the node at this point")
 
-		// Event 2: Set CR to InProgress, send duplicate event (different action, same group)
+		// Event 2: Set CR to InProgress, send duplicate event (different action, same group).
+		// Regression test for issue #1536: the duplicate must be requeued while the CR is
+		// in progress — not checkpointed or finalized — and automatically reconsidered
+		// once the CR reaches a terminal state.
 		updateRebootNodeStatus(ctx, t, crName, "InProgress")
 
 		// Record MongoDB update count before sending duplicate event
-		updateCountBefore := mockStore.updateCalled
+		updateCountBefore := mockStore.updateCalled.Load()
+		_, markedBeforeEvent2, _, _ := mockWatcher.GetCallCounts()
+		waitingBefore := getCounterVecValue(t, metrics.EventsProcessed, metrics.CRStatusWaiting, nodeName)
 
 		eventID2 := "test-event-id-2"
-		event2 := createQuarantineEvent(eventID2, nodeName, protos.RecommendedAction_RESTART_VM)
+		// The event predates the CR so it belongs to the running remediation session and
+		// must be marked remediated (not produce a second CR) once the CR succeeds.
+		event2 := createQuarantineEventCreatedAt(eventID2, nodeName, protos.RecommendedAction_RESTART_VM,
+			time.Now().Add(-time.Hour))
 		eventToken2 := datastore.EventWithToken{
 			Event:       map[string]interface{}(event2),
 			ResumeToken: []byte("test-token-2"),
 		}
 		mockWatcher.EventsChan <- eventToken2
 
-		// Wait for event to be processed and verify deduplication
+		// Wait until the event has been evaluated at least once against the in-progress CR
 		assert.Eventually(t, func() bool {
-			state, _, err = reconciler.annotationManager.GetRemediationState(ctx, nodeName)
-			if err != nil {
-				t.Logf("Failed to get remediation state: %v", err)
-				return false
-			}
-
-			// Check if the CR name is still the original one (deduplication working)
-			if grp, ok := state.EquivalenceGroups["restart"]; ok {
-				return grp.MaintenanceCR == crName
-			}
-
-			return false
-		}, 5*time.Second, 100*time.Millisecond, "Event should be processed and deduplicated")
+			return getCounterVecValue(t, metrics.EventsProcessed, metrics.CRStatusWaiting, nodeName) > waitingBefore
+		}, 5*time.Second, 50*time.Millisecond, "duplicate event should wait behind the in-progress CR")
 
 		// Verify annotation is still on the node and unchanged
 		node, err = testClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
@@ -1290,8 +1307,38 @@ func TestFullReconcilerWithMockedMongoDB_E2E(t *testing.T) {
 		}
 		assert.Equal(t, 1, crCount2, "Should still be only one CR (duplicate event was skipped)")
 
-		// Verify MongoDB update was NOT called (event was skipped due to deduplication)
-		assert.Equal(t, updateCountBefore, mockStore.updateCalled, "MongoDB update should not be called for skipped event")
+		// While waiting, the event must not be finalized: no status write, no checkpoint.
+		assert.Equal(t, updateCountBefore, mockStore.updateCalled.Load(),
+			"MongoDB update should not be called while the event waits for the in-progress CR")
+		_, markedWhileWaiting, _, _ := mockWatcher.GetCallCounts()
+		assert.Equal(t, markedBeforeEvent2, markedWhileWaiting,
+			"resume token should not advance while the event waits for the in-progress CR")
+
+		// Complete the CR: the waiting event must be reconsidered automatically and marked
+		// remediated (covered by the completed remediation session) without a new CR.
+		updateRebootNodeStatus(ctx, t, crName, "Succeeded")
+
+		assert.Eventually(t, func() bool {
+			return mockStore.updateCalled.Load() > updateCountBefore
+		}, 5*time.Second, 50*time.Millisecond,
+			"waiting event should be marked remediated after the CR succeeds")
+
+		assert.Eventually(t, func() bool {
+			_, marked, _, _ := mockWatcher.GetCallCounts()
+			return marked > markedBeforeEvent2
+		}, 5*time.Second, 50*time.Millisecond,
+			"waiting event should be checkpointed after it is resolved")
+
+		// Still exactly one CR: resolving the waiting event must not create a duplicate.
+		crList2, err = testDynamic.Resource(gvr).List(ctx, metav1.ListOptions{})
+		require.NoError(t, err)
+		crCount2 = 0
+		for _, item := range crList2.Items {
+			if item.Object["spec"].(map[string]interface{})["nodeName"] == nodeName {
+				crCount2++
+			}
+		}
+		assert.Equal(t, 1, crCount2, "resolved same-session event must not create a second CR")
 
 		// Event 3: Send unquarantine event
 		unquarantineEvent := createUnquarantineEvent(nodeName)
@@ -1330,10 +1377,12 @@ func TestFullReconcilerWithMockedMongoDB_E2E(t *testing.T) {
 		afterDuration := getHistogramCount(t, metrics.EventHandlingDuration)
 		createdCount := getCounterVecValue(t, metrics.EventsProcessed, metrics.CRStatusCreated, nodeName)
 		skippedCount := getCounterVecValue(t, metrics.EventsProcessed, metrics.CRStatusSkipped, nodeName)
+		waitingCount := getCounterVecValue(t, metrics.EventsProcessed, metrics.CRStatusWaiting, nodeName)
 
 		assert.GreaterOrEqual(t, afterReceived, beforeReceived+3, "TotalEventsReceived should increment for all events")
 		assert.GreaterOrEqual(t, createdCount, float64(1), "EventsProcessed with cr_status=created should increment for CR creation")
-		assert.GreaterOrEqual(t, skippedCount, float64(1), "EventsProcessed with cr_status=skipped should increment for duplicate event")
+		assert.GreaterOrEqual(t, waitingCount, float64(1), "EventsProcessed with cr_status=waiting should increment while the duplicate event waits")
+		assert.GreaterOrEqual(t, skippedCount, float64(1), "EventsProcessed with cr_status=skipped should increment when the duplicate event is covered")
 		assert.GreaterOrEqual(t, afterDuration, beforeDuration+3, "EventHandlingDuration should record observations for all events")
 
 		// Cleanup
@@ -1420,6 +1469,20 @@ func createQuarantineEvent(eventID string, nodeName string, action protos.Recomm
 	}
 }
 
+// createQuarantineEventCreatedAt is createQuarantineEvent with an explicit document
+// creation time, used to position the event inside or outside a remediation session.
+func createQuarantineEventCreatedAt(
+	eventID string,
+	nodeName string,
+	action protos.RecommendedAction,
+	createdAt time.Time,
+) datastore.Event {
+	event := createQuarantineEvent(eventID, nodeName, action)
+	event["fullDocument"].(map[string]interface{})["createdAt"] = createdAt.UTC().Format(time.RFC3339Nano)
+
+	return event
+}
+
 // Helper to create unquarantine event
 func createUnquarantineEvent(nodeName string) datastore.Event {
 	return datastore.Event{
@@ -1458,7 +1521,7 @@ func createCancelledEvent(eventID string, nodeName string, action protos.Recomme
 
 // TestReconciler_CancelledEventCleansAnnotation tests that a cancelled event removes the equivalence group from the annotation
 func TestReconciler_CancelledEventCleansAnnotation(t *testing.T) {
-	mockStore.updateCalled = 0
+	mockStore.updateCalled.Store(0)
 	ctx, cancel := context.WithTimeout(testContext, 30*time.Second)
 	defer cancel()
 
@@ -1532,7 +1595,7 @@ func TestReconciler_CancelledEventCleansAnnotation(t *testing.T) {
 
 // TestReconciler_CancelledEventClearsAllGroups tests that a cancelled event clears all equivalence groups
 func TestReconciler_CancelledEventClearsAllGroups(t *testing.T) {
-	mockStore.updateCalled = 0
+	mockStore.updateCalled.Store(0)
 	ctx, cancel := context.WithTimeout(testContext, 30*time.Second)
 	defer cancel()
 
@@ -1613,7 +1676,7 @@ func TestReconciler_CancelledEventClearsAllGroups(t *testing.T) {
 
 // TestReconciler_CancelledAndUnQuarantinedClearAllState tests that Cancelled followed by UnQuarantined clears all state
 func TestReconciler_CancelledAndUnQuarantinedClearAllState(t *testing.T) {
-	mockStore.updateCalled = 0
+	mockStore.updateCalled.Store(0)
 	ctx, cancel := context.WithTimeout(testContext, 30*time.Second)
 	defer cancel()
 
@@ -1846,7 +1909,7 @@ func cleanupNodeAnnotations(ctx context.Context, t *testing.T, nodeName string) 
 
 // TestMetrics_CRGenerationDuration tests that CR generation duration metric is recorded
 func TestMetrics_CRGenerationDuration(t *testing.T) {
-	mockStore.updateCalled = 0
+	mockStore.updateCalled.Store(0)
 	ctx, cancel := context.WithTimeout(testContext, 30*time.Second)
 	defer cancel()
 
@@ -1994,7 +2057,7 @@ func makeColdStartHealthEvent(
 //  2. HandleColdStart enqueues the missed event into the controller workqueue
 //  3. Controller-runtime processes it and FR creates a maintenance CR
 func TestHandleColdStart_RemediationFlow(t *testing.T) {
-	mockStore.updateCalled = 0
+	mockStore.updateCalled.Store(0)
 
 	ctx, cancel := context.WithTimeout(testContext, 30*time.Second)
 	defer cancel()
@@ -2059,7 +2122,7 @@ func TestHandleColdStart_RemediationFlow(t *testing.T) {
 //  2. While FR was down, the event was cancelled
 //  3. HandleColdStart picks up the cancellation and clears remediation state
 func TestHandleColdStart_CancellationFlow(t *testing.T) {
-	mockStore.updateCalled = 0
+	mockStore.updateCalled.Store(0)
 
 	ctx, cancel := context.WithTimeout(testContext, 30*time.Second)
 	defer cancel()

--- a/fault-remediation/pkg/reconciler/reconciler_test.go
+++ b/fault-remediation/pkg/reconciler/reconciler_test.go
@@ -1048,6 +1048,7 @@ func TestCRBasedDeduplication(t *testing.T) {
 		remediationCreatedByGroup map[string]time.Time
 		expectedShouldCreateCR    bool
 		expectedRemediated        bool
+		expectedInProgress        bool
 	}{
 		{
 			name:                   "NoStatusChecker_AllowRemediation",
@@ -1071,11 +1072,14 @@ func TestCRBasedDeduplication(t *testing.T) {
 			expectedShouldCreateCR: true,
 		},
 		{
-			name:                   "CRSucceeded_SkipRemediation",
+			// The mock maps shouldSkipCRCreation=true to CRStateInProgress, so this covers
+			// the in-progress wait decision.
+			name:                   "CRInProgress_WaitsForTerminalState",
 			existingCRs:            map[string]string{"restart": "maintenance-node-123"},
 			shouldSkipCRCreation:   []bool{true},
 			groupConfig:            getGroupConfig("restart", nil),
 			expectedShouldCreateCR: false,
+			expectedInProgress:     true,
 		},
 		{
 			name:                   "MultipleCRs_SkipRemediation_MultipleEquivalenceGroups_OneInProgress",
@@ -1083,6 +1087,7 @@ func TestCRBasedDeduplication(t *testing.T) {
 			shouldSkipCRCreation:   []bool{false, true},
 			groupConfig:            getGroupConfig("restart", []string{"reset-GPU-123"}),
 			expectedShouldCreateCR: false,
+			expectedInProgress:     true,
 		},
 		{
 			name:                   "MultipleCRs_AllowRemediation_MultipleEquivalenceGroups_BothCompleted",
@@ -1136,6 +1141,7 @@ func TestCRBasedDeduplication(t *testing.T) {
 			eventCreatedAt:         time.Date(2026, 5, 14, 10, 0, 0, 0, time.UTC),
 			expectedShouldCreateCR: false,
 			expectedRemediated:     false,
+			expectedInProgress:     true,
 			remediationCreatedByGroup: map[string]time.Time{
 				"restart":       time.Date(2026, 5, 14, 10, 0, 0, 0, time.UTC),
 				"reset-GPU-123": time.Date(2026, 5, 14, 10, 1, 0, 0, time.UTC),
@@ -1177,10 +1183,303 @@ func TestCRBasedDeduplication(t *testing.T) {
 			healthEvent := &protos.HealthEvent{
 				NodeName: "test-node",
 			}
-			shouldCreateCR, _, remediated, err := r.checkExistingCRStatus(ctx, healthEvent, tt.eventCreatedAt, tt.groupConfig)
+			decision, err := r.checkExistingCRStatus(ctx, healthEvent, tt.eventCreatedAt, tt.groupConfig)
 			assert.NoError(t, err)
-			assert.Equal(t, tt.expectedShouldCreateCR, shouldCreateCR)
-			assert.Equal(t, tt.expectedRemediated, remediated)
+			assert.Equal(t, tt.expectedShouldCreateCR, decision.shouldCreate)
+			assert.Equal(t, tt.expectedRemediated, decision.remediated)
+			assert.Equal(t, tt.expectedInProgress, decision.inProgress)
+		})
+	}
+}
+
+// TestInProgressCREventRequeuedUntilTerminal is the regression test for issue #1536: an
+// event that arrives while an equivalent maintenance CR is still InProgress must be
+// requeued — without advancing the resume token or finalizing the event — and must be
+// automatically reconsidered once the CR reaches a terminal state.
+func TestInProgressCREventRequeuedUntilTerminal(t *testing.T) {
+	crCreatedAt := time.Date(2026, 7, 24, 2, 38, 18, 0, time.UTC)
+
+	tests := []struct {
+		name           string
+		eventCreatedAt time.Time
+		terminalState  crstatus.CRState
+		expectNewCR    bool
+	}{
+		{
+			// The production incident: post-reboot events arrived while the RebootNode CR
+			// was still InProgress and were silently dropped. They are post-session
+			// observations and must produce a new CR once the old CR completes.
+			name:           "PostSessionEvent_NewCRAfterCRSucceeds",
+			eventCreatedAt: crCreatedAt.Add(5 * time.Minute),
+			terminalState:  crstatus.CRStateSucceeded,
+			expectNewCR:    true,
+		},
+		{
+			name:           "SameSessionEvent_MarkedRemediatedAfterCRSucceeds",
+			eventCreatedAt: crCreatedAt.Add(-time.Minute),
+			terminalState:  crstatus.CRStateSucceeded,
+			expectNewCR:    false,
+		},
+		{
+			name:           "PostSessionEvent_NewCRAfterCRFails",
+			eventCreatedAt: crCreatedAt.Add(5 * time.Minute),
+			terminalState:  crstatus.CRStateFailed,
+			expectNewCR:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			nodeName := "test-node"
+			eventID := "post-reboot-event"
+
+			crStates := map[string]crstatus.CRState{"maintenance-cr-1": crstatus.CRStateInProgress}
+			createCalls := 0
+			mockK8sClient := &MockK8sClient{
+				createMaintenanceResourceFn: func(context.Context, *events.HealthEventData,
+					*common.EquivalenceGroupConfig) (string, error) {
+					createCalls++
+					return "maintenance-cr-2", nil
+				},
+				annotationManagerOverride: &MockNodeAnnotationManager{
+					existingCRs:       map[string]string{"restart": "maintenance-cr-1"},
+					existingCRCreated: crCreatedAt,
+				},
+				mockStatusChecker: &mockStatusChecker{stateByCR: crStates},
+			}
+
+			cfg := ReconcilerConfig{
+				RemediationClient: mockK8sClient,
+				StateManager: &statemanager.MockStateManager{
+					UpdateNVSentinelStateNodeLabelFn: func(context.Context, string,
+						statemanager.NVSentinelStateLabelValue, bool) (bool, error) {
+						return true, nil
+					},
+				},
+				InProgressRequeueDelay: 42 * time.Millisecond,
+			}
+			r := NewFaultRemediationReconciler(nil, nil, nil, cfg, false)
+
+			mockWatcher := &MockChangeStreamWatcher{}
+
+			var statusWrites []datastore.HealthEventStatus
+			mockStore := &MockHealthEventStore{
+				UpdateHealthEventStatusFn: func(_ context.Context, id string, status datastore.HealthEventStatus) error {
+					assert.Equal(t, eventID, id)
+					statusWrites = append(statusWrites, status)
+					return nil
+				},
+			}
+
+			healthEventDoc := &events.HealthEventDoc{
+				ID: eventID,
+				HealthEventWithStatus: model.HealthEventWithStatus{
+					CreatedAt: tt.eventCreatedAt,
+					HealthEvent: &protos.HealthEvent{
+						NodeName:          nodeName,
+						RecommendedAction: protos.RecommendedAction_RESTART_BM,
+					},
+					HealthEventStatus: &protos.HealthEventStatus{
+						NodeQuarantined:        string(model.AlreadyQuarantined),
+						UserPodsEvictionStatus: &protos.OperationStatus{Status: string(model.AlreadyDrained)},
+					},
+				},
+			}
+			eventWithToken := datastore.EventWithToken{
+				Event:       testRawHealthEvent(eventID, nodeName, protos.RecommendedAction_RESTART_BM),
+				ResumeToken: []byte("resume-token"),
+			}
+
+			// While the CR is InProgress the event must be requeued and left untouched.
+			result, err := r.handleRemediationEvent(ctx, healthEventDoc, eventWithToken, mockWatcher, mockStore)
+			assert.NoError(t, err)
+			assert.Equal(t, cfg.InProgressRequeueDelay, result.RequeueAfter,
+				"event behind an in-progress CR must be requeued")
+			_, markProcessedCount, _, _ := mockWatcher.GetCallCounts()
+			assert.Equal(t, 0, markProcessedCount, "resume token must not advance while waiting")
+			assert.Empty(t, statusWrites, "faultremediated must stay unset while waiting")
+			assert.Equal(t, 0, createCalls, "no CR may be created while an equivalent CR is in progress")
+
+			// The CR reaches a terminal state; the requeued event must now be resolved.
+			crStates["maintenance-cr-1"] = tt.terminalState
+
+			result, err = r.handleRemediationEvent(ctx, healthEventDoc, eventWithToken, mockWatcher, mockStore)
+			assert.NoError(t, err)
+			assert.True(t, result.IsZero())
+			_, markProcessedCount, _, _ = mockWatcher.GetCallCounts()
+			assert.Equal(t, 1, markProcessedCount, "resume token must advance once the event is resolved")
+
+			if tt.expectNewCR {
+				assert.Equal(t, 1, createCalls, "a new CR must be created once the old CR is terminal")
+			} else {
+				assert.Equal(t, 0, createCalls, "a covered same-session event must not create a new CR")
+			}
+
+			// Both outcomes leave a durable terminal status on the event.
+			if assert.Len(t, statusWrites, 1) {
+				assert.NotNil(t, statusWrites[0].FaultRemediated)
+				assert.True(t, *statusWrites[0].FaultRemediated)
+			}
+		})
+	}
+}
+
+func TestInProgressRequeueDelayDefault(t *testing.T) {
+	r := NewFaultRemediationReconciler(nil, nil, nil, ReconcilerConfig{RemediationClient: &MockK8sClient{}}, false)
+	assert.Equal(t, defaultInProgressRequeueDelay, r.inProgressRequeueDelay())
+
+	r.Config.InProgressRequeueDelay = time.Second
+	assert.Equal(t, time.Second, r.inProgressRequeueDelay())
+}
+
+// TestStaleEventSnapshotResolvedInStoreIsNotRemediated verifies the datastore re-check
+// that guards CR creation: an event snapshot that sat in the workqueue (for example
+// requeued behind an in-progress CR) must not start a remediation when its datastore
+// record was meanwhile closed or its quarantine session ended. A failed-attempt record
+// (faultremediated=false) with a live quarantine must stay retryable.
+func TestStaleEventSnapshotResolvedInStoreIsNotRemediated(t *testing.T) {
+	remediatedTrue := true
+	remediatedFalse := false
+	quarantined := datastore.Quarantined
+	unquarantined := datastore.UnQuarantined
+	cancelled := datastore.Status(string(model.Cancelled))
+
+	tests := []struct {
+		name             string
+		currentStatus    datastore.HealthEventStatus
+		activeQuarantine bool
+		expectResolved   bool
+	}{
+		{
+			name: "RemediatedElsewhere_SkipsWithoutNewCR",
+			currentStatus: datastore.HealthEventStatus{
+				FaultRemediated: &remediatedTrue,
+				NodeQuarantined: &quarantined,
+			},
+			activeQuarantine: true,
+			expectResolved:   true,
+		},
+		{
+			name:             "QuarantineSessionUnquarantined_SkipsWithoutNewCR",
+			currentStatus:    datastore.HealthEventStatus{NodeQuarantined: &unquarantined},
+			activeQuarantine: false,
+			expectResolved:   true,
+		},
+		{
+			name:             "QuarantineSessionCancelled_SkipsWithoutNewCR",
+			currentStatus:    datastore.HealthEventStatus{NodeQuarantined: &cancelled},
+			activeQuarantine: false,
+			expectResolved:   true,
+		},
+		{
+			// closeStaleEquivalentEvents writes faultremediated=false for covered events
+			// when the session ends; their own quarantine status can stay stale, so the
+			// live quarantine annotation is the discriminator.
+			name: "ClosedByCancellationCleanup_SkipsWithoutNewCR",
+			currentStatus: datastore.HealthEventStatus{
+				FaultRemediated: &remediatedFalse,
+				NodeQuarantined: &quarantined,
+			},
+			activeQuarantine: false,
+			expectResolved:   true,
+		},
+		{
+			// A failed remediation attempt writes faultremediated=false; while the
+			// quarantine session is still active the event must remain retryable.
+			name: "FailedAttemptStillQuarantined_ProceedsToRemediation",
+			currentStatus: datastore.HealthEventStatus{
+				FaultRemediated: &remediatedFalse,
+				NodeQuarantined: &quarantined,
+			},
+			activeQuarantine: true,
+			expectResolved:   false,
+		},
+		{
+			name:             "StillUnresolved_ProceedsToRemediation",
+			currentStatus:    datastore.HealthEventStatus{NodeQuarantined: &quarantined},
+			activeQuarantine: true,
+			expectResolved:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			nodeName := "test-node"
+			eventID := "stale-snapshot-event"
+			healthEvent := testAnnotationHealthEvent(
+				eventID, nodeName, protos.RecommendedAction_RESTART_BM, "GPU-test")
+
+			var nodeAnnotations map[string]string
+			if tt.activeQuarantine {
+				nodeAnnotations = quarantineAnnotationForTest(t, healthEvent)
+			}
+
+			createCalls := 0
+			mockK8sClient := &MockK8sClient{
+				createMaintenanceResourceFn: func(context.Context, *events.HealthEventData,
+					*common.EquivalenceGroupConfig) (string, error) {
+					createCalls++
+					return "maintenance-cr-new", nil
+				},
+				annotationManagerOverride: &MockNodeAnnotationManager{},
+			}
+
+			cfg := ReconcilerConfig{
+				RemediationClient: mockK8sClient,
+				StateManager: &statemanager.MockStateManager{
+					UpdateNVSentinelStateNodeLabelFn: func(context.Context, string,
+						statemanager.NVSentinelStateLabelValue, bool) (bool, error) {
+						return true, nil
+					},
+				},
+				NodeReader: newMockNodeReader(nodeAnnotations),
+			}
+			r := NewFaultRemediationReconciler(nil, nil, nil, cfg, false)
+
+			mockWatcher := &MockChangeStreamWatcher{}
+
+			statusWrites := 0
+			mockStore := &MockHealthEventStore{
+				FindHealthEventsByQueryFn: func(context.Context, datastore.QueryBuilder) (
+					[]datastore.HealthEventWithStatus, error) {
+					return []datastore.HealthEventWithStatus{{HealthEventStatus: tt.currentStatus}}, nil
+				},
+				UpdateHealthEventStatusFn: func(context.Context, string, datastore.HealthEventStatus) error {
+					statusWrites++
+					return nil
+				},
+			}
+
+			healthEventDoc := &events.HealthEventDoc{
+				ID: eventID,
+				HealthEventWithStatus: model.HealthEventWithStatus{
+					CreatedAt:   time.Date(2026, 7, 24, 2, 43, 11, 0, time.UTC),
+					HealthEvent: healthEvent,
+					HealthEventStatus: &protos.HealthEventStatus{
+						NodeQuarantined:        string(model.Quarantined),
+						UserPodsEvictionStatus: &protos.OperationStatus{Status: string(model.StatusSucceeded)},
+					},
+				},
+			}
+			eventWithToken := datastore.EventWithToken{
+				Event:       testRawHealthEvent(eventID, nodeName, protos.RecommendedAction_RESTART_BM),
+				ResumeToken: []byte("resume-token"),
+			}
+
+			result, err := r.handleRemediationEvent(ctx, healthEventDoc, eventWithToken, mockWatcher, mockStore)
+			assert.NoError(t, err)
+			assert.True(t, result.IsZero())
+			_, markProcessedCount, _, _ := mockWatcher.GetCallCounts()
+			assert.Equal(t, 1, markProcessedCount, "event must be checkpointed either way")
+
+			if tt.expectResolved {
+				assert.Equal(t, 0, createCalls, "a resolved event must not create a CR from a stale snapshot")
+				assert.Equal(t, 0, statusWrites, "a resolved event must not be rewritten")
+			} else {
+				assert.Equal(t, 1, createCalls, "an unresolved event must proceed to remediation")
+			}
 		})
 	}
 }

--- a/tests/fault_remediation_inprogress_test.go
+++ b/tests/fault_remediation_inprogress_test.go
@@ -156,9 +156,18 @@ func TestEventDuringInProgressCRIsRetriedAfterCompletion(t *testing.T) {
 		})
 
 	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		// Restore janitor-provider loudly: leaving it at 0 replicas would make every later
+		// test that depends on maintenance CRs completing fail with unrelated symptoms.
+		providerRestored := false
+
 		client, err := c.NewClient()
-		if err == nil {
-			_ = helpers.ScaleDeployment(ctx, t, client, "janitor-provider", helpers.NVSentinelNamespace, 1)
+		if err != nil {
+			t.Errorf("teardown could not build a client; janitor-provider may be left scaled to 0: %v", err)
+		} else if scaleErr := helpers.ScaleDeployment(ctx, t, client, "janitor-provider",
+			helpers.NVSentinelNamespace, 1); scaleErr != nil {
+			t.Errorf("failed to restore janitor-provider to 1 replica: %v", scaleErr)
+		} else {
+			providerRestored = true
 		}
 
 		if testCtx != nil && testCtx.NodeName != "" {
@@ -167,7 +176,17 @@ func TestEventDuringInProgressCRIsRetriedAfterCompletion(t *testing.T) {
 			helpers.RecoverEntityFailure(ctx, t, testCtx.NodeName, "GPU", "1", "79")
 		}
 
-		return helpers.TeardownFaultRemediation(ctx, t, c)
+		ctx = helpers.TeardownFaultRemediation(ctx, t, c)
+
+		// Verify the provider actually came back. This runs after the remaining cleanup
+		// because the rollout helper fails the test fatally on timeout, which would
+		// otherwise skip the cleanup steps above.
+		if providerRestored {
+			helpers.WaitForDeploymentRolloutWithTimeout(ctx, t, client,
+				"janitor-provider", helpers.NVSentinelNamespace, 2*time.Minute)
+		}
+
+		return ctx
 	})
 
 	testEnv.Test(t, feature.Feature())

--- a/tests/fault_remediation_inprogress_test.go
+++ b/tests/fault_remediation_inprogress_test.go
@@ -1,0 +1,268 @@
+//go:build amd64_group
+// +build amd64_group
+
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/e2e-framework/klient"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"tests/helpers"
+)
+
+// inProgressRetryTimeout bounds how long we wait for fault-remediation to retry an
+// event that was received while an equivalent maintenance CR was still InProgress.
+// The retry requeue fires every 30s, and the janitor then needs to complete the new
+// CR, so a few minutes is enough headroom without stalling a failing run for the
+// default 10 minutes.
+const inProgressRetryTimeout = 6 * time.Minute
+
+// TestEventDuringInProgressCRIsRetriedAfterCompletion is the E2E regression test for
+// issue #1536: a remediation-ready health event that arrives while an equivalent
+// maintenance CR is still InProgress must not be dropped permanently. Once the CR
+// reaches a terminal state, fault-remediation must reconsider the event and, because
+// the event was created after the running remediation session began, create a new CR.
+//
+// Flow:
+//  1. Scale janitor-provider to 0 so maintenance CRs stay InProgress deterministically:
+//     the janitor treats the unreachable CSP provider as a transient error and retries
+//     without failing the CR. (The janitor deployment itself must stay up because it
+//     serves the RebootNode validating webhook; scaling it down would block CR creation.)
+//  2. Send fatal event A — FQ quarantines, ND drains, FR creates CR-1 (stays InProgress).
+//  3. Send fatal event B for a different GPU (distinct entity so the platform connector
+//     does not deduplicate it) — FR evaluates it against the in-progress CR-1, which is
+//     confirmed via the fault-remediation logs.
+//  4. Scale janitor-provider back to 1 — CR-1 completes.
+//  5. Verify FR automatically retries event B and a second CR is created and completed.
+//     Without the fix, event B is checkpointed on the skip path and never retried, so
+//     the second CR never appears and this test times out at step 5.
+func TestEventDuringInProgressCRIsRetriedAfterCompletion(t *testing.T) {
+	feature := features.New("TestEventDuringInProgressCRIsRetriedAfterCompletion").
+		WithLabel("suite", "fault-remediation-advanced")
+
+	var testCtx *helpers.RemediationTestContext
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		var newCtx context.Context
+		newCtx, testCtx = helpers.SetupFaultRemediationTest(ctx, t, c, "")
+		return newCtx
+	})
+
+	feature.Assess("event received while CR is InProgress is remediated after the CR completes",
+		func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+			client, err := c.NewClient()
+			require.NoError(t, err)
+
+			nodeName := testCtx.NodeName
+
+			t.Log("Step 1: Scaling janitor-provider to 0 so the first maintenance CR stays InProgress")
+			require.NoError(t, helpers.ScaleDeployment(ctx, t, client, "janitor-provider", helpers.NVSentinelNamespace, 0))
+			helpers.WaitForDeploymentRolloutWithTimeout(ctx, t, client,
+				"janitor-provider", helpers.NVSentinelNamespace, 2*time.Minute)
+
+			t.Log("Step 2: Triggering first fault; CR-1 should be created and stay InProgress")
+			helpers.TriggerFullRemediationFlow(ctx, t, client, nodeName, 15)
+
+			cr1 := waitForRebootNodeCRForNode(ctx, t, client, nodeName)
+			t.Logf("CR-1 created: %s", cr1.GetName())
+
+			completionTime, found, _ := unstructured.NestedString(cr1.Object, "status", "completionTime")
+			require.True(t, !found || completionTime == "",
+				"CR-1 must still be InProgress for this scenario, got completionTime=%q", completionTime)
+
+			t.Log("Step 3: Sending second fatal event while CR-1 is InProgress")
+
+			const eventBMessage = "issue-1536: post-reboot XID 79 while CR-1 still InProgress"
+
+			// A different GPU entity keeps the platform connector from deduplicating
+			// the event against event A, while the recommended action still maps to
+			// the same "restart" equivalence group covered by CR-1.
+			eventB := helpers.NewHealthEvent(nodeName).
+				WithErrorCode("79").
+				WithEntitiesImpacted([]helpers.EntityImpacted{{EntityType: "GPU", EntityValue: "1"}}).
+				WithMessage(eventBMessage).
+				WithRecommendedAction(15)
+			helpers.SendHealthEvent(ctx, t, eventB)
+
+			t.Log("Waiting for fault-quarantine to ingest the second event")
+			require.Eventually(t, func() bool {
+				node, err := helpers.GetNodeByName(ctx, client, nodeName)
+				if err != nil {
+					return false
+				}
+
+				return strings.Contains(node.Annotations[helpers.QuarantineHealthEventAnnotationKey], eventBMessage)
+			}, helpers.EventuallyWaitTimeout, helpers.WaitInterval,
+				"quarantine annotation should contain the second event's message")
+
+			// Both the fixed and the unfixed reconciler log this line when they find
+			// the covering CR still InProgress, so waiting on it guarantees event B was
+			// evaluated inside the InProgress window in either build.
+			t.Log("Waiting for fault-remediation to evaluate the second event against in-progress CR-1")
+			waitForFaultRemediationLogLine(ctx, t, client,
+				"CR exists and is in progress", cr1.GetName())
+
+			t.Log("Step 4: Scaling janitor-provider back to 1 so CR-1 completes")
+			require.NoError(t, helpers.ScaleDeployment(ctx, t, client, "janitor-provider", helpers.NVSentinelNamespace, 1))
+			helpers.WaitForDeploymentRolloutWithTimeout(ctx, t, client,
+				"janitor-provider", helpers.NVSentinelNamespace, 2*time.Minute)
+
+			helpers.WaitForCRByName(ctx, t, client, cr1.GetName(), helpers.RebootNodeGVK)
+			t.Logf("CR-1 %s completed", cr1.GetName())
+
+			t.Log("Step 5: Waiting for the retried event to produce and complete a second CR")
+			require.Eventually(t, func() bool {
+				crNames, err := helpers.GetRebootNodeCRsForNode(ctx, client, nodeName)
+				if err != nil {
+					t.Logf("failed to list completed CRs: %v", err)
+					return false
+				}
+
+				t.Logf("Completed CRs for node %s: %v", nodeName, crNames)
+
+				return len(crNames) >= 2
+			}, inProgressRetryTimeout, helpers.WaitInterval,
+				"event received while CR-1 was InProgress must be retried after CR-1 completes "+
+					"and produce a second CR (issue #1536)")
+
+			return ctx
+		})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		client, err := c.NewClient()
+		if err == nil {
+			_ = helpers.ScaleDeployment(ctx, t, client, "janitor-provider", helpers.NVSentinelNamespace, 1)
+		}
+
+		if testCtx != nil && testCtx.NodeName != "" {
+			// Clear the second event's failure (GPU 1); TeardownFaultRemediation's
+			// generic healthy event only covers the default GPU 0 entity.
+			helpers.RecoverEntityFailure(ctx, t, testCtx.NodeName, "GPU", "1", "79")
+		}
+
+		return helpers.TeardownFaultRemediation(ctx, t, c)
+	})
+
+	testEnv.Test(t, feature.Feature())
+}
+
+// waitForRebootNodeCRForNode waits for any RebootNode CR targeting the node to exist,
+// regardless of completion, and returns it. helpers.WaitForCR is not usable here
+// because it waits for the CR to complete, and this test deliberately holds CRs in
+// the InProgress state.
+func waitForRebootNodeCRForNode(
+	ctx context.Context, t *testing.T, client klient.Client, nodeName string,
+) *unstructured.Unstructured {
+	t.Helper()
+
+	var result *unstructured.Unstructured
+
+	require.Eventually(t, func() bool {
+		crList, err := helpers.ListAllCRs(ctx, client, helpers.RebootNodeGVK)
+		if err != nil {
+			t.Logf("failed to list RebootNode CRs: %v", err)
+			return false
+		}
+
+		for i := range crList.Items {
+			item := &crList.Items[i]
+
+			crNodeName, found, _ := unstructured.NestedString(item.Object, "spec", "nodeName")
+			if found && crNodeName == nodeName {
+				result = item
+				return true
+			}
+		}
+
+		return false
+	}, helpers.EventuallyWaitTimeout, helpers.WaitInterval,
+		"a RebootNode CR should be created for node %s", nodeName)
+
+	return result
+}
+
+// waitForFaultRemediationLogLine waits until a running fault-remediation pod has a log
+// line containing all of the given substrings.
+func waitForFaultRemediationLogLine(
+	ctx context.Context, t *testing.T, client klient.Client, substrings ...string,
+) {
+	t.Helper()
+
+	clientset, err := kubernetes.NewForConfig(client.RESTConfig())
+	require.NoError(t, err, "failed to create kubernetes clientset")
+
+	require.Eventually(t, func() bool {
+		pods, err := clientset.CoreV1().Pods(helpers.NVSentinelNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app.kubernetes.io/name=fault-remediation",
+			FieldSelector: "status.phase=Running",
+		})
+		if err != nil || len(pods.Items) == 0 {
+			return false
+		}
+
+		for _, pod := range pods.Items {
+			logs, err := clientset.CoreV1().Pods(helpers.NVSentinelNamespace).
+				GetLogs(pod.Name, &corev1.PodLogOptions{}).DoRaw(ctx)
+			if err != nil {
+				continue
+			}
+
+			if logsContainLineWithAll(logs, substrings) {
+				return true
+			}
+		}
+
+		return false
+	}, helpers.EventuallyWaitTimeout, helpers.WaitInterval,
+		"fault-remediation logs should contain a line with all of %v", substrings)
+}
+
+func logsContainLineWithAll(logs []byte, substrings []string) bool {
+	scanner := bufio.NewScanner(bytes.NewReader(logs))
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		matches := true
+
+		for _, substring := range substrings {
+			if !strings.Contains(line, substring) {
+				matches = false
+				break
+			}
+		}
+
+		if matches {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
## Summary

Fixes #1536.

When a remediation-ready health event arrives while an equivalent maintenance CR is still `InProgress`, fault-remediation skips the event, advances the resume token, and returns success. Nothing reconsiders the event when the CR completes, so the event is dropped permanently.

This happened in production after a reboot: new fatal events (XID 154 and an NVLink failure) arrived a few seconds before the old `RebootNode` CR received its completion condition. All three events were skipped, `faultremediated` stayed `null`, no new CR was created, and the node remained cordoned for more than two hours with an actionable fault.

## Changes

### Requeue events while the covering CR is in progress

When the covering CR is `InProgress`, fault-remediation no longer finalizes the event. It returns a requeue result (30s by default, configurable through `ReconcilerConfig.InProgressRequeueDelay`) and deliberately does not advance the resume token or write any status, so the event stays live until the CR reaches a terminal state.

Once the CR is terminal, the existing decision logic resolves the event:

- created before the CR (same remediation session): marked remediated, no new CR
- created after the CR (post-session, the production case): a new CR is created
- CR failed: a new CR is created

A new `cr_status="waiting"` value on `fault_remediation_events_processed_total` makes waiting events visible.

### Re-read the event status before starting a remediation

A requeued event can sit in the workqueue for minutes or hours, so the snapshot it carries goes stale. Before creating a CR, fault-remediation now re-reads the event's current record and skips it if:

- it was already remediated elsewhere (`faultremediated=true`), or
- its quarantine session ended (`UnQuarantined`/`Cancelled`), or
- it carries `faultremediated=false` and is no longer part of the node's live quarantine annotation, which means cancellation cleanup closed it.

`faultremediated=false` with a still-active quarantine only means the last attempt failed, so those events remain retryable, matching the existing retry behavior.

### Allow a new remediation cycle after a terminal outcome

The state label validation only allowed `remediation-succeeded` and `remediation-failed` to move between each other, so starting a second remediation in the same quarantine session was reported as an invalid transition and aborted CR creation. Both states can now transition back to `remediating`. This is required for the post-session path above and also unblocks the existing failed-CR retry path, which hit the same rejection.

## Test changes

### Unit and envtest

- `TestInProgressCREventRequeuedUntilTerminal` reproduces the issue at the reconciler level: while the CR is `InProgress` the event is requeued with no checkpoint and no status write, and after the CR turns `Succeeded` or `Failed` the event is automatically resolved (covered, new CR, or retry).
- `TestStaleEventSnapshotResolvedInStoreIsNotRemediated` covers the re-read guard, including the case where a failed attempt must stay retryable.
- `TestCRBasedDeduplication` updated for the new decision result and asserts the in-progress flag.
- The envtest `CompleteFlow_WithEventLoop` now drives the scenario through the real controller-runtime requeue machinery: a same-session duplicate waits behind the in-progress CR, is not checkpointed, and is marked remediated once the CR succeeds.
- State manager tests cover the two new valid transitions.

### E2E

Added `TestEventDuringInProgressCRIsRetriedAfterCompletion`. It scales `janitor-provider` to zero so the first CR stays `InProgress` (the janitor keeps retrying the unreachable provider without failing the CR, and its admission webhook stays up), sends a second fatal event for a different GPU, confirms through fault-remediation logs that the event was evaluated inside the `InProgress` window, restores the provider so the first CR completes, and then requires a second CR to be created and completed.

Verified on a local kind cluster: the test fails on main (no second CR appears and the event stays stranded) and passes with this change (the second CR appears within one requeue interval).

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented remediation events from being lost or finalized while an equivalent maintenance operation is still in progress; events are retried and re-checked until the operation reaches a terminal state.
  * Avoided acting on stale event snapshots that may no longer be relevant.
  * Improved support for re-remediation cycles by allowing remediating to restart after successful or failed remediation outcomes.
* **Metrics**
  * Added a new CR status metric value for remediation operations that are waiting on an in-progress maintenance operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->