### PR TITLE
fix(health-events-analyzer): stamp derived events with their own generated timestamp

### DIFF
--- a/health-events-analyzer/pkg/publisher/publisher.go
+++ b/health-events-analyzer/pkg/publisher/publisher.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/nvidia/nvsentinel/commons/pkg/tracing"
@@ -34,6 +35,10 @@ import (
 const (
 	maxRetries int           = 5
 	delay      time.Duration = 5 * time.Second
+
+	// Carries the triggering event's generated timestamp, which the derived event replaces
+	// with its own.
+	sourceGeneratedTimestampMetadataKey = "source_generated_timestamp"
 )
 
 type PublisherConfig struct {
@@ -114,7 +119,8 @@ func NewPublisher(platformConnectorClient protos.PlatformConnectorClient,
 
 // Publish clones the incoming health event, updates the fields defined by the
 // rule (agent, check name, recommended action, isFatal, and processing strategy),
-// and sends the resulting event to the platform-connector with retries.
+// stamps its own generated timestamp, and sends the resulting event to the
+// platform-connector with retries.
 func (p *PublisherConfig) Publish(ctx context.Context, event *protos.HealthEvent,
 	recommendedAction protos.RecommendedAction, ruleName string, message string,
 	rule *config.HealthEventsAnalyzerRule) error {
@@ -133,6 +139,18 @@ func (p *PublisherConfig) Publish(ctx context.Context, event *protos.HealthEvent
 	newEvent.RecommendedAction = recommendedAction
 	newEvent.IsHealthy = false
 	newEvent.Message = message
+
+	// The clone inherits the triggering event's timestamp, which dates the derived event to
+	// the original fault rather than to detection. The source value is kept in metadata.
+	if src := event.GetGeneratedTimestamp(); src != nil {
+		if newEvent.Metadata == nil {
+			newEvent.Metadata = make(map[string]string, 1)
+		}
+
+		newEvent.Metadata[sourceGeneratedTimestampMetadataKey] = src.AsTime().UTC().Format(time.RFC3339Nano)
+	}
+
+	newEvent.GeneratedTimestamp = timestamppb.New(time.Now())
 
 	// Default from module configuration, with an optional rule-level override.
 	newEvent.ProcessingStrategy = p.processingStrategy

--- a/health-events-analyzer/pkg/publisher/publisher_test.go
+++ b/health-events-analyzer/pkg/publisher/publisher_test.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package publisher
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	protos "github.com/nvidia/nvsentinel/data-models/pkg/protos"
+)
+
+type fakePlatformConnectorClient struct {
+	events *protos.HealthEvents
+}
+
+func (f *fakePlatformConnectorClient) HealthEventOccurredV1(
+	_ context.Context, events *protos.HealthEvents, _ ...grpc.CallOption,
+) (*emptypb.Empty, error) {
+	f.events = events
+
+	return &emptypb.Empty{}, nil
+}
+
+// sourceEvent is a detector event from the past, standing in for one replayed off a lagging
+// change stream.
+func sourceEvent(generated time.Time) *protos.HealthEvent {
+	return &protos.HealthEvent{
+		Agent:              "syslog-health-monitor",
+		CheckName:          "SysLogsXIDError",
+		ComponentClass:     "GPU",
+		NodeName:           "node-1",
+		ErrorCode:          []string{"31"},
+		IsHealthy:          false,
+		GeneratedTimestamp: timestamppb.New(generated),
+	}
+}
+
+func TestPublish_LaggingSourceEvent_StampsPublishTimeAndKeepsSourceTimestamp(t *testing.T) {
+	client := &fakePlatformConnectorClient{}
+	pub := NewPublisher(client, protos.ProcessingStrategy_EXECUTE_REMEDIATION)
+
+	sourceTime := time.Date(2026, 8, 21, 8, 27, 36, 0, time.UTC)
+	before := time.Now()
+
+	err := pub.Publish(context.Background(), sourceEvent(sourceTime),
+		protos.RecommendedAction_RUN_DCGMEUD, "RepeatedXID31OnSameGPU", "run field diagnostics", nil)
+	require.NoError(t, err)
+	require.NotNil(t, client.events)
+	require.Len(t, client.events.GetEvents(), 1)
+
+	published := client.events.GetEvents()[0]
+
+	// The derived event must be stamped at publish time, not inherit the source timestamp.
+	require.NotNil(t, published.GetGeneratedTimestamp())
+	require.False(t, published.GetGeneratedTimestamp().AsTime().Equal(sourceTime),
+		"derived event inherited the source generated timestamp")
+	require.False(t, published.GetGeneratedTimestamp().AsTime().Before(before.Add(-time.Second)),
+		"derived event timestamp predates the publish call")
+
+	// The source timestamp is preserved so provenance is not lost.
+	require.Equal(t, sourceTime.Format(time.RFC3339Nano),
+		published.GetMetadata()[sourceGeneratedTimestampMetadataKey])
+}
+
+func TestPublish_SourceWithMetadata_PreservesExistingKeys(t *testing.T) {
+	client := &fakePlatformConnectorClient{}
+	pub := NewPublisher(client, protos.ProcessingStrategy_EXECUTE_REMEDIATION)
+
+	sourceTime := time.Date(2026, 8, 21, 8, 27, 36, 0, time.UTC)
+	src := sourceEvent(sourceTime)
+	src.Metadata = map[string]string{"existing": "value"}
+
+	err := pub.Publish(context.Background(), src,
+		protos.RecommendedAction_NONE, "XIDErrorSoloNoBurst", "no action", nil)
+	require.NoError(t, err)
+
+	published := client.events.GetEvents()[0]
+	require.Equal(t, "value", published.GetMetadata()["existing"])
+	require.Equal(t, sourceTime.Format(time.RFC3339Nano),
+		published.GetMetadata()[sourceGeneratedTimestampMetadataKey])
+}
+
+func TestPublish_SourceWithoutTimestamp_StampsWithoutSourceMetadata(t *testing.T) {
+	client := &fakePlatformConnectorClient{}
+	pub := NewPublisher(client, protos.ProcessingStrategy_EXECUTE_REMEDIATION)
+
+	src := sourceEvent(time.Time{})
+	src.GeneratedTimestamp = nil
+
+	err := pub.Publish(context.Background(), src,
+		protos.RecommendedAction_NONE, "XIDErrorSoloNoBurst", "no action", nil)
+	require.NoError(t, err)
+
+	published := client.events.GetEvents()[0]
+	require.NotNil(t, published.GetGeneratedTimestamp())
+	require.NotContains(t, published.GetMetadata(), sourceGeneratedTimestampMetadataKey)
+}
+
+func TestPublish_AnySourceEvent_DoesNotMutateCaller(t *testing.T) {
+	client := &fakePlatformConnectorClient{}
+	pub := NewPublisher(client, protos.ProcessingStrategy_EXECUTE_REMEDIATION)
+
+	sourceTime := time.Date(2026, 8, 21, 8, 27, 36, 0, time.UTC)
+	src := sourceEvent(sourceTime)
+
+	err := pub.Publish(context.Background(), src,
+		protos.RecommendedAction_RUN_DCGMEUD, "RepeatedXID31OnSameGPU", "run field diagnostics", nil)
+	require.NoError(t, err)
+
+	// Publish clones, so the caller's event must be untouched.
+	require.True(t, src.GetGeneratedTimestamp().AsTime().Equal(sourceTime))
+	require.Equal(t, "syslog-health-monitor", src.GetAgent())
+	require.NotContains(t, src.GetMetadata(), sourceGeneratedTimestampMetadataKey)
+}

--- a/health-events-analyzer/pkg/publisher/publisher_test.go
+++ b/health-events-analyzer/pkg/publisher/publisher_test.go
@@ -80,6 +80,23 @@ func TestPublish_LaggingSourceEvent_StampsPublishTimeAndKeepsSourceTimestamp(t *
 		published.GetMetadata()[sourceGeneratedTimestampMetadataKey])
 }
 
+// Asserts the wire key literally rather than through the constant, so a rename cannot
+// silently change what consumers see while the tests still pass.
+func TestPublish_DerivedEvent_UsesTheDocumentedMetadataKey(t *testing.T) {
+	client := &fakePlatformConnectorClient{}
+	pub := NewPublisher(client, protos.ProcessingStrategy_EXECUTE_REMEDIATION)
+
+	sourceTime := time.Date(2026, 8, 21, 8, 27, 36, 0, time.UTC)
+
+	err := pub.Publish(context.Background(), sourceEvent(sourceTime),
+		protos.RecommendedAction_NONE, "XIDErrorSoloNoBurst", "no action", nil)
+	require.NoError(t, err)
+
+	published := client.events.GetEvents()[0]
+	require.Equal(t, sourceTime.Format(time.RFC3339Nano),
+		published.GetMetadata()["source_generated_timestamp"])
+}
+
 func TestPublish_SourceWithMetadata_PreservesExistingKeys(t *testing.T) {
 	client := &fakePlatformConnectorClient{}
 	pub := NewPublisher(client, protos.ProcessingStrategy_EXECUTE_REMEDIATION)

--- a/health-events-analyzer/pkg/reconciler/reconciler.go
+++ b/health-events-analyzer/pkg/reconciler/reconciler.go
@@ -390,7 +390,8 @@ func (r *Reconciler) publishMatchedEvent(ctx context.Context,
 		return fmt.Errorf("error in publishing the new fatal event: %w", err)
 	}
 
-	slog.InfoContext(ctx, "New event successfully published for matching rule", "rule_name", rule.Name)
+	slog.InfoContext(ctx, "New event successfully published for matching rule",
+		"rule_name", rule.Name, "node", event.HealthEvent.NodeName)
 
 	return nil
 }

--- a/health-events-analyzer/pkg/reconciler/reconciler_test.go
+++ b/health-events-analyzer/pkg/reconciler/reconciler_test.go
@@ -318,7 +318,7 @@ func TestHandleEvent(t *testing.T) {
 				// metadata the source event already carried.
 				!e.GetGeneratedTimestamp().AsTime().Before(src.GetGeneratedTimestamp().AsTime()) &&
 				e.GetMetadata()["SerialNumber"] == src.GetMetadata()["SerialNumber"] &&
-				e.GetMetadata()["nvsentinel.nvidia.com/source-generated-timestamp"] ==
+				e.GetMetadata()["source_generated_timestamp"] ==
 					src.GetGeneratedTimestamp().AsTime().UTC().Format(time.RFC3339Nano)
 		}
 

--- a/health-events-analyzer/pkg/reconciler/reconciler_test.go
+++ b/health-events-analyzer/pkg/reconciler/reconciler_test.go
@@ -295,29 +295,35 @@ func TestHandleEvent(t *testing.T) {
 			databaseClient: mockClient,
 		}
 
-		// Create the expected health event that the publisher will create (transformed)
-		expectedTransformedEvent := &protos.HealthEvent{
-			Version:            healthEvent_13.HealthEvent.Version,
-			Agent:              "health-events-analyzer", // Publisher sets this
-			CheckName:          "rule2",                  // Publisher sets this to ruleName
-			ComponentClass:     healthEvent_13.HealthEvent.ComponentClass,
-			Message:            "XID error occurred",                     // From rule2.Message
-			RecommendedAction:  protos.RecommendedAction_CONTACT_SUPPORT, // From rule2
-			ErrorCode:          healthEvent_13.HealthEvent.ErrorCode,
-			IsHealthy:          false, // Publisher sets this
-			IsFatal:            true,  // Publisher sets this
-			EntitiesImpacted:   healthEvent_13.HealthEvent.EntitiesImpacted,
-			Metadata:           healthEvent_13.HealthEvent.Metadata,
-			GeneratedTimestamp: healthEvent_13.HealthEvent.GeneratedTimestamp,
-			NodeName:           healthEvent_13.HealthEvent.NodeName,
-			ProcessingStrategy: protos.ProcessingStrategy_EXECUTE_REMEDIATION, // Publisher sets this from config
-		}
-		expectedHealthEvents := &protos.HealthEvents{
-			Version: 1,
-			Events:  []*protos.HealthEvent{expectedTransformedEvent},
+		// Matched on fields rather than the whole message: the publisher stamps its own
+		// GeneratedTimestamp and adds the source value to metadata, so neither is fixed.
+		matchesTransformedEvent := func(got *protos.HealthEvents) bool {
+			if got.GetVersion() != 1 || len(got.GetEvents()) != 1 {
+				return false
+			}
+
+			src := healthEvent_13.HealthEvent
+			e := got.GetEvents()[0]
+
+			return e.GetVersion() == src.GetVersion() &&
+				e.GetAgent() == "health-events-analyzer" &&
+				e.GetCheckName() == "rule2" &&
+				e.GetComponentClass() == src.GetComponentClass() &&
+				e.GetMessage() == "XID error occurred" &&
+				e.GetRecommendedAction() == protos.RecommendedAction_CONTACT_SUPPORT &&
+				e.GetIsFatal() && !e.GetIsHealthy() &&
+				e.GetNodeName() == src.GetNodeName() &&
+				e.GetProcessingStrategy() == protos.ProcessingStrategy_EXECUTE_REMEDIATION &&
+				// Stamped at publish time, and the source value kept alongside the
+				// metadata the source event already carried.
+				!e.GetGeneratedTimestamp().AsTime().Before(src.GetGeneratedTimestamp().AsTime()) &&
+				e.GetMetadata()["SerialNumber"] == src.GetMetadata()["SerialNumber"] &&
+				e.GetMetadata()["nvsentinel.nvidia.com/source-generated-timestamp"] ==
+					src.GetGeneratedTimestamp().AsTime().UTC().Format(time.RFC3339Nano)
 		}
 
-		mockPublisher.On("HealthEventOccurredV1", mock.Anything, expectedHealthEvents).Return(&emptypb.Empty{}, nil)
+		mockPublisher.On("HealthEventOccurredV1", mock.Anything,
+			mock.MatchedBy(matchesTransformedEvent)).Return(&emptypb.Empty{}, nil)
 
 		// Rule2 requires 3 occurrences, so return ruleMatched: true
 		cursor, _ := createMockCursor([]map[string]any{


### PR DESCRIPTION
## Summary

Fixes #1704. `Publish` clones the triggering event and overrides `Agent`, `CheckName`,
`RecommendedAction`, `IsHealthy`, `Message` and `ProcessingStrategy`, but not
`GeneratedTimestamp`. A derived event therefore carried the timestamp of the event that
triggered it, dating it to the original fault rather than to when the pattern was detected.

Also adds the node to the success log line, per the discussion on the issue.

## Why it matters

The gap is invisible while the analyzer keeps up, and obvious when it does not. On a 288 node
GB200 fleet whose analyzer was about 11 days behind its change stream, derived events were
inserted today carrying a generated timestamp from 11 days earlier:

```
createdAt 2026-08-31 10:08:11  ->  healthevent.generatedtimestamp 2026-08-21 08:27:36
createdAt 2026-08-31 05:02:34  ->  healthevent.generatedtimestamp 2026-08-21 08:17:36
```

Anything that buckets by generated time mis-dates these by the consumer's lag. In our case a
dashboard reported a resolved fault as current, which is what led to #1704.

## Change

`GeneratedTimestamp` is stamped at publish time using the same
`timestamppb.New(time.Now())` pattern the health monitors already use. The source value is
preserved under a metadata key so provenance is not lost:

```
source_generated_timestamp
```

The key follows the existing namespaced convention, matching
`cancelSourceErrorCodeMetadataKey` in syslog-health-monitor.

The second change adds `node` to the `publishMatchedEvent` success line. It previously carried
only `rule_name`, while the non-match line carries both, so a match could not be attributed to
a node from the logs alone.

## Tests

New `publisher_test.go` covers four cases:

- the derived event is stamped at publish time and does not inherit the source timestamp
- metadata the source event already carried is preserved alongside the new key
- a source event with no `GeneratedTimestamp` still gets stamped, and no metadata key is added
- the caller's event is not mutated, since `Publish` clones

`reconciler_test.go`'s `TestHandleEvent` pinned the whole `HealthEvents` argument on the mock,
which no longer matches now that the timestamp is generated and a metadata key is added. It now
matches on fields via `mock.MatchedBy`, asserting the stable ones exactly and additionally that
the timestamp is not before the source and that the source key holds the source value. That
keeps the assertion and covers the new behaviour rather than weakening it to `mock.Anything`.

## Verification

`go build ./...`, `go vet`, `gofmt` and `go test ./...` are clean for the module.

I could not run `golangci-lint` locally: the repo pins v2.13.1, `make install-golangci-lint`
fails a checksum verification on the release tarball, and the module-proxy build of v2.13.1
refuses to load the config because it is built with go1.26 against a go1.27 target. I checked
the fussier enabled linters by hand instead, `lll` in particular; the longest added line is 102
characters against the 120 default. Flagging it so CI is treated as the real gate for lint here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Published health events now receive a generation timestamp.
  - Original source timestamps are preserved in event metadata.
  - Existing event metadata remains intact.

- **Bug Fixes**
  - Events without source timestamps are handled safely.
  - Source events remain unchanged during publishing.
  - Successful publication logs now include the event’s node name.

- **Tests**
  - Added coverage for timestamp handling, metadata preservation, event immutability, and publication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
