### PR TITLE
fix(kom): recover deletions missed during downtime

### DIFF
--- a/health-monitors/kubernetes-object-monitor/pkg/annotations/manager.go
+++ b/health-monitors/kubernetes-object-monitor/pkg/annotations/manager.go
@@ -35,11 +35,19 @@ const (
 type PolicyMatchState map[string]string
 
 type Manager struct {
-	client client.Client
+	reader client.Reader
+	writer client.Writer
 }
 
 func NewManager(c client.Client) *Manager {
-	return &Manager{client: c}
+	return NewManagerWithReader(c, c)
+}
+
+func NewManagerWithReader(reader client.Reader, writer client.Writer) *Manager {
+	return &Manager{
+		reader: reader,
+		writer: writer,
+	}
 }
 
 func (m *Manager) AddMatch(ctx context.Context, nodeName, stateKey, targetNode string) error {
@@ -77,7 +85,7 @@ func (m *Manager) RemoveMatch(ctx context.Context, nodeName, stateKey string) er
 
 func (m *Manager) GetMatches(ctx context.Context, nodeName string) (PolicyMatchState, error) {
 	node := &v1.Node{}
-	if err := m.client.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
+	if err := m.reader.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
 		if apierrors.IsNotFound(err) {
 			return make(PolicyMatchState), nil
 		}
@@ -85,6 +93,10 @@ func (m *Manager) GetMatches(ctx context.Context, nodeName string) (PolicyMatchS
 		return make(PolicyMatchState), fmt.Errorf("failed to get node: %w", err)
 	}
 
+	return matchesFromNode(node)
+}
+
+func matchesFromNode(node *v1.Node) (PolicyMatchState, error) {
 	if node.Annotations == nil {
 		return make(PolicyMatchState), nil
 	}
@@ -104,14 +116,14 @@ func (m *Manager) GetMatches(ctx context.Context, nodeName string) (PolicyMatchS
 
 func (m *Manager) LoadAllMatches(ctx context.Context) (map[string]string, error) {
 	nodeList := &v1.NodeList{}
-	if err := m.client.List(ctx, nodeList); err != nil {
+	if err := m.reader.List(ctx, nodeList); err != nil {
 		return nil, fmt.Errorf("failed to list nodes: %w", err)
 	}
 
 	allMatches := make(map[string]string)
 
 	for _, node := range nodeList.Items {
-		matches, err := m.GetMatches(ctx, node.Name)
+		matches, err := matchesFromNode(&node)
 		if err != nil {
 			slog.Warn("Failed to load matches from node", "node", node.Name, "error", err)
 			continue
@@ -131,7 +143,7 @@ func (m *Manager) updateAnnotation(ctx context.Context,
 
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		node := &v1.Node{}
-		if err := m.client.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
+		if err := m.reader.Get(ctx, types.NamespacedName{Name: nodeName}, node); err != nil {
 			if apierrors.IsNotFound(err) {
 				slog.Warn("Node not found, assuming deleted", "node", nodeName)
 				return nil
@@ -167,7 +179,7 @@ func (m *Manager) updateAnnotation(ctx context.Context,
 			node.Annotations[AnnotationKey] = string(annotationBytes)
 		}
 
-		return m.client.Update(ctx, node, &client.UpdateOptions{
+		return m.writer.Update(ctx, node, &client.UpdateOptions{
 			FieldManager: "kubernetes-object-monitor",
 		})
 	})

--- a/health-monitors/kubernetes-object-monitor/pkg/controller/reconciler.go
+++ b/health-monitors/kubernetes-object-monitor/pkg/controller/reconciler.go
@@ -18,8 +18,10 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"strings"
 	"sync"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -43,6 +45,7 @@ type HealthEventPublisher interface {
 
 type ResourceReconciler struct {
 	client.Client
+	apiReader     client.Reader
 	evaluator     *policy.Evaluator
 	publisher     HealthEventPublisher
 	annotationMgr *annotations.Manager
@@ -61,8 +64,21 @@ func NewResourceReconciler(
 	policies []config.Policy,
 	gvk schema.GroupVersionKind,
 ) *ResourceReconciler {
+	return NewResourceReconcilerWithReader(c, c, evaluator, pub, annotationMgr, policies, gvk)
+}
+
+func NewResourceReconcilerWithReader(
+	c client.Client,
+	apiReader client.Reader,
+	evaluator *policy.Evaluator,
+	pub HealthEventPublisher,
+	annotationMgr *annotations.Manager,
+	policies []config.Policy,
+	gvk schema.GroupVersionKind,
+) *ResourceReconciler {
 	return &ResourceReconciler{
 		Client:        c,
+		apiReader:     apiReader,
 		evaluator:     evaluator,
 		publisher:     pub,
 		annotationMgr: annotationMgr,
@@ -87,6 +103,102 @@ func (r *ResourceReconciler) LoadState(ctx context.Context) error {
 	slog.Info("Loaded policy match state from annotations", "gvk", r.gvk.String(), "matches", len(allMatches))
 
 	return nil
+}
+
+// LoadStateWithScope reloads persisted policy match state, verifies referenced
+// resources, and recovers deletions that occurred while the monitor was stopped.
+func (r *ResourceReconciler) LoadStateWithScope(ctx context.Context, resourceNamespaced bool) error {
+	allMatches, err := r.annotationMgr.LoadAllMatches(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to load match state: %w", err)
+	}
+
+	loadedMatches := make(map[string]string)
+	requests := make(map[string]ctrl.Request)
+
+	for stateKey, nodeName := range allMatches {
+		req, ok := r.requestFromStateKey(stateKey, resourceNamespaced)
+		if !ok {
+			continue
+		}
+
+		loadedMatches[stateKey] = nodeName
+		requests[stateKey] = req
+	}
+
+	r.matchStatesMu.Lock()
+	r.matchStates = maps.Clone(loadedMatches)
+	r.matchStatesMu.Unlock()
+
+	for stateKey, req := range requests {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(r.gvk)
+
+		if err := r.apiReader.Get(ctx, req.NamespacedName, obj); err != nil {
+			if apierrors.IsNotFound(err) {
+				if err := r.cleanupDeletedResource(ctx, req); err != nil {
+					return fmt.Errorf("failed to recover deleted match %q: %w", stateKey, err)
+				}
+
+				continue
+			}
+
+			return fmt.Errorf("failed to verify loaded match %q: %w", stateKey, err)
+		}
+	}
+
+	r.matchStatesMu.RLock()
+	remainingMatches := len(r.matchStates)
+	r.matchStatesMu.RUnlock()
+
+	slog.Info("Loaded policy match state from annotations", "gvk", r.gvk.String(), "matches", remainingMatches)
+
+	return nil
+}
+
+func (r *ResourceReconciler) requestFromStateKey(stateKey string, resourceNamespaced bool) (ctrl.Request, bool) {
+	parts := strings.Split(stateKey, "/")
+
+	resourcePartCount := 1
+	if resourceNamespaced {
+		resourcePartCount = 2
+	}
+
+	if len(parts) <= resourcePartCount {
+		return ctrl.Request{}, false
+	}
+
+	policyName := strings.Join(parts[:len(parts)-resourcePartCount], "/")
+	if !r.hasEnabledPolicy(policyName) {
+		return ctrl.Request{}, false
+	}
+
+	resourceParts := parts[len(parts)-resourcePartCount:]
+
+	if resourceNamespaced {
+		req := ctrl.Request{
+			NamespacedName: client.ObjectKey{
+				Namespace: resourceParts[0],
+				Name:      resourceParts[1],
+			},
+		}
+
+		return req, resourceParts[0] != "" && resourceParts[1] != ""
+	}
+
+	return ctrl.Request{
+		NamespacedName: client.ObjectKey{Name: resourceParts[0]},
+	}, resourceParts[0] != ""
+}
+
+func (r *ResourceReconciler) hasEnabledPolicy(name string) bool {
+	for i := range r.policies {
+		if r.policies[i].Enabled && r.policies[i].Name == name {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (r *ResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -117,7 +229,10 @@ func (r *ResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 func (r *ResourceReconciler) handleGetError(ctx context.Context, err error, req ctrl.Request) (ctrl.Result, error) {
 	if client.IgnoreNotFound(err) == nil {
-		r.cleanupDeletedResource(ctx, req)
+		if err := r.cleanupDeletedResource(ctx, req); err != nil {
+			return ctrl.Result{}, err
+		}
+
 		return ctrl.Result{}, nil
 	}
 
@@ -129,7 +244,7 @@ func (r *ResourceReconciler) handleGetError(ctx context.Context, err error, req 
 // cleanupDeletedResource handles cleanup when a resource is deleted.
 // when a pod is deleted, we uncordon the node immediately.
 // This means if a replacement pod comes up unhealthy, it will be re-cordoned.
-func (r *ResourceReconciler) cleanupDeletedResource(ctx context.Context, req ctrl.Request) {
+func (r *ResourceReconciler) cleanupDeletedResource(ctx context.Context, req ctrl.Request) error {
 	slog.Info("Cleaning up deleted resource", "resource", req.NamespacedName)
 
 	for _, p := range r.policies {
@@ -180,24 +295,18 @@ func (r *ResourceReconciler) cleanupDeletedResource(ctx context.Context, req ctr
 			slog.Info("Resource deleted, publishing healthy event to uncordon node",
 				"policy", p.Name, "resource", req.NamespacedName, "node", nodeName)
 
-			if err := r.publisher.PublishHealthEvent(ctx, &p, nodeName, true, resourceInfo); err != nil {
-				slog.Error("Failed to publish healthy event for deleted resource",
-					"policy", p.Name,
-					"resource", req.NamespacedName,
-					"node", nodeName,
-					"error", err)
-				metrics.HealthEventsPublishErrors.WithLabelValues(p.Name, "grpc_error").Inc()
-			}
-
-			r.matchStatesMu.Lock()
-			delete(r.matchStates, stateKey)
-			r.matchStatesMu.Unlock()
-
-			if err := r.annotationMgr.RemoveMatch(ctx, nodeName, stateKey); err != nil {
-				slog.Error("Failed to remove match state from annotation", "node", nodeName, "stateKey", stateKey, "error", err)
+			if err := r.handleHealthyTransition(ctx, &p, nodeName, stateKey, resourceInfo); err != nil {
+				return fmt.Errorf(
+					"failed to publish recovery for deleted resource %s with policy %q: %w",
+					req.NamespacedName,
+					p.Name,
+					err,
+				)
 			}
 		}
 	}
+
+	return nil
 }
 
 func (r *ResourceReconciler) reconcilePolicy(

--- a/health-monitors/kubernetes-object-monitor/pkg/controller/reconciler_test.go
+++ b/health-monitors/kubernetes-object-monitor/pkg/controller/reconciler_test.go
@@ -16,6 +16,7 @@ package controller_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -34,6 +35,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/nvidia/nvsentinel/health-monitors/kubernetes-object-monitor/pkg/annotations"
 	celenv "github.com/nvidia/nvsentinel/health-monitors/kubernetes-object-monitor/pkg/cel"
@@ -619,6 +621,366 @@ func TestReconciler_PodHealthyOnNode(t *testing.T) {
 	}, time.Second, 50*time.Millisecond)
 }
 
+func TestReconciler_LoadStateRecoversResourceDeletedWhileStopped(t *testing.T) {
+	setup := setupPodTest(t)
+	nodeName := "test-node-pod-deleted-while-stopped"
+	namespace := "gpu-operator"
+	podName := "test-pod-deleted-while-stopped"
+	stateKey := "gpu-operator-pod-health/gpu-operator/" + podName
+
+	createNode(t, setup, nodeName, v1.ConditionTrue)
+	createNamespace(t, setup, namespace)
+	pod := createPod(t, setup, namespace, podName, nodeName, v1.PodPending)
+
+	_, err := setup.reconciler.Reconcile(setup.ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: namespace, Name: podName},
+	})
+	require.NoError(t, err)
+	require.Len(t, setup.publisher.publishedEvents, 1)
+	require.False(t, setup.publisher.publishedEvents[0].isHealthy)
+
+	annotationMgr := annotations.NewManagerWithReader(setup.k8sClient, setup.k8sClient)
+	matches, err := annotationMgr.GetMatches(setup.ctx, nodeName)
+	require.NoError(t, err)
+	require.Equal(t, nodeName, matches[stateKey])
+
+	require.NoError(t, setup.k8sClient.Delete(setup.ctx, pod, client.GracePeriodSeconds(0)))
+	require.Eventually(t, func() bool {
+		err := setup.k8sClient.Get(
+			setup.ctx,
+			types.NamespacedName{Namespace: namespace, Name: podName},
+			&v1.Pod{},
+		)
+		return apierrors.IsNotFound(err)
+	}, time.Second, 50*time.Millisecond)
+
+	recoveryPublisher := &mockPublisher{}
+	restartedReconciler := controller.NewResourceReconcilerWithReader(
+		setup.k8sClient,
+		setup.k8sClient,
+		setup.evaluator,
+		recoveryPublisher,
+		annotationMgr,
+		[]config.Policy{defaultPodHealthPolicy()},
+		schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+	)
+
+	require.NoError(t, restartedReconciler.LoadStateWithScope(setup.ctx, true))
+	require.Len(t, recoveryPublisher.publishedEvents, 1)
+
+	recoveryEvent := recoveryPublisher.publishedEvents[0]
+	require.True(t, recoveryEvent.isHealthy)
+	require.Equal(t, nodeName, recoveryEvent.nodeName)
+	require.Equal(t, "Pod", recoveryEvent.resourceInfo.Kind)
+	require.Equal(t, "v1", recoveryEvent.resourceInfo.Version)
+	require.Equal(t, namespace, recoveryEvent.resourceInfo.Namespace)
+	require.Equal(t, podName, recoveryEvent.resourceInfo.Name)
+
+	matches, err = annotationMgr.GetMatches(setup.ctx, nodeName)
+	require.NoError(t, err)
+	require.NotContains(t, matches, stateKey)
+
+	_, err = restartedReconciler.Reconcile(setup.ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: namespace, Name: podName},
+	})
+	require.NoError(t, err)
+	require.Len(t, recoveryPublisher.publishedEvents, 1)
+}
+
+func TestReconciler_LoadStatePreservesMatchWhenRecoveryPublishFails(t *testing.T) {
+	setup := setupPodTest(t)
+	nodeName := "test-node-pod-recovery-publish-fails"
+	namespace := "gpu-operator"
+	podName := "test-pod-recovery-publish-fails"
+	stateKey := "gpu-operator-pod-health/gpu-operator/" + podName
+
+	createNode(t, setup, nodeName, v1.ConditionTrue)
+	createNamespace(t, setup, namespace)
+	pod := createPod(t, setup, namespace, podName, nodeName, v1.PodPending)
+
+	_, err := setup.reconciler.Reconcile(setup.ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: namespace, Name: podName},
+	})
+	require.NoError(t, err)
+
+	annotationMgr := annotations.NewManagerWithReader(setup.k8sClient, setup.k8sClient)
+	matches, err := annotationMgr.GetMatches(setup.ctx, nodeName)
+	require.NoError(t, err)
+	require.Equal(t, nodeName, matches[stateKey])
+
+	require.NoError(t, setup.k8sClient.Delete(setup.ctx, pod, client.GracePeriodSeconds(0)))
+	require.Eventually(t, func() bool {
+		err := setup.k8sClient.Get(
+			setup.ctx,
+			types.NamespacedName{Namespace: namespace, Name: podName},
+			&v1.Pod{},
+		)
+		return apierrors.IsNotFound(err)
+	}, time.Second, 50*time.Millisecond)
+
+	publishErr := errors.New("publisher unavailable")
+	recoveryPublisher := &mockPublisher{publishErr: publishErr}
+	restartedReconciler := controller.NewResourceReconcilerWithReader(
+		setup.k8sClient,
+		setup.k8sClient,
+		setup.evaluator,
+		recoveryPublisher,
+		annotationMgr,
+		[]config.Policy{defaultPodHealthPolicy()},
+		schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+	)
+
+	err = restartedReconciler.LoadStateWithScope(setup.ctx, true)
+	require.ErrorIs(t, err, publishErr)
+	require.Empty(t, recoveryPublisher.publishedEvents)
+
+	matches, err = annotationMgr.GetMatches(setup.ctx, nodeName)
+	require.NoError(t, err)
+	require.Equal(t, nodeName, matches[stateKey])
+
+	recoveryPublisher.publishErr = nil
+	_, err = restartedReconciler.Reconcile(setup.ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: namespace, Name: podName},
+	})
+	require.NoError(t, err)
+	require.Len(t, recoveryPublisher.publishedEvents, 1)
+
+	matches, err = annotationMgr.GetMatches(setup.ctx, nodeName)
+	require.NoError(t, err)
+	require.NotContains(t, matches, stateKey)
+}
+
+func TestReconciler_LoadStateDoesNotTreatReadErrorAsDeletion(t *testing.T) {
+	setup := setupPodTest(t)
+	nodeName := "test-node-pod-read-error"
+	namespace := "gpu-operator"
+	podName := "test-pod-read-error"
+	stateKey := "gpu-operator-pod-health/gpu-operator/" + podName
+
+	createNode(t, setup, nodeName, v1.ConditionTrue)
+	createNamespace(t, setup, namespace)
+	createPod(t, setup, namespace, podName, nodeName, v1.PodPending)
+
+	_, err := setup.reconciler.Reconcile(setup.ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: namespace, Name: podName},
+	})
+	require.NoError(t, err)
+
+	readErr := errors.New("API server unavailable")
+	apiReader := &getErrorReader{
+		Reader: setup.k8sClient,
+		err:    readErr,
+	}
+	annotationMgr := annotations.NewManagerWithReader(apiReader, setup.k8sClient)
+	recoveryPublisher := &mockPublisher{}
+	restartedReconciler := controller.NewResourceReconcilerWithReader(
+		setup.k8sClient,
+		apiReader,
+		setup.evaluator,
+		recoveryPublisher,
+		annotationMgr,
+		[]config.Policy{defaultPodHealthPolicy()},
+		schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+	)
+
+	err = restartedReconciler.LoadStateWithScope(setup.ctx, true)
+	require.ErrorIs(t, err, readErr)
+	require.Empty(t, recoveryPublisher.publishedEvents)
+
+	matches, err := annotations.NewManager(setup.k8sClient).GetMatches(setup.ctx, nodeName)
+	require.NoError(t, err)
+	require.Equal(t, nodeName, matches[stateKey])
+}
+
+func TestAnnotationManager_LoadAllMatchesUsesListedNodes(t *testing.T) {
+	reader := &countingNodeReader{
+		nodes: []v1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-a",
+					Annotations: map[string]string{
+						annotations.AnnotationKey: `{"policy-a/namespace-a/resource-a":"node-a"}`,
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-b",
+					Annotations: map[string]string{
+						annotations.AnnotationKey: `{"policy-b/resource-b":"node-b"}`,
+					},
+				},
+			},
+		},
+	}
+
+	annotationMgr := annotations.NewManagerWithReader(reader, nil)
+	matches, err := annotationMgr.LoadAllMatches(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		"policy-a/namespace-a/resource-a": "node-a",
+		"policy-b/resource-b":             "node-b",
+	}, matches)
+	require.Equal(t, 1, reader.listCalls)
+	require.Zero(t, reader.getCalls)
+}
+
+func TestReconciler_LoadStateBeforeManagerCacheStarts(t *testing.T) {
+	setup := setupPodTest(t)
+	nodeName := "test-node-manager-not-started"
+	namespace := "gpu-operator"
+	podName := "test-pod-manager-not-started"
+	stateKey := "gpu-operator-pod-health/gpu-operator/" + podName
+
+	createNode(t, setup, nodeName, v1.ConditionTrue)
+	createNamespace(t, setup, namespace)
+	createPod(t, setup, namespace, podName, nodeName, v1.PodPending)
+
+	_, err := setup.reconciler.Reconcile(setup.ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: namespace, Name: podName},
+	})
+	require.NoError(t, err)
+
+	mgr, err := ctrl.NewManager(setup.testEnv.Config, ctrl.Options{
+		Metrics: metricsserver.Options{BindAddress: "0"},
+	})
+	require.NoError(t, err)
+
+	publisher := &mockPublisher{}
+	apiReader := mgr.GetAPIReader()
+	annotationMgr := annotations.NewManagerWithReader(apiReader, mgr.GetClient())
+	reconciler := controller.NewResourceReconcilerWithReader(
+		mgr.GetClient(),
+		apiReader,
+		setup.evaluator,
+		publisher,
+		annotationMgr,
+		[]config.Policy{defaultPodHealthPolicy()},
+		schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+	)
+
+	require.NoError(t, reconciler.LoadStateWithScope(setup.ctx, true))
+	require.Empty(t, publisher.publishedEvents)
+
+	matches, err := annotations.NewManagerWithReader(setup.k8sClient, setup.k8sClient).GetMatches(setup.ctx, nodeName)
+	require.NoError(t, err)
+	require.Equal(t, nodeName, matches[stateKey])
+}
+
+func TestReconciler_LoadStateAcceptsUnambiguousPolicyNameContainingSlash(t *testing.T) {
+	shortPolicy := defaultPodHealthPolicy()
+	shortPolicy.Name = "operator"
+	slashPolicy := defaultPodHealthPolicy()
+	slashPolicy.Name = "operator/pod-health"
+
+	setup := setupPodTestWithPolicies(t, []config.Policy{shortPolicy, slashPolicy})
+	nodeName := "test-node-slash-policy"
+	namespace := "gpu-operator"
+	podName := "test-pod-slash-policy"
+	stateKey := slashPolicy.Name + "/" + namespace + "/" + podName
+
+	createNode(t, setup, nodeName, v1.ConditionTrue)
+	createNamespace(t, setup, namespace)
+	createPod(t, setup, namespace, podName, nodeName, v1.PodRunning)
+	require.NoError(t, annotations.NewManager(setup.k8sClient).AddMatch(
+		setup.ctx,
+		nodeName,
+		stateKey,
+		nodeName,
+	))
+
+	require.NoError(t, setup.reconciler.LoadStateWithScope(setup.ctx, true))
+	require.Empty(t, setup.publisher.publishedEvents)
+
+	matches, err := annotations.NewManager(setup.k8sClient).GetMatches(setup.ctx, nodeName)
+	require.NoError(t, err)
+	require.Equal(t, nodeName, matches[stateKey])
+}
+
+func TestReconciler_LoadStateUsesNamespacedScopeForSlashLikeNamespace(t *testing.T) {
+	shortPolicy := defaultPodHealthPolicy()
+	shortPolicy.Name = "operator"
+	slashPolicy := defaultPodHealthPolicy()
+	slashPolicy.Name = "operator/pod-health"
+
+	setup := setupPodTestWithPolicies(t, []config.Policy{shortPolicy, slashPolicy})
+	targetNodeName := "test-node-slash-like-namespace"
+	namespace := "pod-health"
+	podName := "missing-pod"
+	stateKey := shortPolicy.Name + "/" + namespace + "/" + podName
+
+	createNode(t, setup, targetNodeName, v1.ConditionTrue)
+	require.NoError(t, annotations.NewManager(setup.k8sClient).AddMatch(
+		setup.ctx,
+		targetNodeName,
+		stateKey,
+		targetNodeName,
+	))
+
+	require.NoError(t, setup.reconciler.LoadStateWithScope(setup.ctx, true))
+	require.Len(t, setup.publisher.publishedEvents, 1)
+
+	event := setup.publisher.publishedEvents[0]
+	require.Equal(t, shortPolicy.Name, event.policy.Name)
+	require.True(t, event.isHealthy)
+	require.Equal(t, namespace, event.resourceInfo.Namespace)
+	require.Equal(t, podName, event.resourceInfo.Name)
+
+	matches, err := annotations.NewManager(setup.k8sClient).GetMatches(setup.ctx, targetNodeName)
+	require.NoError(t, err)
+	require.NotContains(t, matches, stateKey)
+}
+
+func TestReconciler_LoadStateUsesClusterScopeToDisambiguatePolicyPrefixes(t *testing.T) {
+	shortPolicy := defaultNodeNotReadyPolicy()
+	shortPolicy.Name = "node"
+	slashPolicy := defaultNodeNotReadyPolicy()
+	slashPolicy.Name = "node/not-ready"
+
+	setup := setupTestWithPolicies(t, []config.Policy{shortPolicy, slashPolicy})
+	nodeName := "test-node-ambiguous-policy"
+	stateKey := slashPolicy.Name + "/" + nodeName
+
+	createNode(t, setup, nodeName, v1.ConditionTrue)
+	require.NoError(t, annotations.NewManager(setup.k8sClient).AddMatch(
+		setup.ctx,
+		nodeName,
+		stateKey,
+		nodeName,
+	))
+
+	require.NoError(t, setup.reconciler.LoadStateWithScope(setup.ctx, false))
+	require.Empty(t, setup.publisher.publishedEvents)
+
+	matches, getErr := annotations.NewManager(setup.k8sClient).GetMatches(setup.ctx, nodeName)
+	require.NoError(t, getErr)
+	require.Equal(t, nodeName, matches[stateKey])
+}
+
+func TestReconciler_LoadStateDoesNotClaimStateForRemovedSlashPolicy(t *testing.T) {
+	policy := defaultNodeNotReadyPolicy()
+	policy.Name = "node"
+
+	setup := setupTestWithPolicies(t, []config.Policy{policy})
+	targetNodeName := "test-node-removed-slash-policy-target"
+	stateKey := "node/not-ready/missing-node"
+
+	createNode(t, setup, targetNodeName, v1.ConditionTrue)
+	require.NoError(t, annotations.NewManager(setup.k8sClient).AddMatch(
+		setup.ctx,
+		targetNodeName,
+		stateKey,
+		targetNodeName,
+	))
+
+	require.NoError(t, setup.reconciler.LoadStateWithScope(setup.ctx, false))
+	require.Empty(t, setup.publisher.publishedEvents)
+
+	matches, err := annotations.NewManager(setup.k8sClient).GetMatches(setup.ctx, targetNodeName)
+	require.NoError(t, err)
+	require.Equal(t, targetNodeName, matches[stateKey])
+}
+
 func TestReconciler_PodPolicyNamespaceSkipsOtherNamespaces(t *testing.T) {
 	policy := defaultPodHealthPolicy()
 	policy.Resource.Namespace = "gpu-operator"
@@ -745,9 +1107,10 @@ func setupTestWithPolicies(t *testing.T, policies []config.Policy) *testSetup {
 		Kind:    "Node",
 	}
 
-	annotationMgr := annotations.NewManager(k8sClient)
+	annotationMgr := annotations.NewManagerWithReader(k8sClient, k8sClient)
 
-	reconciler := controller.NewResourceReconciler(
+	reconciler := controller.NewResourceReconcilerWithReader(
+		k8sClient,
 		k8sClient,
 		evaluator,
 		mockPub,
@@ -800,9 +1163,10 @@ func setupTestWithCRD(t *testing.T, policies []config.Policy, crd *apiextensions
 		Kind:    crd.Spec.Names.Kind,
 	}
 
-	annotationMgr := annotations.NewManager(k8sClient)
+	annotationMgr := annotations.NewManagerWithReader(k8sClient, k8sClient)
 
-	reconciler := controller.NewResourceReconciler(
+	reconciler := controller.NewResourceReconcilerWithReader(
+		k8sClient,
 		k8sClient,
 		evaluator,
 		mockPub,
@@ -831,6 +1195,55 @@ type mockPublishedEvent struct {
 
 type mockPublisher struct {
 	publishedEvents []mockPublishedEvent
+	publishErr      error
+}
+
+type countingNodeReader struct {
+	nodes     []v1.Node
+	getCalls  int
+	listCalls int
+}
+
+type getErrorReader struct {
+	client.Reader
+	err error
+}
+
+func (r *getErrorReader) Get(
+	_ context.Context,
+	_ client.ObjectKey,
+	_ client.Object,
+	_ ...client.GetOption,
+) error {
+	return r.err
+}
+
+func (r *countingNodeReader) Get(
+	_ context.Context,
+	_ client.ObjectKey,
+	_ client.Object,
+	_ ...client.GetOption,
+) error {
+	r.getCalls++
+
+	return errors.New("unexpected Get call")
+}
+
+func (r *countingNodeReader) List(
+	_ context.Context,
+	list client.ObjectList,
+	_ ...client.ListOption,
+) error {
+	r.listCalls++
+
+	nodeList, ok := list.(*v1.NodeList)
+	if !ok {
+		return errors.New("expected NodeList")
+	}
+
+	nodeList.Items = append(nodeList.Items, r.nodes...)
+
+	return nil
 }
 
 func (m *mockPublisher) PublishHealthEvent(
@@ -840,6 +1253,10 @@ func (m *mockPublisher) PublishHealthEvent(
 	isHealthy bool,
 	resourceInfo *config.ResourceInfo,
 ) error {
+	if m.publishErr != nil {
+		return m.publishErr
+	}
+
 	m.publishedEvents = append(m.publishedEvents, mockPublishedEvent{
 		ctx:          ctx,
 		policy:       policy,
@@ -911,9 +1328,10 @@ func restartReconciler(t *testing.T, setup *testSetup) *testSetup {
 
 	policies := []config.Policy{defaultNodeNotReadyPolicy()}
 
-	annotationMgr := annotations.NewManager(setup.k8sClient)
+	annotationMgr := annotations.NewManagerWithReader(setup.k8sClient, setup.k8sClient)
 
-	reconciler := controller.NewResourceReconciler(
+	reconciler := controller.NewResourceReconcilerWithReader(
+		setup.k8sClient,
 		setup.k8sClient,
 		setup.evaluator,
 		mockPub,
@@ -949,9 +1367,10 @@ func restartReconcilerWithCRD(t *testing.T, setup *testSetup, policies []config.
 		publishedEvents: []mockPublishedEvent{},
 	}
 
-	annotationMgr := annotations.NewManager(setup.k8sClient)
+	annotationMgr := annotations.NewManagerWithReader(setup.k8sClient, setup.k8sClient)
 
-	reconciler := controller.NewResourceReconciler(
+	reconciler := controller.NewResourceReconcilerWithReader(
+		setup.k8sClient,
 		setup.k8sClient,
 		setup.evaluator,
 		mockPub,
@@ -1102,9 +1521,10 @@ func setupPodTestWithPolicies(t *testing.T, policies []config.Policy) *testSetup
 		Kind:    "Pod",
 	}
 
-	annotationMgr := annotations.NewManager(k8sClient)
+	annotationMgr := annotations.NewManagerWithReader(k8sClient, k8sClient)
 
-	reconciler := controller.NewResourceReconciler(
+	reconciler := controller.NewResourceReconcilerWithReader(
+		k8sClient,
 		k8sClient,
 		evaluator,
 		mockPub,

--- a/health-monitors/kubernetes-object-monitor/pkg/initializer/initializer.go
+++ b/health-monitors/kubernetes-object-monitor/pkg/initializer/initializer.go
@@ -267,33 +267,170 @@ func setupHealthChecks(mgr ctrl.Manager) error {
 func registerControllers(
 	mgr ctrl.Manager,
 	evaluator *policy.Evaluator,
-	pub *publisher.Publisher,
+	pub controller.HealthEventPublisher,
 	policies []config.Policy,
 	maxConcurrentReconciles int,
 ) error {
-	annotationMgr := annotations.NewManager(mgr.GetClient())
+	apiReader := mgr.GetAPIReader()
+	annotationMgr := annotations.NewManagerWithReader(apiReader, mgr.GetClient())
 	gvkPolicies := groupPoliciesByGVK(policies)
+	// The shared barrier prevents workers from consuming initial informer events
+	// before every controller has restored its persisted match state.
+	stateBarrier := newStateLoadBarrier()
+	stateLoader := &controllerStateLoader{
+		barrier: stateBarrier,
+	}
+	enableWarmup := true
 
 	for gvk, policies := range gvkPolicies {
-		reconciler := controller.NewResourceReconciler(mgr.GetClient(), evaluator, pub, annotationMgr, policies, gvk)
-
-		if err := reconciler.LoadState(context.Background()); err != nil {
-			slog.Warn("Failed to load state for controller, starting fresh", "gvk", gvk.String(), "error", err)
+		mapping, err := mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
+		if err != nil {
+			return fmt.Errorf("failed to resolve resource scope for %s: %w", gvk.String(), err)
 		}
 
-		if err := ctrl.NewControllerManagedBy(mgr).
+		var resourceNamespaced bool
+
+		switch mapping.Scope.Name() {
+		case meta.RESTScopeNameNamespace:
+			resourceNamespaced = true
+		case meta.RESTScopeNameRoot:
+			resourceNamespaced = false
+		default:
+			return fmt.Errorf(
+				"unsupported resource scope %q for %s",
+				mapping.Scope.Name(),
+				gvk.String(),
+			)
+		}
+
+		reconciler := controller.NewResourceReconcilerWithReader(
+			mgr.GetClient(),
+			apiReader,
+			evaluator,
+			pub,
+			annotationMgr,
+			policies,
+			gvk,
+		)
+
+		gatedReconciler := &stateLoadingReconciler{
+			reconciler: reconciler,
+			barrier:    stateBarrier,
+		}
+
+		builtController, err := ctrl.NewControllerManagedBy(mgr).
 			For(newUnstructuredForGVK(gvk)).
 			WithOptions(ctrlcontroller.Options{
 				MaxConcurrentReconciles: maxConcurrentReconciles,
+				EnableWarmup:            &enableWarmup,
 			}).
-			Complete(reconciler); err != nil {
+			Build(gatedReconciler)
+		if err != nil {
 			return fmt.Errorf("failed to create controller for %s: %w", gvk.String(), err)
 		}
+
+		warmupController, ok := builtController.(interface {
+			Warmup(context.Context) error
+		})
+		if !ok {
+			return fmt.Errorf("controller for %s does not support source warmup", gvk.String())
+		}
+
+		stateLoader.controllers = append(stateLoader.controllers, controllerState{
+			gvk:                gvk,
+			resourceNamespaced: resourceNamespaced,
+			reconciler:         reconciler,
+			controller:         warmupController,
+		})
 
 		slog.Info("Registered controller", "gvk", gvk.String(), "policies", len(policies))
 	}
 
+	if err := mgr.Add(stateLoader); err != nil {
+		return fmt.Errorf("failed to register controller state loader: %w", err)
+	}
+
 	return nil
+}
+
+type stateLoadBarrier struct {
+	done chan struct{}
+	err  error
+}
+
+func newStateLoadBarrier() *stateLoadBarrier {
+	return &stateLoadBarrier{done: make(chan struct{})}
+}
+
+func (b *stateLoadBarrier) complete(err error) {
+	b.err = err
+	close(b.done)
+}
+
+func (b *stateLoadBarrier) wait(ctx context.Context) error {
+	select {
+	case <-b.done:
+		return b.err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+type stateLoadingReconciler struct {
+	reconciler *controller.ResourceReconciler
+	barrier    *stateLoadBarrier
+}
+
+func (r *stateLoadingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if err := r.barrier.wait(ctx); err != nil {
+		return ctrl.Result{}, fmt.Errorf("initial state load failed: %w", err)
+	}
+
+	return r.reconciler.Reconcile(ctx, req)
+}
+
+type controllerState struct {
+	gvk                schema.GroupVersionKind
+	resourceNamespaced bool
+	reconciler         *controller.ResourceReconciler
+	controller         interface {
+		Warmup(context.Context) error
+	}
+}
+
+type controllerStateLoader struct {
+	barrier     *stateLoadBarrier
+	controllers []controllerState
+}
+
+func (l *controllerStateLoader) Start(ctx context.Context) error {
+	for _, state := range l.controllers {
+		// Controller warmup is serialized and idempotent. Calling it here waits
+		// for the source handler and cache to be ready before the final API scan,
+		// even when the manager's warmup phase is still finishing concurrently.
+		if err := state.controller.Warmup(ctx); err != nil {
+			loadErr := fmt.Errorf("failed to warm up controller source for %s: %w", state.gvk.String(), err)
+			l.barrier.complete(loadErr)
+
+			return loadErr
+		}
+
+		if err := state.reconciler.LoadStateWithScope(ctx, state.resourceNamespaced); err != nil {
+			loadErr := fmt.Errorf("failed to load state for controller %s: %w", state.gvk.String(), err)
+			l.barrier.complete(loadErr)
+
+			return loadErr
+		}
+	}
+
+	l.barrier.complete(nil)
+	<-ctx.Done()
+
+	return nil
+}
+
+func (*controllerStateLoader) NeedLeaderElection() bool {
+	return true
 }
 
 func dialPlatformConnector(socket string) (*grpc.ClientConn, error) {

--- a/health-monitors/kubernetes-object-monitor/pkg/initializer/initializer_test.go
+++ b/health-monitors/kubernetes-object-monitor/pkg/initializer/initializer_test.go
@@ -14,15 +14,29 @@
 package initializer
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	"github.com/nvidia/nvsentinel/health-monitors/kubernetes-object-monitor/pkg/annotations"
+	celenv "github.com/nvidia/nvsentinel/health-monitors/kubernetes-object-monitor/pkg/cel"
 	"github.com/nvidia/nvsentinel/health-monitors/kubernetes-object-monitor/pkg/config"
+	"github.com/nvidia/nvsentinel/health-monitors/kubernetes-object-monitor/pkg/controller"
+	"github.com/nvidia/nvsentinel/health-monitors/kubernetes-object-monitor/pkg/policy"
 )
 
 func TestBuildCacheOptionsLimitsGVKToConfiguredNamespaces(t *testing.T) {
@@ -64,6 +78,313 @@ func TestBuildCacheOptionsRejectsNamespaceForClusterScopedGVK(t *testing.T) {
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "resource.namespace cannot be set for cluster-scoped resource example.com/v1, Kind=ClusterThing")
+}
+
+func TestRegisterControllersRecoversDeletedStateAfterSourceWarmup(t *testing.T) {
+	publisher := &testHealthEventPublisher{
+		events: make(chan testHealthEvent, 1),
+	}
+	mgr, k8sClient, nodeName, stateKey := setupStateRecoveryManager(t, publisher)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	managerErr := make(chan error, 1)
+	go func() {
+		managerErr <- mgr.Start(ctx)
+	}()
+
+	select {
+	case event := <-publisher.events:
+		require.True(t, event.isHealthy)
+		require.Equal(t, nodeName, event.nodeName)
+		require.Equal(t, "Pod", event.resourceInfo.Kind)
+		require.Equal(t, "gpu-operator", event.resourceInfo.Namespace)
+		require.Equal(t, "missing-pod", event.resourceInfo.Name)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for state recovery event")
+	}
+
+	require.Eventually(t, func() bool {
+		matches, err := annotations.NewManager(k8sClient).GetMatches(context.Background(), nodeName)
+
+		return err == nil && matches[stateKey] == ""
+	}, 5*time.Second, 50*time.Millisecond)
+
+	cancel()
+	require.NoError(t, receiveError(t, managerErr))
+}
+
+func TestRegisterControllersFailsManagerStartWhenStateRecoveryFails(t *testing.T) {
+	publishErr := errors.New("publisher unavailable")
+	publisher := &testHealthEventPublisher{
+		events: make(chan testHealthEvent, 1),
+		err:    publishErr,
+	}
+	mgr, _, _, _ := setupStateRecoveryManager(t, publisher)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	managerErr := make(chan error, 1)
+	go func() {
+		managerErr <- mgr.Start(ctx)
+	}()
+
+	select {
+	case err := <-managerErr:
+		require.ErrorIs(t, err, publishErr)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for manager startup to fail")
+	}
+}
+
+func TestStateLoadingReconcilerWaitsForInitialLoad(t *testing.T) {
+	t.Run("propagates load error", func(t *testing.T) {
+		barrier := newStateLoadBarrier()
+		reconciler := &stateLoadingReconciler{barrier: barrier}
+		reconcileErr := make(chan error, 1)
+
+		go func() {
+			_, err := reconciler.Reconcile(context.Background(), ctrl.Request{})
+			reconcileErr <- err
+		}()
+
+		assertReconcileBlocked(t, reconcileErr)
+
+		loadErr := errors.New("initial state load failed")
+		barrier.complete(loadErr)
+		require.ErrorIs(t, receiveError(t, reconcileErr), loadErr)
+	})
+
+	t.Run("calls delegate after successful load", func(t *testing.T) {
+		k8sClient := &getCountingClient{Client: fake.NewClientBuilder().Build()}
+		delegate := controller.NewResourceReconciler(
+			k8sClient,
+			nil,
+			nil,
+			annotations.NewManager(k8sClient),
+			nil,
+			schema.GroupVersionKind{Version: "v1", Kind: "Node"},
+		)
+		barrier := newStateLoadBarrier()
+		reconciler := &stateLoadingReconciler{
+			reconciler: delegate,
+			barrier:    barrier,
+		}
+		reconcileErr := make(chan error, 1)
+
+		go func() {
+			_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: client.ObjectKey{Name: "missing-node"},
+			})
+			reconcileErr <- err
+		}()
+
+		assertReconcileBlocked(t, reconcileErr)
+		require.Zero(t, k8sClient.getCalls)
+
+		barrier.complete(nil)
+		require.NoError(t, receiveError(t, reconcileErr))
+		require.Equal(t, 1, k8sClient.getCalls)
+	})
+}
+
+func TestControllerStateLoaderWarmsSourceBeforeLoadingState(t *testing.T) {
+	warmup := &testWarmupController{}
+	reader := &warmupCheckingReader{warmup: warmup}
+	annotationMgr := annotations.NewManagerWithReader(reader, nil)
+	reconciler := controller.NewResourceReconcilerWithReader(
+		nil,
+		reader,
+		nil,
+		nil,
+		annotationMgr,
+		nil,
+		schema.GroupVersionKind{Version: "v1", Kind: "Pod"},
+	)
+	barrier := newStateLoadBarrier()
+	loader := &controllerStateLoader{
+		barrier: barrier,
+		controllers: []controllerState{
+			{
+				gvk:                schema.GroupVersionKind{Version: "v1", Kind: "Pod"},
+				resourceNamespaced: true,
+				reconciler:         reconciler,
+				controller:         warmup,
+			},
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	startErr := make(chan error, 1)
+	go func() {
+		startErr <- loader.Start(ctx)
+	}()
+
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), time.Second)
+	defer waitCancel()
+	require.NoError(t, barrier.wait(waitCtx))
+	require.True(t, warmup.called)
+	require.Equal(t, 1, reader.listCalls)
+
+	cancel()
+	require.NoError(t, receiveError(t, startErr))
+}
+
+type testHealthEvent struct {
+	nodeName     string
+	isHealthy    bool
+	resourceInfo *config.ResourceInfo
+}
+
+type testHealthEventPublisher struct {
+	events chan testHealthEvent
+	err    error
+}
+
+type testWarmupController struct {
+	called bool
+}
+
+func (c *testWarmupController) Warmup(context.Context) error {
+	c.called = true
+
+	return nil
+}
+
+type warmupCheckingReader struct {
+	warmup    *testWarmupController
+	listCalls int
+}
+
+func (*warmupCheckingReader) Get(
+	context.Context,
+	client.ObjectKey,
+	client.Object,
+	...client.GetOption,
+) error {
+	return errors.New("unexpected Get call")
+}
+
+func (r *warmupCheckingReader) List(
+	_ context.Context,
+	_ client.ObjectList,
+	_ ...client.ListOption,
+) error {
+	if !r.warmup.called {
+		return errors.New("state loaded before source warmup")
+	}
+
+	r.listCalls++
+
+	return nil
+}
+
+type getCountingClient struct {
+	client.Client
+	getCalls int
+}
+
+func (c *getCountingClient) Get(
+	ctx context.Context,
+	key client.ObjectKey,
+	obj client.Object,
+	opts ...client.GetOption,
+) error {
+	c.getCalls++
+
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func (p *testHealthEventPublisher) PublishHealthEvent(
+	_ context.Context,
+	_ *config.Policy,
+	nodeName string,
+	isHealthy bool,
+	resourceInfo *config.ResourceInfo,
+) error {
+	if p.err != nil {
+		return p.err
+	}
+
+	p.events <- testHealthEvent{
+		nodeName:     nodeName,
+		isHealthy:    isHealthy,
+		resourceInfo: resourceInfo,
+	}
+
+	return nil
+}
+
+func setupStateRecoveryManager(
+	t *testing.T,
+	publisher *testHealthEventPublisher,
+) (ctrl.Manager, client.Client, string, string) {
+	t.Helper()
+
+	testEnv := &envtest.Environment{}
+	cfg, err := testEnv.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, testEnv.Stop())
+	})
+
+	skipNameValidation := true
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		HealthProbeBindAddress: "0",
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		Controller: ctrlconfig.Controller{
+			SkipNameValidation: &skipNameValidation,
+		},
+	})
+	require.NoError(t, err)
+
+	k8sClient, err := client.New(cfg, client.Options{})
+	require.NoError(t, err)
+
+	nodeName := "state-recovery-node"
+	stateKey := "gpu-operator-pod-health/gpu-operator/missing-pod"
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+			Annotations: map[string]string{
+				annotations.AnnotationKey: `{"` + stateKey + `":"` + nodeName + `"}`,
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(context.Background(), node))
+
+	policies := []config.Policy{
+		testPolicy("gpu-operator-pod-health", "", "v1", "Pod", "gpu-operator"),
+	}
+	celEnvironment, err := celenv.NewEnvironment(mgr.GetClient())
+	require.NoError(t, err)
+	evaluator, err := policy.NewEvaluator(celEnvironment, policies)
+	require.NoError(t, err)
+
+	require.NoError(t, registerControllers(mgr, evaluator, publisher, policies, 1))
+
+	return mgr, k8sClient, nodeName, stateKey
+}
+
+func assertReconcileBlocked(t *testing.T, reconcileErr <-chan error) {
+	t.Helper()
+
+	select {
+	case err := <-reconcileErr:
+		t.Fatalf("reconcile returned before initial state load completed: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func receiveError(t *testing.T, errCh <-chan error) error {
+	t.Helper()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for operation to finish")
+		return nil
+	}
 }
 
 func testRESTMapper() meta.RESTMapper {


### PR DESCRIPTION
## Summary

- warm each Kubernetes object controller source before the final persisted-state scan
- gate reconciliation workers until every controller has finished state recovery
- use the direct API reader for startup reads while keeping the cached client for normal reconciliation and writes
- publish the normal healthy transition for resources deleted during downtime, while preserving recoverable state on read or publish failure
- decode persisted keys from the right using the REST-mapped GVK scope, so slash-containing policy names remain compatible and removed policies cannot be claimed by a shorter prefix

This preserves the existing exported `LoadState(ctx)` API; the manager startup
path uses the new scope-aware recovery method.

Closes #1542.

## Why the startup ordering matters

A scan before the controller source starts still leaves a gap: an object can be
present during the scan and disappear before the informer's initial list,
producing neither `NotFound` nor a delete event. The state-loader runnable
therefore waits for the controller's idempotent source warmup first, performs
the direct-API verification second, and only then releases the shared worker
barrier.

If source warmup, state loading, an API read, or recovery publication fails,
`Manager.Start` returns the error so the workload can retry instead of running
with silently stale quarantine state.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected

- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [x] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing

- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

The public DCO-signed head `7915b7cac35663577a9bc858e78ccf9d6e1c4931`
was validated on its original base with Kubernetes envtest 1.36.2:

- full module race suite: 50 tests passed
- correct module-path statement coverage: 64.2%
- repository-pinned `golangci-lint` v2.5.0: 0 issues
- component `make lint-test`, `go vet ./...`, and `go build ./...`

Current-main compatibility was revalidated locally on
`0a95948f5a200c8d08641e4e89b8e3f210ec9fe3` after preserving the newer
cache-sync timeout and platform-connector token-auth changes:

- full module `-race -count=1` suite: 51 tests passed
- correct module-path statement coverage: 68.7% total and 40.6% for the controller package
- four scope/key regressions: 12/12 across three race-enabled repetitions
- barrier success/error paths: 100 assertions across 25 race-enabled repetitions
- `go vet ./...`, `go build ./...`, `gofmt`, and `git diff --check`
- Go 1.27-built `golangci-lint` v2.12.2: 0 issues
- independent final review: 0 Critical and 0 Important findings

The current main branch targets Go 1.27, while the repository's pinned
`golangci-lint` v2.5.0 cannot decode Go 1.27 export data. The newer linter was
used only for the current-main compatibility check; the pinned version had
already passed on the public head's original base.

The regression coverage includes a real Manager lifecycle, a Pod deleted with
zero grace while the monitor is stopped, direct reads before the manager cache
starts, non-`NotFound` API errors, recovery publication failure, Node deletion,
cluster- and namespace-scoped slash/prefix collisions, and state left by a
removed policy.

## Branch status

This PR remains Draft because the public head has not yet been refreshed and is
currently conflicting with `main`. The current-main port is locally verified;
a refreshed DCO-signed commit is still required before marking the PR ready.

## Checklist

- [x] Self-review completed
- [x] Documentation updated (if needed)
- [ ] Ready for review
