### PR TITLE
Add lambda janitor plugin

### DIFF
--- a/commons/pkg/lambda/client.go
+++ b/commons/pkg/lambda/client.go
@@ -17,8 +17,10 @@
 package lambda
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -41,7 +43,15 @@ const (
 	defaultInitialBackoff = 500 * time.Millisecond
 	defaultBackoffFactor  = 2.0
 	defaultBackoffJitter  = 0.2
+
+	// maxRedirects mirrors net/http's own cap, which is dropped the moment
+	// CheckRedirect is set.
+	maxRedirects = 10
 )
+
+// errRedirect marks a redirect this client refused to follow. A redirect chain
+// is deterministic, so retrying only replays it.
+var errRedirect = errors.New("redirect refused")
 
 // Client is an authenticated HTTP client for the Lambda Cloud API.
 // The API key is read from LAMBDA_API_KEY on every request so credential
@@ -50,13 +60,15 @@ const (
 // Requests are retried with exponential backoff on transient failures
 // (network errors, 5xx responses, and 429 Too Many Requests). Permanent
 // failures (4xx other than 429, malformed responses, missing API key)
-// short-circuit the retry loop.
+// short-circuit the retry loop. Post retries on less, see retryRateLimitOnly.
 type Client struct {
 	endpoint string
 	http     *http.Client
 	retry    retryPolicy
 }
 
+// retryPolicy is the exponential-backoff schedule applied to a request.
+// maxAttempts counts the initial attempt.
 type retryPolicy struct {
 	maxAttempts    int
 	initialBackoff time.Duration
@@ -114,13 +126,70 @@ func NewClient(endpoint string, opts ...Option) *Client {
 		o(c)
 	}
 
+	// Wrapped rather than assigned outright, and after the options so an
+	// injected client cannot opt out of the scheme check.
+	c.http.CheckRedirect = refuseInsecureRedirect(c.http.CheckRedirect)
+
 	return c
+}
+
+// redirectPolicy is net/http's CheckRedirect signature.
+type redirectPolicy func(req *http.Request, via []*http.Request) error
+
+// refuseInsecureRedirect wraps next with a scheme check. net/http copies
+// Authorization to the same host or a subdomain without looking at the scheme,
+// so a downgrade would hand the API key to a plaintext listener.
+//
+// Setting CheckRedirect at all replaces net/http's ten-redirect cap, so with no
+// next to defer to this reimposes it. Without that an https to https loop runs
+// until the client timeout.
+func refuseInsecureRedirect(next redirectPolicy) redirectPolicy {
+	return func(req *http.Request, via []*http.Request) error {
+		if req.URL.Scheme != "https" {
+			return fmt.Errorf("%w: %s would send the API key over %s",
+				errRedirect, req.URL.Redacted(), req.URL.Scheme)
+		}
+
+		if next != nil {
+			return next(req, via)
+		}
+
+		if len(via) >= maxRedirects {
+			return fmt.Errorf("%w: stopped after %d redirects", errRedirect, maxRedirects)
+		}
+
+		return nil
+	}
 }
 
 // Get performs an authenticated GET against endpoint+path with optional query
 // params and decodes the JSON response body into out. If out is nil, the body
 // is discarded. Retries transient failures with exponential backoff.
 func (c *Client) Get(ctx context.Context, path string, query url.Values, out any) error {
+	return c.do(ctx, http.MethodGet, path, query, nil, out, retryTransient)
+}
+
+// Post performs an authenticated POST against endpoint+path with in marshalled
+// as the JSON request body, and decodes the JSON response into out.
+//
+// It serves the instance-operations endpoints, which are not idempotent and
+// take no idempotency key, so it retries on less than Get does. See
+// retryRateLimitOnly.
+func (c *Client) Post(ctx context.Context, path string, in, out any) error {
+	// Marshalled once so every retry resends identical bytes.
+	payload, err := json.Marshal(in)
+	if err != nil {
+		return fmt.Errorf("marshal request body: %w", err)
+	}
+
+	return c.do(ctx, http.MethodPost, path, nil, payload, out, retryRateLimitOnly)
+}
+
+// do performs an authenticated request and decodes the JSON response into out.
+// payload is nil for methods without a request body.
+func (c *Client) do(
+	ctx context.Context, method, path string, query url.Values, payload []byte, out any, retry retryScope,
+) error {
 	apiKey := os.Getenv(APIKeyEnvVar)
 	if apiKey == "" {
 		return fmt.Errorf("env var %s is not set", APIKeyEnvVar)
@@ -146,25 +215,30 @@ func (c *Client) Get(ctx context.Context, path string, query url.Values, out any
 	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
 		attempts++
 
-		body, statusCode, doErr := c.doOnce(ctx, u, apiKey)
+		body, statusCode, doErr := c.doOnce(ctx, method, u, apiKey, payload)
 		if doErr != nil {
-			// Transport-level failures (dial, TLS, i/o) are transient.
+			// Transport-level failures (dial, TLS, i/o).
+			if !retry(statusCode, doErr) {
+				return false, doErr
+			}
+
 			lastErr = doErr
 			slog.Debug("Lambda API request failed, will retry", "url", u, "error", doErr)
 
 			return false, nil
 		}
 
-		if statusCode == http.StatusTooManyRequests || statusCode >= 500 {
-			lastErr = fmt.Errorf("GET %s: status %d: %s", u, statusCode, body)
+		if statusCode != http.StatusOK {
+			statusErr := fmt.Errorf("%s %s: status %d: %s", method, u, statusCode, body)
+			if !retry(statusCode, nil) {
+				return false, statusErr
+			}
+
+			lastErr = statusErr
+
 			slog.Debug("Lambda API returned retryable status", "url", u, "status", statusCode)
 
 			return false, nil
-		}
-
-		if statusCode != http.StatusOK {
-			// Permanent client error (401, 403, 404, ...) — do not retry.
-			return false, fmt.Errorf("GET %s: status %d: %s", u, statusCode, body)
 		}
 
 		return true, decodeBody(body, out)
@@ -183,8 +257,32 @@ func (c *Client) Get(ctx context.Context, path string, query url.Values, out any
 	return err
 }
 
+// retryScope reports whether a failed attempt can be repeated. transportErr is
+// nil when the request completed, in which case statusCode holds the response
+// status.
+type retryScope func(statusCode int, transportErr error) bool
+
+// retryTransient retries network errors, 429, and 5xx. Safe for a request that
+// can be repeated without side effects. A refused redirect is excluded: the
+// chain is deterministic, so a repeat earns the same refusal.
+func retryTransient(statusCode int, transportErr error) bool {
+	if errors.Is(transportErr, errRedirect) {
+		return false
+	}
+
+	return transportErr != nil || statusCode == http.StatusTooManyRequests || statusCode >= 500
+}
+
+// retryRateLimitOnly retries only 429, where the rate limiter rejected the
+// request without acting on it. A transport error or 5xx is ambiguous, the
+// request may already have taken effect so it surfaces on the first attempt
+// rather than resubmitting an operation that cannot be undone.
+func retryRateLimitOnly(statusCode int, transportErr error) bool {
+	return transportErr == nil && statusCode == http.StatusTooManyRequests
+}
+
 // decodeBody unmarshals body into out when out is non-nil, otherwise discards
-// body. Extracted from Get so the retry closure stays under the cyclomatic
+// body. Extracted from do so the retry closure stays under the cyclomatic
 // complexity limit.
 func decodeBody(body []byte, out any) error {
 	if out == nil {
@@ -201,8 +299,13 @@ func decodeBody(body []byte, out any) error {
 // doOnce performs a single request. It returns the response body and status
 // code separately so the retry loop can classify the outcome without having
 // to keep the *http.Response around.
-func (c *Client) doOnce(ctx context.Context, u, apiKey string) ([]byte, int, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+func (c *Client) doOnce(ctx context.Context, method, u, apiKey string, payload []byte) ([]byte, int, error) {
+	var reqBody io.Reader
+	if payload != nil {
+		reqBody = bytes.NewReader(payload)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, u, reqBody)
 	if err != nil {
 		return nil, 0, fmt.Errorf("build request: %w", err)
 	}
@@ -210,9 +313,13 @@ func (c *Client) doOnce(ctx context.Context, u, apiKey string) ([]byte, int, err
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return nil, 0, fmt.Errorf("GET %s: %w", u, err)
+		return nil, 0, fmt.Errorf("%s %s: %w", method, u, err)
 	}
 	defer resp.Body.Close()
 

--- a/commons/pkg/lambda/client_test.go
+++ b/commons/pkg/lambda/client_test.go
@@ -17,6 +17,7 @@ package lambda
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -34,11 +35,29 @@ func fastRetry(maxAttempts int) Option {
 	return WithRetryPolicy(maxAttempts, time.Microsecond, 2.0, 0.0)
 }
 
+// TestClientGetSuccess pins the request shape every Lambda call depends on:
+// bearer auth, a JSON Accept header, query params carried through, and no
+// Content-Type on a body-less GET.
 func TestClientGetSuccess(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
-		require.Equal(t, "application/json", r.Header.Get("Accept"))
-		require.Equal(t, "abc", r.URL.Query().Get("page_token"))
+		// assert, not require: this runs on the server goroutine, and require's
+		// FailNow is only valid on the test's own.
+		if !assert.Equal(t, "Bearer test-key", r.Header.Get("Authorization")) {
+			return
+		}
+
+		if !assert.Equal(t, "application/json", r.Header.Get("Accept")) {
+			return
+		}
+
+		if !assert.Empty(t, r.Header.Get("Content-Type")) {
+			return
+		}
+
+		if !assert.Equal(t, "abc", r.URL.Query().Get("page_token")) {
+			return
+		}
+
 		fmt.Fprint(w, `{"data":{"id":"i-1"}}`)
 	}))
 	defer srv.Close()
@@ -57,6 +76,8 @@ func TestClientGetSuccess(t *testing.T) {
 	assert.Equal(t, "i-1", out.Data.ID)
 }
 
+// TestClientGetMissingAPIKey checks an unset key fails before any request is
+// built, and that the error names the env var an operator has to set.
 func TestClientGetMissingAPIKey(t *testing.T) {
 	c := NewClient("http://example.invalid")
 	t.Setenv(APIKeyEnvVar, "")
@@ -64,6 +85,9 @@ func TestClientGetMissingAPIKey(t *testing.T) {
 	assert.ErrorContains(t, err, "LAMBDA_API_KEY")
 }
 
+// TestClientGetPermanent4xxNoRetry checks a client error short-circuits the
+// backoff loop. Retrying a 401 burns the whole retry budget on a credential
+// problem that cannot fix itself.
 func TestClientGetPermanent4xxNoRetry(t *testing.T) {
 	var calls atomic.Int32
 
@@ -82,6 +106,8 @@ func TestClientGetPermanent4xxNoRetry(t *testing.T) {
 	assert.EqualValues(t, 1, calls.Load(), "4xx should short-circuit the retry loop")
 }
 
+// TestClientGetRetriesOn5xxThenSucceeds covers the idempotent-GET path: a
+// server error is transient, so the call recovers instead of failing a poll.
 func TestClientGetRetriesOn5xxThenSucceeds(t *testing.T) {
 	var calls atomic.Int32
 
@@ -109,6 +135,9 @@ func TestClientGetRetriesOn5xxThenSucceeds(t *testing.T) {
 	assert.EqualValues(t, 3, calls.Load())
 }
 
+// TestClientGetRetriesOn429ThenGivesUp checks the retry budget is bounded and
+// that the surfaced error reports the attempts actually made, not the
+// configured maximum.
 func TestClientGetRetriesOn429ThenGivesUp(t *testing.T) {
 	var calls atomic.Int32
 
@@ -128,6 +157,8 @@ func TestClientGetRetriesOn429ThenGivesUp(t *testing.T) {
 	assert.EqualValues(t, 3, calls.Load())
 }
 
+// TestClientGetContextCancelStopsRetries checks a cancelled context stops the
+// backoff loop, so a shutting-down process does not keep hitting the API.
 func TestClientGetContextCancelStopsRetries(t *testing.T) {
 	var calls atomic.Int32
 
@@ -146,4 +177,156 @@ func TestClientGetContextCancelStopsRetries(t *testing.T) {
 	err := c.Get(ctx, "/api/v1/things", nil, nil)
 	require.Error(t, err)
 	assert.LessOrEqual(t, calls.Load(), int32(1), "cancelled ctx should not hit the server multiple times")
+}
+
+// TestClient_Post_Success_SendsJSONBodyAndDecodesResponse pins the POST request
+// shape: a marshalled JSON body plus the Content-Type header a GET must not
+// carry.
+func TestClient_Post_Success_SendsJSONBodyAndDecodesResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.JSONEq(t, `{"ids":["i-1"]}`, string(body))
+
+		fmt.Fprint(w, `{"data":{"id":"i-1"}}`)
+	}))
+	defer srv.Close()
+
+	t.Setenv(APIKeyEnvVar, "test-key")
+
+	c := NewClient(srv.URL, WithHTTPClient(srv.Client()))
+	in := struct {
+		IDs []string `json:"ids"`
+	}{IDs: []string{"i-1"}}
+
+	var out struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+
+	require.NoError(t, c.Post(context.Background(), "/api/v1/things", in, &out))
+	assert.Equal(t, "i-1", out.Data.ID)
+}
+
+// TestClient_Post_UnmarshalableBody_ReturnsErrorWithoutRequesting checks a body
+// that cannot be marshalled fails before anything reaches the network. The
+// endpoint is deliberately unroutable so a regression shows up as a test error
+// rather than a hang.
+func TestClient_Post_UnmarshalableBody_ReturnsErrorWithoutRequesting(t *testing.T) {
+	t.Setenv(APIKeyEnvVar, "test-key")
+
+	c := NewClient("http://example.invalid")
+	err := c.Post(context.Background(), "/api/v1/things", make(chan int), nil)
+	assert.ErrorContains(t, err, "marshal request body")
+}
+
+// net/http copies Authorization to the same host or a subdomain without looking
+// at the scheme, so an https endpoint redirecting to http would hand the API key
+// to a plaintext listener. Both servers here are on 127.0.0.1, which is what
+// makes the stdlib treat them as the same host.
+func TestClient_HTTPSToHTTPRedirect_RefusedWithoutSendingAPIKey(t *testing.T) {
+	var gotAuth atomic.Value
+
+	gotAuth.Store("")
+
+	plain := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth.Store(r.Header.Get("Authorization"))
+		fmt.Fprint(w, `{}`)
+	}))
+	defer plain.Close()
+
+	secure := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, plain.URL, http.StatusFound)
+	}))
+	defer secure.Close()
+
+	t.Setenv(APIKeyEnvVar, "test-key")
+
+	c := NewClient(secure.URL, WithHTTPClient(secure.Client()), fastRetry(1))
+	err := c.Get(context.Background(), "/api/v1/things", nil, nil)
+
+	assert.ErrorContains(t, err, "redirect refused")
+	assert.Empty(t, gotAuth.Load(), "the API key must never reach the plaintext server")
+}
+
+// TestClient_HTTPSRedirectLoop_StopsAtLimitWithoutRetrying guards the cap that
+// setting CheckRedirect silently drops. Left unhandled an https to https loop
+// runs until the client timeout, and the timeout then looks transient enough to
+// retry, replaying the whole chain.
+func TestClient_HTTPSRedirectLoop_StopsAtLimitWithoutRetrying(t *testing.T) {
+	var calls atomic.Int32
+
+	secure := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.Redirect(w, r, r.URL.String(), http.StatusFound)
+	}))
+	defer secure.Close()
+
+	t.Setenv(APIKeyEnvVar, "test-key")
+
+	client := secure.Client()
+	client.Timeout = 10 * time.Second // bounds the damage if the cap regresses
+
+	c := NewClient(secure.URL, WithHTTPClient(client), fastRetry(4))
+	err := c.Get(context.Background(), "/api/v1/things", nil, nil)
+
+	assert.ErrorContains(t, err, "stopped after 10 redirects")
+	assert.LessOrEqual(t, calls.Load(), int32(maxRedirects),
+		"one capped chain: neither an uncapped loop nor a retried one")
+}
+
+// TestClient_InjectedCheckRedirect_RunsAfterTheSchemeCheck covers the wrapping:
+// a caller's own policy still applies, but only for redirects that survive the
+// https check.
+func TestClient_InjectedCheckRedirect_RunsAfterTheSchemeCheck(t *testing.T) {
+	var injectedCalls atomic.Int32
+
+	target := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"data":{"id":"i-1"}}`)
+	}))
+	defer target.Close()
+
+	secure := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer secure.Close()
+
+	t.Setenv(APIKeyEnvVar, "test-key")
+
+	client := secure.Client()
+	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		injectedCalls.Add(1)
+
+		return fmt.Errorf("injected policy says no")
+	}
+
+	c := NewClient(secure.URL, WithHTTPClient(client), fastRetry(1))
+	err := c.Get(context.Background(), "/api/v1/things", nil, nil)
+
+	assert.ErrorContains(t, err, "injected policy says no")
+	assert.EqualValues(t, 1, injectedCalls.Load(), "the injected policy must still be consulted")
+}
+
+// TestClient_Post_Permanent4xx_ErrorNamesTheMethod checks the error carries the
+// verb and status, so a failed remediation can be diagnosed from the message
+// alone.
+func TestClient_Post_Permanent4xx_ErrorNamesTheMethod(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"error":{"code":"global/not-found"}}`)
+	}))
+	defer srv.Close()
+
+	t.Setenv(APIKeyEnvVar, "test-key")
+
+	c := NewClient(srv.URL, WithHTTPClient(srv.Client()), fastRetry(3))
+	err := c.Post(context.Background(), "/api/v1/things", struct{}{}, nil)
+	assert.ErrorContains(t, err, "POST")
+	assert.ErrorContains(t, err, "404")
 }

--- a/commons/pkg/lambda/instances.go
+++ b/commons/pkg/lambda/instances.go
@@ -1,0 +1,173 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lambda
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+const (
+	instancesPath          = "/api/v1/instances"
+	powerCycleInstancePath = "/api/v1/instance-operations/power-cycle"
+	terminateInstancePath  = "/api/v1/instance-operations/terminate"
+)
+
+// Instance status values NVSentinel branches on. The API's InstanceStatus enum
+// has more; everything else is treated as a transient state.
+const (
+	InstanceStatusActive      = "active"
+	InstanceStatusTerminated  = "terminated"
+	InstanceStatusTerminating = "terminating"
+	InstanceStatusPreempted   = "preempted"
+)
+
+// Instance is the subset of the Lambda instance object NVSentinel needs.
+type Instance struct {
+	ID      string          `json:"id"`
+	Status  string          `json:"status"`
+	Actions InstanceActions `json:"actions"`
+}
+
+// InstanceAction reports whether an operation can be performed on an instance
+// right now, and why not when it cannot.
+type InstanceAction struct {
+	Available         bool   `json:"available"`
+	ReasonCode        string `json:"reason_code"`
+	ReasonDescription string `json:"reason_description"`
+}
+
+// InstanceActions is the subset of the API's action-availability block
+// NVSentinel checks. Fields are pointers so callers can tell "the API did not
+// report on this action" from "the action is unavailable".
+type InstanceActions struct {
+	PowerCycle *InstanceAction `json:"power_cycle"`
+	ColdReboot *InstanceAction `json:"cold_reboot"`
+	Terminate  *InstanceAction `json:"terminate"`
+}
+
+// PowerCycleAction returns the reported availability of the power-cycle action,
+// or nil when the API did not report on it.
+//
+// The API reports it under cold_reboot: internally the action type is
+// COLD_REBOOT and it maps to the public power_cycle operation. power_cycle is
+// read first so this keeps working once the field is renamed to match the
+// surviving endpoint.
+func (i *Instance) PowerCycleAction() *InstanceAction {
+	if i.Actions.PowerCycle != nil {
+		return i.Actions.PowerCycle
+	}
+
+	return i.Actions.ColdReboot
+}
+
+// instanceIDsRequest is the body shared by the instance-operations endpoints,
+// which are batch APIs even when acting on a single instance.
+type instanceIDsRequest struct {
+	InstanceIDs []string `json:"instance_ids"`
+}
+
+// instanceResponse is the envelope GET /instances/{id} returns.
+type instanceResponse struct {
+	Data Instance `json:"data"`
+}
+
+// powerCycleResponse is the envelope the power-cycle endpoint returns. The
+// instances it echoes back are what acknowledged checks.
+type powerCycleResponse struct {
+	Data struct {
+		PowerCycledInstances []Instance `json:"power_cycled_instances"`
+	} `json:"data"`
+}
+
+// terminateResponse is the envelope the terminate endpoint returns, differing
+// from powerCycleResponse only in the key holding the echoed instances.
+type terminateResponse struct {
+	Data struct {
+		TerminatedInstances []Instance `json:"terminated_instances"`
+	} `json:"data"`
+}
+
+// GetInstance fetches a single instance by ID. Retry/backoff is handled by the
+// underlying Client.
+func (c *Client) GetInstance(ctx context.Context, instanceID string) (*Instance, error) {
+	if instanceID == "" {
+		return nil, fmt.Errorf("instance id is empty")
+	}
+
+	var parsed instanceResponse
+	if err := c.Get(ctx, instancesPath+"/"+url.PathEscape(instanceID), nil, &parsed); err != nil {
+		return nil, fmt.Errorf("get instance %s: %w", instanceID, err)
+	}
+
+	return &parsed.Data, nil
+}
+
+// PowerCycleInstance hard power-cycles an instance at the host level. It is
+// asynchronous: the instance still reports its pre-power-cycle status when this
+// returns, so callers must poll for completion.
+func (c *Client) PowerCycleInstance(ctx context.Context, instanceID string) error {
+	if instanceID == "" {
+		return fmt.Errorf("instance id is empty")
+	}
+
+	var parsed powerCycleResponse
+
+	req := instanceIDsRequest{InstanceIDs: []string{instanceID}}
+	if err := c.Post(ctx, powerCycleInstancePath, req, &parsed); err != nil {
+		return fmt.Errorf("power cycle instance %s: %w", instanceID, err)
+	}
+
+	if !acknowledged(parsed.Data.PowerCycledInstances, instanceID) {
+		return fmt.Errorf("power cycle instance %s: not acknowledged by the API", instanceID)
+	}
+
+	return nil
+}
+
+// TerminateInstance terminates an instance. It is asynchronous: the instance is
+// typically still reported as "terminating" when this returns.
+func (c *Client) TerminateInstance(ctx context.Context, instanceID string) error {
+	if instanceID == "" {
+		return fmt.Errorf("instance id is empty")
+	}
+
+	var parsed terminateResponse
+
+	req := instanceIDsRequest{InstanceIDs: []string{instanceID}}
+	if err := c.Post(ctx, terminateInstancePath, req, &parsed); err != nil {
+		return fmt.Errorf("terminate instance %s: %w", instanceID, err)
+	}
+
+	if !acknowledged(parsed.Data.TerminatedInstances, instanceID) {
+		return fmt.Errorf("terminate instance %s: not acknowledged by the API", instanceID)
+	}
+
+	return nil
+}
+
+// acknowledged reports whether the API echoed the instance back. These
+// endpoints re-read the IDs they were given, so a missing one means the
+// operation did not apply to our instance.
+func acknowledged(instances []Instance, instanceID string) bool {
+	for _, i := range instances {
+		if i.ID == instanceID {
+			return true
+		}
+	}
+
+	return false
+}

--- a/commons/pkg/lambda/instances_test.go
+++ b/commons/pkg/lambda/instances_test.go
@@ -1,0 +1,304 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lambda
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClient_GetInstance_ExistingInstance_ReturnsInstance pins the path and
+// verb used to read one instance, and that the response envelope is unwrapped.
+func TestClient_GetInstance_ExistingInstance_ReturnsInstance(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, instancesPath+"/i-123", r.URL.Path)
+		assert.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
+
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(instanceResponse{
+			Data: Instance{ID: "i-123", Status: InstanceStatusActive},
+		}))
+	}))
+	defer srv.Close()
+
+	t.Setenv(APIKeyEnvVar, "test-key")
+
+	inst, err := NewClient(srv.URL, WithHTTPClient(srv.Client())).GetInstance(context.Background(), "i-123")
+	require.NoError(t, err)
+	assert.Equal(t, "i-123", inst.ID)
+	assert.Equal(t, InstanceStatusActive, inst.Status)
+}
+
+// TestClient_GetInstance_EmptyID_ReturnsError checks an empty ID is rejected
+// locally rather than becoming a request for the whole instance collection.
+func TestClient_GetInstance_EmptyID_ReturnsError(t *testing.T) {
+	_, err := NewClient("http://example.invalid").GetInstance(context.Background(), "")
+	assert.ErrorContains(t, err, "instance id is empty")
+}
+
+// TestClient_GetInstance_NotFound_ReturnsErrorWithoutRetrying checks a 404 is
+// terminal and that the API's error code survives into the returned error.
+func TestClient_GetInstance_NotFound_ReturnsErrorWithoutRetrying(t *testing.T) {
+	var calls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"error":{"code":"global/object-does-not-exist","message":"not found"}}`)
+	}))
+	defer srv.Close()
+
+	t.Setenv(APIKeyEnvVar, "test-key")
+
+	_, err := NewClient(srv.URL, WithHTTPClient(srv.Client()), fastRetry(4)).
+		GetInstance(context.Background(), "i-gone")
+	assert.ErrorContains(t, err, "404")
+	assert.ErrorContains(t, err, "global/object-does-not-exist")
+	assert.EqualValues(t, 1, calls.Load(), "4xx should short-circuit the retry loop")
+}
+
+// instanceOperationCase drives the two instance-operations endpoints, which
+// differ only in path and response envelope key.
+type instanceOperationCase struct {
+	name     string
+	wantPath string
+	respBody string
+	call     func(context.Context, *Client) error
+}
+
+// instanceOperationCases returns both instance-operation endpoints so every
+// test below runs against power-cycle and terminate alike.
+func instanceOperationCases() []instanceOperationCase {
+	return []instanceOperationCase{
+		{
+			name:     "power cycle",
+			wantPath: powerCycleInstancePath,
+			respBody: `{"data":{"power_cycled_instances":[{"id":"i-123","status":"active"}]}}`,
+			call: func(ctx context.Context, c *Client) error {
+				return c.PowerCycleInstance(ctx, "i-123")
+			},
+		},
+		{
+			name:     "terminate",
+			wantPath: terminateInstancePath,
+			respBody: `{"data":{"terminated_instances":[{"id":"i-123","status":"terminating"}]}}`,
+			call: func(ctx context.Context, c *Client) error {
+				return c.TerminateInstance(ctx, "i-123")
+			},
+		},
+	}
+}
+
+// TestClient_InstanceOperations_Success_PostsInstanceID pins the wire contract
+// of both operations: the right path, and the single instance ID wrapped in the
+// batch body the API expects.
+func TestClient_InstanceOperations_Success_PostsInstanceID(t *testing.T) {
+	for _, tc := range instanceOperationCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, tc.wantPath, r.URL.Path)
+				assert.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
+				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+				body, err := io.ReadAll(r.Body)
+				assert.NoError(t, err)
+				assert.JSONEq(t, `{"instance_ids":["i-123"]}`, string(body))
+
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, tc.respBody)
+			}))
+			defer srv.Close()
+
+			t.Setenv(APIKeyEnvVar, "test-key")
+
+			require.NoError(t, tc.call(context.Background(), NewClient(srv.URL, WithHTTPClient(srv.Client()))))
+		})
+	}
+}
+
+// The API re-reads the IDs it was given, so a response missing ours means the
+// operation did not apply to our instance.
+func TestClient_InstanceOperations_UnacknowledgedInstance_ReturnsError(t *testing.T) {
+	for _, tc := range instanceOperationCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, strings.Replace(tc.respBody, `"id":"i-123"`, `"id":"i-999"`, 1))
+			}))
+			defer srv.Close()
+
+			t.Setenv(APIKeyEnvVar, "test-key")
+
+			err := tc.call(context.Background(), NewClient(srv.URL, WithHTTPClient(srv.Client())))
+			assert.ErrorContains(t, err, "not acknowledged")
+			assert.ErrorContains(t, err, "i-123")
+		})
+	}
+}
+
+// An empty ID is caught locally, matching GetInstance. Left through, it posts
+// {"instance_ids":[""]} and burns a round-trip to learn nothing matched. The
+// table above bakes in a valid ID, so these take the methods directly.
+func TestClient_InstanceOperations_EmptyID_ReturnsErrorWithoutRequesting(t *testing.T) {
+	ops := []struct {
+		name string
+		call func(*Client, context.Context, string) error
+	}{
+		{"power cycle", (*Client).PowerCycleInstance},
+		{"terminate", (*Client).TerminateInstance},
+	}
+
+	for _, op := range ops {
+		t.Run(op.name, func(t *testing.T) {
+			var calls atomic.Int32
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				calls.Add(1)
+				fmt.Fprint(w, `{"data":{}}`)
+			}))
+			defer srv.Close()
+
+			t.Setenv(APIKeyEnvVar, "test-key")
+
+			c := NewClient(srv.URL, WithHTTPClient(srv.Client()))
+			assert.ErrorContains(t, op.call(c, context.Background(), ""), "instance id is empty")
+			assert.Zero(t, calls.Load(), "an empty ID must not reach the API")
+		})
+	}
+}
+
+// 429 means the rate limiter rejected the request without acting on it, so it
+// is the one outcome a non-idempotent POST may retry. The retry must resend the
+// body, not an already-drained reader.
+func TestClient_InstanceOperations_RateLimited_RetriesWithSameBody(t *testing.T) {
+	for _, tc := range instanceOperationCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls atomic.Int32
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				assert.NoError(t, err)
+				assert.JSONEq(t, `{"instance_ids":["i-123"]}`, string(body))
+
+				if calls.Add(1) < 3 {
+					w.WriteHeader(http.StatusTooManyRequests)
+					fmt.Fprint(w, `{"error":"slow down"}`)
+
+					return
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, tc.respBody)
+			}))
+			defer srv.Close()
+
+			t.Setenv(APIKeyEnvVar, "test-key")
+
+			require.NoError(t, tc.call(context.Background(), NewClient(srv.URL, WithHTTPClient(srv.Client()), fastRetry(5))))
+			assert.EqualValues(t, 3, calls.Load())
+		})
+	}
+}
+
+// A 5xx is ambiguous: the operation may already have landed. Resubmitting could
+// power cycle a host that is already booting, so these POSTs must not retry.
+func TestClient_InstanceOperations_ServerError_DoesNotRetry(t *testing.T) {
+	for _, tc := range instanceOperationCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls atomic.Int32
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				calls.Add(1)
+				w.WriteHeader(http.StatusInternalServerError)
+				fmt.Fprint(w, `{"error":"boom"}`)
+			}))
+			defer srv.Close()
+
+			t.Setenv(APIKeyEnvVar, "test-key")
+
+			err := tc.call(context.Background(), NewClient(srv.URL, WithHTTPClient(srv.Client()), fastRetry(5)))
+			assert.ErrorContains(t, err, "500")
+			assert.ErrorContains(t, err, "i-123")
+			assert.EqualValues(t, 1, calls.Load(), "a 5xx POST may already have taken effect")
+		})
+	}
+}
+
+// Same reasoning as the 5xx case: a lost response does not mean a lost request.
+func TestClient_InstanceOperations_TransportError_DoesNotRetry(t *testing.T) {
+	for _, tc := range instanceOperationCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls atomic.Int32
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				calls.Add(1)
+
+				// assert, not require: this runs on the server goroutine, and
+				// require's FailNow is only valid on the test's own.
+				hj, ok := w.(http.Hijacker)
+				if !assert.True(t, ok) {
+					return
+				}
+
+				conn, _, err := hj.Hijack()
+				if !assert.NoError(t, err) {
+					return
+				}
+
+				conn.Close()
+			}))
+			defer srv.Close()
+
+			t.Setenv(APIKeyEnvVar, "test-key")
+
+			err := tc.call(context.Background(), NewClient(srv.URL, WithHTTPClient(srv.Client()), fastRetry(5)))
+			assert.Error(t, err)
+			assert.EqualValues(t, 1, calls.Load(), "the request may have reached the API")
+		})
+	}
+}
+
+// TestClient_InstanceOperations_Forbidden_ErrorNamesInstance checks a rejected
+// operation names the instance it was for, so one failure in a fleet-wide
+// remediation can be traced back to a node.
+func TestClient_InstanceOperations_Forbidden_ErrorNamesInstance(t *testing.T) {
+	for _, tc := range instanceOperationCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+				fmt.Fprint(w, `{"error":{"code":"global/account-inactive","message":"nope"}}`)
+			}))
+			defer srv.Close()
+
+			t.Setenv(APIKeyEnvVar, "test-key")
+
+			err := tc.call(context.Background(), NewClient(srv.URL, WithHTTPClient(srv.Client()), fastRetry(3)))
+			assert.ErrorContains(t, err, "i-123")
+			assert.ErrorContains(t, err, "403")
+		})
+	}
+}

--- a/distros/kubernetes/nvsentinel/charts/janitor-provider/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor-provider/templates/deployment.yaml
@@ -167,6 +167,20 @@ spec:
               value: {{ .Values.csp.nebius.iamToken | quote }}
             {{- end }}
             {{- end }}
+            {{- if eq (lower (.Values.csp.provider | default "kind")) "lambda" }}
+            # Lambda-specific environment variables
+            {{- if .Values.csp.lambda.apiEndpoint }}
+            # Validated in code against a fixed host allowlist, an unapproved
+            # host fails at startup rather than on the first remediation.
+            - name: LAMBDA_API_ENDPOINT
+              value: {{ .Values.csp.lambda.apiEndpoint | quote }}
+            {{- end }}
+            - name: LAMBDA_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "csp.lambda.apiKeySecretRef.name must be set when csp.provider=lambda" .Values.csp.lambda.apiKeySecretRef.name }}
+                  key: {{ .Values.csp.lambda.apiKeySecretRef.key | default "LAMBDA_API_KEY" }}
+            {{- end }}
             {{- if .Values.tls.enabled }}
             - name: TLS_CERT_PATH
               value: "{{ .Values.tls.certDir }}/tls.crt"

--- a/distros/kubernetes/nvsentinel/charts/janitor-provider/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor-provider/values.yaml
@@ -98,7 +98,7 @@ auth:
 # The janitor-provider module supports multiple cloud providers for node reboot operations
 # Configure the appropriate CSP for your environment
 csp:
-  # CSP provider type (kind, kwok, aws, gcp, azure, oci, nebius, generic)
+  # CSP provider type (kind, kwok, aws, gcp, azure, oci, nebius, lambda, generic)
   # - kind: For local development with kind clusters (simulated reboots)
   # - kwok: For testing with kwok (simulated nodes)
   # - aws: For AWS EKS clusters
@@ -106,6 +106,7 @@ csp:
   # - azure: For Microsoft Azure AKS clusters
   # - oci: For Oracle Cloud Infrastructure OKE clusters
   # - nebius: For Nebius Managed Kubernetes (MK8s) clusters
+  # - lambda: For Lambda Cloud clusters (reboot = power cycle, terminate = terminate instance)
   # - generic: For bare-metal / on-premises clusters (reboots via privileged Job)
   provider: "kind"
 
@@ -231,3 +232,22 @@ csp:
     # - NEBIUS_SA_KEY_FILE: Path to service account credentials JSON file (recommended)
     #   The service account must have compute.instances.stop and compute.instances.start permissions
     # - NEBIUS_IAM_TOKEN: Direct IAM token (for testing only)
+
+  # Lambda Cloud specific configuration (only required when provider=lambda)
+  # Reboot maps to the power-cycle operation, terminate to the terminate operation.
+  lambda:
+    # apiEndpoint overrides the Lambda Cloud API base URL, set via LAMBDA_API_ENDPOINT.
+    # Must be https, and the host is checked in code against a fixed allowlist,
+    # so an unapproved host fails at startup.
+    apiEndpoint: ""
+    # apiKeySecretRef names the Secret containing the LAMBDA_API_KEY env var.
+    # Required when provider=lambda, plaintext key values are not supported.
+    # The key needs permission to power cycle and terminate instances.
+    # Example:
+    #   apiKeySecretRef:
+    #     name: lambda-api-key
+    #     key: LAMBDA_API_KEY
+    apiKeySecretRef:
+      name: ""
+      key: "LAMBDA_API_KEY"
+

--- a/docs/configuration/janitor-provider.md
+++ b/docs/configuration/janitor-provider.md
@@ -78,7 +78,7 @@ List of accepted token audiences. Must include the value set in `janitor.config.
 ```yaml
 janitor-provider:
   csp:
-    provider: "kind"  # Options: kind, kwok, aws, gcp, azure, oci, nebius, generic
+    provider: "kind"  # Options: kind, kwok, aws, gcp, azure, oci, nebius, lambda, generic
 ```
 
 Only one provider is active at a time. `kind` and `kwok` are for development only; they simulate reboots without contacting any cloud API.
@@ -186,6 +186,26 @@ Profile name within the credentials file. Defaults to `DEFAULT`. Ignored when `c
 
 ### principalId
 OCI principal OCID used for Workload Identity. Required when `credentialsFile` is empty.
+
+## Lambda
+
+Uses a Lambda Cloud API key for authentication. Reboot maps to the Lambda power-cycle operation (a host-level power cycle, not a guest restart) and terminate maps to the Lambda terminate operation. Nodes must carry `spec.providerID` in the form `lambda://<instanceID>`.
+
+```yaml
+janitor-provider:
+  csp:
+    provider: "lambda"
+    lambda:
+      apiKeySecretRef:
+        name: "lambda-api-key"
+        key: "LAMBDA_API_KEY"
+```
+
+### apiEndpoint
+Optional. Overrides the base URL of the Lambda Cloud API, passed as `LAMBDA_API_ENDPOINT`. Defaults to `https://cloud.lambda.ai` when unset. Must be https, and must not carry userinfo, a query string, or a fragment. The host is checked against a fixed allowlist built into the provider, so an unapproved host fails at startup rather than on the first remediation.
+
+### apiKeySecretRef
+Secret holding the Lambda API key, injected as `LAMBDA_API_KEY`. `name` is required when `csp.provider` is `lambda`; the install fails without it. `key` defaults to `LAMBDA_API_KEY`. The same Secret can be shared with the CSP Health Monitor, which reads the key the same way. The key needs permission to power cycle and terminate instances.
 
 ## Generic / Bare-Metal
 

--- a/janitor-provider/pkg/csp/client.go
+++ b/janitor-provider/pkg/csp/client.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nvidia/nvsentinel/janitor-provider/pkg/csp/gcp"
 	"github.com/nvidia/nvsentinel/janitor-provider/pkg/csp/generic"
 	"github.com/nvidia/nvsentinel/janitor-provider/pkg/csp/kind"
+	"github.com/nvidia/nvsentinel/janitor-provider/pkg/csp/lambda"
 	"github.com/nvidia/nvsentinel/janitor-provider/pkg/csp/nebius"
 	"github.com/nvidia/nvsentinel/janitor-provider/pkg/csp/oci"
 	"github.com/nvidia/nvsentinel/janitor-provider/pkg/model"
@@ -38,6 +39,7 @@ const (
 	ProviderAzure   Provider = "azure"
 	ProviderOCI     Provider = "oci"
 	ProviderNebius  Provider = "nebius"
+	ProviderLambda  Provider = "lambda"
 	ProviderGeneric Provider = "generic"
 )
 
@@ -85,6 +87,8 @@ func NewWithProvider(ctx context.Context, provider Provider) (model.CSPClient, e
 		return oci.NewClientFromEnv(ctx)
 	case ProviderNebius:
 		return nebius.NewClientFromEnv(ctx)
+	case ProviderLambda:
+		return lambda.NewClientFromEnv(ctx)
 	case ProviderGeneric:
 		return generic.NewClient(ctx)
 	default:
@@ -118,6 +122,8 @@ func GetProviderFromString(providerStr string) (Provider, error) {
 		return ProviderOCI, nil
 	case "nebius":
 		return ProviderNebius, nil
+	case "lambda":
+		return ProviderLambda, nil
 	case "generic":
 		return ProviderGeneric, nil
 	default:

--- a/janitor-provider/pkg/csp/client_test.go
+++ b/janitor-provider/pkg/csp/client_test.go
@@ -35,6 +35,7 @@ func TestProvider_String(t *testing.T) {
 		{"azure provider", ProviderAzure, "azure"},
 		{"oci provider", ProviderOCI, "oci"},
 		{"nebius provider", ProviderNebius, "nebius"},
+		{"lambda provider", ProviderLambda, "lambda"},
 		{"generic provider", ProviderGeneric, "generic"},
 	}
 
@@ -67,6 +68,7 @@ func TestGetProviderFromEnv_Valid(t *testing.T) {
 		{"azure", "azure", ProviderAzure},
 		{"oci", "oci", ProviderOCI},
 		{"nebius", "nebius", ProviderNebius},
+		{"lambda", "lambda", ProviderLambda},
 		{"generic", "generic", ProviderGeneric},
 	}
 
@@ -193,6 +195,7 @@ func TestProviderConstants(t *testing.T) {
 	assert.Equal(t, Provider("azure"), ProviderAzure)
 	assert.Equal(t, Provider("oci"), ProviderOCI)
 	assert.Equal(t, Provider("nebius"), ProviderNebius)
+	assert.Equal(t, Provider("lambda"), ProviderLambda)
 	assert.Equal(t, Provider("generic"), ProviderGeneric)
 }
 
@@ -238,6 +241,12 @@ func TestNewWithProvider_AllProviders(t *testing.T) {
 			name:          "nebius provider",
 			provider:      ProviderNebius,
 			shouldSucceed: true,
+		},
+		{
+			name:          "lambda provider",
+			provider:      ProviderLambda,
+			shouldSucceed: false,
+			skipReason:    "Lambda client requires an API key",
 		},
 	}
 
@@ -300,12 +309,14 @@ func TestGetProviderFromString(t *testing.T) {
 		{"azure lowercase", "azure", ProviderAzure, false},
 		{"oci lowercase", "oci", ProviderOCI, false},
 		{"nebius lowercase", "nebius", ProviderNebius, false},
+		{"lambda lowercase", "lambda", ProviderLambda, false},
 		{"generic lowercase", "generic", ProviderGeneric, false},
 		{"kind uppercase", "KIND", ProviderKind, false}, // case insensitive
 		{"aws uppercase", "AWS", ProviderAWS, false},
 		{"gcp mixed case", "GcP", ProviderGCP, false},
 		{"azure mixed case", "Azure", ProviderAzure, false},
 		{"nebius mixed case", "Nebius", ProviderNebius, false},
+		{"lambda mixed case", "Lambda", ProviderLambda, false},
 		{"generic mixed case", "Generic", ProviderGeneric, false},
 		{"invalid", "invalid", "", true},
 		{"empty", "", "", true},

--- a/janitor-provider/pkg/csp/lambda/lambda.go
+++ b/janitor-provider/pkg/csp/lambda/lambda.go
@@ -1,0 +1,352 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package lambda implements the Lambda Cloud CSP client for NVSentinel janitor
+// node operations, using the shared Lambda REST client in commons/pkg/lambda.
+// Reboot maps to the Lambda power-cycle operation, terminate to the Lambda
+// terminate operation.
+//
+// Both are asynchronous. IsNodeReady reports the reboot done only once the
+// kubelet-reported bootID differs from the one recorded before the power cycle;
+// instance status alone still reads "active" for a while after the API accepts
+// the request.
+package lambda
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/nvidia/nvsentinel/commons/pkg/auditlogger"
+	commonslambda "github.com/nvidia/nvsentinel/commons/pkg/lambda"
+	"github.com/nvidia/nvsentinel/janitor-provider/pkg/model"
+)
+
+const (
+	// APIEndpointEnvVar overrides the Lambda Cloud API base URL.
+	APIEndpointEnvVar = "LAMBDA_API_ENDPOINT"
+
+	// DefaultAPIHost is the host of the production Lambda Cloud API.
+	DefaultAPIHost = "cloud.lambda.ai"
+
+	// DefaultAPIEndpoint is the production Lambda Cloud API.
+	DefaultAPIEndpoint = "https://" + DefaultAPIHost
+
+	providerIDPrefix = "lambda://"
+
+	// requestRefSeparator joins the requestRef fields below.
+	requestRefSeparator = "|"
+
+	// requestRefFields is instanceID, preRebootBootID, startedAt.
+	requestRefFields = 3
+
+	// powerCycleStatusFloor absorbs the eventual consistency of the instance
+	// status, which still reads "active" for a while after the API accepts
+	// the power-cycle request.
+	powerCycleStatusFloor = 120 * time.Second
+
+	// apiTimeout bounds a single Lambda API call. Longer than the shared
+	// client's default: a power cycle reaches through to the hypervisor, and a
+	// timeout on a request that already took effect costs a second one.
+	apiTimeout = 120 * time.Second
+)
+
+// allowedAPIHosts is every host LAMBDA_API_ENDPOINT may point at. Anything
+// else fails at startup, bounding where the API key can be sent.
+var allowedAPIHosts = []string{
+	DefaultAPIHost,
+	"cloud.lambdastaging.com",
+}
+
+var _ model.CSPClient = (*Client)(nil)
+
+// InstanceAPI is the subset of the shared Lambda client this package needs.
+type InstanceAPI interface {
+	GetInstance(ctx context.Context, instanceID string) (*commonslambda.Instance, error)
+	PowerCycleInstance(ctx context.Context, instanceID string) error
+	TerminateInstance(ctx context.Context, instanceID string) error
+}
+
+// Client is the Lambda implementation of the CSP Client interface.
+type Client struct {
+	api InstanceAPI
+}
+
+// NewClient creates a Lambda client backed by the given API.
+func NewClient(api InstanceAPI) *Client {
+	return &Client{api: api}
+}
+
+// NewClientFromEnv creates a Lambda client from LAMBDA_API_ENDPOINT (optional)
+// and LAMBDA_API_KEY.
+func NewClientFromEnv(_ context.Context) (*Client, error) {
+	endpoint, err := endpointFromEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	if os.Getenv(commonslambda.APIKeyEnvVar) == "" {
+		return nil, fmt.Errorf("env var %s is not set", commonslambda.APIKeyEnvVar)
+	}
+
+	httpClient := &http.Client{
+		Timeout:   apiTimeout,
+		Transport: auditlogger.NewAuditingRoundTripper(http.DefaultTransport),
+	}
+
+	slog.Info("Using Lambda Cloud API")
+
+	return NewClient(commonslambda.NewClient(endpoint, commonslambda.WithHTTPClient(httpClient))), nil
+}
+
+// endpointFromEnv resolves the API base URL, rejecting anything that is not an
+// absolute https URL so a typo fails at startup, not on the first remediation.
+//
+// http is refused outright rather than warned about or gated behind an opt-in:
+// the API key is a bearer token on every request, so there is no configuration
+// under which sending it in cleartext is acceptable.
+//
+// The host must be one of allowedAPIHosts, so a mistyped or altered endpoint
+// cannot send the API key somewhere unintended.
+func endpointFromEnv() (string, error) {
+	raw := strings.TrimSpace(os.Getenv(APIEndpointEnvVar))
+	if raw == "" {
+		return DefaultAPIEndpoint, nil
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("parse %s: %w", APIEndpointEnvVar, err)
+	}
+
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("%s must not include userinfo, query parameters, or fragments", APIEndpointEnvVar)
+	}
+
+	if parsed.Scheme == "http" {
+		return "", fmt.Errorf("%s uses http, which would send the API key in cleartext: use https",
+			APIEndpointEnvVar)
+	}
+
+	if parsed.Scheme != "https" {
+		return "", fmt.Errorf("%s %q must be an absolute https URL", APIEndpointEnvVar, raw)
+	}
+
+	if parsed.Host == "" {
+		return "", fmt.Errorf("%s %q has no host", APIEndpointEnvVar, raw)
+	}
+
+	if !allowedHost(parsed.Hostname()) {
+		return "", fmt.Errorf("%s host %q is not an approved Lambda API host", APIEndpointEnvVar, parsed.Hostname())
+	}
+
+	return strings.TrimSuffix(raw, "/"), nil
+}
+
+// allowedHost reports whether the bearer token may be sent to host. The list is
+// deliberately fixed: making it configurable would let whoever sets the
+// endpoint widen the bound too, which defeats the point of having one.
+func allowedHost(host string) bool {
+	for _, allowed := range allowedAPIHosts {
+		if strings.EqualFold(allowed, host) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// SendRebootSignal power-cycles the node's Lambda instance and returns
+// immediately, the janitor controller polls IsNodeReady for completion.
+func (c *Client) SendRebootSignal(ctx context.Context, node corev1.Node) (model.ResetSignalRequestRef, error) {
+	instanceID, err := parseProviderID(node.Spec.ProviderID)
+	if err != nil {
+		return "", fmt.Errorf("node %s: %w", node.Name, err)
+	}
+
+	preRebootBootID := node.Status.NodeInfo.BootID
+	if preRebootBootID == "" {
+		return "", fmt.Errorf("node %s has no bootID", node.Name)
+	}
+
+	instance, err := c.api.GetInstance(ctx, instanceID)
+	if err != nil {
+		return "", fmt.Errorf("power cycle node %s: %w", node.Name, err)
+	}
+
+	// Lambda's power-cycle endpoint does no in-flight validation, so this is the
+	// only thing stopping a second power cycle landing on a booting host.
+	if err := actionBlocked(instance.PowerCycleAction(), "power cycle", instanceID); err != nil {
+		return "", fmt.Errorf("node %s: %w", node.Name, err)
+	}
+
+	slog.InfoContext(ctx, "Power cycling Lambda instance",
+		"node", node.Name, "instanceID", instanceID, "bootID", preRebootBootID)
+
+	if err := c.api.PowerCycleInstance(ctx, instanceID); err != nil {
+		return "", fmt.Errorf("power cycle node %s: %w", node.Name, err)
+	}
+
+	return model.ResetSignalRequestRef(strings.Join([]string{
+		instanceID,
+		preRebootBootID,
+		time.Now().UTC().Format(time.RFC3339),
+	}, requestRefSeparator)), nil
+}
+
+// IsNodeReady reports whether the node came back from the power cycle.
+func (c *Client) IsNodeReady(ctx context.Context, node corev1.Node, requestID string) (bool, error) {
+	ref, err := parseRequestRef(requestID)
+	if err != nil {
+		return false, fmt.Errorf("node %s: %w", node.Name, err)
+	}
+
+	instanceID := ref.instanceID
+
+	if elapsed := time.Since(ref.startedAt); elapsed < powerCycleStatusFloor {
+		slog.InfoContext(ctx, "Within power cycle startup floor, not ready yet",
+			"node", node.Name, "instanceID", instanceID, "elapsed", elapsed.String())
+
+		return false, nil
+	}
+
+	instance, err := c.api.GetInstance(ctx, instanceID)
+	if err != nil {
+		slog.WarnContext(ctx, "Failed to read Lambda instance, treating node as not ready yet",
+			"node", node.Name, "instanceID", instanceID, "error", err)
+
+		return false, nil
+	}
+
+	switch instance.Status {
+	case commonslambda.InstanceStatusTerminated,
+		commonslambda.InstanceStatusTerminating,
+		commonslambda.InstanceStatusPreempted:
+		return false, fmt.Errorf("node %s: instance %s is %s, it will not come back from the power cycle",
+			node.Name, instanceID, instance.Status)
+	case commonslambda.InstanceStatusActive:
+		// Checked against the bootID below.
+	default:
+		slog.InfoContext(ctx, "Lambda instance not active yet",
+			"node", node.Name, "instanceID", instanceID, "status", instance.Status)
+
+		return false, nil
+	}
+
+	// An empty bootID means kubelet has not reported yet, not that the node
+	// came back on a new boot.
+	currentBootID := node.Status.NodeInfo.BootID
+	if currentBootID == "" || currentBootID == ref.preRebootBootID {
+		slog.InfoContext(ctx, "Node has not yet rebooted",
+			"node", node.Name, "instanceID", instanceID, "bootID", currentBootID)
+
+		return false, nil
+	}
+
+	slog.InfoContext(ctx, "Node rebooted",
+		"node", node.Name, "instanceID", instanceID,
+		"oldBootID", ref.preRebootBootID, "newBootID", currentBootID)
+
+	return true, nil
+}
+
+// SendTerminateSignal terminates the node's Lambda instance. The janitor
+// controller then waits for the Kubernetes Node to go NotReady and deletes it.
+func (c *Client) SendTerminateSignal(ctx context.Context, node corev1.Node) (model.TerminateNodeRequestRef, error) {
+	instanceID, err := parseProviderID(node.Spec.ProviderID)
+	if err != nil {
+		return "", fmt.Errorf("node %s: %w", node.Name, err)
+	}
+
+	instance, err := c.api.GetInstance(ctx, instanceID)
+	if err != nil {
+		return "", fmt.Errorf("terminate node %s: %w", node.Name, err)
+	}
+
+	if err := actionBlocked(instance.Actions.Terminate, "terminate", instanceID); err != nil {
+		return "", fmt.Errorf("node %s: %w", node.Name, err)
+	}
+
+	slog.InfoContext(ctx, "Terminating Lambda instance", "node", node.Name, "instanceID", instanceID)
+
+	if err := c.api.TerminateInstance(ctx, instanceID); err != nil {
+		return "", fmt.Errorf("terminate node %s: %w", node.Name, err)
+	}
+
+	return model.TerminateNodeRequestRef(instanceID), nil
+}
+
+// actionBlocked errors only if the API explicitly marks the action unavailable.
+// A nil action (not reported) is treated as available, not blocked.
+func actionBlocked(action *commonslambda.InstanceAction, op, instanceID string) error {
+	if action == nil || action.Available {
+		return nil
+	}
+
+	return fmt.Errorf("%s is blocked for instance %s: %s [reason_code=%s]",
+		op, instanceID,
+		cmp.Or(action.ReasonDescription, "no reason given"),
+		cmp.Or(action.ReasonCode, "unknown"))
+}
+
+// parseProviderID extracts the instance ID from lambda://<instanceID>.
+func parseProviderID(providerID string) (string, error) {
+	if providerID == "" {
+		return "", fmt.Errorf("no provider ID set")
+	}
+
+	// Instance IDs are opaque hex, so a slash means this is not our shape.
+	instanceID, ok := strings.CutPrefix(providerID, providerIDPrefix)
+	if !ok || instanceID == "" || strings.Contains(instanceID, "/") {
+		return "", fmt.Errorf("provider ID %q is not %s<instanceID>", providerID, providerIDPrefix)
+	}
+
+	return instanceID, nil
+}
+
+// requestRef is the opaque ref SendRebootSignal returns and IsNodeReady gets
+// back verbatim.
+type requestRef struct {
+	instanceID      string
+	preRebootBootID string
+	startedAt       time.Time
+}
+
+// parseRequestRef splits a ref back into its fields.
+func parseRequestRef(requestID string) (requestRef, error) {
+	malformed := fmt.Errorf(
+		"malformed request ref %q, want <instanceID>%s<bootID>%s<RFC3339 time>",
+		requestID, requestRefSeparator, requestRefSeparator,
+	)
+
+	parts := strings.Split(requestID, requestRefSeparator)
+	if len(parts) != requestRefFields || parts[0] == "" || parts[1] == "" {
+		return requestRef{}, malformed
+	}
+
+	startedAt, err := time.Parse(time.RFC3339, parts[2])
+	if err != nil {
+		return requestRef{}, malformed
+	}
+
+	return requestRef{instanceID: parts[0], preRebootBootID: parts[1], startedAt: startedAt}, nil
+}

--- a/janitor-provider/pkg/csp/lambda/lambda_test.go
+++ b/janitor-provider/pkg/csp/lambda/lambda_test.go
@@ -1,0 +1,624 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lambda
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	commonslambda "github.com/nvidia/nvsentinel/commons/pkg/lambda"
+)
+
+// fakeAPI records the instance IDs each operation was called with.
+type fakeAPI struct {
+	instance  *commonslambda.Instance
+	getErr    error
+	powerErr  error
+	terminErr error
+
+	powerCycleCalls []string
+	terminateCalls  []string
+	getCalls        []string
+}
+
+// GetInstance returns the canned instance, recording the ID it was asked for so
+// tests can assert which instance was polled.
+func (f *fakeAPI) GetInstance(_ context.Context, instanceID string) (*commonslambda.Instance, error) {
+	f.getCalls = append(f.getCalls, instanceID)
+
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+
+	return f.instance, nil
+}
+
+// PowerCycleInstance records the call so tests can assert a power cycle was, or
+// crucially was not, issued.
+func (f *fakeAPI) PowerCycleInstance(_ context.Context, instanceID string) error {
+	f.powerCycleCalls = append(f.powerCycleCalls, instanceID)
+
+	return f.powerErr
+}
+
+// TerminateInstance records the call so tests can assert a terminate was, or
+// crucially was not, issued.
+func (f *fakeAPI) TerminateInstance(_ context.Context, instanceID string) error {
+	f.terminateCalls = append(f.terminateCalls, instanceID)
+
+	return f.terminErr
+}
+
+// available/blocked build the API's action-availability entries.
+func available() *commonslambda.InstanceAction {
+	return &commonslambda.InstanceAction{Available: true}
+}
+
+// blocked builds an action the API reports as unavailable, with the reason
+// fields an operator would see in the resulting error.
+func blocked(code, desc string) *commonslambda.InstanceAction {
+	return &commonslambda.InstanceAction{ReasonCode: code, ReasonDescription: desc}
+}
+
+// node builds the minimal Node the client reads: a provider ID and the bootID
+// kubelet reports.
+func node(providerID, bootID string) corev1.Node {
+	return corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-a"},
+		Spec:       corev1.NodeSpec{ProviderID: providerID},
+		Status:     corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{BootID: bootID}},
+	}
+}
+
+// ref builds a request ref for a power cycle that started ago in the past.
+func ref(instanceID, bootID string, ago time.Duration) string {
+	return strings.Join([]string{
+		instanceID,
+		bootID,
+		time.Now().UTC().Add(-ago).Format(time.RFC3339),
+	}, requestRefSeparator)
+}
+
+// pastFloor is comfortably beyond powerCycleStatusFloor.
+const pastFloor = 2 * powerCycleStatusFloor
+
+// TestSendRebootSignal_Scenarios_PowerCyclesOrErrors covers the preconditions a
+// reboot must satisfy before the API is touched, and the request ref handed
+// back to the janitor on success.
+func TestSendRebootSignal_Scenarios_PowerCyclesOrErrors(t *testing.T) {
+	okInstance := &commonslambda.Instance{
+		ID:     "i-123",
+		Status: commonslambda.InstanceStatusActive,
+		Actions: commonslambda.InstanceActions{
+			ColdReboot: available(),
+			Terminate:  available(),
+		},
+	}
+
+	tests := []struct {
+		name    string
+		node    corev1.Node
+		api     fakeAPI
+		wantErr string
+	}{
+		{
+			name: "power cycles the instance",
+			node: node("lambda://i-123", "boot-1"),
+			api:  fakeAPI{instance: okInstance},
+		},
+		{
+			// The API reports power cycle under cold_reboot today, but the key
+			// is expected to be renamed as the older operations are deprecated.
+			name: "accepts the power_cycle action key",
+			node: node("lambda://i-123", "boot-1"),
+			api: fakeAPI{instance: &commonslambda.Instance{
+				ID:      "i-123",
+				Actions: commonslambda.InstanceActions{PowerCycle: available()},
+			}},
+		},
+		{
+			// An absent action block must not block the reboot, or a rename
+			// upstream would silently stop every remediation.
+			name: "proceeds when the API reports no actions",
+			node: node("lambda://i-123", "boot-1"),
+			api:  fakeAPI{instance: &commonslambda.Instance{ID: "i-123"}},
+		},
+		{
+			name: "power cycle blocked by the API",
+			node: node("lambda://i-123", "boot-1"),
+			api: fakeAPI{instance: &commonslambda.Instance{
+				ID: "i-123",
+				Actions: commonslambda.InstanceActions{
+					ColdReboot: blocked("vm-action-in-progress", "another action is running"),
+				},
+			}},
+			wantErr: "power cycle is blocked for instance i-123: another action is running [reason_code=vm-action-in-progress]",
+		},
+		{
+			name:    "instance lookup fails",
+			node:    node("lambda://i-123", "boot-1"),
+			api:     fakeAPI{getErr: errors.New("boom")},
+			wantErr: "power cycle node node-a: boom",
+		},
+		{
+			name:    "missing provider ID",
+			node:    node("", "boot-1"),
+			api:     fakeAPI{},
+			wantErr: "no provider ID set",
+		},
+		{
+			name:    "non-lambda provider ID",
+			node:    node("aws:///us-west-2/i-123", "boot-1"),
+			api:     fakeAPI{},
+			wantErr: "is not lambda://",
+		},
+		{
+			name:    "missing bootID",
+			node:    node("lambda://i-123", ""),
+			api:     fakeAPI{},
+			wantErr: "has no bootID",
+		},
+		{
+			name:    "API error",
+			node:    node("lambda://i-123", "boot-1"),
+			api:     fakeAPI{instance: okInstance, powerErr: errors.New("boom")},
+			wantErr: "power cycle node node-a: boom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := tt.api
+
+			got, err := NewClient(&api).SendRebootSignal(context.Background(), tt.node)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				assert.Empty(t, got)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, []string{"i-123"}, api.powerCycleCalls)
+
+			parsed, err := parseRequestRef(string(got))
+			require.NoError(t, err)
+			assert.Equal(t, "i-123", parsed.instanceID)
+			assert.Equal(t, "boot-1", parsed.preRebootBootID)
+			assert.WithinDuration(t, time.Now(), parsed.startedAt, time.Minute)
+		})
+	}
+}
+
+// A malformed provider ID must fail before any destructive call reaches the API.
+func TestSendRebootSignal_BadProviderID_DoesNotCallAPI(t *testing.T) {
+	api := fakeAPI{}
+
+	_, err := NewClient(&api).SendRebootSignal(context.Background(), node("lambda://", "boot-1"))
+	require.Error(t, err)
+	assert.Empty(t, api.powerCycleCalls)
+}
+
+// TestSendRebootSignal_BlockedAction_DoesNotPowerCycle is the guard against
+// power cycling a host the API has already marked ineligible. The endpoint does
+// no in-flight validation, so this check is the only thing standing in the way.
+func TestSendRebootSignal_BlockedAction_DoesNotPowerCycle(t *testing.T) {
+	api := fakeAPI{instance: &commonslambda.Instance{
+		ID:      "i-123",
+		Actions: commonslambda.InstanceActions{ColdReboot: blocked("vm-is-too-old", "unsupported")},
+	}}
+
+	_, err := NewClient(&api).SendRebootSignal(context.Background(), node("lambda://i-123", "boot-1"))
+	require.Error(t, err)
+	assert.Empty(t, api.powerCycleCalls)
+}
+
+// TestIsNodeReady_Scenarios_ReportsReadiness covers readiness reporting: which
+// instance states are still transient, which mean the node is never coming
+// back, and the bootID comparison that actually proves the reboot happened.
+func TestIsNodeReady_Scenarios_ReportsReadiness(t *testing.T) {
+	active := &commonslambda.Instance{ID: "i-123", Status: commonslambda.InstanceStatusActive}
+
+	tests := []struct {
+		name      string
+		bootID    string
+		requestID string
+		api       fakeAPI
+		want      bool
+		wantErr   string
+	}{
+		{
+			name:      "active instance with a new bootID is ready",
+			bootID:    "boot-2",
+			requestID: ref("i-123", "boot-1", pastFloor),
+			api:       fakeAPI{instance: active},
+			want:      true,
+		},
+		{
+			name:      "active instance with the pre-reboot bootID has not rebooted yet",
+			bootID:    "boot-1",
+			requestID: ref("i-123", "boot-1", pastFloor),
+			api:       fakeAPI{instance: active},
+			want:      false,
+		},
+		{
+			name:      "active instance with no bootID reported is not ready",
+			bootID:    "",
+			requestID: ref("i-123", "boot-1", pastFloor),
+			api:       fakeAPI{instance: active},
+			want:      false,
+		},
+		{
+			name:      "within the startup floor nothing is ready",
+			bootID:    "boot-2",
+			requestID: ref("i-123", "boot-1", time.Second),
+			api:       fakeAPI{instance: active},
+			want:      false,
+		},
+		{
+			name:      "booting instance is not ready",
+			bootID:    "boot-2",
+			requestID: ref("i-123", "boot-1", pastFloor),
+			api:       fakeAPI{instance: &commonslambda.Instance{ID: "i-123", Status: "booting"}},
+			want:      false,
+		},
+		{
+			name:      "unhealthy instance is not ready",
+			bootID:    "boot-2",
+			requestID: ref("i-123", "boot-1", pastFloor),
+			api:       fakeAPI{instance: &commonslambda.Instance{ID: "i-123", Status: "unhealthy"}},
+			want:      false,
+		},
+		{
+			name:      "terminated instance will never come back",
+			bootID:    "boot-2",
+			requestID: ref("i-123", "boot-1", pastFloor),
+			api:       fakeAPI{instance: &commonslambda.Instance{ID: "i-123", Status: commonslambda.InstanceStatusTerminated}},
+			wantErr:   "will not come back",
+		},
+		{
+			name:      "terminating instance will never come back",
+			bootID:    "boot-2",
+			requestID: ref("i-123", "boot-1", pastFloor),
+			api:       fakeAPI{instance: &commonslambda.Instance{ID: "i-123", Status: commonslambda.InstanceStatusTerminating}},
+			wantErr:   "will not come back",
+		},
+		{
+			name:      "preempted instance will never come back",
+			bootID:    "boot-2",
+			requestID: ref("i-123", "boot-1", pastFloor),
+			api:       fakeAPI{instance: &commonslambda.Instance{ID: "i-123", Status: commonslambda.InstanceStatusPreempted}},
+			wantErr:   "will not come back",
+		},
+		{
+			// The janitor treats an error here as terminal for the CR.
+			name:      "API error reports not ready instead of failing",
+			bootID:    "boot-2",
+			requestID: ref("i-123", "boot-1", pastFloor),
+			api:       fakeAPI{getErr: errors.New("503")},
+			want:      false,
+		},
+		{
+			name:      "request ref missing the timestamp",
+			bootID:    "boot-2",
+			requestID: "i-123|boot-1",
+			api:       fakeAPI{},
+			wantErr:   "malformed request ref",
+		},
+		{
+			name:      "request ref with an unparseable timestamp",
+			bootID:    "boot-2",
+			requestID: "i-123|boot-1|yesterday",
+			api:       fakeAPI{},
+			wantErr:   "malformed request ref",
+		},
+		{
+			name:      "request ref with an empty instance ID",
+			bootID:    "boot-2",
+			requestID: ref("", "boot-1", pastFloor),
+			api:       fakeAPI{},
+			wantErr:   "malformed request ref",
+		},
+		{
+			name:      "empty request ref",
+			bootID:    "boot-2",
+			requestID: "",
+			api:       fakeAPI{},
+			wantErr:   "malformed request ref",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := tt.api
+
+			ready, err := NewClient(&api).IsNodeReady(
+				context.Background(), node("lambda://i-123", tt.bootID), tt.requestID)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				assert.False(t, ready)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, ready)
+		})
+	}
+}
+
+// The polled instance must come from the ref, not the live Node: the ref is
+// immutable for the CR's lifetime, the providerID is not. The providerID here
+// deliberately names a different instance.
+func TestIsNodeReady_PastFloor_PollsInstanceFromRequestRefNotProviderID(t *testing.T) {
+	api := fakeAPI{instance: &commonslambda.Instance{ID: "i-123", Status: commonslambda.InstanceStatusActive}}
+
+	ready, err := NewClient(&api).IsNodeReady(
+		context.Background(), node("lambda://i-replacement", "boot-2"), ref("i-123", "boot-1", pastFloor))
+	require.NoError(t, err)
+	assert.True(t, ready)
+	assert.Equal(t, []string{"i-123"}, api.getCalls)
+}
+
+// Inside the floor the provider must not spend an API call.
+func TestIsNodeReady_WithinFloor_DoesNotCallAPI(t *testing.T) {
+	api := fakeAPI{instance: &commonslambda.Instance{ID: "i-123", Status: commonslambda.InstanceStatusActive}}
+
+	ready, err := NewClient(&api).IsNodeReady(
+		context.Background(), node("lambda://i-123", "boot-2"), ref("i-123", "boot-1", time.Second))
+	require.NoError(t, err)
+	assert.False(t, ready)
+	assert.Empty(t, api.getCalls)
+}
+
+// TestSendTerminateSignal_Scenarios_TerminatesOrErrors mirrors the reboot
+// scenarios for termination, including the availability check that stops a
+// terminate the API would refuse.
+func TestSendTerminateSignal_Scenarios_TerminatesOrErrors(t *testing.T) {
+	okInstance := &commonslambda.Instance{
+		ID:      "i-123",
+		Actions: commonslambda.InstanceActions{Terminate: available()},
+	}
+
+	tests := []struct {
+		name    string
+		node    corev1.Node
+		api     fakeAPI
+		wantRef string
+		wantErr string
+	}{
+		{
+			name:    "terminates the instance",
+			node:    node("lambda://i-123", "boot-1"),
+			api:     fakeAPI{instance: okInstance},
+			wantRef: "i-123",
+		},
+		{
+			// The controller waits for the Node to go NotReady instead.
+			name:    "does not require a bootID",
+			node:    node("lambda://i-123", ""),
+			api:     fakeAPI{instance: okInstance},
+			wantRef: "i-123",
+		},
+		{
+			name:    "missing provider ID",
+			node:    node("", "boot-1"),
+			api:     fakeAPI{},
+			wantErr: "no provider ID set",
+		},
+		{
+			name:    "API error",
+			node:    node("lambda://i-123", "boot-1"),
+			api:     fakeAPI{instance: okInstance, terminErr: errors.New("boom")},
+			wantErr: "terminate node node-a: boom",
+		},
+		{
+			name: "terminate blocked by the API",
+			node: node("lambda://i-123", "boot-1"),
+			api: fakeAPI{instance: &commonslambda.Instance{
+				ID: "i-123",
+				Actions: commonslambda.InstanceActions{
+					Terminate: blocked("vm-is-terminating", "already terminating"),
+				},
+			}},
+			wantErr: "terminate is blocked for instance i-123: already terminating [reason_code=vm-is-terminating]",
+		},
+		{
+			name:    "instance lookup fails",
+			node:    node("lambda://i-123", "boot-1"),
+			api:     fakeAPI{getErr: errors.New("boom")},
+			wantErr: "terminate node node-a: boom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api := tt.api
+
+			got, err := NewClient(&api).SendTerminateSignal(context.Background(), tt.node)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				assert.Empty(t, got)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantRef, string(got))
+			assert.Equal(t, []string{"i-123"}, api.terminateCalls)
+		})
+	}
+}
+
+// TestParseProviderID_Formats_ExtractsInstanceID pins the lambda:// shape the
+// cloud controller manager writes, and rejects anything else so another CSP's
+// provider ID cannot be read as a Lambda instance.
+func TestParseProviderID_Formats_ExtractsInstanceID(t *testing.T) {
+	tests := []struct {
+		name       string
+		providerID string
+		want       string
+		wantErr    bool
+	}{
+		{name: "lambda provider ID", providerID: "lambda://i-123", want: "i-123"},
+		{name: "opaque hex id", providerID: "lambda://0920582c7ff041399e34823a0be62549", want: "0920582c7ff041399e34823a0be62549"},
+		{name: "empty", providerID: "", wantErr: true},
+		{name: "prefix only", providerID: "lambda://", wantErr: true},
+		{name: "wrong scheme", providerID: "aws:///us-west-2/i-123", wantErr: true},
+		{name: "no scheme", providerID: "i-123", wantErr: true},
+		{name: "triple slash", providerID: "lambda:///i-123", wantErr: true},
+		{name: "extra path segment", providerID: "lambda://region/i-123", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseProviderID(tt.providerID)
+			if tt.wantErr {
+				assert.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestParseRequestRef_RoundTrip_PreservesFields checks the ref SendRebootSignal
+// emits survives the trip through the janitor and parses back to the same
+// fields, since IsNodeReady has nothing else to work from.
+func TestParseRequestRef_RoundTrip_PreservesFields(t *testing.T) {
+	started := time.Now().UTC().Truncate(time.Second)
+
+	got, err := parseRequestRef(strings.Join(
+		[]string{"i-123", "boot-1", started.Format(time.RFC3339)}, requestRefSeparator))
+	require.NoError(t, err)
+	assert.Equal(t, "i-123", got.instanceID)
+	assert.Equal(t, "boot-1", got.preRebootBootID)
+	assert.True(t, started.Equal(got.startedAt), "want %s, got %s", started, got.startedAt)
+}
+
+// TestEndpointFromEnv_Values_DefaultsOrValidates checks the endpoint is
+// validated at startup rather than on the first remediation, and asserts which
+// error fires so the http rejection cannot be quietly folded into the general
+// scheme check.
+func TestEndpointFromEnv_Values_DefaultsOrValidates(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     string
+		want    string
+		wantErr string
+	}{
+		{name: "unset defaults to production", env: "", want: DefaultAPIEndpoint},
+		{name: "trailing slash trimmed", env: "https://cloud.lambda.ai/", want: "https://cloud.lambda.ai"},
+		// The allowlist is fixed, so the bearer token can only ever reach a
+		// known Lambda API host.
+		{name: "unapproved host rejected", env: "https://cloud.example.com", wantErr: "is not an approved"},
+		{
+			name: "approved host matches case-insensitively",
+			env:  "https://Cloud.Lambda.AI",
+			want: "https://Cloud.Lambda.AI",
+		},
+		{
+			name: "port is not part of the host match",
+			env:  "https://cloud.lambda.ai:8443",
+			want: "https://cloud.lambda.ai:8443",
+		},
+		// The API key is a bearer token on every request, so http would put it
+		// on the wire in cleartext. There is no opt-in that relaxes this.
+		{name: "plain http rejected", env: "http://cloud.lambda.ai", wantErr: "cleartext"},
+		{name: "plain http rejected for loopback too", env: "http://127.0.0.1:8080", wantErr: "cleartext"},
+		{name: "whitespace only defaults", env: "   ", want: DefaultAPIEndpoint},
+		{name: "relative URL rejected", env: "/api/v1", wantErr: "must be an absolute https URL"},
+		{name: "host only rejected", env: "cloud.lambda.ai", wantErr: "must be an absolute https URL"},
+		{name: "non-http scheme rejected", env: "ftp://cloud.lambda.ai", wantErr: "must be an absolute https URL"},
+		{name: "scheme without host rejected", env: "https://", wantErr: "has no host"},
+		// Userinfo rides along in every request URL the client logs. A query or
+		// fragment is worse than cosmetic: request paths are appended by string
+		// concatenation, so "?token=x" + "/api/v1/instances" leaves the path
+		// inside the query.
+		{name: "userinfo rejected", env: "https://user:pass@cloud.lambda.ai", wantErr: "must not include userinfo"},
+		{name: "query rejected", env: "https://cloud.lambda.ai?token=x", wantErr: "must not include userinfo"},
+		{name: "fragment rejected", env: "https://cloud.lambda.ai#frag", wantErr: "must not include userinfo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(APIEndpointEnvVar, tt.env)
+
+			got, err := endpointFromEnv()
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestNewClientFromEnv_MissingAPIKey_ReturnsError checks a missing key fails at
+// construction, so the pod crash-loops instead of waiting for a remediation to
+// discover it has no credential.
+func TestNewClientFromEnv_MissingAPIKey_ReturnsError(t *testing.T) {
+	t.Setenv(commonslambda.APIKeyEnvVar, "")
+	t.Setenv(APIEndpointEnvVar, "")
+
+	_, err := NewClientFromEnv(context.Background())
+	assert.ErrorContains(t, err, commonslambda.APIKeyEnvVar)
+}
+
+// TestNewClientFromEnv_BadEndpoint_ReturnsError checks a malformed endpoint
+// fails at construction and that the error names the env var to fix.
+func TestNewClientFromEnv_BadEndpoint_ReturnsError(t *testing.T) {
+	t.Setenv(commonslambda.APIKeyEnvVar, "test-key")
+	t.Setenv(APIEndpointEnvVar, "not-a-url")
+
+	_, err := NewClientFromEnv(context.Background())
+	assert.ErrorContains(t, err, APIEndpointEnvVar)
+}
+
+// TestNewClientFromEnv_ValidEnv_ReturnsClient checks the happy path wires up a
+// usable client from environment alone, with no Kubernetes or CSP SDK involved.
+func TestNewClientFromEnv_ValidEnv_ReturnsClient(t *testing.T) {
+	t.Setenv(commonslambda.APIKeyEnvVar, "test-key")
+	t.Setenv(APIEndpointEnvVar, DefaultAPIEndpoint)
+
+	c, err := NewClientFromEnv(context.Background())
+	require.NoError(t, err)
+	assert.NotNil(t, c)
+}
+
+// TestNewClientFromEnv_UnapprovedHost_ReturnsError checks the allowlist is
+// enforced before an authenticated client exists, so the bearer token is never
+// wired up against a host outside allowedAPIHosts.
+func TestNewClientFromEnv_UnapprovedHost_ReturnsError(t *testing.T) {
+	t.Setenv(commonslambda.APIKeyEnvVar, "test-key")
+	t.Setenv(APIEndpointEnvVar, "https://attacker.example.com")
+
+	_, err := NewClientFromEnv(context.Background())
+	assert.ErrorContains(t, err, "is not an approved")
+}


### PR DESCRIPTION
## Summary

This PR adds lambda janitor plugin, the plugin supports all provided interfaces and is based on client located in `commons`.

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [x] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Lambda Cloud support for janitor operations.
  - Added instance retrieval, power cycling, termination, action validation, and asynchronous readiness tracking.
  - Added authenticated JSON requests with safe retry handling and HTTPS redirect protection.
  - Added Kubernetes configuration for Lambda endpoints and Secret-based API keys.
  - Added Lambda as a selectable cloud provider.

- **Documentation**
  - Documented Lambda setup, endpoint configuration, authentication, supported operations, provider ID requirements, and reboot/termination behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->