### PR TITLE
ci: setup apt cache for CI

### DIFF
--- a/.github/actions/setup-ci-env/action.yml
+++ b/.github/actions/setup-ci-env/action.yml
@@ -18,6 +18,11 @@ description: 'Install all CI tools and setup build environment'
 runs:
   using: 'composite'
   steps:
+    - name: Setup proxy cache
+      uses: nv-gha-runners/setup-proxy-cache@14229018fe157c83e03c008f27d183d8e99bc67c # main
+      with:
+        enable-apt: true
+
     - name: Load versions from .versions.yaml
       id: versions
       shell: bash


### PR DESCRIPTION
## Summary

setup apt cache for CI

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [X] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [X] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI environment setup by enabling APT package caching through the NVIDIA proxy cache.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->