### PR TITLE
fix: fix flaky informer cache race in reconciler integration tests

### DIFF
--- a/node-drainer/pkg/reconciler/reconciler_integration_test.go
+++ b/node-drainer/pkg/reconciler/reconciler_integration_test.go
@@ -937,6 +937,10 @@ func TestReconciler_ProcessEvent(t *testing.T) {
 			}
 
 			createNodeWithLabelsAndAnnotations(setup.ctx, t, setup.client, tt.nodeName, nodeLabels, nodeAnnotations)
+			// Some cases (AlreadyQuarantined) read the node through the
+			// informer cache immediately; wait for watch delivery so the
+			// evaluation does not race it.
+			waitForNodeInInformer(t, setup.informersInstance, tt.nodeName)
 
 			for _, ns := range tt.namespaces {
 				createNamespace(setup.ctx, t, setup.client, ns)
@@ -1599,6 +1603,20 @@ func createNode(ctx context.Context, t *testing.T, client kubernetes.Interface, 
 	createNodeWithLabelsAndAnnotations(ctx, t, client, nodeName, map[string]string{"test": "true"}, nil)
 }
 
+// waitForNodeInInformer blocks until the node created through the API server
+// becomes visible in the shared informer's local cache. Node creation and the
+// informer's watch delivery are asynchronous, so tests that evaluate a health
+// event immediately after creating the node race the cache and flake on
+// loaded runners without this wait.
+func waitForNodeInInformer(t *testing.T, inf *informers.Informers, nodeName string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		_, err := inf.GetNode(nodeName)
+		return err == nil
+	}, 30*time.Second, 50*time.Millisecond,
+		"node %s should become visible in the informer cache", nodeName)
+}
+
 func createNodeWithLabelsAndAnnotations(ctx context.Context, t *testing.T, client kubernetes.Interface,
 	nodeName string, labels map[string]string, annotations map[string]string) {
 	t.Helper()
@@ -1811,6 +1829,10 @@ func TestMetrics_AlreadyQuarantinedDoesNotIncrementDrainSuccess(t *testing.T) {
 	assert.NoError(t, err)
 	createNodeWithLabelsAndAnnotations(setup.ctx, t, setup.client, nodeName, map[string]string{"test": "true"},
 		map[string]string{common.QuarantineHealthEventAnnotationKey: annotationValue})
+	// The AlreadyQuarantined path reads the node through the informer cache,
+	// which learns about the node asynchronously; without this wait the
+	// evaluation below races the watch delivery and flakes on loaded runners.
+	waitForNodeInInformer(t, setup.informersInstance, nodeName)
 
 	setup.healthEventStore.healthEvents = []datastore.HealthEventWithStatus{
 		{


### PR DESCRIPTION
## Summary

TestMetrics_AlreadyQuarantinedDoesNotIncrementDrainSuccess failed on an unrelated PR's CI run (https://github.com/NVIDIA/NVSentinel/actions/runs/33077960024/job/98537087529) with "Node not found in cache" followed by the metric assertion failing.

The root cause is a race in the test, not in the reconciler. The test creates a node through the envtest API server and immediately processes an AlreadyQuarantined health event. The evaluator reads that node through the shared informer's local cache, but the cache only learns about the node through an asynchronous watch event, and nothing in the test waits for that. On a loaded CI runner the watch delivery lags, the lookup misses, the evaluator takes its defensive Wait branch, and the skipped counter the test asserts on never increments. In production this is harmless because the event is simply retried a minute later.

The fix adds a small waitForNodeInInformer helper to the integration test file and calls it after node creation in the two tests that evaluate through the informer cache right away: the failing metrics test and the TestReconciler_ProcessEvent table runner, which contains an AlreadyQuarantined case with the same latent race.

## Testing

All runs were done locally on a 20 core Linux machine against envtest (kube-apiserver and etcd from kubebuilder assets, Kubernetes 1.36.2).

To confirm the diagnosis deterministically, a temporary local patch (not part of this PR) delayed node watch delivery to the informer by 1 second, which turns the sub-millisecond race window into a guaranteed one. Without the fix the test then failed 3 out of 3 runs with the exact CI signature ("Node not found in cache node=metrics-already-drained-node", then the assertion "0 is not greater than or equal to 1"). With the fix it passed 3 out of 3, and also passed with a 5 second delay.

To reproduce the actual CI conditions, the test was run 15 times with 40 busy loop processes oversubscribing the 20 cores by 2x, matching the contention on a CI runner where several envtest based test packages run concurrently. Without the fix it failed 4 out of 15 runs. With the fix it passed 15 out of 15 under the same load.

Regression: the full TestMetrics_* group plus TestReconciler_ProcessEvent pass unloaded with the fix in place. The changed file is gofmt clean and go vet passes.


## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [x] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reconciler and metrics test reliability by waiting for newly created nodes to become available before validation.
  * Added coverage for already quarantined node behavior using synchronized informer data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->