### PR TITLE
fix(store-client): stop on uncheckpointed events

### DIFF
--- a/store-client/pkg/client/event_processor.go
+++ b/store-client/pkg/client/event_processor.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -70,6 +71,24 @@ type DefaultEventProcessor struct {
 	config              EventProcessorConfig
 	eventHandler        EventHandler
 	stopCh              chan struct{}
+}
+
+// uncheckpointedEventError indicates that the processor must stop before
+// consuming another event, because the current event remains unresolved.
+type uncheckpointedEventError struct {
+	cause error
+}
+
+func (e *uncheckpointedEventError) Error() string {
+	return fmt.Sprintf("event was not checkpointed: %v", e.cause)
+}
+
+func (e *uncheckpointedEventError) Unwrap() error {
+	return e.cause
+}
+
+func newUncheckpointedEventError(cause error) error {
+	return &uncheckpointedEventError{cause: cause}
 }
 
 // NewEventProcessor creates a new unified event processor
@@ -145,6 +164,11 @@ func (p *DefaultEventProcessor) processEvents(ctx context.Context) error {
 
 			if err := p.handleSingleEvent(ctx, event); err != nil {
 				slog.Error("Failed to handle event", "eventID", eventID, "error", err)
+
+				var uncheckpointedErr *uncheckpointedEventError
+				if errors.As(err, &uncheckpointedErr) {
+					return fmt.Errorf("stopping at uncheckpointed event %q: %w", eventID, err)
+				}
 			}
 		}
 	}
@@ -194,7 +218,7 @@ func (p *DefaultEventProcessor) handleSingleEvent(ctx context.Context, event Eve
 	if markErr := p.markProcessed(ctx, token); markErr != nil {
 		p.updateMetrics("mark_processed_error", eventID, time.Since(startTime), false)
 
-		return fmt.Errorf("failed to mark event as processed: %w", markErr)
+		return newUncheckpointedEventError(fmt.Errorf("failed to mark event as processed: %w", markErr))
 	}
 
 	return nil
@@ -207,7 +231,7 @@ func (p *DefaultEventProcessor) handleProcessingError(
 		slog.Error("Event processing failed, NOT marking as processed - will retry on restart",
 			"eventID", eventID, "error", processErr)
 
-		return processErr
+		return newUncheckpointedEventError(processErr)
 	}
 
 	slog.Warn("Marking failed event as processed due to MarkProcessedOnError=true",
@@ -216,7 +240,9 @@ func (p *DefaultEventProcessor) handleProcessingError(
 	if markErr := p.markProcessed(ctx, token); markErr != nil {
 		slog.Error("Failed to mark processed after error", "error", markErr)
 
-		return fmt.Errorf("failed to mark event as processed: %w", markErr)
+		return newUncheckpointedEventError(fmt.Errorf(
+			"failed to mark event as processed after processing error (%w): %w", processErr, markErr,
+		))
 	}
 
 	return processErr

--- a/store-client/pkg/client/event_processor.go
+++ b/store-client/pkg/client/event_processor.go
@@ -159,7 +159,11 @@ func (p *DefaultEventProcessor) processEvents(ctx context.Context) error {
 				return nil
 			}
 
-			eventID, _ := event.GetDocumentID()
+			eventID, err := event.GetDocumentID()
+			if err != nil || eventID == "" {
+				eventID = "unknown"
+			}
+
 			slog.Debug("Processing event", "eventID", eventID)
 
 			if err := p.handleSingleEvent(ctx, event); err != nil {

--- a/store-client/pkg/client/event_processor.go
+++ b/store-client/pkg/client/event_processor.go
@@ -186,7 +186,9 @@ func (p *DefaultEventProcessor) handleSingleEvent(ctx context.Context, event Eve
 		p.updateMetrics("unmarshal_error", "", time.Since(startTime), false)
 
 		if markErr := p.markProcessed(ctx, token); markErr != nil {
-			slog.Error("Failed to mark processed after unmarshal error", "error", markErr)
+			return newUncheckpointedEventError(fmt.Errorf(
+				"failed to mark processed after unmarshal error (%w): %w", err, markErr,
+			))
 		}
 
 		return fmt.Errorf("failed to unmarshal event: %w", err)
@@ -197,7 +199,9 @@ func (p *DefaultEventProcessor) handleSingleEvent(ctx context.Context, event Eve
 		p.updateMetrics("document_id_error", "", time.Since(startTime), false)
 
 		if markErr := p.markProcessed(ctx, token); markErr != nil {
-			slog.Error("Failed to mark processed after document ID error", "error", markErr)
+			return newUncheckpointedEventError(fmt.Errorf(
+				"failed to mark processed after document ID error (%w): %w", err, markErr,
+			))
 		}
 
 		return fmt.Errorf("failed to get document ID: %w", err)

--- a/store-client/pkg/client/event_processor_test.go
+++ b/store-client/pkg/client/event_processor_test.go
@@ -26,9 +26,12 @@ import (
 	"github.com/nvidia/nvsentinel/data-models/pkg/protos"
 )
 
+// TestProcessEvents_EventHandlingAndCheckpointOutcomes_PreserveCheckpointOrdering verifies ordered checkpoints.
 func TestProcessEvents_EventHandlingAndCheckpointOutcomes_PreserveCheckpointOrdering(t *testing.T) {
 	processingErr := errors.New("processing failed")
 	checkpointErr := errors.New("checkpoint write failed")
+	unmarshalErr := errors.New("invalid event")
+	documentIDErr := errors.New("invalid document ID")
 
 	tests := []struct {
 		name          string
@@ -80,10 +83,10 @@ func TestProcessEvents_EventHandlingAndCheckpointOutcomes_PreserveCheckpointOrde
 			firstEvent: &eventProcessorTestEvent{
 				id:           "1",
 				token:        []byte("1"),
-				unmarshalErr: errors.New("invalid event"),
+				unmarshalErr: unmarshalErr,
 			},
 			markErrors:    map[string]error{"1": checkpointErr},
-			wantErrors:    []error{checkpointErr},
+			wantErrors:    []error{unmarshalErr, checkpointErr},
 			wantMarkCalls: []string{"1"},
 		},
 		{
@@ -91,10 +94,10 @@ func TestProcessEvents_EventHandlingAndCheckpointOutcomes_PreserveCheckpointOrde
 			firstEvent: &eventProcessorTestEvent{
 				id:            "1",
 				token:         []byte("1"),
-				documentIDErr: errors.New("invalid document ID"),
+				documentIDErr: documentIDErr,
 			},
 			markErrors:    map[string]error{"1": checkpointErr},
-			wantErrors:    []error{checkpointErr},
+			wantErrors:    []error{documentIDErr, checkpointErr},
 			wantMarkCalls: []string{"1"},
 		},
 		{

--- a/store-client/pkg/client/event_processor_test.go
+++ b/store-client/pkg/client/event_processor_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/nvidia/nvsentinel/data-models/pkg/protos"
 )
 
-func TestDefaultEventProcessorCheckpointOrdering(t *testing.T) {
+func TestProcessEvents_EventHandlingAndCheckpointOutcomes_PreserveCheckpointOrdering(t *testing.T) {
 	processingErr := errors.New("processing failed")
 	checkpointErr := errors.New("checkpoint write failed")
 

--- a/store-client/pkg/client/event_processor_test.go
+++ b/store-client/pkg/client/event_processor_test.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nvidia/nvsentinel/data-models/pkg/model"
+	"github.com/nvidia/nvsentinel/data-models/pkg/protos"
+)
+
+func TestDefaultEventProcessorCheckpointOrdering(t *testing.T) {
+	processingErr := errors.New("processing failed")
+	checkpointErr := errors.New("checkpoint write failed")
+
+	tests := []struct {
+		name          string
+		config        EventProcessorConfig
+		firstEvent    *eventProcessorTestEvent
+		handlerErrors map[string]error
+		markErrors    map[string]error
+		wantErrors    []error
+		wantHandled   []string
+		wantMarkCalls []string
+		wantMarked    []string
+	}{
+		{
+			name:          "handler failure keeps later event unprocessed",
+			firstEvent:    newEventProcessorTestEvent("1"),
+			handlerErrors: map[string]error{"1": processingErr},
+			wantErrors:    []error{processingErr},
+			wantHandled:   []string{"1"},
+		},
+		{
+			name:          "checkpoint failure keeps later event unprocessed",
+			firstEvent:    newEventProcessorTestEvent("1"),
+			markErrors:    map[string]error{"1": checkpointErr},
+			wantErrors:    []error{checkpointErr},
+			wantHandled:   []string{"1"},
+			wantMarkCalls: []string{"1"},
+		},
+		{
+			name:          "configured handler failure skip continues after checkpoint",
+			config:        EventProcessorConfig{MarkProcessedOnError: true},
+			firstEvent:    newEventProcessorTestEvent("1"),
+			handlerErrors: map[string]error{"1": processingErr},
+			wantHandled:   []string{"1", "2"},
+			wantMarkCalls: []string{"1", "2"},
+			wantMarked:    []string{"1", "2"},
+		},
+		{
+			name:          "configured skip stops when checkpoint fails",
+			config:        EventProcessorConfig{MarkProcessedOnError: true},
+			firstEvent:    newEventProcessorTestEvent("1"),
+			handlerErrors: map[string]error{"1": processingErr},
+			markErrors:    map[string]error{"1": checkpointErr},
+			wantErrors:    []error{processingErr, checkpointErr},
+			wantHandled:   []string{"1"},
+			wantMarkCalls: []string{"1"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			watcher := newEventProcessorTestWatcher(test.firstEvent, newEventProcessorTestEvent("2"))
+			watcher.markErrors = test.markErrors
+			processor := newDefaultEventProcessorForTest(watcher, test.config)
+
+			var handled []string
+			processor.SetEventHandler(EventHandlerFunc(
+				func(_ context.Context, event *model.HealthEventWithStatus) error {
+					eventID := event.HealthEvent.GetId()
+					handled = append(handled, eventID)
+
+					return test.handlerErrors[eventID]
+				},
+			))
+
+			err := processor.processEvents(context.Background())
+			if len(test.wantErrors) == 0 {
+				require.NoError(t, err)
+			} else {
+				for _, wantErr := range test.wantErrors {
+					require.ErrorIs(t, err, wantErr)
+				}
+			}
+
+			require.Equal(t, test.wantHandled, handled)
+			require.Equal(t, test.wantMarkCalls, watcher.markCalls)
+			require.Equal(t, test.wantMarked, watcher.markedTokens)
+		})
+	}
+}
+
+func newDefaultEventProcessorForTest(
+	watcher ChangeStreamWatcher, config EventProcessorConfig,
+) *DefaultEventProcessor {
+	return NewEventProcessor(watcher, nil, config).(*DefaultEventProcessor)
+}
+
+type eventProcessorTestEvent struct {
+	id    string
+	token []byte
+}
+
+func newEventProcessorTestEvent(id string) *eventProcessorTestEvent {
+	return &eventProcessorTestEvent{id: id, token: []byte(id)}
+}
+
+func (e *eventProcessorTestEvent) GetDocumentID() (string, error) {
+	return e.id, nil
+}
+
+func (e *eventProcessorTestEvent) GetRecordUUID() (string, error) {
+	return "", nil
+}
+
+func (e *eventProcessorTestEvent) GetNodeName() (string, error) {
+	return "", nil
+}
+
+func (e *eventProcessorTestEvent) GetResumeToken() []byte {
+	return e.token
+}
+
+func (e *eventProcessorTestEvent) UnmarshalDocument(value any) error {
+	event, ok := value.(*model.HealthEventWithStatus)
+	if !ok {
+		return fmt.Errorf("unexpected document type %T", value)
+	}
+
+	event.HealthEvent = &protos.HealthEvent{Id: e.id}
+
+	return nil
+}
+
+type eventProcessorTestWatcher struct {
+	events       chan Event
+	markErrors   map[string]error
+	markCalls    []string
+	markedTokens []string
+}
+
+func newEventProcessorTestWatcher(events ...Event) *eventProcessorTestWatcher {
+	eventChannel := make(chan Event, len(events))
+	for _, event := range events {
+		eventChannel <- event
+	}
+	close(eventChannel)
+
+	return &eventProcessorTestWatcher{
+		events:     eventChannel,
+		markErrors: make(map[string]error),
+	}
+}
+
+func (w *eventProcessorTestWatcher) Start(context.Context) {}
+
+func (w *eventProcessorTestWatcher) Events() <-chan Event {
+	return w.events
+}
+
+func (w *eventProcessorTestWatcher) MarkProcessed(_ context.Context, token []byte) error {
+	tokenString := string(token)
+	w.markCalls = append(w.markCalls, tokenString)
+	if err := w.markErrors[tokenString]; err != nil {
+		return err
+	}
+
+	w.markedTokens = append(w.markedTokens, tokenString)
+
+	return nil
+}
+
+func (w *eventProcessorTestWatcher) Close(context.Context) error {
+	return nil
+}

--- a/store-client/pkg/client/event_processor_test.go
+++ b/store-client/pkg/client/event_processor_test.go
@@ -40,10 +40,18 @@ func TestProcessEvents_EventHandlingAndCheckpointOutcomes_PreserveCheckpointOrde
 		handlerErrors map[string]error
 		markErrors    map[string]error
 		wantErrors    []error
+		wantErrorText string
 		wantHandled   []string
 		wantMarkCalls []string
 		wantMarked    []string
 	}{
+		{
+			name:          "successful events are checkpointed in order",
+			firstEvent:    newEventProcessorTestEvent("1"),
+			wantHandled:   []string{"1", "2"},
+			wantMarkCalls: []string{"1", "2"},
+			wantMarked:    []string{"1", "2"},
+		},
 		{
 			name:          "handler failure keeps later event unprocessed",
 			firstEvent:    newEventProcessorTestEvent("1"),
@@ -92,12 +100,12 @@ func TestProcessEvents_EventHandlingAndCheckpointOutcomes_PreserveCheckpointOrde
 		{
 			name: "document ID error stops when checkpoint fails",
 			firstEvent: &eventProcessorTestEvent{
-				id:            "1",
 				token:         []byte("1"),
 				documentIDErr: documentIDErr,
 			},
 			markErrors:    map[string]error{"1": checkpointErr},
 			wantErrors:    []error{documentIDErr, checkpointErr},
+			wantErrorText: `stopping at uncheckpointed event "unknown"`,
 			wantMarkCalls: []string{"1"},
 		},
 		{
@@ -136,6 +144,9 @@ func TestProcessEvents_EventHandlingAndCheckpointOutcomes_PreserveCheckpointOrde
 				for _, wantErr := range test.wantErrors {
 					require.ErrorIs(t, err, wantErr)
 				}
+			}
+			if test.wantErrorText != "" {
+				require.ErrorContains(t, err, test.wantErrorText)
 			}
 
 			require.Equal(t, test.wantHandled, handled)

--- a/store-client/pkg/client/event_processor_test.go
+++ b/store-client/pkg/client/event_processor_test.go
@@ -75,6 +75,39 @@ func TestDefaultEventProcessorCheckpointOrdering(t *testing.T) {
 			wantHandled:   []string{"1"},
 			wantMarkCalls: []string{"1"},
 		},
+		{
+			name: "unmarshal error stops when checkpoint fails",
+			firstEvent: &eventProcessorTestEvent{
+				id:           "1",
+				token:        []byte("1"),
+				unmarshalErr: errors.New("invalid event"),
+			},
+			markErrors:    map[string]error{"1": checkpointErr},
+			wantErrors:    []error{checkpointErr},
+			wantMarkCalls: []string{"1"},
+		},
+		{
+			name: "document ID error stops when checkpoint fails",
+			firstEvent: &eventProcessorTestEvent{
+				id:            "1",
+				token:         []byte("1"),
+				documentIDErr: errors.New("invalid document ID"),
+			},
+			markErrors:    map[string]error{"1": checkpointErr},
+			wantErrors:    []error{checkpointErr},
+			wantMarkCalls: []string{"1"},
+		},
+		{
+			name: "invalid event continues after checkpoint",
+			firstEvent: &eventProcessorTestEvent{
+				id:           "1",
+				token:        []byte("1"),
+				unmarshalErr: errors.New("invalid event"),
+			},
+			wantHandled:   []string{"2"},
+			wantMarkCalls: []string{"1", "2"},
+			wantMarked:    []string{"1", "2"},
+		},
 	}
 
 	for _, test := range tests {
@@ -116,8 +149,10 @@ func newDefaultEventProcessorForTest(
 }
 
 type eventProcessorTestEvent struct {
-	id    string
-	token []byte
+	id            string
+	token         []byte
+	unmarshalErr  error
+	documentIDErr error
 }
 
 func newEventProcessorTestEvent(id string) *eventProcessorTestEvent {
@@ -125,7 +160,7 @@ func newEventProcessorTestEvent(id string) *eventProcessorTestEvent {
 }
 
 func (e *eventProcessorTestEvent) GetDocumentID() (string, error) {
-	return e.id, nil
+	return e.id, e.documentIDErr
 }
 
 func (e *eventProcessorTestEvent) GetRecordUUID() (string, error) {
@@ -141,6 +176,10 @@ func (e *eventProcessorTestEvent) GetResumeToken() []byte {
 }
 
 func (e *eventProcessorTestEvent) UnmarshalDocument(value any) error {
+	if e.unmarshalErr != nil {
+		return e.unmarshalErr
+	}
+
 	event, ok := value.(*model.HealthEventWithStatus)
 	if !ok {
 		return fmt.Errorf("unexpected document type %T", value)


### PR DESCRIPTION
## Summary

`DefaultEventProcessor` currently logs handler and checkpoint errors, then continues consuming events. If a later event succeeds, its checkpoint can advance past the unresolved event.

This change stops the loop whenever the current event has not been safely checkpointed. It preserves the existing `MarkProcessedOnError=true` behavior when the failed event is successfully checkpointed.

## How this surfaced

I found this while tracing the Health Events Analyzer failure and restart path, not from a production incident. HEA sets `MarkProcessedOnError=false` and documents that failed events will be retried after restart.

I reproduced the failure with a deterministic watcher: event 1 returns a handler error, event 2 succeeds, and the processor checkpoints event 2 even though event 1 remains unresolved.

## Impact

For PostgreSQL, checkpointing event 2 marks changelog entries through that ID as processed. For MongoDB, it stores event 2's resume token. In either case, event 1 may not be retried after restart. In HEA, that means a transient rule-evaluation or publication failure can prevent the expected fatal event from reaching downstream processing.

Supersedes #1682, which GitHub closed when the fork branch was renamed to match the project naming convention.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring
- [ ] Build/CI

## Component Affected
- Core Services: store-client

## Testing
- [x] `go test -race ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run --config ../.golangci.yml`
- [x] No public API or configuration changes

## Checklist
- [x] Self-review completed
- [x] Documentation is not needed for this behavior fix
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event processing now stops when an event cannot be safely checkpointed, preventing later events from being processed incorrectly.
  * Processing failures now preserve both the original error and any checkpoint failure.
  * Events with unavailable document IDs are reported with a consistent fallback value.
  * Configured error-handling behavior is now applied consistently when deciding whether to continue processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->