### PR TITLE
fix(mongodb-store): bump psmdb-operator to 1.22.0

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/mongodb-store/Chart.lock
+++ b/distros/kubernetes/nvsentinel/charts/mongodb-store/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 16.2.2
 - name: psmdb-operator
   repository: ""
-  version: 1.21.1
+  version: 1.22.0
 - name: psmdb-db
   repository: ""
   version: 1.21.1
-digest: sha256:52544f60c2e88079cc18da78164440e042103e5adc065668a648864e2ad938b9
-generated: "2025-11-19T15:26:21.985280107+05:30"
+digest: sha256:1b23ec6672ce758cfa2bb8346506c6c08ef01d2a5a964e049f680115799f4235
+generated: "2026-08-24T16:59:58.660281-07:00"

--- a/distros/kubernetes/nvsentinel/charts/mongodb-store/Chart.yaml
+++ b/distros/kubernetes/nvsentinel/charts/mongodb-store/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
     repository: ""
     condition: useBitnami
   - name: psmdb-operator
-    version: "1.21.1"
+    version: "1.22.0"
     repository: ""
     condition: usePerconaOperator
   - name: psmdb-db

--- a/distros/kubernetes/nvsentinel/charts/mongodb-store/charts/psmdb-operator/Chart.yaml
+++ b/distros/kubernetes/nvsentinel/charts/mongodb-store/charts/psmdb-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.21.0
+appVersion: 1.22.0
 description: A Helm chart for deploying the Percona Operator for MongoDB
 home: https://docs.percona.com/percona-operator-for-mongodb/
 maintainers:
@@ -10,4 +10,4 @@ maintainers:
 - email: eleonora.zinchenko@percona.com
   name: eleo007
 name: psmdb-operator
-version: 1.21.1
+version: 1.22.0

--- a/distros/kubernetes/nvsentinel/charts/mongodb-store/charts/psmdb-operator/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/mongodb-store/charts/psmdb-operator/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: percona/percona-server-mongodb-operator
-  tag: 1.21.0
+  tag: 1.22.0
   pullPolicy: IfNotPresent
 
 # disableTelemetry: according to


### PR DESCRIPTION
## Summary

Bumps the vendored `psmdb-operator` subchart's image tag from `1.21.0` to `1.22.0` to pick up an upstream Percona fix.

## Problem

Percona's `percona-server-mongodb-operator` 1.21.x has a bug in its cert-manager TLS handling. When cert-manager is run with `--enable-certificate-owner-ref=true`, it sets the issued `Certificate` object as the controller-owner of the `Secret`s it creates. The operator's `WaitForCerts()` in 1.21.x unconditionally tries to *also* set the `PerconaServerMongoDB` CR as controller-owner of that same Secret — which Kubernetes rejects, since an object can only have a single controller-owner reference.

The result: when cert-manager has that flag enabled, TLS secret provisioning for the MongoDB cluster never succeeds. It fails identically on every reconcile with no automatic recovery:

```
TLS secrets handler: "create ssl by cert-manager: update cert mangager certs: failed to
apply cert-manager certificates: failed to wait for ca cert: set controller reference:
Object <namespace>/<cluster>-ca-cert is already owned by another Certificate controller
<cluster>-ca-cert". Please create your TLS secret <cluster>-ssl manually or setup
cert-manager correctly
```

This is a known upstream issue: [percona/percona-server-mongodb-operator#1981](https://github.com/percona/percona-server-mongodb-operator/issues/1981), fixed in [1.22.0](https://github.com/percona/percona-server-mongodb-operator/pull/1850) by adding an `IsControlledBy()` check before attempting to set the owner reference.

## Change

- `charts/mongodb-store/charts/psmdb-operator/values.yaml`: `image.tag` 1.21.0 → 1.22.0
- `charts/mongodb-store/charts/psmdb-operator/Chart.yaml`: `appVersion`/`version` 1.21.x → 1.22.0
- `charts/mongodb-store/Chart.yaml`: dependency pin for `psmdb-operator` → 1.22.0
- `charts/mongodb-store/Chart.lock`: regenerated via `helm dependency update`

The vendored CRDs (`charts/psmdb-operator/crds/crd.yaml`) are intentionally left unchanged. 1.22.0's release notes list only additive, optional features (service-mesh `appProtocol` support, restore replset remapping, a disable-auth option, custom env vars) — none of which this chart's `psmdb-db` values currently use — so running the 1.22.0 operator binary against the existing 1.21.1-era CRD schema is expected to be safe.

## Testing

- `helm dependency update` on `charts/mongodb-store` — resolves cleanly, `Chart.lock` regenerated.
- `helm template` of the full `nvsentinel` chart with `usePerconaOperator=true` — confirmed the rendered operator Deployment resolves `image: "percona/percona-server-mongodb-operator:1.22.0"`.
- Verified in a live cluster that reproduced the exact "already owned by another Certificate controller" error on 1.21.1 with `cert-manager --enable-certificate-owner-ref=true`, and that this matches the root cause and fix described in the upstream issue/PR.

NO-REF

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the MongoDB store’s database operator to version 1.22.0.
  * Updated the associated container image and Helm chart versions to 1.22.0.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->