### PR TITLE
docs(labeler): document assumeDriverInstalled for host drivers

### DIFF
--- a/docs/configuration/labeler.md
+++ b/docs/configuration/labeler.md
@@ -54,6 +54,15 @@ labeler:
   logLevel: info  # Options: debug, info, warn, error
 ```
 
+## Pre-Installed Drivers
+
+Assumes NVIDIA drivers are installed directly on the host rather than via GPU Operator driver containers. When enabled, the labeler sets `nvsentinel.dgxc.nvidia.com/driver.installed=true` on all GPU nodes it manages (`nvidia.com/gpu.present=true`; nodes opted out with `nvsentinel.dgxc.nvidia.com/managed=false` — for example during external remediation — are excluded), skipping driver pod detection.
+
+```yaml
+labeler:
+  assumeDriverInstalled: false
+```
+
 ## DCGM Bootstrap Gating
 
 Controls whether the DCGM pod must be ready before the DCGM version label is set for the first time on a node.

--- a/docs/labeler.md
+++ b/docs/labeler.md
@@ -84,11 +84,16 @@ Indicates whether the NVIDIA driver is installed on the node. The Labeler detect
 
 In GKE clusters with pre-installed drivers, the `nvidia-driver-daemonset` is not deployed. Instead, Google manages driver installation through `nvidia-driver-installer` DaemonSet pods. The Labeler watches these pods to detect driver installation in GKE environments with pre-installed drivers.
 
-**Note**: For environments with pre-installed drivers where no `nvidia-driver-installer` pods exist (e.g., custom machine images with pre-baked drivers), use the following command to manually label the node:
+**Note**: For environments with pre-installed drivers where no driver pods exist at all (e.g., custom machine images with pre-baked drivers, or cloud node images that ship the driver), enable the `assumeDriverInstalled` Helm value:
 
-```bash
-kubectl label nodes {node-name} nvsentinel.dgxc.nvidia.com/driver.installed=true
+```yaml
+labeler:
+  assumeDriverInstalled: true
 ```
+
+With this setting the Labeler sets `driver.installed=true` on every GPU node (`nvidia.com/gpu.present=true`) it manages, skips driver pod detection, and automatically covers nodes added later. Nodes opted out with `nvsentinel.dgxc.nvidia.com/managed=false` — for example during external remediation — are excluded.
+
+Do not apply the label manually with `kubectl label`. Instead, enable `assumeDriverInstalled`; without it, the Labeler computes an empty desired value for a node with no driver pod and silently removes a manually applied `driver.installed` label as stale on its next relevant reconciliation — for example, any Labeler restart, a driver or DCGM pod readiness change on the node, or a change to the node labels the Labeler watches — so a manual label cannot be relied on to persist.
 
 ### Kata Enabled
 **Label**: `nvsentinel.dgxc.nvidia.com/kata.enabled`


### PR DESCRIPTION
## Summary

#1583 established that for host-installed NVIDIA drivers (no driver pod on the node), the `labeler.assumeDriverInstalled` chart value is the recommended mechanism and documentation is the intended guidance. This PR is that documentation update, fixing two defects:

1. **`docs/labeler.md` documented a manual-label procedure that silently self-reverts.** It told operators to run `kubectl label nodes <node> nvsentinel.dgxc.nvidia.com/driver.installed=true` when no driver pod exists. Verified against the labeler source: `getDriverLabelForNode` returns an empty desired value for a node with no driver pod (and no GKE installer pod), and `updateDriverLabel` then deletes the label as stale on the next relevant reconciliation (startup `reconcileAllNodes` after cache sync — i.e., any labeler restart — a driver/DCGM pod readiness transition on the node, or a node event that changes labels `nodeRequiresReconciliation` compares). The doc now points to `labeler.assumeDriverInstalled: true` (renders `--assume-driver-installed`), which the labeler applies persistently and which covers nodes added later, and explains why a bare `kubectl label` cannot be relied on to persist.

2. **`docs/configuration/labeler.md` did not document `assumeDriverInstalled`** despite covering the labeler's Helm configuration options. Added a section in the file's existing format, matching the values.yaml description.

`docs/designs/018-syslog-monitor-preinstalled-driver-support.md` is intentionally untouched per maintainer guidance: design docs are historical records in this repo, and updating the user docs is sufficient.

The "all GPU nodes" claim is qualified to nodes the labeler manages: nodes opted out with `nvsentinel.dgxc.nvidia.com/managed=false` (set by the janitor during external remediation) have detection labels stripped even with `assumeDriverInstalled` enabled.

## Type of Change
- [x] 📚 Documentation

## Component(s) Affected
- [x] Documentation/CI

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

Ran the Fern docs CI checks locally: `fern check` (fern-api 5.30.2) — 0 errors; the MDX `<img>` safety grep — clean; the markdown filename check — no new warnings.

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented the `assumeDriverInstalled` setting for GPU driver pre-installation.
  * Clarified that enabling the setting identifies managed GPU nodes as driver-ready and skips driver pod detection.
  * Noted that the setting applies to newly added nodes while excluding nodes opted out of management.
  * Explained that manually applied driver labels may be removed during reconciliation when the setting is disabled or no qualifying driver pods remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Context: #1583 (closed — decided as documentation-only) is the design discussion; the automatic-detection alternative was #1584, closed per that decision.






