### PR TITLE
Lambda CSP: Add workload identities authentication

### DIFF
--- a/commons/pkg/lambda/client.go
+++ b/commons/pkg/lambda/client.go
@@ -26,7 +26,6 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
-	"os"
 	"regexp"
 	"time"
 
@@ -55,16 +54,21 @@ const (
 var errRedirect = errors.New("redirect refused")
 
 // Client is an authenticated HTTP client for the Lambda Cloud API.
-// The API key is read from LAMBDA_API_KEY on every request so credential
-// rotation works without a process restart.
+//
+// It authenticates with whichever credential the environment implies, see
+// DetectAuthMode: a workload identity when the pod-identity webhook injected
+// one, otherwise the static LAMBDA_API_KEY. The static key is read on every
+// request so rotation works without a process restart; a workload identity
+// token is cached and replaced before it expires.
 //
 // Requests are retried with exponential backoff on transient failures
 // (network errors, 5xx responses, and 429 Too Many Requests). Permanent
-// failures (4xx other than 429, malformed responses, missing API key)
+// failures (4xx other than 429, malformed responses, missing credential)
 // short-circuit the retry loop. Post retries on less, see retryRateLimitOnly.
 type Client struct {
 	endpoint    string
 	workspaceID string
+	creds       credentialSource
 	http        *http.Client
 	retry       retryPolicy
 }
@@ -133,7 +137,8 @@ func WithRetryPolicy(maxAttempts int, initialBackoff time.Duration, factor, jitt
 }
 
 // NewClient constructs a Lambda API client. endpoint is the base URL,
-// e.g. "https://cloud.lambda.ai".
+// e.g. "https://cloud.lambda.ai". The credential is picked from the
+// environment, see DetectAuthMode.
 func NewClient(endpoint string, opts ...Option) *Client {
 	c := &Client{
 		endpoint: endpoint,
@@ -153,6 +158,12 @@ func NewClient(endpoint string, opts ...Option) *Client {
 	// Wrapped rather than assigned outright, and after the options so an
 	// injected client cannot opt out of the scheme check.
 	c.http.CheckRedirect = refuseInsecureRedirect(c.http.CheckRedirect)
+
+	// After the redirect guard, so the token exchange shares a protected
+	// http.Client rather than one that can be redirected to plaintext.
+	if c.creds == nil {
+		c.creds = detectCredential(c.endpoint, c.http, c.retry)
+	}
 
 	return c
 }
@@ -200,13 +211,23 @@ func (c *Client) Get(ctx context.Context, path string, query url.Values, out any
 // take no idempotency key, so it retries on less than Get does. See
 // retryRateLimitOnly.
 func (c *Client) Post(ctx context.Context, path string, in, out any) error {
-	// Marshalled once so every retry resends identical bytes.
-	payload, err := json.Marshal(in)
+	payload, err := marshalJSON(in)
 	if err != nil {
-		return fmt.Errorf("marshal request body: %w", err)
+		return err
 	}
 
 	return c.do(ctx, http.MethodPost, path, nil, payload, out, retryRateLimitOnly)
+}
+
+// marshalJSON encodes a request body once, so every retry resends identical
+// bytes.
+func marshalJSON(in any) ([]byte, error) {
+	payload, err := json.Marshal(in)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request body: %w", err)
+	}
+
+	return payload, nil
 }
 
 // do performs an authenticated request and decodes the JSON response into out.
@@ -214,9 +235,12 @@ func (c *Client) Post(ctx context.Context, path string, in, out any) error {
 func (c *Client) do(
 	ctx context.Context, method, path string, query url.Values, payload []byte, out any, retry retryScope,
 ) error {
-	apiKey := os.Getenv(APIKeyEnvVar)
-	if apiKey == "" {
-		return fmt.Errorf("env var %s is not set", APIKeyEnvVar)
+	// Resolved once per call rather than per attempt: a workload identity
+	// token that was fresh when the first attempt started is still fresh
+	// across the retry budget.
+	apiKey, err := c.creds.token(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve Lambda credential: %w", err)
 	}
 
 	u := c.endpoint + path
@@ -236,7 +260,7 @@ func (c *Client) do(
 		attempts int
 	)
 
-	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+	err = wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
 		attempts++
 
 		body, statusCode, doErr := c.doOnce(ctx, method, u, apiKey, payload)
@@ -253,6 +277,13 @@ func (c *Client) do(
 		}
 
 		if statusCode != http.StatusOK {
+			// A credential the API rejects is dropped so the next request
+			// mints a fresh one. This is how a token revoked before its
+			// stated expiry gets noticed.
+			if statusCode == http.StatusUnauthorized {
+				c.creds.invalidate()
+			}
+
 			statusErr := fmt.Errorf("%s %s: status %d: %s", method, u, statusCode, body)
 			if !retry(statusCode, nil) {
 				return false, statusErr
@@ -335,7 +366,12 @@ func (c *Client) doOnce(ctx context.Context, method, u, apiKey string, payload [
 	}
 
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	// Empty only for the token exchange, which is unauthenticated: the JWT in
+	// its body is the credential.
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
 
 	if payload != nil {
 		req.Header.Set("Content-Type", "application/json")

--- a/commons/pkg/lambda/credentials.go
+++ b/commons/pkg/lambda/credentials.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lambda
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+)
+
+// AuthMode names the credential a Client authenticates with.
+type AuthMode string
+
+const (
+	// AuthWorkloadIdentity exchanges a projected Kubernetes ServiceAccount
+	// token for a short-lived API key. No static secret on the cluster.
+	AuthWorkloadIdentity AuthMode = "workload-identity"
+
+	// AuthAPIKey sends the static key held in LAMBDA_API_KEY.
+	AuthAPIKey AuthMode = "api-key"
+
+	// AuthNone means neither credential is configured. Requests will fail.
+	AuthNone AuthMode = "none"
+)
+
+// DetectAuthMode reports which credential the process environment implies.
+//
+// The pod-identity webhook injects the identity LRN into every pod whose
+// ServiceAccount carries the lambda.ai/identity-lrn annotation, so its presence
+// means the operator asked for workload identity and it wins over any static
+// key that happens to also be set. A missing token file is then a broken
+// injection, and surfaces as an error naming the path rather than as a silent
+// fall back to the key.
+//
+// Callers use this to fail at startup and to log which credential is in play,
+// rather than discovering it on the first request.
+func DetectAuthMode() AuthMode {
+	switch {
+	case os.Getenv(IdentityLRNEnvVar) != "":
+		return AuthWorkloadIdentity
+	case os.Getenv(APIKeyEnvVar) != "":
+		return AuthAPIKey
+	default:
+		return AuthNone
+	}
+}
+
+// credentialSource supplies the bearer token for each request. The two
+// implementations are the static key and workload identity; noCredential
+// serves the unauthenticated token-exchange call itself.
+type credentialSource interface {
+	// token returns the bearer token to send, or "" to send no
+	// Authorization header at all.
+	token(ctx context.Context) (string, error)
+
+	// invalidate drops any cached token so the next call mints a fresh one.
+	// Called when the API rejects a request as unauthorized.
+	invalidate()
+}
+
+// envAPIKey reads the static key from the environment on every request, so
+// credential rotation works without a process restart.
+type envAPIKey struct{}
+
+func (envAPIKey) token(_ context.Context) (string, error) {
+	key := os.Getenv(APIKeyEnvVar)
+	if key == "" {
+		return "", fmt.Errorf("env var %s is not set", APIKeyEnvVar)
+	}
+
+	return key, nil
+}
+
+// invalidate is a no-op: there is nothing cached, the env var is read every
+// time.
+func (envAPIKey) invalidate() {}
+
+// noCredential sends no Authorization header. It backs the token-exchange
+// call, which is unauthenticated and must not loop back through the
+// credential it is minting.
+type noCredential struct{}
+
+func (noCredential) token(_ context.Context) (string, error) { return "", nil }
+
+func (noCredential) invalidate() {}
+
+// detectCredential builds the credential DetectAuthMode selects, and logs which
+// one so the choice is visible from the client itself rather than inferred from
+// the deployment. The unconfigured case is deferred rather than reported here:
+// NewClient cannot fail, and envAPIKey already names the missing variable on
+// first use.
+func detectCredential(endpoint string, httpClient *http.Client, retry retryPolicy) credentialSource {
+	mode := DetectAuthMode()
+
+	slog.Info("Lambda API credential selected", "authMode", mode, "endpoint", endpoint)
+
+	if mode == AuthWorkloadIdentity {
+		// A static key left wired alongside an injected identity is ignored,
+		// which is worth saying out loud: it usually means the deployment still
+		// mounts a Secret it no longer needs.
+		if os.Getenv(APIKeyEnvVar) != "" {
+			slog.Warn("Both credentials are configured, using workload identity and ignoring the static key",
+				"ignoredEnvVar", APIKeyEnvVar)
+		}
+
+		return newWorkloadIdentity(endpoint, httpClient, retry)
+	}
+
+	return envAPIKey{}
+}

--- a/commons/pkg/lambda/endpoint.go
+++ b/commons/pkg/lambda/endpoint.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lambda
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+const (
+	// DefaultAPIHost is the host of the production Lambda Cloud API.
+	DefaultAPIHost = "cloud.lambda.ai"
+
+	// DefaultAPIEndpoint is the production Lambda Cloud API.
+	DefaultAPIEndpoint = "https://" + DefaultAPIHost
+)
+
+// allowedAPIHosts is every host an endpoint may point at. Anything else fails
+// at startup, bounding where the credential can be sent.
+var allowedAPIHosts = []string{
+	DefaultAPIHost,
+	"cloud.lambdastaging.com",
+}
+
+// NormalizeEndpoint validates raw as a Lambda API base URL and returns it with
+// any trailing slash trimmed. An empty raw yields DefaultAPIEndpoint. setting
+// names the configuration key in every error, so the operator is told which
+// value to fix rather than which package rejected it.
+//
+// Callers must run this before constructing a Client: both credentials are
+// bearer tokens sent on every request, including the workload identity token
+// exchange, so an unvalidated endpoint is an endpoint that can be handed a
+// credential.
+//
+// http is refused outright rather than warned about or gated behind an opt-in:
+// there is no configuration under which sending a bearer token in cleartext is
+// acceptable.
+//
+// The host must be one of allowedAPIHosts, so a mistyped or altered endpoint
+// cannot send the credential somewhere unintended.
+func NormalizeEndpoint(setting, raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return DefaultAPIEndpoint, nil
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("parse %s: %w", setting, err)
+	}
+
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("%s must not include userinfo, query parameters, or fragments", setting)
+	}
+
+	if parsed.Scheme == "http" {
+		return "", fmt.Errorf("%s uses http, which would send the credential in cleartext: use https", setting)
+	}
+
+	if parsed.Scheme != "https" {
+		return "", fmt.Errorf("%s %q must be an absolute https URL", setting, raw)
+	}
+
+	if parsed.Host == "" {
+		return "", fmt.Errorf("%s %q has no host", setting, raw)
+	}
+
+	if !allowedHost(parsed.Hostname()) {
+		return "", fmt.Errorf("%s host %q is not an approved Lambda API host", setting, parsed.Hostname())
+	}
+
+	return strings.TrimRight(raw, "/"), nil
+}
+
+// allowedHost reports whether a bearer token may be sent to host. The list is
+// deliberately fixed: making it configurable would let whoever sets the
+// endpoint widen the bound too, which defeats the point of having one.
+func allowedHost(host string) bool {
+	for _, allowed := range allowedAPIHosts {
+		if strings.EqualFold(allowed, host) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/commons/pkg/lambda/endpoint_test.go
+++ b/commons/pkg/lambda/endpoint_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lambda
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testSetting stands in for whichever configuration key a caller names, and is
+// asserted on so every error keeps pointing at the value the operator set.
+const testSetting = "LAMBDA_API_ENDPOINT"
+
+// TestNormalizeEndpoint_ValidationRules_NormalizesOrRejectsEndpoint checks the endpoint is validated before a credential
+// can be sent to it, and asserts which error fires so the http rejection cannot
+// be quietly folded into the general scheme check.
+func TestNormalizeEndpoint_ValidationRules_NormalizesOrRejectsEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr string
+	}{
+		{name: "unset defaults to production", raw: "", want: DefaultAPIEndpoint},
+		{name: "trailing slash trimmed", raw: "https://cloud.lambda.ai/", want: "https://cloud.lambda.ai"},
+		// Paths are appended by concatenation, so one leftover slash is enough
+		// to send every request to a doubled path.
+		{name: "repeated trailing slashes trimmed", raw: "https://cloud.lambda.ai///", want: "https://cloud.lambda.ai"},
+		// The allowlist is fixed, so a bearer token can only ever reach a known
+		// Lambda API host.
+		{name: "unapproved host rejected", raw: "https://cloud.example.com", wantErr: "is not an approved"},
+		{
+			name: "approved host matches case-insensitively",
+			raw:  "https://Cloud.Lambda.AI",
+			want: "https://Cloud.Lambda.AI",
+		},
+		{
+			name: "port is not part of the host match",
+			raw:  "https://cloud.lambda.ai:8443",
+			want: "https://cloud.lambda.ai:8443",
+		},
+		// Both credentials are bearer tokens on every request, so http would put
+		// one on the wire in cleartext. There is no opt-in that relaxes this.
+		{name: "plain http rejected", raw: "http://cloud.lambda.ai", wantErr: "cleartext"},
+		{name: "plain http rejected for loopback too", raw: "http://127.0.0.1:8080", wantErr: "cleartext"},
+		{name: "whitespace only defaults", raw: "   ", want: DefaultAPIEndpoint},
+		{name: "relative URL rejected", raw: "/api/v1", wantErr: "must be an absolute https URL"},
+		{name: "host only rejected", raw: "cloud.lambda.ai", wantErr: "must be an absolute https URL"},
+		{name: "non-http scheme rejected", raw: "ftp://cloud.lambda.ai", wantErr: "must be an absolute https URL"},
+		{name: "scheme without host rejected", raw: "https://", wantErr: "has no host"},
+		// Userinfo rides along in every request URL the client logs. A query or
+		// fragment is worse than cosmetic: request paths are appended by string
+		// concatenation, so "?token=x" + "/api/v1/instances" leaves the path
+		// inside the query.
+		{name: "userinfo rejected", raw: "https://user:pass@cloud.lambda.ai", wantErr: "must not include userinfo"},
+		{name: "query rejected", raw: "https://cloud.lambda.ai?token=x", wantErr: "must not include userinfo"},
+		{name: "fragment rejected", raw: "https://cloud.lambda.ai#frag", wantErr: "must not include userinfo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := NormalizeEndpoint(testSetting, tt.raw)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				// Every rejection names the setting, so the operator knows
+				// which value to fix.
+				assert.ErrorContains(t, err, testSetting)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/commons/pkg/lambda/workload_identity.go
+++ b/commons/pkg/lambda/workload_identity.go
@@ -1,0 +1,271 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lambda
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// IdentityLRNEnvVar names the service identity to assume, in the form
+	// lrn:iam:identity:<id>. Injected by lambda-pod-identity-webhook from the
+	// ServiceAccount's lambda.ai/identity-lrn annotation.
+	IdentityLRNEnvVar = "LAMBDA_IDENTITY_LRN"
+
+	// TokenFileEnvVar points at the projected ServiceAccount token the
+	// webhook mounts. Also injected by the webhook.
+	TokenFileEnvVar = "LAMBDA_WORKLOAD_IDENTITY_TOKEN_FILE" //nolint:gosec // path to a token, not a credential
+
+	// DefaultTokenFile is where the webhook projects the token when
+	// TokenFileEnvVar is unset.
+	DefaultTokenFile = "/var/run/secrets/lambda.ai/serviceaccount/token" //nolint:gosec // path, not a credential
+
+	// oidcTokenPath mints a short-lived API key from a ServiceAccount token.
+	// It takes no Authorization header: the presented JWT is the credential.
+	oidcTokenPath = "/api/v1/oidc/token" //nolint:gosec // URL path, not a credential
+
+	// refreshWindow is how long before expiry a token is replaced, so a
+	// request never rides one that is about to lapse.
+	refreshWindow = 5 * time.Minute
+
+	// jitterFrac spreads refreshes across a fleet so every pod does not
+	// re-exchange at the same instant.
+	jitterFrac = 0.2
+)
+
+// exchangeRequest is the body POST /api/v1/oidc/token takes.
+type exchangeRequest struct {
+	Token       string `json:"token"`
+	IdentityLRN string `json:"identity_lrn"`
+}
+
+// exchangeResponse is the envelope it returns. Every failure is a 401 with no
+// detail, by design: an unauthenticated caller must not learn why.
+type exchangeResponse struct {
+	Data struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+		ExpiresIn   int    `json:"expires_in"`
+		ExpiresAt   string `json:"expires_at"`
+	} `json:"data"`
+}
+
+// cachedToken is a minted key and the two deadlines that govern it.
+type cachedToken struct {
+	accessToken string
+	expiresAt   time.Time // the server's hard deadline
+	refreshAt   time.Time // when we start minting a replacement
+}
+
+// workloadIdentity mints, caches and refreshes a short-lived API key from a
+// projected ServiceAccount token. Safe for concurrent use.
+type workloadIdentity struct {
+	// exchangeClient carries noCredential, so minting a key never recurses
+	// through the credential being minted.
+	exchangeClient *Client
+	identityLRN    string
+	tokenFile      string
+	clock          func() time.Time
+
+	mu  sync.RWMutex // guards cur
+	cur *cachedToken // nil until the first exchange
+
+	refreshMu sync.Mutex // admits one refresher at a time
+}
+
+// newWorkloadIdentity builds the credential from the environment the webhook
+// injected. It performs no I/O: the token file is read on first use, so a
+// broken injection surfaces as a request error naming the path rather than at
+// construction, where NewClient has no way to report it.
+func newWorkloadIdentity(endpoint string, httpClient *http.Client, retry retryPolicy) *workloadIdentity {
+	tokenFile := os.Getenv(TokenFileEnvVar)
+	if tokenFile == "" {
+		tokenFile = DefaultTokenFile
+	}
+
+	return &workloadIdentity{
+		exchangeClient: &Client{
+			endpoint: endpoint,
+			http:     httpClient,
+			retry:    retry,
+			creds:    noCredential{},
+		},
+		identityLRN: os.Getenv(IdentityLRNEnvVar),
+		tokenFile:   tokenFile,
+		clock:       time.Now,
+	}
+}
+
+// token returns the cached key, minting a replacement once it is due.
+func (w *workloadIdentity) token(ctx context.Context) (string, error) {
+	// Fast path: the cached key is not due for replacement yet.
+	w.mu.RLock()
+	cur := w.cur
+	w.mu.RUnlock()
+
+	if cur != nil && w.clock().Before(cur.refreshAt) {
+		return cur.accessToken, nil
+	}
+
+	w.refreshMu.Lock()
+	defer w.refreshMu.Unlock()
+
+	// Another goroutine may have refreshed while we waited for the lock.
+	w.mu.RLock()
+	cur = w.cur
+	w.mu.RUnlock()
+
+	if cur != nil && w.clock().Before(cur.refreshAt) {
+		return cur.accessToken, nil
+	}
+
+	fresh, err := w.exchange(ctx)
+	if err != nil {
+		// A key that has not actually expired outlives a failed refresh;
+		// only a dead one surfaces the error.
+		if cur != nil && w.clock().Before(cur.expiresAt) {
+			return cur.accessToken, nil
+		}
+
+		return "", err
+	}
+
+	w.mu.Lock()
+	w.cur = &fresh
+	w.mu.Unlock()
+
+	return fresh.accessToken, nil
+}
+
+// invalidate drops the cached key so the next request mints a fresh one. Called
+// when the API rejects a request as unauthorized, which is how a key revoked
+// before its stated expiry is noticed.
+func (w *workloadIdentity) invalidate() {
+	w.mu.Lock()
+	w.cur = nil
+	w.mu.Unlock()
+}
+
+// exchange trades the current ServiceAccount token for a new API key.
+func (w *workloadIdentity) exchange(ctx context.Context) (cachedToken, error) {
+	if w.identityLRN == "" {
+		return cachedToken{}, fmt.Errorf("env var %s is not set", IdentityLRNEnvVar)
+	}
+
+	// Read the file every time: the kubelet rotates the projected token.
+	raw, err := os.ReadFile(w.tokenFile)
+	if err != nil {
+		return cachedToken{}, fmt.Errorf("read workload identity token %s: %w", w.tokenFile, err)
+	}
+
+	saToken := strings.TrimSpace(string(raw))
+	if saToken == "" {
+		return cachedToken{}, fmt.Errorf("workload identity token %s is empty", w.tokenFile)
+	}
+
+	var parsed exchangeResponse
+
+	req := exchangeRequest{Token: saToken, IdentityLRN: w.identityLRN}
+
+	// Retries transient failures, unlike Post: minting a key has no side
+	// effect worth protecting, and an unused key simply expires.
+	payload, err := marshalJSON(req)
+	if err != nil {
+		return cachedToken{}, fmt.Errorf("exchange workload identity token: %w", err)
+	}
+
+	if err := w.exchangeClient.do(
+		ctx, http.MethodPost, oidcTokenPath, nil, payload, &parsed, retryTransient,
+	); err != nil {
+		return cachedToken{}, fmt.Errorf("exchange workload identity token: %w", err)
+	}
+
+	if parsed.Data.AccessToken == "" {
+		return cachedToken{}, fmt.Errorf("exchange workload identity token: response carried no access_token")
+	}
+
+	now := w.clock()
+	expiresAt := expiryOf(parsed, now)
+	replaceAt := refreshAt(expiresAt, now)
+
+	slog.Info("Minted a Lambda API key from the workload identity",
+		"identityLRN", w.identityLRN,
+		"expiresAt", expiresAt.UTC().Format(time.RFC3339),
+		"refreshAt", replaceAt.UTC().Format(time.RFC3339))
+
+	return cachedToken{
+		accessToken: parsed.Data.AccessToken,
+		expiresAt:   expiresAt,
+		refreshAt:   replaceAt,
+	}, nil
+}
+
+// expiryOf prefers the absolute expires_at and falls back to expires_in. A
+// response carrying neither is treated as already expired, so the next request
+// mints again rather than reusing a key of unknown life.
+func expiryOf(r exchangeResponse, now time.Time) time.Time {
+	if r.Data.ExpiresAt != "" {
+		for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+			if t, err := time.Parse(layout, r.Data.ExpiresAt); err == nil {
+				return t
+			}
+		}
+	}
+
+	if r.Data.ExpiresIn > 0 {
+		return now.Add(time.Duration(r.Data.ExpiresIn) * time.Second)
+	}
+
+	return now
+}
+
+// refreshAt picks when to mint a replacement: refreshWindow before expiry,
+// pulled earlier still by jitter, so refreshWindow is a floor on the margin
+// rather than a ceiling. A key that lives less than the window aims for its
+// half-life instead, so a short-lived one still gets replaced in time.
+func refreshAt(expiresAt, now time.Time) time.Time {
+	window := refreshWindow
+	if life := expiresAt.Sub(now); window >= life {
+		window = life / 2
+	}
+
+	jitter := time.Duration(randFrac() * jitterFrac * float64(window))
+
+	at := expiresAt.Add(-(window + jitter))
+	if !at.After(now) {
+		return now.Add(expiresAt.Sub(now) / 2)
+	}
+
+	return at
+}
+
+// randFrac returns a random fraction in [0, 1) for refresh jitter only.
+func randFrac() float64 {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return 0 // no randomness: skip jitter rather than fail the refresh
+	}
+
+	return float64(binary.BigEndian.Uint64(b[:])>>11) / float64(1<<53)
+}

--- a/commons/pkg/lambda/workload_identity_test.go
+++ b/commons/pkg/lambda/workload_identity_test.go
@@ -1,0 +1,433 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lambda
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testIdentityLRN = "lrn:iam:identity:3cd2d107c6a347eeb0ef9498820d637d"
+
+// writeTokenFile drops a ServiceAccount token in a temp dir and returns its
+// path, standing in for the volume the webhook projects.
+func writeTokenFile(t *testing.T, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+
+	return path
+}
+
+// exchangeHandler serves the token-exchange endpoint, recording how many times
+// it was called and asserting the request shape the API requires.
+func exchangeHandler(t *testing.T, calls *atomic.Int64, accessToken string, expiresIn int) http.HandlerFunc {
+	t.Helper()
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+
+		assert.Equal(t, "/api/v1/oidc/token", r.URL.Path)
+		// The exchange is unauthenticated: the JWT in the body is the
+		// credential, and sending a half-built header would be a bug.
+		assert.Empty(t, r.Header.Get("Authorization"))
+
+		var req exchangeRequest
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "sa-jwt", req.Token)
+		assert.Equal(t, testIdentityLRN, req.IdentityLRN)
+
+		var resp exchangeResponse
+		resp.Data.AccessToken = accessToken
+		resp.Data.TokenType = "Bearer"
+		resp.Data.ExpiresIn = expiresIn
+
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(resp))
+	}
+}
+
+// newTestWorkloadIdentity wires a credential at srvURL against tokenFile,
+// bypassing the webhook env so tests stay independent of process state.
+func newTestWorkloadIdentity(srvURL, tokenFile string, httpClient *http.Client) *workloadIdentity {
+	return &workloadIdentity{
+		exchangeClient: &Client{
+			endpoint: srvURL,
+			http:     httpClient,
+			retry:    retryPolicy{maxAttempts: 1, initialBackoff: time.Microsecond, factor: 2, jitter: 0},
+			creds:    noCredential{},
+		},
+		identityLRN: testIdentityLRN,
+		tokenFile:   tokenFile,
+		clock:       time.Now,
+	}
+}
+
+func TestWorkloadIdentity_TokenLifecycle_ExchangesCachesAndRemintsAfterInvalidation(t *testing.T) {
+	var calls atomic.Int64
+
+	srv := httptest.NewServer(exchangeHandler(t, &calls, "minted-key", 3600))
+	defer srv.Close()
+
+	w := newTestWorkloadIdentity(srv.URL, writeTokenFile(t, "sa-jwt\n"), srv.Client())
+
+	first, err := w.token(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "minted-key", first)
+
+	// A key nowhere near expiry is reused rather than re-minted.
+	second, err := w.token(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "minted-key", second)
+	assert.Equal(t, int64(1), calls.Load(), "second call must be served from cache")
+
+	// Invalidate is what a 401 triggers; the next call must mint again.
+	w.invalidate()
+
+	third, err := w.token(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "minted-key", third)
+	assert.Equal(t, int64(2), calls.Load(), "invalidate must force a fresh exchange")
+}
+
+// TestWorkloadIdentity_TokenNearExpiry_RefreshesBeforeExpiry pins the point of the refresh
+// window: a token still technically valid but inside the window is replaced, so
+// no request rides one that lapses mid-flight.
+func TestWorkloadIdentity_TokenNearExpiry_RefreshesBeforeExpiry(t *testing.T) {
+	var calls atomic.Int64
+
+	srv := httptest.NewServer(exchangeHandler(t, &calls, "minted-key", 3600))
+	defer srv.Close()
+
+	w := newTestWorkloadIdentity(srv.URL, writeTokenFile(t, "sa-jwt"), srv.Client())
+
+	_, err := w.token(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(1), calls.Load())
+
+	// Jump to one minute before expiry, inside the five minute window.
+	expiry := w.cur.expiresAt
+	w.clock = func() time.Time { return expiry.Add(-time.Minute) }
+
+	_, err = w.token(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), calls.Load(), "a token inside the refresh window must be replaced")
+}
+
+// TestWorkloadIdentity_RefreshFailure_UsesValidCacheAndRejectsExpiredToken covers the case where
+// the refresh fails but the cached key has not actually expired: the API call
+// should still go out rather than fail on a credential that is still good.
+func TestWorkloadIdentity_RefreshFailure_UsesValidCacheAndRejectsExpiredToken(t *testing.T) {
+	var calls atomic.Int64
+
+	srv := httptest.NewServer(func() http.HandlerFunc {
+		good := exchangeHandler(t, &calls, "minted-key", 3600)
+
+		return func(w http.ResponseWriter, r *http.Request) {
+			if calls.Load() == 0 {
+				good(w, r)
+				return
+			}
+
+			calls.Add(1)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}())
+	defer srv.Close()
+
+	w := newTestWorkloadIdentity(srv.URL, writeTokenFile(t, "sa-jwt"), srv.Client())
+
+	_, err := w.token(context.Background())
+	require.NoError(t, err)
+
+	expiry := w.cur.expiresAt
+	w.clock = func() time.Time { return expiry.Add(-time.Minute) }
+
+	token, err := w.token(context.Background())
+	require.NoError(t, err, "a still-valid key must outlive a failed refresh")
+	assert.Equal(t, "minted-key", token)
+
+	// Past the hard deadline the error surfaces instead.
+	w.clock = func() time.Time { return expiry.Add(time.Minute) }
+
+	_, err = w.token(context.Background())
+	assert.Error(t, err, "an expired key must not be served")
+}
+
+func TestWorkloadIdentity_MissingOrEmptyTokenFile_ReturnsError(t *testing.T) {
+	var calls atomic.Int64
+
+	srv := httptest.NewServer(exchangeHandler(t, &calls, "minted-key", 3600))
+	defer srv.Close()
+
+	tests := []struct {
+		name        string
+		tokenFile   func(t *testing.T) string
+		wantErrPart string
+	}{
+		{
+			name:        "missing file names the path",
+			tokenFile:   func(t *testing.T) string { return filepath.Join(t.TempDir(), "absent") },
+			wantErrPart: "read workload identity token",
+		},
+		{
+			name:        "empty file is refused",
+			tokenFile:   func(t *testing.T) string { return writeTokenFile(t, "  \n") },
+			wantErrPart: "is empty",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := newTestWorkloadIdentity(srv.URL, tc.tokenFile(t), srv.Client())
+
+			_, err := w.token(context.Background())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErrPart)
+		})
+	}
+}
+
+// TestWorkloadIdentity_ConcurrentColdCacheRequests_MintsTokenOnce covers the single-flight guard:
+// a burst of callers on a cold cache must produce one exchange, not one each.
+func TestWorkloadIdentity_ConcurrentColdCacheRequests_MintsTokenOnce(t *testing.T) {
+	var calls atomic.Int64
+
+	srv := httptest.NewServer(exchangeHandler(t, &calls, "minted-key", 3600))
+	defer srv.Close()
+
+	w := newTestWorkloadIdentity(srv.URL, writeTokenFile(t, "sa-jwt"), srv.Client())
+
+	var wg sync.WaitGroup
+
+	for range 16 {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			token, err := w.token(context.Background())
+			assert.NoError(t, err)
+			assert.Equal(t, "minted-key", token)
+		}()
+	}
+
+	wg.Wait()
+	assert.Equal(t, int64(1), calls.Load(), "concurrent callers must share one exchange")
+}
+
+// TestClient_WorkloadIdentityAndStaticKeyConfigured_UsesExchangedBearerToken drives a real Client through the whole
+// path: mint on the first call, then send the minted key as the bearer token.
+func TestClient_WorkloadIdentityAndStaticKeyConfigured_UsesExchangedBearerToken(t *testing.T) {
+	var (
+		exchanges atomic.Int64
+		gotAuth   = make(chan string, 1)
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/oidc/token", exchangeHandler(t, &exchanges, "minted-key", 3600))
+	mux.HandleFunc("/api/v1/things", func(w http.ResponseWriter, r *http.Request) {
+		gotAuth <- r.Header.Get("Authorization")
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"ok":true}`)
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	t.Setenv(IdentityLRNEnvVar, testIdentityLRN)
+	t.Setenv(TokenFileEnvVar, writeTokenFile(t, "sa-jwt"))
+	// A static key must be ignored entirely when a workload identity is
+	// injected, otherwise the pod silently keeps using the secret it was
+	// supposed to stop needing.
+	t.Setenv(APIKeyEnvVar, "static-key-that-must-not-be-used")
+
+	require.Equal(t, AuthWorkloadIdentity, DetectAuthMode())
+
+	c := NewClient(srv.URL, WithHTTPClient(srv.Client()))
+
+	require.NoError(t, c.Get(context.Background(), "/api/v1/things", nil, nil))
+	assert.Equal(t, "Bearer minted-key", <-gotAuth)
+	assert.Equal(t, int64(1), exchanges.Load())
+}
+
+// TestExpiryOf_ExpiryMetadataVariants_UsesAbsoluteExpiryOrFallback pins parsing against what the API actually sends. The server
+// renders expires_at with Python's datetime.isoformat(), which emits a numeric
+// "+00:00" offset rather than "Z", and includes microseconds only when the
+// value has them. A form we cannot parse must fall back to expires_in rather
+// than silently yielding a zero time, which would re-mint on every request.
+func TestExpiryOf_ExpiryMetadataVariants_UsesAbsoluteExpiryOrFallback(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		expiresAt string
+		expiresIn int
+		want      time.Time
+	}{
+		{
+			name:      "isoformat with microseconds and offset",
+			expiresAt: "2026-08-14T11:09:12.479653+00:00",
+			want:      time.Date(2026, 8, 14, 11, 9, 12, 479653000, time.UTC),
+		},
+		{
+			name:      "isoformat with offset, no microseconds",
+			expiresAt: "2026-08-14T11:09:12+00:00",
+			want:      time.Date(2026, 8, 14, 11, 9, 12, 0, time.UTC),
+		},
+		{
+			name:      "RFC3339 with Z",
+			expiresAt: "2026-08-14T11:09:12Z",
+			want:      time.Date(2026, 8, 14, 11, 9, 12, 0, time.UTC),
+		},
+		{
+			name:      "a naive timestamp falls back to expires_in",
+			expiresAt: "2026-08-14T11:09:12.479653",
+			expiresIn: 3600,
+			want:      now.Add(time.Hour),
+		},
+		{
+			name:      "expires_in alone",
+			expiresIn: 900,
+			want:      now.Add(15 * time.Minute),
+		},
+		{
+			name: "neither is treated as already expired",
+			want: now,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var r exchangeResponse
+			r.Data.ExpiresAt = tc.expiresAt
+			r.Data.ExpiresIn = tc.expiresIn
+
+			assert.True(t, expiryOf(r, now).Equal(tc.want),
+				"expiresAt=%q expiresIn=%d: got %s, want %s",
+				tc.expiresAt, tc.expiresIn, expiryOf(r, now), tc.want)
+		})
+	}
+}
+
+// TestRefreshAt_VariedTokenLifetimes_SchedulesRefreshWithinExpectedBounds pins the margin refreshAt leaves before expiry, since
+// randFrac draws from crypto/rand and can't be substituted: each case checks
+// invariants across repeated draws instead of a single deterministic value.
+func TestRefreshAt_VariedTokenLifetimes_SchedulesRefreshWithinExpectedBounds(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 14, 10, 0, 0, 0, time.UTC)
+	maxMargin := refreshWindow + time.Duration(jitterFrac*float64(refreshWindow))
+
+	tests := []struct {
+		name  string
+		life  time.Duration
+		check func(t *testing.T, expiresAt, at time.Time)
+	}{
+		{
+			name: "life longer than the window: jitter only pulls refresh earlier",
+			life: time.Hour,
+			check: func(t *testing.T, expiresAt, at time.Time) {
+				t.Helper()
+
+				margin := expiresAt.Sub(at)
+				assert.GreaterOrEqual(t, margin, refreshWindow, "margin=%s fell short of refreshWindow", margin)
+				assert.LessOrEqual(t, margin, maxMargin, "margin=%s exceeded refreshWindow+jitter", margin)
+			},
+		},
+		{
+			name: "life exactly at the window: aims for its half-life",
+			life: refreshWindow,
+			check: func(t *testing.T, expiresAt, at time.Time) {
+				t.Helper()
+
+				assert.True(t, at.After(now), "refresh time must not be in the past")
+				assert.True(t, at.Before(expiresAt), "refresh time must be before expiry")
+			},
+		},
+		{
+			name: "life shorter than the window: aims for its half-life",
+			life: 2 * time.Minute,
+			check: func(t *testing.T, expiresAt, at time.Time) {
+				t.Helper()
+
+				assert.True(t, at.After(now), "refresh time must not be in the past")
+				assert.True(t, at.Before(expiresAt), "refresh time must be before expiry")
+			},
+		},
+		{
+			name: "already expired: immediately due for refresh",
+			life: -time.Minute,
+			check: func(t *testing.T, _, at time.Time) {
+				t.Helper()
+
+				assert.False(t, now.Before(at), "refresh must be immediately due")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			expiresAt := now.Add(tc.life)
+
+			for i := 0; i < 100; i++ {
+				tc.check(t, expiresAt, refreshAt(expiresAt, now))
+			}
+		})
+	}
+}
+
+func TestDetectAuthMode_CredentialEnvironmentCombinations_SelectsExpectedAuthMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		identityLRN string
+		apiKey      string
+		want        AuthMode
+	}{
+		{name: "webhook injection wins", identityLRN: testIdentityLRN, apiKey: "key", want: AuthWorkloadIdentity},
+		{name: "identity alone", identityLRN: testIdentityLRN, want: AuthWorkloadIdentity},
+		{name: "static key alone", apiKey: "key", want: AuthAPIKey},
+		{name: "neither configured", want: AuthNone},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(IdentityLRNEnvVar, tc.identityLRN)
+			t.Setenv(APIKeyEnvVar, tc.apiKey)
+
+			assert.Equal(t, tc.want, DetectAuthMode())
+		})
+	}
+}

--- a/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/deployment.yaml
@@ -29,6 +29,11 @@ spec:
       annotations:
         # Force pod restart when configmap changes
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if and (eq .Values.cspName "lambda") ((.Values.lambdaWorkloadIdentity).identityLRN) }}
+        # Force pod restart when identityLRN changes; it lives on the
+        # ServiceAccount annotation, which the pod template doesn't reference.
+        checksum/lambda-workload-identity: {{ .Values.lambdaWorkloadIdentity.identityLRN | sha256sum }}
+        {{- end }}
         {{- with ((.Values.global).podAnnotations | default .Values.podAnnotations) }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -151,11 +156,16 @@ spec:
             - name: APP_NAME
               value: {{ .Chart.Name | quote }}
             {{- if eq .Values.cspName "lambda" }}
+            {{- if not ((.Values.lambdaWorkloadIdentity).identityLRN) }}
             - name: LAMBDA_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "lambdaApiKeySecret.name must be set when cspName=lambda" .Values.lambdaApiKeySecret.name }}
-                  key: {{ required "lambdaApiKeySecret.key must be set when cspName=lambda" .Values.lambdaApiKeySecret.key }}
+                  name: {{ required "lambdaApiKeySecret.name must be set when cspName=lambda and lambdaWorkloadIdentity.identityLRN is empty" .Values.lambdaApiKeySecret.name }}
+                  key: {{ required "lambdaApiKeySecret.key must be set when cspName=lambda and lambdaWorkloadIdentity.identityLRN is empty" .Values.lambdaApiKeySecret.key }}
+            {{- end }}
+            {{- /* With workload identity the credential env vars and the token
+                   volume are injected by lambda-pod-identity-webhook, keyed off
+                   the ServiceAccount annotation, so nothing is declared here. */}}
             {{- end }}
           envFrom:
             - configMapRef:

--- a/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/serviceaccount.yaml
+++ b/distros/kubernetes/nvsentinel/charts/csp-health-monitor/templates/serviceaccount.yaml
@@ -30,3 +30,9 @@ metadata:
         {{- end }}
       {{- end }}
     {{- end }}
+    {{- if and (eq .Values.cspName "lambda") .Values.lambdaWorkloadIdentity .Values.lambdaWorkloadIdentity.identityLRN }}
+    # Lambda Workload Identity annotation. lambda-pod-identity-webhook watches
+    # for it and injects the projected ServiceAccount token plus
+    # LAMBDA_IDENTITY_LRN into every pod using this ServiceAccount.
+    lambda.ai/identity-lrn: {{ .Values.lambdaWorkloadIdentity.identityLRN | quote }}
+    {{- end }}

--- a/distros/kubernetes/nvsentinel/charts/csp-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/csp-health-monitor/values.yaml
@@ -116,7 +116,18 @@ configToml:
     # exercising csp-health-monitor without hitting cloud.lambda.ai.
 
 # lambdaApiKeySecret names the Secret containing the LAMBDA_API_KEY env var.
-# Required when cspName=lambda.
+# Required when cspName=lambda unless lambdaWorkloadIdentity.identityLRN is set.
 lambdaApiKeySecret:
   name: ""
   key: "LAMBDA_API_KEY"
+
+# lambdaWorkloadIdentity authenticates with a short-lived token instead of a
+# static key, so no Lambda credential is stored in the cluster. Setting
+# identityLRN annotates the ServiceAccount and lambdaApiKeySecret is no longer
+# required. See docs/configuration/csp-health-monitor.md.
+lambdaWorkloadIdentity:
+  # identityLRN is the service identity to assume, in the form
+  # lrn:iam:identity:<id>, e.g. "lrn:iam:identity:3cd2d107c6a347eeb0ef9498820d637d".
+  # It needs permission to read maintenance events in the workspace named by
+  # configToml.lambda.workspaceId, and must trust this cluster's ServiceAccount.
+  identityLRN: ""

--- a/distros/kubernetes/nvsentinel/charts/janitor-provider/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor-provider/templates/deployment.yaml
@@ -26,9 +26,20 @@ spec:
       {{- include "provider.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with ((.Values.global).podAnnotations | default .Values.podAnnotations) }}
+      {{- $lambdaIdentityLRN := "" }}
+      {{- if eq (lower (.Values.csp.provider | default "kind")) "lambda" }}
+      {{- $lambdaIdentityLRN = ((.Values.csp.lambda).workloadIdentity).identityLRN }}
+      {{- end }}
+      {{- if or ((.Values.global).podAnnotations | default .Values.podAnnotations) $lambdaIdentityLRN }}
       annotations:
+        {{- if $lambdaIdentityLRN }}
+        # Force pod restart when identityLRN changes; it lives on the
+        # ServiceAccount annotation, which the pod template doesn't reference.
+        checksum/lambda-workload-identity: {{ $lambdaIdentityLRN | sha256sum }}
+        {{- end }}
+        {{- with ((.Values.global).podAnnotations | default .Values.podAnnotations) }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       labels:
         {{- include "provider.selectorLabels" . | nindent 8 }}
@@ -175,11 +186,16 @@ spec:
             - name: LAMBDA_API_ENDPOINT
               value: {{ .Values.csp.lambda.apiEndpoint | quote }}
             {{- end }}
+            {{- if not $lambdaIdentityLRN }}
             - name: LAMBDA_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "csp.lambda.apiKeySecretRef.name must be set when csp.provider=lambda" .Values.csp.lambda.apiKeySecretRef.name }}
+                  name: {{ required "csp.lambda.apiKeySecretRef.name must be set when csp.provider=lambda and csp.lambda.workloadIdentity.identityLRN is empty" .Values.csp.lambda.apiKeySecretRef.name }}
                   key: {{ .Values.csp.lambda.apiKeySecretRef.key | default "LAMBDA_API_KEY" }}
+            {{- end }}
+            {{- /* With workload identity the credential env vars and the token
+                   volume are injected by lambda-pod-identity-webhook, keyed off
+                   the ServiceAccount annotation, so nothing is declared here. */}}
             {{- end }}
             {{- if .Values.tls.enabled }}
             - name: TLS_CERT_PATH

--- a/distros/kubernetes/nvsentinel/charts/janitor-provider/templates/serviceaccount.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor-provider/templates/serviceaccount.yaml
@@ -47,3 +47,11 @@ metadata:
     oke.oraclecloud.com/principal-ocid: {{ .Values.csp.oci.principalId | quote }}
     {{- end }}
     {{- end }}
+    {{- if eq (lower (.Values.csp.provider | default "kind")) "lambda" }}
+    {{- if .Values.csp.lambda.workloadIdentity.identityLRN }}
+    # Lambda Workload Identity annotation. lambda-pod-identity-webhook watches
+    # for it and injects the projected ServiceAccount token plus
+    # LAMBDA_IDENTITY_LRN into every pod using this ServiceAccount.
+    lambda.ai/identity-lrn: {{ .Values.csp.lambda.workloadIdentity.identityLRN | quote }}
+    {{- end }}
+    {{- end }}

--- a/distros/kubernetes/nvsentinel/charts/janitor-provider/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor-provider/values.yaml
@@ -241,8 +241,9 @@ csp:
     # so an unapproved host fails at startup.
     apiEndpoint: ""
     # apiKeySecretRef names the Secret containing the LAMBDA_API_KEY env var.
-    # Required when provider=lambda, plaintext key values are not supported.
-    # The key needs permission to power cycle and terminate instances.
+    # Required when provider=lambda unless workloadIdentity.identityLRN is set;
+    # plaintext key values are not supported. The key needs permission to power
+    # cycle and terminate instances.
     # Example:
     #   apiKeySecretRef:
     #     name: lambda-api-key
@@ -250,4 +251,15 @@ csp:
     apiKeySecretRef:
       name: ""
       key: "LAMBDA_API_KEY"
+
+    # workloadIdentity authenticates with a short-lived token instead of a
+    # static key, so no Lambda credential is stored in the cluster. Setting
+    # identityLRN annotates the ServiceAccount and apiKeySecretRef is no longer
+    # required. See docs/configuration/janitor-provider.md.
+    workloadIdentity:
+      # identityLRN is the service identity to assume, in the form
+      # lrn:iam:identity:<id>, e.g. "lrn:iam:identity:3cd2d107c6a347eeb0ef9498820d637d".
+      # It needs permission to power cycle and terminate instances, and must
+      # trust this cluster's ServiceAccount.
+      identityLRN: ""
 

--- a/docs/configuration/csp-health-monitor.md
+++ b/docs/configuration/csp-health-monitor.md
@@ -20,7 +20,7 @@ The `cspName` field determines which cloud provider to monitor. Only one provide
 
 ```yaml
 csp-health-monitor:
-  cspName: "gcp"  # Options: "gcp" or "aws"
+  cspName: "gcp"  # Options: "gcp", "aws", or "lambda"
 ```
 
 ## Global Settings
@@ -206,6 +206,186 @@ csp-health-monitor:
       iamRoleName: "my-custom-nvsentinel-role"
 ```
 
+## Lambda Configuration
+
+Polls the Lambda maintenance-events API and raises a health event for each event affecting a node in this cluster. Nodes are matched by the instance UUID in the event's `entity_lrns`, so they must carry `spec.providerID` in the form `lambda://<instanceID>`.
+
+### Static API Key Example
+
+```yaml
+csp-health-monitor:
+  cspName: "lambda"
+
+  lambdaApiKeySecret:
+    name: "lambda-api-key"
+    key: "LAMBDA_API_KEY"
+
+  configToml:
+    clusterName: "my-cluster"
+
+    lambda:
+      apiEndpoint: "https://cloud.lambda.ai"
+      workspaceId: "c4d291f47f9d436fa39f58493ce3b50d"
+      pollingIntervalSeconds: 30
+```
+
+### apiEndpoint
+Base URL of the Lambda API. Defaults to the production endpoint, so the happy path needs no override.
+
+### workspaceId
+Optional. Scopes the maintenance-events query to one workspace, in dashed or undashed UUID form. Leave it empty to use the default workspace for the credential.
+
+Set it whenever that default is not the workspace running this cluster. Getting it wrong is quiet: the API answers `200` with an empty list rather than an error, so the monitor looks healthy while never seeing a maintenance event for these nodes. A value that is not a UUID fails at startup rather than returning `400` on every poll.
+
+This matters more with workload identity, where the credential belongs to a service identity whose role is assigned at workspace scope — its default workspace is unlikely to be the cluster's.
+
+### pollingIntervalSeconds
+How often the maintenance-events API is polled. Minimum 30.
+
+### lambdaApiKeySecret
+Secret holding the Lambda API key, injected as `LAMBDA_API_KEY`. `name` is required when `cspName` is `lambda`, unless `lambdaWorkloadIdentity.identityLRN` is set; the install fails without one of the two. The same Secret can be shared with the Janitor Provider, which reads the key the same way. The key needs permission to read maintenance events in the target workspace.
+
+### lambdaWorkloadIdentity.identityLRN
+
+The service identity to assume, in the form `lrn:iam:identity:<id>`. Preferred over a static key: no Lambda credential is stored in the cluster, and the token is short-lived and rotated automatically.
+
+Setting it annotates the csp-health-monitor ServiceAccount with `lambda.ai/identity-lrn`. The pod is then given a short-lived Kubernetes token, which the monitor exchanges for a Lambda API key and refreshes before it expires — so no Lambda credential is stored in the cluster.
+
+```yaml
+csp-health-monitor:
+  cspName: "lambda"
+
+  lambdaWorkloadIdentity:
+    identityLRN: "lrn:iam:identity:3cd2d107c6a347eeb0ef9498820d637d"
+
+  configToml:
+    clusterName: "my-cluster"
+    lambda:
+      workspaceId: "c4d291f47f9d436fa39f58493ce3b50d"
+```
+
+When set, `lambdaApiKeySecret` is not required and no `LAMBDA_API_KEY` is placed in the pod. If both are configured, workload identity wins and the static key is ignored; the monitor logs which one it selected at startup (`authMode`).
+
+On the Lambda side, the identity must exist, hold permission to read maintenance events in the workspace named by `workspaceId`, and trust this cluster's ServiceAccount.
+
+```bash
+(
+  set -euo pipefail
+
+  NAMESPACE=$(
+    kubectl get deployments --all-namespaces \
+      -l app.kubernetes.io/name=csp-health-monitor -o json |
+      jq -er '
+        .items
+        | if length == 1 then .[0] else error("expected exactly one csp-health-monitor Deployment") end
+        | .metadata.namespace
+      '
+  )
+  kubectl -n "$NAMESPACE" get sa -l app.kubernetes.io/name=csp-health-monitor
+)
+```
+
+#### Setting up the identity
+
+Run once per cluster, with an admin API key. `$WS` is the workspace the cluster's instances belong to — the same one you set as `workspaceId` above.
+
+```bash
+# Stop at the first failed call: a half-applied setup prints an identityLRN
+# that looks usable but has no role or no trust behind it.
+set -euo pipefail
+
+KEY=<admin-api-key>
+export WS=<workspace-id>
+
+lambda_curl() {
+  printf 'Authorization: Bearer %s\n' "$KEY" | curl -sf -H @- "$@"
+}
+
+# 1. Create a service identity for the CSP Health Monitor.
+SID=$(lambda_curl "https://cloud.lambda.ai/api/v1/identities" \
+  -H 'Content-Type: application/json' \
+  -d '{"display_name":"nvsentinel-csp-health-monitor"}' | jq -r .data.id)
+[ -n "$SID" ] && [ "$SID" != "null" ] || { echo "identity was not created" >&2; exit 1; }
+
+# 2. Add it to the workspace. A workspace-scoped role assignment needs membership.
+lambda_curl "https://cloud.lambda.ai/api/v1/workspaces/$WS/memberships" \
+  -H 'Content-Type: application/json' \
+  -d "{\"member_type\":\"identity\",\"member_id\":\"$SID\"}"
+
+# 3. Assign the built-in roles, scoped to that workspace.
+for role in maintenance-api-reader; do
+  ROLE=$(lambda_curl "https://cloud.lambda.ai/api/v1/roles" \
+    | jq -r --arg n "$role" '.data[] | select(.name==$n) | .id')
+  [ -n "$ROLE" ] && [ "$ROLE" != "null" ] || { echo "role $role not found" >&2; exit 1; }
+  lambda_curl "https://cloud.lambda.ai/api/v1/identities/$SID/role-assignments" \
+    -H 'Content-Type: application/json' \
+    -d "{\"role_id\":\"$ROLE\",\"scope\":{\"type\":\"workspace\",\"workspace_id\":\"$WS\"}}"
+done
+
+# 4. Trust this cluster's ServiceAccount to assume the identity. Registering the
+#    issuer is an idempotent upsert keyed on the issuer URL, so re-running is safe.
+SUBJECT=$(
+  kubectl get deployments --all-namespaces \
+    -l app.kubernetes.io/name=csp-health-monitor -o json |
+    jq -er '
+      .items
+      | if length == 1 then .[0] else error("expected exactly one csp-health-monitor Deployment") end
+      | "system:serviceaccount:\(.metadata.namespace):\(.spec.template.spec.serviceAccountName)"
+    '
+)
+ISS=$(kubectl get --raw /.well-known/openid-configuration |
+  jq -er '.issuer | select(type == "string" and length > 0)') ||
+  { echo "OIDC discovery returned no valid issuer" >&2; exit 1; }
+kubectl get --raw /openid/v1/jwks > /tmp/jwks.json
+lambda_curl "https://cloud.lambda.ai/api/v1/oidc-providers" \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -n --arg iss "$ISS" --arg lrn "lrn:iam:identity:$SID" \
+        --arg subject "$SUBJECT" --slurpfile jwks /tmp/jwks.json \
+        '{issuer_url:$iss, jwks:$jwks[0],
+          trusts:[{identity_lrn:$lrn, subject:$subject}]}')"
+
+echo "identityLRN: lrn:iam:identity:$SID"
+```
+
+The printed LRN is what goes in the chart value above.
+
+| Built-in role | Grants | Needed for |
+| --- | --- | --- |
+| `maintenance-api-reader` | `support:maintenance-event:read` | Polling the maintenance-events API |
+
+The role is workspace-scoped, so the identity only sees events for `$WS` — which is why `workspaceId` should name that same workspace.
+
+#### Verifying
+
+The identity is attached when the pod is created, so it only appears on pods created *after* the annotation lands. Restart the deployment if you added it to a running install.
+
+```bash
+(
+  set -euo pipefail
+
+  NAMESPACE=$(
+    kubectl get deployments --all-namespaces \
+      -l app.kubernetes.io/name=csp-health-monitor -o json |
+      jq -er '
+        .items
+        | if length == 1 then .[0] else error("expected exactly one csp-health-monitor Deployment") end
+        | .metadata.namespace
+      '
+  )
+
+  # The identity the pod received.
+  kubectl -n "$NAMESPACE" get pod -l app.kubernetes.io/name=csp-health-monitor \
+    -o jsonpath='{.items[0].spec.containers[0].env[?(@.name=="LAMBDA_IDENTITY_LRN")]}'
+
+  # Which credential the monitor selected, and the workspace it polls.
+  kubectl -n "$NAMESPACE" logs -l app.kubernetes.io/name=csp-health-monitor | grep authMode
+)
+```
+
+Expect `authMode=workload-identity`. If it says `api-key`, the pod never received an identity — check that the annotation is on the ServiceAccount and that the pod was created after it landed.
+
+Failures in the exchange itself surface on the first poll, not at startup, because the token is minted lazily. When the exchange endpoint rejects the token it returns `401` with no detail by design, so an unauthenticated caller cannot probe for which identities exist; that means a missing trust, a wrong identity LRN and a disabled account all look identical from the client. Check the trust and the identity LRN first.
+
 ## CSP-Specific IAM Requirements
 
 Each cloud provider handles IAM identity for the CSP Health Monitor differently:
@@ -214,6 +394,7 @@ Each cloud provider handles IAM identity for the CSP Health Monitor differently:
 |----------|---------------------------|-------------------|
 | **GCP**  | `gcp.gcpServiceAccountName` — User provides any GCP Service Account name. The ServiceAccount annotation is built as `{SA_NAME}@{PROJECT}.iam.gserviceaccount.com`. | Fully flexible. No naming convention enforced. |
 | **AWS (EKS)** | `aws.iamRoleName` (optional) — User provides a custom IAM role name. If omitted, the role name defaults to `{CLUSTER_NAME}-nvsentinel-health-monitor-assume-role-policy`. | Flexible when `iamRoleName` is set. The default convention imposes a **19-character cluster name limit** (AWS IAM role names max 64 chars, default suffix is 45 chars). |
+| **Lambda** | Either a static API key in `lambdaApiKeySecret`, or `lambdaWorkloadIdentity.identityLRN` — the ServiceAccount is annotated with `lambda.ai/identity-lrn` and the pod receives a short-lived token instead of a stored key. | Fully flexible. The identity is named by LRN, so no naming convention is enforced. |
 
 > **Recommendation for EKS users**: If your cluster name is longer than 19 characters, always set `aws.iamRoleName` explicitly and create the corresponding IAM role with that name. See [IAM Setup](../csp-health-monitor-iam.md) for detailed instructions.
 

--- a/docs/configuration/janitor-provider.md
+++ b/docs/configuration/janitor-provider.md
@@ -189,7 +189,9 @@ OCI principal OCID used for Workload Identity. Required when `credentialsFile` i
 
 ## Lambda
 
-Uses a Lambda Cloud API key for authentication. Reboot maps to the Lambda power-cycle operation (a host-level power cycle, not a guest restart) and terminate maps to the Lambda terminate operation. Nodes must carry `spec.providerID` in the form `lambda://<instanceID>`.
+Reboot maps to the Lambda power-cycle operation (a host-level power cycle, not a guest restart) and terminate maps to the Lambda terminate operation. Nodes must carry `spec.providerID` in the form `lambda://<instanceID>`.
+
+Authenticate either with a static API key or with workload identity. Workload identity is preferred: no Lambda credential is stored in the cluster, and the token it uses is short-lived and rotated automatically.
 
 ```yaml
 janitor-provider:
@@ -205,7 +207,129 @@ janitor-provider:
 Optional. Overrides the base URL of the Lambda Cloud API, passed as `LAMBDA_API_ENDPOINT`. Defaults to `https://cloud.lambda.ai` when unset. Must be https, and must not carry userinfo, a query string, or a fragment. The host is checked against a fixed allowlist built into the provider, so an unapproved host fails at startup rather than on the first remediation.
 
 ### apiKeySecretRef
-Secret holding the Lambda API key, injected as `LAMBDA_API_KEY`. `name` is required when `csp.provider` is `lambda`; the install fails without it. `key` defaults to `LAMBDA_API_KEY`. The same Secret can be shared with the CSP Health Monitor, which reads the key the same way. The key needs permission to power cycle and terminate instances.
+Secret holding the Lambda API key, injected as `LAMBDA_API_KEY`. `name` is required when `csp.provider` is `lambda`, unless `workloadIdentity.identityLRN` is set; the install fails without one of the two. `key` defaults to `LAMBDA_API_KEY`. The same Secret can be shared with the CSP Health Monitor, which reads the key the same way. The key needs permission to power cycle and terminate instances.
+
+### workloadIdentity.identityLRN
+
+The service identity to assume, in the form `lrn:iam:identity:<id>`. Setting it annotates the janitor-provider ServiceAccount with `lambda.ai/identity-lrn`. The pod is then given a short-lived Kubernetes token, which the provider exchanges for a Lambda API key and refreshes before it expires — so no Lambda credential is stored in the cluster.
+
+```yaml
+janitor-provider:
+  csp:
+    provider: "lambda"
+    lambda:
+      workloadIdentity:
+        identityLRN: "lrn:iam:identity:3cd2d107c6a347eeb0ef9498820d637d"
+```
+
+When set, `apiKeySecretRef` is not required and no `LAMBDA_API_KEY` is placed in the pod. If both are configured, workload identity wins and the static key is ignored; the provider logs which one it selected at startup (`authMode`).
+
+On the Lambda side, the identity must exist, hold permission to power cycle and terminate instances, and trust this cluster's ServiceAccount.
+
+#### Setting up the identity
+
+Run once per cluster, with an admin API key. `$WS` is the workspace the cluster's instances belong to.
+
+```bash
+# Stop at the first failed call: a half-applied setup prints an identityLRN
+# that looks usable but has no role or no trust behind it.
+set -euo pipefail
+
+KEY=<admin-api-key>
+export WS=<workspace-id>
+
+lambda_curl() {
+  printf 'Authorization: Bearer %s\n' "$KEY" | curl -sf -H @- "$@"
+}
+
+# 1. Create a service identity for the Janitor Provider.
+SID=$(lambda_curl "https://cloud.lambda.ai/api/v1/identities" \
+  -H 'Content-Type: application/json' \
+  -d '{"display_name":"nvsentinel-janitor-provider"}' | jq -r .data.id)
+[ -n "$SID" ] && [ "$SID" != "null" ] || { echo "identity was not created" >&2; exit 1; }
+
+# 2. Add it to the workspace. A workspace-scoped role assignment needs membership.
+lambda_curl "https://cloud.lambda.ai/api/v1/workspaces/$WS/memberships" \
+  -H 'Content-Type: application/json' \
+  -d "{\"member_type\":\"identity\",\"member_id\":\"$SID\"}"
+
+# 3. Assign the built-in roles, scoped to that workspace.
+for role in instance-reader instance-power-cycle instance-terminate; do
+  ROLE=$(lambda_curl "https://cloud.lambda.ai/api/v1/roles" \
+    | jq -r --arg n "$role" '.data[] | select(.name==$n) | .id')
+  [ -n "$ROLE" ] && [ "$ROLE" != "null" ] || { echo "role $role not found" >&2; exit 1; }
+  lambda_curl "https://cloud.lambda.ai/api/v1/identities/$SID/role-assignments" \
+    -H 'Content-Type: application/json' \
+    -d "{\"role_id\":\"$ROLE\",\"scope\":{\"type\":\"workspace\",\"workspace_id\":\"$WS\"}}"
+done
+
+# 4. Trust this cluster's ServiceAccount to assume the identity. Registering the
+#    issuer is an idempotent upsert keyed on the issuer URL, so re-running is safe.
+SUBJECT=$(
+  kubectl get deployments --all-namespaces \
+    -l app.kubernetes.io/name=janitor-provider -o json |
+    jq -er '
+      .items
+      | if length == 1 then .[0] else error("expected exactly one janitor-provider Deployment") end
+      | "system:serviceaccount:\(.metadata.namespace):\(.spec.template.spec.serviceAccountName)"
+    '
+)
+ISS=$(kubectl get --raw /.well-known/openid-configuration |
+  jq -er '.issuer | select(type == "string" and length > 0)') ||
+  { echo "OIDC discovery returned no valid issuer" >&2; exit 1; }
+kubectl get --raw /openid/v1/jwks > /tmp/jwks.json
+lambda_curl "https://cloud.lambda.ai/api/v1/oidc-providers" \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -n --arg iss "$ISS" --arg lrn "lrn:iam:identity:$SID" \
+        --arg subject "$SUBJECT" --slurpfile jwks /tmp/jwks.json \
+        '{issuer_url:$iss, jwks:$jwks[0],
+          trusts:[{identity_lrn:$lrn, subject:$subject}]}')"
+
+echo "identityLRN: lrn:iam:identity:$SID"
+```
+
+The printed LRN is what goes in the chart value above.
+
+| Built-in role | Grants | Needed for |
+| --- | --- | --- |
+| `instance-reader` | `compute:instance:read` | Reading instance state before and after a reboot |
+| `instance-power-cycle` | `compute:instance:power-cycle` | The reboot itself |
+| `instance-terminate` | `compute:instance:terminate` | Terminating a node the remediation policy replaces rather than reboots |
+
+All three are workspace-scoped, so the identity can only act on instances in `$WS`.
+
+Drop `instance-terminate` from the loop if your remediation policy only ever reboots — the roles are additive, so granting just the two leaves terminate unauthorized.
+
+#### Verifying
+
+The identity is attached when the pod is created, so it only appears on pods created *after* the annotation lands. Restart the deployment if you added it to a running install.
+
+```bash
+(
+  set -euo pipefail
+
+  NAMESPACE=$(
+    kubectl get deployments --all-namespaces \
+      -l app.kubernetes.io/name=janitor-provider -o json |
+      jq -er '
+        .items
+        | if length == 1 then .[0] else error("expected exactly one janitor-provider Deployment") end
+        | .metadata.namespace
+      '
+  )
+
+  # The identity the pod received.
+  kubectl -n "$NAMESPACE" get pod -l app.kubernetes.io/name=janitor-provider \
+    -o jsonpath='{.items[0].spec.containers[0].env[?(@.name=="LAMBDA_IDENTITY_LRN")]}'
+
+  # Which credential the provider selected.
+  kubectl -n "$NAMESPACE" logs -l app.kubernetes.io/name=janitor-provider | grep authMode
+)
+```
+
+Expect `authMode=workload-identity`. If it says `api-key`, the pod never received an identity — check that the annotation is on the ServiceAccount and that the pod was created after it landed.
+
+Failures in the exchange itself surface on the first remediation, not at startup, because the token is minted lazily. When the exchange endpoint rejects the token it returns `401` with no detail by design, so an unauthenticated caller cannot probe for which identities exist; that means a missing trust, a wrong identity LRN and a disabled account all look identical from the client. Check the trust and the identity LRN first.
 
 ## Generic / Bare-Metal
 

--- a/health-monitors/csp-health-monitor/pkg/csp/lambda/lambda.go
+++ b/health-monitors/csp-health-monitor/pkg/csp/lambda/lambda.go
@@ -104,8 +104,6 @@ func NewClient(
 		return nil, fmt.Errorf("failed to create Lambda node informer: %w", err)
 	}
 
-	nodeInformer.Start(ctx)
-
 	normalizer, err := eventpkg.GetNormalizer(model.CSPLambda)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Lambda normalizer: %w", err)
@@ -117,11 +115,32 @@ func NewClient(
 		slog.Info("Lambda client: using mock events file (dev/test mode)", "path", cfg.MockEventsFilePath)
 		source = &fileSource{path: cfg.MockEventsFilePath}
 	} else {
-		slog.Info("Lambda client: using real API", "endpoint", cfg.APIEndpoint, "workspaceID", cfg.WorkspaceID)
+		mode := lambdaapi.DetectAuthMode()
+		if mode == lambdaapi.AuthNone {
+			return nil, fmt.Errorf(
+				"no Lambda credential: set %s, or annotate the ServiceAccount with lambda.ai/identity-lrn so the "+
+					"pod-identity webhook injects %s",
+				lambdaapi.APIKeyEnvVar, lambdaapi.IdentityLRNEnvVar)
+		}
+
+		// Bounds where the credential can be sent, before a client that holds
+		// one exists.
+		endpoint, err := lambdaapi.NormalizeEndpoint("lambda.apiEndpoint", cfg.APIEndpoint)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve Lambda API endpoint: %w", err)
+		}
+
+		slog.Info("Lambda client: using real API",
+			"endpoint", endpoint, "workspaceID", cfg.WorkspaceID, "authMode", mode)
+
 		source = &apiSource{
-			client: lambdaapi.NewClient(cfg.APIEndpoint, lambdaapi.WithWorkspaceID(cfg.WorkspaceID)),
+			client: lambdaapi.NewClient(endpoint, lambdaapi.WithWorkspaceID(cfg.WorkspaceID)),
 		}
 	}
+
+	// Started last: everything above can fail, and the caller gets no handle to
+	// stop the informer on an error return.
+	nodeInformer.Start(ctx)
 
 	return &Client{
 		cfg:          cfg,

--- a/janitor-provider/pkg/csp/lambda/lambda.go
+++ b/janitor-provider/pkg/csp/lambda/lambda.go
@@ -29,7 +29,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -44,12 +43,6 @@ import (
 const (
 	// APIEndpointEnvVar overrides the Lambda Cloud API base URL.
 	APIEndpointEnvVar = "LAMBDA_API_ENDPOINT"
-
-	// DefaultAPIHost is the host of the production Lambda Cloud API.
-	DefaultAPIHost = "cloud.lambda.ai"
-
-	// DefaultAPIEndpoint is the production Lambda Cloud API.
-	DefaultAPIEndpoint = "https://" + DefaultAPIHost
 
 	providerIDPrefix = "lambda://"
 
@@ -69,13 +62,6 @@ const (
 	// timeout on a request that already took effect costs a second one.
 	apiTimeout = 120 * time.Second
 )
-
-// allowedAPIHosts is every host LAMBDA_API_ENDPOINT may point at. Anything
-// else fails at startup, bounding where the API key can be sent.
-var allowedAPIHosts = []string{
-	DefaultAPIHost,
-	"cloud.lambdastaging.com",
-}
 
 var _ model.CSPClient = (*Client)(nil)
 
@@ -104,8 +90,12 @@ func NewClientFromEnv(_ context.Context) (*Client, error) {
 		return nil, err
 	}
 
-	if os.Getenv(commonslambda.APIKeyEnvVar) == "" {
-		return nil, fmt.Errorf("env var %s is not set", commonslambda.APIKeyEnvVar)
+	mode := commonslambda.DetectAuthMode()
+	if mode == commonslambda.AuthNone {
+		return nil, fmt.Errorf(
+			"no Lambda credential: set %s, or annotate the ServiceAccount with lambda.ai/identity-lrn so the "+
+				"pod-identity webhook injects %s",
+			commonslambda.APIKeyEnvVar, commonslambda.IdentityLRNEnvVar)
 	}
 
 	httpClient := &http.Client{
@@ -113,66 +103,16 @@ func NewClientFromEnv(_ context.Context) (*Client, error) {
 		Transport: auditlogger.NewAuditingRoundTripper(http.DefaultTransport),
 	}
 
-	slog.Info("Using Lambda Cloud API")
+	slog.Info("Using Lambda Cloud API", "authMode", mode)
 
 	return NewClient(commonslambda.NewClient(endpoint, commonslambda.WithHTTPClient(httpClient))), nil
 }
 
-// endpointFromEnv resolves the API base URL, rejecting anything that is not an
-// absolute https URL so a typo fails at startup, not on the first remediation.
-//
-// http is refused outright rather than warned about or gated behind an opt-in:
-// the API key is a bearer token on every request, so there is no configuration
-// under which sending it in cleartext is acceptable.
-//
-// The host must be one of allowedAPIHosts, so a mistyped or altered endpoint
-// cannot send the API key somewhere unintended.
+// endpointFromEnv resolves the API base URL from the environment. The policy
+// itself lives in the shared client, so both Lambda callers bound where a
+// credential can be sent the same way.
 func endpointFromEnv() (string, error) {
-	raw := strings.TrimSpace(os.Getenv(APIEndpointEnvVar))
-	if raw == "" {
-		return DefaultAPIEndpoint, nil
-	}
-
-	parsed, err := url.Parse(raw)
-	if err != nil {
-		return "", fmt.Errorf("parse %s: %w", APIEndpointEnvVar, err)
-	}
-
-	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
-		return "", fmt.Errorf("%s must not include userinfo, query parameters, or fragments", APIEndpointEnvVar)
-	}
-
-	if parsed.Scheme == "http" {
-		return "", fmt.Errorf("%s uses http, which would send the API key in cleartext: use https",
-			APIEndpointEnvVar)
-	}
-
-	if parsed.Scheme != "https" {
-		return "", fmt.Errorf("%s %q must be an absolute https URL", APIEndpointEnvVar, raw)
-	}
-
-	if parsed.Host == "" {
-		return "", fmt.Errorf("%s %q has no host", APIEndpointEnvVar, raw)
-	}
-
-	if !allowedHost(parsed.Hostname()) {
-		return "", fmt.Errorf("%s host %q is not an approved Lambda API host", APIEndpointEnvVar, parsed.Hostname())
-	}
-
-	return strings.TrimSuffix(raw, "/"), nil
-}
-
-// allowedHost reports whether the bearer token may be sent to host. The list is
-// deliberately fixed: making it configurable would let whoever sets the
-// endpoint widen the bound too, which defeats the point of having one.
-func allowedHost(host string) bool {
-	for _, allowed := range allowedAPIHosts {
-		if strings.EqualFold(allowed, host) {
-			return true
-		}
-	}
-
-	return false
+	return commonslambda.NormalizeEndpoint(APIEndpointEnvVar, os.Getenv(APIEndpointEnvVar))
 }
 
 // SendRebootSignal power-cycles the node's Lambda instance and returns

--- a/janitor-provider/pkg/csp/lambda/lambda_test.go
+++ b/janitor-provider/pkg/csp/lambda/lambda_test.go
@@ -519,65 +519,20 @@ func TestParseRequestRef_RoundTrip_PreservesFields(t *testing.T) {
 	assert.True(t, started.Equal(got.startedAt), "want %s, got %s", started, got.startedAt)
 }
 
-// TestEndpointFromEnv_Values_DefaultsOrValidates checks the endpoint is
-// validated at startup rather than on the first remediation, and asserts which
-// error fires so the http rejection cannot be quietly folded into the general
-// scheme check.
-func TestEndpointFromEnv_Values_DefaultsOrValidates(t *testing.T) {
-	tests := []struct {
-		name    string
-		env     string
-		want    string
-		wantErr string
-	}{
-		{name: "unset defaults to production", env: "", want: DefaultAPIEndpoint},
-		{name: "trailing slash trimmed", env: "https://cloud.lambda.ai/", want: "https://cloud.lambda.ai"},
-		// The allowlist is fixed, so the bearer token can only ever reach a
-		// known Lambda API host.
-		{name: "unapproved host rejected", env: "https://cloud.example.com", wantErr: "is not an approved"},
-		{
-			name: "approved host matches case-insensitively",
-			env:  "https://Cloud.Lambda.AI",
-			want: "https://Cloud.Lambda.AI",
-		},
-		{
-			name: "port is not part of the host match",
-			env:  "https://cloud.lambda.ai:8443",
-			want: "https://cloud.lambda.ai:8443",
-		},
-		// The API key is a bearer token on every request, so http would put it
-		// on the wire in cleartext. There is no opt-in that relaxes this.
-		{name: "plain http rejected", env: "http://cloud.lambda.ai", wantErr: "cleartext"},
-		{name: "plain http rejected for loopback too", env: "http://127.0.0.1:8080", wantErr: "cleartext"},
-		{name: "whitespace only defaults", env: "   ", want: DefaultAPIEndpoint},
-		{name: "relative URL rejected", env: "/api/v1", wantErr: "must be an absolute https URL"},
-		{name: "host only rejected", env: "cloud.lambda.ai", wantErr: "must be an absolute https URL"},
-		{name: "non-http scheme rejected", env: "ftp://cloud.lambda.ai", wantErr: "must be an absolute https URL"},
-		{name: "scheme without host rejected", env: "https://", wantErr: "has no host"},
-		// Userinfo rides along in every request URL the client logs. A query or
-		// fragment is worse than cosmetic: request paths are appended by string
-		// concatenation, so "?token=x" + "/api/v1/instances" leaves the path
-		// inside the query.
-		{name: "userinfo rejected", env: "https://user:pass@cloud.lambda.ai", wantErr: "must not include userinfo"},
-		{name: "query rejected", env: "https://cloud.lambda.ai?token=x", wantErr: "must not include userinfo"},
-		{name: "fragment rejected", env: "https://cloud.lambda.ai#frag", wantErr: "must not include userinfo"},
-	}
+// TestEndpointFromEnv_ReadsEnvAndAppliesSharedPolicy checks the env var is
+// what feeds the shared policy, and that an unset one still defaults. The
+// policy's own cases live in commons/pkg/lambda.
+func TestEndpointFromEnv_ReadsEnvAndAppliesSharedPolicy(t *testing.T) {
+	t.Setenv(APIEndpointEnvVar, "")
+	got, err := endpointFromEnv()
+	require.NoError(t, err)
+	assert.Equal(t, commonslambda.DefaultAPIEndpoint, got)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv(APIEndpointEnvVar, tt.env)
+	t.Setenv(APIEndpointEnvVar, "http://cloud.lambda.ai")
 
-			got, err := endpointFromEnv()
-			if tt.wantErr != "" {
-				assert.ErrorContains(t, err, tt.wantErr)
-
-				return
-			}
-
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, got)
-		})
-	}
+	_, err = endpointFromEnv()
+	assert.ErrorContains(t, err, "cleartext")
+	assert.ErrorContains(t, err, APIEndpointEnvVar)
 }
 
 // TestNewClientFromEnv_MissingAPIKey_ReturnsError checks a missing key fails at
@@ -605,7 +560,7 @@ func TestNewClientFromEnv_BadEndpoint_ReturnsError(t *testing.T) {
 // usable client from environment alone, with no Kubernetes or CSP SDK involved.
 func TestNewClientFromEnv_ValidEnv_ReturnsClient(t *testing.T) {
 	t.Setenv(commonslambda.APIKeyEnvVar, "test-key")
-	t.Setenv(APIEndpointEnvVar, DefaultAPIEndpoint)
+	t.Setenv(APIEndpointEnvVar, commonslambda.DefaultAPIEndpoint)
 
 	c, err := NewClientFromEnv(context.Background())
 	require.NoError(t, err)
@@ -614,7 +569,7 @@ func TestNewClientFromEnv_ValidEnv_ReturnsClient(t *testing.T) {
 
 // TestNewClientFromEnv_UnapprovedHost_ReturnsError checks the allowlist is
 // enforced before an authenticated client exists, so the bearer token is never
-// wired up against a host outside allowedAPIHosts.
+// wired up against a host outside the shared allowlist.
 func TestNewClientFromEnv_UnapprovedHost_ReturnsError(t *testing.T) {
 	t.Setenv(commonslambda.APIKeyEnvVar, "test-key")
 	t.Setenv(APIEndpointEnvVar, "https://attacker.example.com")


### PR DESCRIPTION
## Summary

<!-- Brief description of your changes -->

This PR adds workload identities authentication method for Lambda CSP Health Monitor and Janitor. Workload identities is a feature that allows exchanging signed JWTs for temp and scoped API access.

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [x] Health Monitors
- [x] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Lambda workload identity authentication with short-lived, automatically refreshed credentials.
  - Continued support for static API keys and unauthenticated requests where applicable.
  - Added workload identity configuration for Kubernetes deployments.
  - Added secure Lambda endpoint validation and normalization.

- **Bug Fixes**
  - Improved credential caching, refresh behavior, concurrent access, and unauthorized-token recovery.
  - Added startup validation when Lambda authentication is not configured.

- **Documentation**
  - Added setup, permissions, configuration, verification, and troubleshooting guidance for Lambda authentication methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->