### PR TITLE
fix: run kwok without hostNetwork to stop fake nodes breaking pod networking in e2e

### DIFF
--- a/.versions.yaml
+++ b/.versions.yaml
@@ -75,8 +75,8 @@ testing_tools:
   kind: '0.30.0'
   helm: 'v3.19.2'
   helm_unittest: 'v1.0.3'
-  kwok: 'v0.7.0'
-  kwok_chart: '0.2.0'  # KWOK Helm chart version (different from app version)
+  kwok: 'v0.8.0'
+  kwok_chart: '0.3.0'  # KWOK Helm chart version (different from app version); tilt/Tiltfile pins this
   ctlptl: '0.8.43'
   tilt: '0.35.2'
 

--- a/tests/data/log-collector-failure-stage.yaml
+++ b/tests/data/log-collector-failure-stage.yaml
@@ -1,3 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # KWOK Stage to simulate log-collector pod failure for negative testing
 # WARNING: This will affect ALL log-collector pods cluster-wide while active
 # The test MUST run in isolation and clean up the Stage in teardown

--- a/tests/data/log-collector-failure-stage.yaml
+++ b/tests/data/log-collector-failure-stage.yaml
@@ -2,26 +2,28 @@
 # WARNING: This will affect ALL log-collector pods cluster-wide while active
 # The test MUST run in isolation and clean up the Stage in teardown
 # Weight: 10 ensures this Stage takes precedence over default stage-fast (weight 0)
+# resourceRef must be spelled exactly {apiGroup: v1, kind: Pod}: any other
+# spelling (including apiGroup: "") routes the Stage to kwok's generic
+# controller, which has no node scoping and patches pods on REAL nodes.
 apiVersion: kwok.x-k8s.io/v1alpha1
 kind: Stage
 metadata:
   name: log-collector-failure
 spec:
   resourceRef:
-    apiGroup: ""
+    apiGroup: v1
     kind: Pod
   selector:
     matchLabels:
       app: log-collector
+    matchExpressions:
+    - key: '.status.phase'
+      operator: 'In'
+      values:
+      - 'Pending'
   weight: 10
   delay:
     durationMilliseconds: 100
-  when:
-  - field: status.phase
-    operator: In
-    values:
-    - ""
-    - "Pending"
   next:
     statusTemplate: |
       {{ $now := Now }}

--- a/tests/uat/install-apps.sh
+++ b/tests/uat/install-apps.sh
@@ -137,10 +137,12 @@ install_kwok() {
     helm repo add sigs-kwok https://kwok.sigs.k8s.io/charts/
     helm repo update
     
+    # kwok must NOT run with hostNetwork: it stamps its own pod IP on every
+    # fake node, so with hostNetwork the fake nodes clone the host node's IP
+    # and break pod networking on that node (see issue #1567).
     if ! helm upgrade --install kwok sigs-kwok/kwok \
         --namespace kube-system \
         --version "$KWOK_CHART_VERSION" \
-        --set hostNetwork=true \
         --wait \
         --timeout=5m; then
         error "Failed to install KWOK"

--- a/tilt/Tiltfile
+++ b/tilt/Tiltfile
@@ -75,19 +75,27 @@ local_resource(
 )
 
 helm_repo('sigs-kwok', 'https://kwok.sigs.k8s.io/charts/')
+# kwok must NOT run with hostNetwork: kwok stamps its own pod IP on every fake
+# node (--node-ip=$(POD_IP)), so with hostNetwork the fake nodes clone this
+# pod's host-node IP, kindnetd then treats them as that node and rewrites its
+# CNI config with fake podCIDRs, and real pods created there get duplicate IPs
+# whose traffic NetworkPolicy enforcement misattributes and drops.
 helm_resource(
     'kwok',
     chart='sigs-kwok/kwok',
     namespace='kube-system',
     flags=[
-        '--set=hostNetwork=true'
+        '--version=0.3.0'  # pin: an unpinned chart floats to new releases mid-flight
     ]
 )
 helm_resource(
     'kwok-stage-fast',
     chart='sigs-kwok/stage-fast',
     resource_deps=['kwok'],
-    pod_readiness='ignore'
+    pod_readiness='ignore',
+    flags=[
+        '--version=0.3.0'
+    ]
 )
 
 namespace_create('gpu-operator')


### PR DESCRIPTION
## Summary

Fixes #1567.

Our E2E jobs were flaking with janitor to janitor-provider gRPC calls timing out for 10 to 25 minutes, which made RebootNode CRs so slow that two tests ran out of time. The full investigation is in the issue, the short version:

We install kwok with hostNetwork enabled (the kwok chart's own advice for kind clusters). With host networking, the kwok pod runs on the node's IP, and kwok stamps that IP on every fake node it creates. kindnetd decides "is this node me" by comparing IPs, so it mistook all 55 fake nodes for the real node it runs on and kept rewriting that node's CNI config with fake pod CIDRs. Any pod created on that node afterwards got an IP from a fake range, and that IP was always already held by one of kwok's fake pods. Since kind v0.30 kindnetd actually enforces our NetworkPolicies, and its policy engine resolved the shared IP to the wrong pod, so the janitor's traffic was evaluated under the metrics-only policy and silently dropped.

Changes:
- tilt/Tiltfile: install kwok without hostNetwork, with a comment explaining why it must stay off. Also pin both kwok charts to 0.3.0 so CI stops floating to whatever the latest release is (the floating itself was not the cause, but it made the investigation harder).
- tests/data/log-collector-failure-stage.yaml: found during the investigation. resourceRef said apiGroup "" instead of v1, which routes the Stage to a kwok controller that has no node scoping and can patch pods on real nodes. Also the when: field is not part of the Stage CRD (kubectl rejects the file under strict validation, the e2e helper only worked because client-go drops unknown fields), so the intended phase condition never applied. Replaced it with a selector expression that does.
- .versions.yaml: updated the kwok entries to chart 0.3.0 / app v0.8.0. The UAT installer (tests/uat/install-apps.sh) reads these values, so this also moves the UAT path onto the same chart version that Tilt and CI actually run, instead of the stale 0.2.0 pin.

## Tests

Validated both directions on a cluster matching CI exactly (kind v0.30.0, Kubernetes v1.34.0, kindnetd v20250512, our real NetworkPolicies), toggling exactly the helm flags this PR changes:

- With this fix: fake nodes advertise kwok's own pod IP, the CNI config on every real node stays correct, the test pod gets a normal in-range IP that no other pod holds, and 20 out of 20 dials to its Service succeed.
- With the old config: the CNI config gets corrupted within a minute, the test pod's IP collides with a fake pod again, and only 3 out of 20 dials get through, the same flapping we saw in CI.

Also verified the stage file fix on the same cluster: a log-collector-labeled pod on a fake node still gets failed (the test's purpose is preserved), while an identically labeled pod on a real node is left alone, and the file now applies cleanly under kubectl strict validation.

The E2E run on this PR is the remaining full-suite check that nothing else depended on hostNetwork.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [x] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Tests**
  - Improved log-collector testing by precisely targeting Pending pods.
  - Updated KWOK testing components for more reliable test environments.

- **Chores**
  - Refined test-cluster networking to preserve distinct pod addresses and improve compatibility.
  - Standardized the KWOK chart version across test resources.
  - Preserved fast test execution behavior with the updated configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->