### PR TITLE
feat(kubernetes-object-monitor): expose cacheSyncTimeout as a helm value

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/templates/deployment.yaml
@@ -56,6 +56,7 @@ spec:
             - "--health-probe-bind-address=:8081"
             - "--max-concurrent-reconciles={{ .Values.maxConcurrentReconciles }}"
             - "--resync-period={{ .Values.resyncPeriod }}"
+            - "--cache-sync-timeout={{ .Values.cacheSyncTimeout }}"
             - "--processing-strategy={{ .Values.processingStrategy }}"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/values.yaml
@@ -29,6 +29,7 @@ podAnnotations: {}
 
 maxConcurrentReconciles: 1
 resyncPeriod: 5m
+cacheSyncTimeout: 10m
 
 # RBAC permissions are automatically generated based on the resources defined in policies.
 # Nodes always get write permissions (patch/update) for annotations.

--- a/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/kubernetes-object-monitor/values.yaml
@@ -29,7 +29,7 @@ podAnnotations: {}
 
 maxConcurrentReconciles: 1
 resyncPeriod: 5m
-cacheSyncTimeout: 10m
+cacheSyncTimeout: 10m # Duration limiting startup cache synchronization.
 
 # RBAC permissions are automatically generated based on the resources defined in policies.
 # Nodes always get write permissions (patch/update) for annotations.

--- a/distros/kubernetes/nvsentinel/values-full.yaml
+++ b/distros/kubernetes/nvsentinel/values-full.yaml
@@ -853,6 +853,17 @@ fault-remediation:
     enableAwsSosCollection: false
 
 ################################################################################
+# KUBERNETES-OBJECT-MONITOR CONFIGURATION
+#
+# Watches configured Kubernetes resources and generates health events when
+# policy predicates identify unhealthy objects.
+################################################################################
+kubernetes-object-monitor:
+  # Maximum time to wait for informer caches to synchronize on startup.
+  # Large clusters may require a longer timeout while caches are populated.
+  cacheSyncTimeout: 10m
+
+################################################################################
 # GPU-HEALTH-MONITOR CONFIGURATION
 #
 # Monitors GPU hardware health using NVIDIA DCGM (Data Center GPU Manager).

--- a/docs/configuration/kubernetes-object-monitor.md
+++ b/docs/configuration/kubernetes-object-monitor.md
@@ -48,6 +48,7 @@ Controls behavior of the Kubernetes controller watching resources.
 kubernetes-object-monitor:
   maxConcurrentReconciles: 1
   resyncPeriod: 5m
+  cacheSyncTimeout: 10m
 ```
 
 #### maxConcurrentReconciles
@@ -55,6 +56,9 @@ Maximum number of concurrent reconciliation workers. Higher values allow paralle
 
 #### resyncPeriod
 How often the controller re-evaluates all watched resources even without changes.
+
+#### cacheSyncTimeout
+Maximum time to wait for informer caches to synchronize on startup. Increase this value for large clusters where the initial cache population takes longer.
 
 ## Policies Configuration
 

--- a/health-monitors/kubernetes-object-monitor/main.go
+++ b/health-monitors/kubernetes-object-monitor/main.go
@@ -61,6 +61,11 @@ var (
 		5*time.Minute,
 		"Periodic reconciliation interval",
 	)
+	cacheSyncTimeout = flag.Duration(
+		"cache-sync-timeout",
+		10*time.Minute,
+		"Maximum time to wait for informer caches to sync on startup",
+	)
 	maxConcurrentReconciles = flag.Int(
 		"max-concurrent-reconciles",
 		1,
@@ -104,6 +109,7 @@ func run() error {
 		MetricsBindAddress:      *metricsBindAddress,
 		HealthProbeBindAddress:  *healthProbeBindAddress,
 		ResyncPeriod:            *resyncPeriod,
+		CacheSyncTimeout:        *cacheSyncTimeout,
 		MaxConcurrentReconciles: *maxConcurrentReconciles,
 		PlatformConnectorSocket: *platformConnectorSocket,
 		ProcessingStrategy:      *processingStrategyFlag,

--- a/health-monitors/kubernetes-object-monitor/pkg/initializer/initializer.go
+++ b/health-monitors/kubernetes-object-monitor/pkg/initializer/initializer.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -52,6 +53,7 @@ type Params struct {
 	MetricsBindAddress      string
 	HealthProbeBindAddress  string
 	ResyncPeriod            time.Duration
+	CacheSyncTimeout        time.Duration
 	MaxConcurrentReconciles int
 	PlatformConnectorSocket string
 	ProcessingStrategy      string
@@ -143,13 +145,7 @@ func createManager(params Params, policies []config.Policy) (ctrl.Manager, error
 		return nil, err
 	}
 
-	mgrOpts := ctrl.Options{
-		Metrics: server.Options{
-			BindAddress: params.MetricsBindAddress,
-		},
-		HealthProbeBindAddress: params.HealthProbeBindAddress,
-		Cache:                  cacheOptions,
-	}
+	mgrOpts := buildManagerOptions(params, cacheOptions)
 
 	mgr, err := ctrl.NewManager(restConfig, mgrOpts)
 	if err != nil {
@@ -157,6 +153,19 @@ func createManager(params Params, policies []config.Policy) (ctrl.Manager, error
 	}
 
 	return mgr, nil
+}
+
+func buildManagerOptions(params Params, cacheOptions cache.Options) ctrl.Options {
+	return ctrl.Options{
+		Metrics: server.Options{
+			BindAddress: params.MetricsBindAddress,
+		},
+		HealthProbeBindAddress: params.HealthProbeBindAddress,
+		Cache:                  cacheOptions,
+		Controller: ctrlconfig.Controller{
+			CacheSyncTimeout: params.CacheSyncTimeout,
+		},
+	}
 }
 
 func buildCacheOptions(

--- a/health-monitors/kubernetes-object-monitor/pkg/initializer/initializer_test.go
+++ b/health-monitors/kubernetes-object-monitor/pkg/initializer/initializer_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/nvidia/nvsentinel/health-monitors/kubernetes-object-monitor/pkg/config"
 )
 
-func TestBuildManagerOptionsSetsCacheSyncTimeout(t *testing.T) {
+func TestBuildManagerOptions_CacheSyncTimeout_PreservesConfiguredValue(t *testing.T) {
 	timeout := 10 * time.Minute
 
 	opts := buildManagerOptions(Params{CacheSyncTimeout: timeout}, cache.Options{})

--- a/health-monitors/kubernetes-object-monitor/pkg/initializer/initializer_test.go
+++ b/health-monitors/kubernetes-object-monitor/pkg/initializer/initializer_test.go
@@ -25,6 +25,14 @@ import (
 	"github.com/nvidia/nvsentinel/health-monitors/kubernetes-object-monitor/pkg/config"
 )
 
+func TestBuildManagerOptionsSetsCacheSyncTimeout(t *testing.T) {
+	timeout := 10 * time.Minute
+
+	opts := buildManagerOptions(Params{CacheSyncTimeout: timeout}, cache.Options{})
+
+	require.Equal(t, timeout, opts.Controller.CacheSyncTimeout)
+}
+
 func TestBuildCacheOptionsLimitsGVKToConfiguredNamespaces(t *testing.T) {
 	resyncPeriod := time.Minute
 	opts, err := buildCacheOptionsWithRESTMapper(testRESTMapper(), []config.Policy{


### PR DESCRIPTION
## Summary

Exposes `cacheSyncTimeout` as a Helm value for kubernetes-object-monitor. The default controller-runtime cache sync timeout (2 minutes) is too short for KOM at 100k nodes, causing a crash-loop on every restart.

## Root Cause

KOM stores every watched object as `unstructured.Unstructured` — a `map[string]interface{}` where each field is a separate heap allocation. Syncing 99k nodes takes ~56 seconds; adding ~600k gpu-operator pods pushes the total past 2 minutes.

CPU profiling during cache sync confirms the bottleneck is **JSON deserialization**, not network I/O. 80% of CPU time is spent in the JSON parser:

```
Duration: 75s, Total samples = 60.91s (81.21%)

      flat  flat%   sum%        cum   cum%
     7.38s 12.12% 12.12%     11.74s 19.27%  encoding/json.checkValid
     7.06s 11.59% 23.71%     11.63s 19.09%  encoding/json.(*decodeState).skip
     5.86s  9.62% 33.33%      6.01s  9.87%  encoding/json.stateInString
     5.18s  8.50% 41.83%      7.98s 13.10%  json.(*decodeState).skip
     4.64s  7.62% 49.45%         8s 13.13%  encoding/json.checkValid
```

A typed informer (`corev1.Node`) decodes the same objects in 5 seconds — the struct layout is known at compile time, no per-field allocation. The unstructured path scans every byte twice (validation + decode), allocating a map entry per field.

`CacheSyncTimeout` is applied **per source** (per informer), not globally. The node source (~56s) fits within 2 minutes; the pod source (~600k objects, ~340s estimated) does not.

## Fix

Expose `--cache-sync-timeout` as a KOM flag and wire it into `ctrl.Options{CacheSyncTimeout: &timeout}`. Default in the Helm chart: `10m` (covers 100k nodes + pods with headroom).

## Validation

Deployed `bench-synctimeout` image (commit `475149b2`) against the live 99k-node cluster with `--cache-sync-timeout=10m`:

- Cache synced in **~2m32s** (both Node and Pod sources)
- **0 restarts** — no crash-loop
- Both controllers started workers successfully

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [x] Other: kubernetes-object-monitor