### PR TITLE
chore: validate Percona as default MongoDB backend on ARM64 (#1497) [DO NOT MERGE]

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/mongodb-store/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/mongodb-store/values.yaml
@@ -14,22 +14,22 @@
 
 # Feature flags to switch between Bitnami MongoDB and Percona MongoDB Operator
 # Due to Helm limitations, both flags must be explicitly set when switching modes
-# 
-# Default (Bitnami MongoDB - backward compatible):
+#
+# Default (Percona MongoDB Operator - multi-arch, supports ARM64):
 #   global.mongodbStore.enabled: true
-#   mongodb-store.useBitnami: true           # Default
-#   mongodb-store.usePerconaOperator: false  # Default
-# 
-# Percona MongoDB Operator:
+#   mongodb-store.useBitnami: false          # Default
+#   mongodb-store.usePerconaOperator: true   # Default
+#
+# Bitnami MongoDB (legacy, amd64-only images):
 #   global.mongodbStore.enabled: true
-#   mongodb-store.useBitnami: false          # Must explicitly disable
-#   mongodb-store.usePerconaOperator: true   # Must explicitly enable
+#   mongodb-store.useBitnami: true           # Must explicitly enable
+#   mongodb-store.usePerconaOperator: false  # Must explicitly disable
 #
 # IMPORTANT: These flags control which chart dependencies are loaded.
 # Both must be set correctly to avoid loading unnecessary charts.
 
-useBitnami: true
-usePerconaOperator: false
+useBitnami: false
+usePerconaOperator: true
 
 # SCRAM application user (created when mongodb.tls.enabled is false).
 # Instead of X.509 cert-based users, the Job creates a SCRAM-SHA-256 user

--- a/distros/kubernetes/nvsentinel/values-tilt-mongodb-tls-disabled.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt-mongodb-tls-disabled.yaml
@@ -54,7 +54,11 @@ postgresql:
   enabled: false
 
 # MongoDB subchart configuration — TLS and auth disabled
+# Explicitly pinned to the Bitnami backend: this leg keeps covering the
+# legacy Bitnami path (the chart default is the Percona operator).
 mongodb-store:
+  useBitnami: true
+  usePerconaOperator: false
   mongodb:
     enabled: true
     tls:

--- a/distros/kubernetes/nvsentinel/values-tilt-mongodb.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt-mongodb.yaml
@@ -15,6 +15,11 @@
 # MongoDB-specific values for Tilt development
 # This file is automatically included when USE_POSTGRESQL is not set
 # Example: Run `tilt up` (default uses MongoDB)
+#
+# This overlay intentionally does NOT set mongodb-store.useBitnami /
+# mongodb-store.usePerconaOperator, so the deployment uses the chart's
+# default backend (Percona Operator). The connection host below must match
+# the service created by that default backend.
 
 global:
   dryRun: false
@@ -31,8 +36,8 @@ global:
   datastore:
     provider: "mongodb"
     connection:
-      # Use the headless service for replica set connection
-      host: "mongodb-headless.nvsentinel.svc.cluster.local"
+      # Percona operator exposes the replica set via the <cluster>-rs0 service
+      host: "mongodb-rs0.nvsentinel.svc.cluster.local"
       port: 27017
       database: "HealthEventsDatabase"
       collection: "HealthEvents"
@@ -55,8 +60,6 @@ global:
 postgresql:
   enabled: false
 
-# MongoDB subchart configuration
-mongodb-store:
-  mongodb:
-    enabled: true
+# No mongodb-store backend flags here: this leg validates that the chart's
+# default backend selection works without any explicit override.
 

--- a/distros/kubernetes/nvsentinel/values-tilt.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt.yaml
@@ -126,10 +126,10 @@ preflight:
       command: ["/bin/sh", "-c"]
       args: ["echo 'preflight-dcgm-diag: no real GPU, exiting ok'; exit 0"]
 
+# NOTE: useBitnami/usePerconaOperator are intentionally NOT set here so the
+# default MongoDB legs exercise the chart's default backend selection.
+# Legs that need a specific backend pin it in their values-tilt-mongodb-*.yaml.
 mongodb-store:
-  useBitnami: true
-  usePerconaOperator: false
-  
   job:
     nodeSelector:
       node-role.kubernetes.io/control-plane: ""

--- a/tilt/Tiltfile
+++ b/tilt/Tiltfile
@@ -219,8 +219,13 @@ local_resource(
 
 k8s_yaml(yaml)
 
-# Check if using Percona operator (only relevant when using MongoDB)
-use_percona = effective_values.get('mongodb-store', {}).get('usePerconaOperator', False) if not use_postgresql else False
+# Check if using Percona operator (only relevant when using MongoDB).
+# The mongodb-store subchart's own values.yaml is not part of the values-file
+# merge above, so read it explicitly: when no values file overrides the flag,
+# helm falls back to the chart default and Tilt must follow the same logic.
+mongodb_store_chart_defaults = read_yaml('../distros/kubernetes/nvsentinel/charts/mongodb-store/values.yaml')
+default_use_percona = mongodb_store_chart_defaults.get('usePerconaOperator', False)
+use_percona = effective_values.get('mongodb-store', {}).get('usePerconaOperator', default_use_percona) if not use_postgresql else False
 if use_percona:
     print("Using Percona MongoDB Operator for MongoDB installation.")
 else:


### PR DESCRIPTION

## Summary

This is a test PR for #1497. Do not merge.

The default MongoDB backend (Bitnami) has no ARM64 image, so the default
NVSentinel configuration cannot run on ARM-only clusters. The Percona
operator backend is multi-arch and already passes the ARM64 e2e legs, but
only when it is explicitly selected. Issue #1497 proposes making Percona
the default.

Today the e2e matrix never tests the chart defaults, because every leg
pins the backend through the Tilt values. This PR flips the chart default
to Percona and removes those pins, so the plain MongoDB legs deploy
whatever the chart selects on its own. A green run proves that Percona as
the default backend works end to end on ARM64 (and AMD64) before we make
the real change.

Changes:
- charts/mongodb-store/values.yaml: default is now useBitnami=false,
  usePerconaOperator=true
- values-tilt.yaml: removed the backend pins so the e2e legs inherit the
  chart default
- values-tilt-mongodb.yaml: points the datastore host at the Percona
  service (mongodb-rs0) and sets no backend flags on purpose
- values-tilt-mongodb-tls-disabled.yaml: now pinned to Bitnami so the
  no-TLS legs keep covering the legacy path unchanged

What the e2e matrix tests after this change:
- AMD64/ARM64 + MongoDB: Percona selected purely by chart defaults. This
  is the new signal, especially the ARM64 leg.
- AMD64/ARM64 + MongoDB (Percona): explicitly pinned Percona, unchanged.
  Control legs. Locally these render exactly the same manifests as the
  defaults legs.
- AMD64/ARM64 + MongoDB (no TLS): Bitnami via the new explicit pin,
  behavior unchanged. Legacy control legs.
- PostgreSQL legs: unaffected. Verified locally that no MongoDB objects
  render.

Validated locally: helm template for all four values chains plus pure
chart defaults (Percona renders by default, the no-TLS chain still
renders only Bitnami, postgres renders no MongoDB objects), and
make helm-lint passes with the flipped default.

Out of scope, planned as follow-ups if this run is green: documentation
updates (docs/configuration/mongodb-store.md still describes Bitnami as
the default), promoting the ADR-013 migration steps into user docs, demo
and UAT values, and cleanup of the ARM image swap workaround in CI. The
migration runbook will be verified separately on an amd64 cluster.

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [x] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [x] Other: ____________

## Testing
- [ ] Tests pass locally
- [x] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * MongoDB deployments now use the Percona MongoDB Operator by default.
  * TLS-disabled Tilt deployments explicitly continue using the Bitnami MongoDB backend.
  * Tilt configurations now use the appropriate MongoDB service endpoint and clearly separate default and backend-specific settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->