### PR TITLE
fix: treat XID 45 as non-fatal per catalog guidance

### DIFF
--- a/health-monitors/syslog-health-monitor/pkg/common/common.go
+++ b/health-monitors/syslog-health-monitor/pkg/common/common.go
@@ -77,7 +77,14 @@ func MapActionStringToProto(s string) pb.RecommendedAction {
 	// If no XID 154 present, RESTART_APP. Since each XID is acted on, the recommendation for XID 154 will be
 	// applied as a part of the XID 154 cycle therefore we don't need lookback/lookforward for the XID. Hence
 	// XID_154_EVAL is considered equivalent to RESTART_APP.
-	case "RESTART_APP", "IGNORE", "XID_154_EVAL":
+	//
+	// WORKFLOW_XID_45: catalog guidance is "Solo: RESTART_APP (Recovery); REPORT_ISSUE
+	// (Investigatory). Not Solo: IGNORE (follow guidance in other Xid)". Both branches resolve
+	// to no node-level action, so the bucket maps to NONE without needing to correlate against
+	// co-occurring XIDs. XID 45 is a channel-teardown breadcrumb and never appears as a
+	// driving signal in the catalog's XID parsing policy; the co-occurring XID carries the
+	// recovery action.
+	case "RESTART_APP", "IGNORE", "XID_154_EVAL", "WORKFLOW_XID_45":
 		return pb.RecommendedAction_NONE
 	// RECOVER_FEATURE_RESET_GPU: power-smoothing feature recovery (XID 163);
 	// trigger guidance is "reload the driver or reset the GPU" — same proto

--- a/health-monitors/syslog-health-monitor/pkg/common/common_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/common/common_test.go
@@ -94,6 +94,10 @@ func TestMapActionStringToProto(t *testing.T) {
 			expectedOutput: pb.RecommendedAction_NONE,
 		},
 		{
+			input:          "WORKFLOW_XID_45",
+			expectedOutput: pb.RecommendedAction_NONE,
+		},
+		{
 			input:          "WORKFLOW_XID_48",
 			expectedOutput: pb.RecommendedAction_COMPONENT_RESET,
 		},


### PR DESCRIPTION
## Summary

XID 45 is classified as fatal today, which drains and reboots the node. The catalog asks for no node-level action.

`MapActionStringToProto` has no case for the `WORKFLOW_XID_45` guidance class, so it falls through to `CONTACT_SUPPORT`. `determineFatality` treats `NONE` as the only non-fatal action, so every XID 45 marks its node fatal and `buildConditionEventsMap` turns that into a `SysLogsXIDError` node condition.

The catalog's guidance class for XID 45 is:

```
Solo:     RESTART_APP (Recovery); REPORT_ISSUE (Investigatory)
Not Solo: IGNORE (follow guidance in other Xid)
```

`RESTART_APP` and `IGNORE` both already map to `RecommendedAction_NONE` in this file, so the bucket resolves to `NONE` without needing to correlate against co-occurring XIDs. That matters because the alternative — implementing solo/non-solo correlation — is not required here: both branches have the same target.

The catalog's XID parsing policy supports the same reading. Across its rules, XID 45 never appears under *XIDs Present*; it appears only as partially or optionally present, i.e. a corroborating signal, with the co-occurring XID carrying the recovery action.

### Observed impact

After one multi-node NVLink job crash on a GB300 NVL72 cluster, 77 nodes across 11 racks were flagged by XID 45 bursts raised during teardown. Every GPU was healthy in `nvidia-smi` throughout, and only 15 of the 77 had an actual stuck teardown — so the signal that drove the drains had roughly 20% precision, and the genuine problem was not detectable from XID 45 at all.

## Type of Change

- [x] 🐛 Bug fix

## Component(s) Affected

- [x] Health Monitors

## Testing

- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

Validated on a Kubernetes cluster against the real embedded catalog.

**Red/green through the full path.** A test driving `XIDHandler.ProcessLine` with the handler's own parser (no mocks, real embedded catalog) fails before the change and passes after:

```
before:  Found action for XID code xidCode=45 action=CONTACT_SUPPORT
         xid 45 -> action=CONTACT_SUPPORT isFatal=true    FAIL
after:   Found action for XID code xidCode=45 action=NONE
         xid 45 -> action=NONE isFatal=false              PASS
```

**Blast radius, measured over the whole catalog rather than sampled.** The full `errorResolutionMap` was dumped before and after and diffed:

```
changed lines (+/-): 2
-xid 45 CONTACT_SUPPORT
+xid 45 NONE
entries before = 167   after = 167
distinct xid codes touched: 45
```

Action distribution moves by exactly one entry: `CONTACT_SUPPORT` 81 → 80, `NONE` 69 → 70.

**Negative guard — the change must not mask anything else.** Driving `ProcessLine` with the real catalog, these still raise the node condition after the change:

| XID | Action | Raises condition |
|---|---|---|
| 48 (double-bit ECC) | `COMPONENT_RESET` | yes |
| 64 (row remap failed) | `COMPONENT_RESET` | yes |
| 74 (NVLink) | `CONTACT_SUPPORT` | yes |
| 79 (off the bus) | `RESTART_BM` | yes |
| 95 (uncontained ECC) | `COMPONENT_RESET` | yes |
| 119 (GSP RPC timeout) | `COMPONENT_RESET` | yes |
| 63 (row remap succeeded) | `NONE` | no — catalog says so |
| 43 | `NONE` | no — catalog says ignore |
| **45** | **`NONE`** | **no — this change** |

**Signal is preserved, not hidden.** A non-fatal, non-healthy event is excluded from `buildConditionEventsMap` but still takes the node-event path in `process_node_events.go`, and `XidCounterMetric` still increments. The XID remains visible; only the node-level verdict changes. Measured across all four `(IsHealthy, IsFatal)` combinations.

**Regression.** With `setup-envtest` provisioned at the version pinned in `.versions.yaml`, the full suites for the affected and downstream modules pass:

```
ok  .../health-monitors/syslog-health-monitor/pkg/common
ok  .../health-monitors/syslog-health-monitor/pkg/xid
ok  .../health-monitors/syslog-health-monitor/pkg/xid/parser
ok  .../platform-connectors/pkg/connectors/kubernetes    57.4s
ok  .../fault-quarantine/pkg/reconciler                  52.4s
ok  .../fault-quarantine/pkg/breaker
ok  .../fault-quarantine/pkg/evaluator
ok  .../fault-quarantine/pkg/informer
```

`go build`, `go vet`, and `go test -race` across `syslog-health-monitor/pkg/...` are clean.

## Scope — what this does not fix

Worth stating so the change is not read as more than it is.

**This is preventive only.** Measured against a real API server: a node already carrying `SysLogsXIDError` keeps it after this change. The non-fatal event neither creates nor clears a condition, so nodes affected before an upgrade need an explicit recovery step (a healthy event on the same key sets the condition to `False`; it is not removed).

**A fan-out event is not contained by this change alone.** On the cluster above, XID 149 with a peer-side port-down reason code also raises the condition on its own, through a separate path (`parseNVL5Row` reads the decode sheet's recovery-action column). Fixing XID 45 removes one contributor to that incident, not the dominant one. I am preparing that finding separately rather than widening this PR.

## Checklist

- [x] Self-review completed
- [ ] Documentation updated (if needed) — no doc change: the catalog is the source of truth and is unchanged
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated action handling so `WORKFLOW_XID_45` is correctly treated as requiring no recommended action.
  * Added coverage to verify the corrected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->