### PR TITLE
Lambda CSP Health monitor: add workspace id support to API requests

### DIFF
--- a/commons/pkg/lambda/client.go
+++ b/commons/pkg/lambda/client.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -62,9 +63,10 @@ var errRedirect = errors.New("redirect refused")
 // failures (4xx other than 429, malformed responses, missing API key)
 // short-circuit the retry loop. Post retries on less, see retryRateLimitOnly.
 type Client struct {
-	endpoint string
-	http     *http.Client
-	retry    retryPolicy
+	endpoint    string
+	workspaceID string
+	http        *http.Client
+	retry       retryPolicy
 }
 
 // retryPolicy is the exponential-backoff schedule applied to a request.
@@ -83,6 +85,28 @@ type Option func(*Client)
 // need to inject an httptest.NewServer's client.
 func WithHTTPClient(h *http.Client) Option {
 	return func(c *Client) { c.http = h }
+}
+
+// WithWorkspaceID scopes requests to a Lambda workspace. An empty ID leaves the
+// parameter off, so the API defaults to the key's own workspace.
+//
+// Only ListMaintenanceEvents takes it today, the instance endpoints resolve the
+// workspace from the instance itself.
+func WithWorkspaceID(workspaceID string) Option {
+	return func(c *Client) { c.workspaceID = workspaceID }
+}
+
+// workspaceIDPattern matches a UUID with or without dashes, the two forms the
+// API accepts for workspace_id.
+var workspaceIDPattern = regexp.MustCompile(
+	`^[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{12}$`,
+)
+
+// ValidWorkspaceID reports whether id is in a form the API accepts for
+// workspace_id. Callers check it at startup: the API answers 400 to anything
+// else, which would otherwise repeat on every request.
+func ValidWorkspaceID(id string) bool {
+	return workspaceIDPattern.MatchString(id)
 }
 
 // WithRetryPolicy overrides the retry defaults. maxAttempts includes the

--- a/commons/pkg/lambda/client_test.go
+++ b/commons/pkg/lambda/client_test.go
@@ -330,3 +330,37 @@ func TestClient_Post_Permanent4xx_ErrorNamesTheMethod(t *testing.T) {
 	assert.ErrorContains(t, err, "POST")
 	assert.ErrorContains(t, err, "404")
 }
+
+// TestValidWorkspaceID pins the two forms the API accepts, dashed and undashed,
+// against the near-misses a hand-copied ID turns into.
+func TestValidWorkspaceID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{name: "undashed", id: "c4d291f47f9d436fa39f58493ce3b50d", want: true},
+		{name: "dashed", id: "c4d291f4-7f9d-436f-a39f-58493ce3b50d", want: true},
+		{name: "uppercase", id: "C4D291F47F9D436FA39F58493CE3B50D", want: true},
+		{name: "empty", id: ""},
+		{name: "a name, not an ID", id: "my-workspace"},
+		{name: "one digit short", id: "c4d291f47f9d436fa39f58493ce3b50"},
+		{name: "one digit long", id: "c4d291f47f9d436fa39f58493ce3b50da"},
+		{name: "non-hex digit", id: "g4d291f47f9d436fa39f58493ce3b50d"},
+		// Each dash is optional independently, matching the API, which strips
+		// every dash before checking the length.
+		{name: "some dashes missing", id: "c4d291f4-7f9d436f-a39f-58493ce3b50d", want: true},
+		{name: "surrounding whitespace", id: " c4d291f47f9d436fa39f58493ce3b50d "},
+		{name: "an LRN, not an ID", id: "lrn:iam:workspace:c4d291f47f9d436fa39f58493ce3b50d"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, ValidWorkspaceID(tc.id))
+		})
+	}
+}

--- a/commons/pkg/lambda/maintenance_events.go
+++ b/commons/pkg/lambda/maintenance_events.go
@@ -53,6 +53,9 @@ type apiResponse struct {
 // ListMaintenanceEvents fetches all maintenance events, walking pagination
 // via the API's page_token cursor. Retry/backoff is handled by the underlying
 // Client.
+//
+// Events are scoped to the workspace given to WithWorkspaceID, or to the
+// default workspace when none was given.
 func (c *Client) ListMaintenanceEvents(ctx context.Context) ([]Event, error) {
 	var all []Event
 
@@ -60,6 +63,10 @@ func (c *Client) ListMaintenanceEvents(ctx context.Context) ([]Event, error) {
 
 	for page := 0; page < maxEventPages; page++ {
 		q := url.Values{}
+		if c.workspaceID != "" {
+			q.Set("workspace_id", c.workspaceID)
+		}
+
 		if pageToken != nil {
 			q.Set("page_token", *pageToken)
 		}

--- a/commons/pkg/lambda/maintenance_events_test.go
+++ b/commons/pkg/lambda/maintenance_events_test.go
@@ -71,6 +71,54 @@ func TestClient_ListMaintenanceEvents_PaginatedResponse_ReturnsAllEvents(t *test
 	assert.Equal(t, "event-2", events[1].ID)
 }
 
+// TestClient_ListMaintenanceEvents_WorkspaceID checks the workspace scope is
+// sent on every page, and left off entirely when none was configured so the API
+// keeps falling back to the key's own workspace.
+func TestClient_ListMaintenanceEvents_WorkspaceID(t *testing.T) {
+	tests := []struct {
+		name        string
+		workspaceID string
+	}{
+		{name: "configured workspace is sent", workspaceID: "c4d291f47f9d436fa39f58493ce3b50d"},
+		{name: "unset workspace omits the parameter", workspaceID: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			nextToken := "token-page2"
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				query := r.URL.Query()
+
+				// Presence is asserted separately from the value: Get returns ""
+				// both for an absent parameter and for a bare "workspace_id=",
+				// so dropping the guard in ListMaintenanceEvents would otherwise
+				// go unnoticed here. The API answers 400 to an empty one.
+				_, present := query["workspace_id"]
+				assert.Equal(t, tc.workspaceID != "", present, "workspace_id present in query")
+				assert.Equal(t, tc.workspaceID, query.Get("workspace_id"))
+
+				resp := apiResponse{Data: []Event{{ID: "event-2"}}}
+				if query.Get("page_token") == "" {
+					resp = apiResponse{Data: []Event{{ID: "event-1"}}, PageToken: &nextToken}
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				assert.NoError(t, json.NewEncoder(w).Encode(resp))
+			}))
+			defer srv.Close()
+
+			t.Setenv(APIKeyEnvVar, "test-key")
+
+			client := NewClient(srv.URL, WithHTTPClient(srv.Client()), WithWorkspaceID(tc.workspaceID))
+
+			events, err := client.ListMaintenanceEvents(context.Background())
+			require.NoError(t, err)
+			require.Len(t, events, 2)
+		})
+	}
+}
+
 func TestClient_ListMaintenanceEvents_ServerError_ReturnsWrappedStatus(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)

--- a/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/configmap.yaml
@@ -49,4 +49,5 @@ data:
     [lambda]
     enabled = {{ eq .Values.cspName "lambda" }}
     apiEndpoint = {{ .Values.configToml.lambda.apiEndpoint | default "" | quote }}
+    workspaceId = {{ .Values.configToml.lambda.workspaceId | default "" | quote }}
     pollingIntervalSeconds = {{ .Values.configToml.lambda.pollingIntervalSeconds | default 30 }}

--- a/distros/kubernetes/nvsentinel/charts/csp-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/csp-health-monitor/values.yaml
@@ -99,6 +99,13 @@ configToml:
     # Defaulted to the production endpoint so the happy path works out of the
     # box; override for staging (cloud.lambdastaging.com) or a local fake.
     apiEndpoint: "https://cloud.lambda.ai"
+    # workspaceId scopes the maintenance-events query to one Lambda workspace,
+    # in dashed or undashed UUID form, e.g. "c4d291f47f9d436fa39f58493ce3b50d"
+    # or "c4d291f4-7f9d-436f-a39f-58493ce3b50d". Leave it empty to use the
+    # default workspace; set it when that is not the workspace running this
+    # cluster, otherwise the poller reads the wrong workspace's events and no
+    # maintenance is ever seen for these nodes.
+    workspaceId: ""
     # pollingIntervalSeconds controls how often the Lambda maintenance-events
     # API is polled for new / updated events. Lower values reduce trigger
     # latency at the cost of more API traffic.

--- a/health-monitors/csp-health-monitor/pkg/config/config.go
+++ b/health-monitors/csp-health-monitor/pkg/config/config.go
@@ -20,6 +20,8 @@ import (
 	"os"
 
 	"github.com/BurntSushi/toml"
+
+	lambdaapi "github.com/nvidia/nvsentinel/commons/pkg/lambda"
 )
 
 const (
@@ -69,6 +71,7 @@ type AWSConfig struct {
 type LambdaConfig struct {
 	Enabled                bool   `toml:"enabled"`
 	APIEndpoint            string `toml:"apiEndpoint"`
+	WorkspaceID            string `toml:"workspaceId"`        // optional; defaults to the API key's own workspace
 	MockEventsFilePath     string `toml:"mockEventsFilePath"` // dev/test only; if set, skips real API
 	PollingIntervalSeconds int    `toml:"pollingIntervalSeconds"`
 }
@@ -196,6 +199,10 @@ func validateCSPConfig(cfg *Config) error {
 		return err
 	}
 
+	if err := validateLambdaWorkspaceID(cfg); err != nil {
+		return err
+	}
+
 	return validateSingleCSPEnabled(cfg)
 }
 
@@ -242,6 +249,20 @@ func validateLambdaEventSource(cfg *Config) error {
 
 	if cfg.Lambda.APIEndpoint != "" && cfg.Lambda.MockEventsFilePath != "" {
 		return fmt.Errorf("lambda: apiEndpoint and mockEventsFilePath are mutually exclusive")
+	}
+
+	return nil
+}
+
+// validateLambdaWorkspaceID checks the optional workspace ID looks like a UUID,
+// so a typo fails at startup rather than earning a 400 on every poll.
+func validateLambdaWorkspaceID(cfg *Config) error {
+	if !cfg.Lambda.Enabled || cfg.Lambda.WorkspaceID == "" {
+		return nil
+	}
+
+	if !lambdaapi.ValidWorkspaceID(cfg.Lambda.WorkspaceID) {
+		return fmt.Errorf("lambda: workspaceId %q is not a UUID", cfg.Lambda.WorkspaceID)
 	}
 
 	return nil

--- a/health-monitors/csp-health-monitor/pkg/csp/lambda/lambda.go
+++ b/health-monitors/csp-health-monitor/pkg/csp/lambda/lambda.go
@@ -117,8 +117,10 @@ func NewClient(
 		slog.Info("Lambda client: using mock events file (dev/test mode)", "path", cfg.MockEventsFilePath)
 		source = &fileSource{path: cfg.MockEventsFilePath}
 	} else {
-		slog.Info("Lambda client: using real API", "endpoint", cfg.APIEndpoint)
-		source = &apiSource{client: lambdaapi.NewClient(cfg.APIEndpoint)}
+		slog.Info("Lambda client: using real API", "endpoint", cfg.APIEndpoint, "workspaceID", cfg.WorkspaceID)
+		source = &apiSource{
+			client: lambdaapi.NewClient(cfg.APIEndpoint, lambdaapi.WithWorkspaceID(cfg.WorkspaceID)),
+		}
 	}
 
 	return &Client{


### PR DESCRIPTION
## Summary

<!-- Brief description of your changes -->

Add workspace id parameter when CSP Health monitor calls Lambda APIs.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [x] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional workspace scoping for Lambda maintenance-event queries.
  * Added configuration for specifying workspace IDs in dashed or undashed UUID formats.
  * Workspace settings now apply consistently across paginated event requests.
* **Bug Fixes**
  * Invalid workspace IDs are rejected while unset values preserve default behavior.
  * Logging now includes the configured workspace context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->