### PR TITLE
docs: add B300 to the validated GPU list

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -54,7 +54,7 @@ NVSentinel has been validated on the following NVIDIA GPU architectures:
 | Ampere | A100 |
 | Hopper | H100, H200 |
 | Ada Lovelace | L4 Tensor Core GPU, L40, L40S |
-| Blackwell | B200, GB200, GB300, RTX Pro 6000 |
+| Blackwell | B200, B300, GB200, GB300, RTX Pro 6000 |
 
 NVSentinel is designed to work with any GPU supported by the NVIDIA GPU Operator. Architectures and GPUs not listed above have not been formally validated but may work in your environment.
 


### PR DESCRIPTION
## Summary

Add B300 to the Blackwell examples in the GPU support table in `docs/OVERVIEW.md`.

Health-monitor UAT on AWS B300 (`p6-b300.48xlarge`, `NVIDIA-B300-SXM6-AC`) passed for NKX-13436:
- Non-fatal DCGM (`GpuPowerWatchIsNotHealthy`)
- Fatal DCGM XID 95 → quarantine + reboot
- Syslog XID 79 → quarantine + reboot

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [x] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the supported GPU architectures list to include the Blackwell B300 variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->