### PR TITLE
fix(gpu-reset): disable persistence mode before resetting a GPU

### DIFF
--- a/gpu-reset/gpu_reset.sh
+++ b/gpu-reset/gpu_reset.sh
@@ -51,6 +51,42 @@ nvidia_smi_helper() {
   chroot "$DRIVER_ROOT" nvidia-smi "$@"
 }
 
+# Persistence mode counts as an attachment to the device, so nvidia-smi --gpu-reset
+# is refused with "In use by another client" while it is enabled. Record the
+# per-GPU state so it can be restored exactly, including on the failure path.
+PERSISTENCE_RESTORE=""
+
+disable_persistence_mode() {
+  local uuid
+  local mode
+  for uuid in $(echo "$1" | tr ',' ' '); do
+    # Tolerate an unqueryable GPU: the script runs under `set -e`, and a device
+    # that has dropped off the bus must not abort the whole reset here.
+    mode=$(nvidia_smi_helper --query-gpu=persistence_mode --format=csv,noheader -i "$uuid" 2>/dev/null | tr -d '[:space:]' || true)
+    if [ "$mode" != "Enabled" ]; then
+      continue
+    fi
+    if nvidia_smi_helper -pm 0 -i "$uuid" >/dev/null 2>&1; then
+      PERSISTENCE_RESTORE="${PERSISTENCE_RESTORE}${uuid} "
+      log "INFO: Disabled persistence mode on ${uuid} for the duration of the reset."
+    else
+      log "WARN: Failed to disable persistence mode on ${uuid}; the reset may be refused."
+    fi
+  done
+}
+
+restore_persistence_mode() {
+  local uuid
+  for uuid in $PERSISTENCE_RESTORE; do
+    if nvidia_smi_helper -pm 1 -i "$uuid" >/dev/null 2>&1; then
+      log "INFO: Restored persistence mode on ${uuid}."
+    else
+      log "WARN: Failed to restore persistence mode on ${uuid}."
+    fi
+  done
+  PERSISTENCE_RESTORE=""
+}
+
 prepend_driver_root() {
   if [ "$DRIVER_ROOT" = "/" ]; then
     printf "%s\n" "$1"
@@ -119,7 +155,7 @@ RESET_STATUS=0
 FINAL_EXIT_STATUS=0
 RESET_OUTPUT_FILE=$(mktemp)
 HEALTH_CHECK_OUTPUT_FILE=$(mktemp)
-trap 'rm -f -- "$RESET_OUTPUT_FILE" "$HEALTH_CHECK_OUTPUT_FILE"' EXIT
+trap 'restore_persistence_mode; rm -f -- "$RESET_OUTPUT_FILE" "$HEALTH_CHECK_OUTPUT_FILE"' EXIT
 
 log "INFO: Starting GPU reset workflow..."
 
@@ -148,6 +184,8 @@ echo "${TARGET_UUIDS}" | tr ',' '\n' | sed 's/^/  /'
 #----------------
 # RESET EXECUTION
 #----------------
+
+disable_persistence_mode "${TARGET_UUIDS}"
 
 log "INFO: Resetting GPUs..."
 


### PR DESCRIPTION
Fixes #1690.

## What

Disables persistence mode on the target GPUs before `nvidia-smi --gpu-reset`, and
restores it afterwards.

## Why

Persistence mode counts as an attachment to the device, so the reset is refused
while it is enabled:

```
The following GPUs could not be reset:
  GPU 00000000:1A:00.0: In use by another client
exit=255
```

Disabling it is sufficient to make the same reset succeed seconds later on the
same GPU, with nothing else changed:

```
$ nvidia-smi -pm 0 -i <uuid>
All done.
$ nvidia-smi -r -i <uuid>
GPU 00000000:1A:00.0 was successfully reset.
exit=0
```

#126 describes this as part of the intended design — "along with also disabling
persistent mode on that GPU which is a process started the driver pod". The pod
teardown half is implemented; this adds the other half.

## Notes on the implementation

**Prior state is recorded per GPU and restored from the existing `EXIT` trap.** A
GPU whose persistence mode was already disabled is left untouched, and a failed
reset does not leave the setting changed — the trap runs on the error path too.

**The query is `|| true`-guarded.** The script runs under `set -eou pipefail`, so
an unqueryable GPU would otherwise abort the whole reset via the failed command
substitution. That case is real rather than theoretical: a GPU that has dropped
off the PCIe bus is exactly the kind of fault a reset gets requested for, and one
bad device must not prevent the others from being reset.

**No behaviour change when persistence mode is already off**, which is the default
after boot, so this is inert on nodes that never enable it.

## Testing

Verified on an 8-GPU bare-metal node (B300 SXM6, driver 580.95.05):

- with persistence mode enabled, `--gpu-reset` returns exit 255 `In use by another client`
- after `-pm 0`, the same reset returns exit 0 and the node returns to its full GPU count

Also exercised the `set -e` guard with a stub that fails the query, confirming the
loop continues rather than exiting.

One incidental finding worth recording: an open file descriptor on `/dev/nvidia*`
is *not* what blocks the reset. `nvidia-persistenced` still held the device open
during the successful run above. It is persistence *mode* that constitutes the
attachment, which is why this is the right fix rather than stopping the driver pod.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - GPU resets now safely handle GPUs with persistence mode enabled.
  - Persistence mode is restored after resets, including when failures occur.
  - Unavailable GPU status information and restoration failures no longer interrupt the reset workflow.
  - Reset operations now log persistence-mode changes and related failures clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->