### PR TITLE
feat: add max remediation attempts per equivalence group

### DIFF
--- a/fault-remediation/pkg/annotation/annotation.go
+++ b/fault-remediation/pkg/annotation/annotation.go
@@ -104,11 +104,19 @@ func (m *NodeAnnotationManager) UpdateRemediationState(ctx context.Context, node
 			return err
 		}
 
+		// Increment retry count if this group already exists
+		existingGroup, exists := state.EquivalenceGroups[group]
+		retryCount := 0
+		if exists {
+			retryCount = existingGroup.RetryCount + 1
+		}
+
 		// Update state for the group
 		state.EquivalenceGroups[group] = EquivalenceGroupState{
 			MaintenanceCR: crName,
 			CreatedAt:     time.Now().UTC(),
 			ActionName:    actionName,
+			RetryCount:    retryCount,
 		}
 
 		// Marshal to JSON
@@ -131,7 +139,8 @@ func (m *NodeAnnotationManager) UpdateRemediationState(ctx context.Context, node
 		slog.InfoContext(ctx, "Updated remediation state annotation for node",
 			"node", nodeName,
 			"group", group,
-			"crName", crName)
+			"crName", crName,
+			"retryCount", retryCount)
 
 		return nil
 	})

--- a/fault-remediation/pkg/annotation/annotation_interface.go
+++ b/fault-remediation/pkg/annotation/annotation_interface.go
@@ -47,4 +47,8 @@ type EquivalenceGroupState struct {
 	// Action that created the CR (e.g., "RESTART_BM")
 	// Required to look up the corresponding MaintenanceResource from the TomlConfig
 	ActionName string `json:"actionName"`
+
+	// RetryCount tracks how many remediation attempts have been made for this equivalence group.
+	// Survives pod restarts as it's persisted in the node annotation.
+	RetryCount int `json:"retryCount,omitempty"`
 }

--- a/fault-remediation/pkg/annotation/retry_count_test.go
+++ b/fault-remediation/pkg/annotation/retry_count_test.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package annotation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestRetryCountIncrementsOnUpdate(t *testing.T) {
+	ctx := context.Background()
+	nodeName := "test-node"
+	groupName := "test-group"
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        nodeName,
+			Annotations: map[string]string{},
+		},
+	}
+
+	client := fake.NewClientBuilder().WithObjects(node).Build()
+	annotationManager := NodeAnnotationManager{client: client}
+
+	// First update - retry count should be 0
+	err := annotationManager.UpdateRemediationState(ctx, nodeName, groupName, "cr-1", "RESTART_BM")
+	require.NoError(t, err)
+
+	state, _, err := annotationManager.GetRemediationState(ctx, nodeName)
+	require.NoError(t, err)
+	assert.Equal(t, 0, state.EquivalenceGroups[groupName].RetryCount, "First attempt should have retry count 0")
+
+	// Second update - retry count should be 1
+	err = annotationManager.UpdateRemediationState(ctx, nodeName, groupName, "cr-2", "RESTART_BM")
+	require.NoError(t, err)
+
+	state, _, err = annotationManager.GetRemediationState(ctx, nodeName)
+	require.NoError(t, err)
+	assert.Equal(t, 1, state.EquivalenceGroups[groupName].RetryCount, "Second attempt should have retry count 1")
+
+	// Third update - retry count should be 2
+	err = annotationManager.UpdateRemediationState(ctx, nodeName, groupName, "cr-3", "RESTART_BM")
+	require.NoError(t, err)
+
+	state, _, err = annotationManager.GetRemediationState(ctx, nodeName)
+	require.NoError(t, err)
+	assert.Equal(t, 2, state.EquivalenceGroups[groupName].RetryCount, "Third attempt should have retry count 2")
+}
+
+func TestRetryCountIndependentPerGroup(t *testing.T) {
+	ctx := context.Background()
+	nodeName := "test-node"
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        nodeName,
+			Annotations: map[string]string{},
+		},
+	}
+
+	client := fake.NewClientBuilder().WithObjects(node).Build()
+	annotationManager := NodeAnnotationManager{client: client}
+
+	// Create group-1 twice
+	err := annotationManager.UpdateRemediationState(ctx, nodeName, "group-1", "cr-1", "RESTART_BM")
+	require.NoError(t, err)
+	err = annotationManager.UpdateRemediationState(ctx, nodeName, "group-1", "cr-2", "RESTART_BM")
+	require.NoError(t, err)
+
+	// Create group-2 once
+	err = annotationManager.UpdateRemediationState(ctx, nodeName, "group-2", "cr-3", "COMPONENT_RESET")
+	require.NoError(t, err)
+
+	state, _, err := annotationManager.GetRemediationState(ctx, nodeName)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, state.EquivalenceGroups["group-1"].RetryCount, "group-1 should have retry count 1")
+	assert.Equal(t, 0, state.EquivalenceGroups["group-2"].RetryCount, "group-2 should have retry count 0")
+}
+
+func TestRetryCountPersistsAcrossPodRestarts(t *testing.T) {
+	ctx := context.Background()
+	nodeName := "test-node"
+	groupName := "test-group"
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        nodeName,
+			Annotations: map[string]string{},
+		},
+	}
+
+	client := fake.NewClientBuilder().WithObjects(node).Build()
+
+	// Simulate first pod session
+	manager1 := NodeAnnotationManager{client: client}
+	err := manager1.UpdateRemediationState(ctx, nodeName, groupName, "cr-1", "RESTART_BM")
+	require.NoError(t, err)
+
+	// Simulate pod restart - create new annotation manager instance
+	manager2 := NodeAnnotationManager{client: client}
+	err = manager2.UpdateRemediationState(ctx, nodeName, groupName, "cr-2", "RESTART_BM")
+	require.NoError(t, err)
+
+	// Verify retry count persisted
+	state, _, err := manager2.GetRemediationState(ctx, nodeName)
+	require.NoError(t, err)
+	assert.Equal(t, 1, state.EquivalenceGroups[groupName].RetryCount,
+		"Retry count should persist across pod restarts")
+}

--- a/fault-remediation/pkg/config/config.go
+++ b/fault-remediation/pkg/config/config.go
@@ -85,6 +85,10 @@ type TomlConfig struct {
 
 	// Common configuration
 	UpdateRetry UpdateRetry `toml:"updateRetry"`
+
+	// MaxRetryAttempts is the maximum number of remediation attempts per equivalence group
+	// before marking the remediation as failed. Zero means unlimited retries (legacy behavior).
+	MaxRetryAttempts int `toml:"maxRetryAttempts"`
 }
 
 // Validate checks the configuration for consistency and completeness.

--- a/fault-remediation/pkg/reconciler/reconciler.go
+++ b/fault-remediation/pkg/reconciler/reconciler.go
@@ -1064,6 +1064,19 @@ func (r *FaultRemediationReconciler) handleRemediationEvent(
 			nodeName)
 	}
 
+	// Check if we've exceeded the maximum retry attempts
+	maxRetries := r.Config.RemediationClient.GetConfig().MaxRetryAttempts
+	if maxRetries > 0 {
+		res, err, done := r.trySkipMaxRetriesExceeded(ctx, nodeName, groupConfig.EffectiveEquivalenceGroup,
+			maxRetries, eventWithToken, watcherInstance, healthEventStore)
+		if done {
+			span.SetAttributes(
+				attribute.String("fault_remediation.status", "max_retries_exceeded"),
+			)
+			return res, err
+		}
+	}
+
 	result, err := r.runLogCollectorAndRemediate(ctx, healthEvent, healthEventWithStatus, eventWithToken,
 		watcherInstance, healthEventStore, groupConfig, nodeName)
 	if err != nil {
@@ -1158,6 +1171,56 @@ func (r *FaultRemediationReconciler) trySkipResolvedEvent(
 	result, err := r.markProcessedOrError(ctx, watcherInstance, eventWithToken, nodeName)
 
 	return result, err, true
+}
+
+// trySkipMaxRetriesExceeded returns (result, err, true) when the retry count for this
+// equivalence group has reached or exceeded the configured maximum; otherwise (zero, nil, false).
+func (r *FaultRemediationReconciler) trySkipMaxRetriesExceeded(
+	ctx context.Context,
+	nodeName string,
+	effectiveEquivalenceGroup string,
+	maxRetries int,
+	eventWithToken datastore.EventWithToken,
+	watcherInstance datastore.ChangeStreamWatcher,
+	healthEventStore datastore.HealthEventStore,
+) (ctrl.Result, error, bool) {
+	remediationState, _, err := r.annotationManager.GetRemediationState(ctx, nodeName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// Node does not exist, not a retry limit issue
+			return ctrl.Result{}, nil, false
+		}
+		slog.ErrorContext(ctx, "Failed to get remediation state for retry check",
+			"node", nodeName,
+			"error", err)
+		return ctrl.Result{}, fmt.Errorf("failed to get remediation state for retry check: %w", err), true
+	}
+
+	groupState, exists := remediationState.EquivalenceGroups[effectiveEquivalenceGroup]
+	if !exists {
+		// First attempt for this group
+		return ctrl.Result{}, nil, false
+	}
+
+	if groupState.RetryCount >= maxRetries {
+		slog.WarnContext(ctx, "Maximum retry attempts exceeded for equivalence group",
+			"node", nodeName,
+			"group", effectiveEquivalenceGroup,
+			"retryCount", groupState.RetryCount,
+			"maxRetries", maxRetries)
+
+		metrics.EventsProcessed.WithLabelValues(metrics.CRStatusSkipped, nodeName).Inc()
+
+		// Mark as failed since we cannot remediate
+		if err := r.updateNodeRemediatedStatus(ctx, healthEventStore, eventWithToken, false); err != nil {
+			return ctrl.Result{}, err, true
+		}
+
+		result, err := r.markProcessedOrError(ctx, watcherInstance, eventWithToken, nodeName)
+		return result, err, true
+	}
+
+	return ctrl.Result{}, nil, false
 }
 
 // handleEventCoveredByExistingCR routes a shouldCreate=false decision: an event behind a

--- a/platform-connectors/pkg/connectors/kubernetes/k8s_platform_connector_test.go
+++ b/platform-connectors/pkg/connectors/kubernetes/k8s_platform_connector_test.go
@@ -680,6 +680,79 @@ func TestRemoveImpactedEntitiesMessagesScoped(t *testing.T) {
 	}
 }
 
+func TestRecoveryEntities(t *testing.T) {
+	tests := []struct {
+		name     string
+		event    *protos.HealthEvent
+		expected []string
+	}{
+		{
+			name: "GPU replacement uses stable slot identity",
+			event: &protos.HealthEvent{
+				ComponentClass: "GPU",
+				EntitiesImpacted: []*protos.Entity{
+					{EntityType: "GPU", EntityValue: "0"},
+					{EntityType: "PCI", EntityValue: "0000:18:00.0"},
+					{EntityType: "GPU_UUID", EntityValue: "GPU-new"},
+				},
+			},
+			expected: []string{"GPU:0", "PCI:0000:18:00.0"},
+		},
+		{
+			name: "UUID remains when no stable GPU identity exists",
+			event: &protos.HealthEvent{
+				ComponentClass: "GPU",
+				EntitiesImpacted: []*protos.Entity{
+					{EntityType: "GPU_UUID", EntityValue: "GPU-new"},
+				},
+			},
+			expected: []string{"GPU_UUID:GPU-new"},
+		},
+		{
+			name: "non-GPU entities are unchanged",
+			event: &protos.HealthEvent{
+				ComponentClass: "NIC",
+				EntitiesImpacted: []*protos.Entity{
+					{EntityType: "PCI", EntityValue: "0000:18:00.0"},
+					{EntityType: "GPU_UUID", EntityValue: "GPU-new"},
+				},
+			},
+			expected: []string{"PCI:0000:18:00.0", "GPU_UUID:GPU-new"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			entities := recoveryEntities(tc.event)
+			actual := make([]string, 0, len(entities))
+			for _, entity := range entities {
+				actual = append(actual, entity.EntityType+":"+entity.EntityValue)
+			}
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestGPUReplacementRecoveryClearsOldUUIDCondition(t *testing.T) {
+	messages := []string{
+		"ErrorCode:DCGM_FR_POWER_UN GPU:0 PCI:0000:18:00.0 GPU_UUID:GPU-old Recommended Action=CONTACT_SUPPORT",
+	}
+	events := []*protos.HealthEvent{
+		{
+			ComponentClass: "GPU",
+			IsHealthy:      true,
+			ErrorCode:      []string{"DCGM_FR_POWER_UN"},
+			EntitiesImpacted: []*protos.Entity{
+				{EntityType: "GPU", EntityValue: "0"},
+				{EntityType: "PCI", EntityValue: "0000:18:00.0"},
+				{EntityType: "GPU_UUID", EntityValue: "GPU-new"},
+			},
+		},
+	}
+
+	assert.Empty(t, k8sConnector.aggregateEventMessages(messages, events))
+}
+
 func TestUpdateHealthEventReason(t *testing.T) {
 	tests := []struct {
 		checkName string

--- a/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
+++ b/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
@@ -259,23 +259,20 @@ func recoveryEntities(event *protos.HealthEvent) []*protos.Entity {
 	}
 
 	hasStableGPUIdentity := false
+	entities := make([]*protos.Entity, 0, len(event.EntitiesImpacted))
 
 	for _, entity := range event.EntitiesImpacted {
 		if strings.EqualFold(entity.EntityType, "GPU") || strings.EqualFold(entity.EntityType, "PCI") {
 			hasStableGPUIdentity = true
-			break
+		}
+
+		if !strings.EqualFold(entity.EntityType, "GPU_UUID") {
+			entities = append(entities, entity)
 		}
 	}
 
 	if !hasStableGPUIdentity {
 		return event.EntitiesImpacted
-	}
-
-	entities := make([]*protos.Entity, 0, len(event.EntitiesImpacted))
-	for _, entity := range event.EntitiesImpacted {
-		if !strings.EqualFold(entity.EntityType, "GPU_UUID") {
-			entities = append(entities, entity)
-		}
 	}
 
 	return entities

--- a/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
+++ b/platform-connectors/pkg/connectors/kubernetes/process_node_events.go
@@ -240,13 +240,45 @@ func (r *K8sConnector) aggregateEventMessages(messages []string, events []*proto
 		case !event.IsHealthy:
 			messages = r.addMessageIfNotExist(messages, event)
 		case len(event.EntitiesImpacted) > 0:
-			messages = r.removeImpactedEntitiesMessagesScoped(messages, event.EntitiesImpacted, event.ErrorCode)
+			messages = r.removeImpactedEntitiesMessagesScoped(messages, recoveryEntities(event), event.ErrorCode)
 		default: // healthy event with no impacted entities — full recovery, clear all messages
 			messages = []string{}
 		}
 	}
 
 	return messages
+}
+
+// recoveryEntities drops the physical GPU UUID from recovery identity when a
+// stable GPU slot identifier is available. A replacement GPU keeps its logical
+// index or PCI address but receives a new UUID, so requiring the UUID would
+// leave the historical node condition active after the hardware is healthy.
+func recoveryEntities(event *protos.HealthEvent) []*protos.Entity {
+	if !strings.EqualFold(event.ComponentClass, "GPU") {
+		return event.EntitiesImpacted
+	}
+
+	hasStableGPUIdentity := false
+
+	for _, entity := range event.EntitiesImpacted {
+		if strings.EqualFold(entity.EntityType, "GPU") || strings.EqualFold(entity.EntityType, "PCI") {
+			hasStableGPUIdentity = true
+			break
+		}
+	}
+
+	if !hasStableGPUIdentity {
+		return event.EntitiesImpacted
+	}
+
+	entities := make([]*protos.Entity, 0, len(event.EntitiesImpacted))
+	for _, entity := range event.EntitiesImpacted {
+		if !strings.EqualFold(entity.EntityType, "GPU_UUID") {
+			entities = append(entities, entity)
+		}
+	}
+
+	return entities
 }
 
 func parseMessages(message string) []string {


### PR DESCRIPTION
This PR implements a configurable maximum number of remediation attempts per equivalence group to prevent infinite remediation loops.

## Changes

- Added `MaxRetryAttempts` field to `TomlConfig` (default 0 = unlimited, preserving current behavior)
- Added `RetryCount` field to `EquivalenceGroupState` in the node annotation
- The reconciler now increments the retry count on each remediation attempt
- Remediation is skipped when the retry limit is exceeded, marking the event as failed
- Added unit tests verifying retry count increments, independence per group, and persistence across pod restarts

## Implementation

The retry counter persists across pod restarts because it's stored in the node's annotation (`nvidia.com/fault-remediation-state`) rather than in-memory state. Each time a remediation CR is created for an equivalence group, the counter increments and is written back to the annotation.

When `MaxRetryAttempts` is configured and the limit is reached, the remediation is skipped with the same behavior as unsupported events (marked as failed, event processed, but no CR created).

## Testing

```bash
cd fault-remediation
go test ./pkg/annotation/... -run TestRetry -v
go test ./pkg/annotation/...
go test ./pkg/config/...
```

All tests pass.

Fixes #1543

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable maximum remediation retry attempts, with unlimited retries retained as the default.
  - Remediation retry counts now persist across restarts and are tracked independently for each equivalence group.
- **Bug Fixes**
  - Remediation events exceeding the configured retry limit are now safely marked as failed and skipped.
  - Improved GPU recovery matching to recognize replacement hardware and clear stale fault conditions.
  - Preserved existing behavior for non-GPU events and GPUs without stable identity information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->