### PR TITLE
fix(health-events-analyzer): exclude XID 45 from RepeatedXIDErrorOnSameGPU

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
@@ -115,7 +115,7 @@ config: |
 
   [[rules]]
   name = "RepeatedXIDErrorOnSameGPU"
-  description = "Detect occurrence of XID errors (any XID except 31) on the same GPU 5 times within 24 hours where the burst window is 3 minutes and sticky XIDs window is 3 hours"
+  description = "Detect occurrence of XID errors (any XID except 31 and 45) on the same GPU 5 times within 24 hours where the burst window is 3 minutes and sticky XIDs window is 3 hours"
   recommended_action = "CONTACT_SUPPORT"
   evaluate_rule = {{ .Values.enableRepeatedXIDErrorOnSameGPURule }}
   stage = [

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
@@ -163,6 +163,10 @@ config: |
     ''',
     # Candidate docs must also be XID events so non-XID unhealthy events on
     # the same node are not merged into GPU burst counts.
+    #
+    # Excluded codes: 31 has its own dedicated rules; 45 is preemptive channel cleanup that
+    # the Xid catalogue resolves as "Not Solo: IGNORE (follow other Xid)", and a repeat is
+    # never solo.
     '''
     {
       "$match": {
@@ -171,7 +175,7 @@ config: |
         "healthevent.nodename": "this.healthevent.nodename",
         "$expr": {
           "$and": [
-            {"$ne": [{"$arrayElemAt": ["$healthevent.errorcode", 0]}, "31"]},
+            {"$not": [{"$in": [{"$arrayElemAt": ["$healthevent.errorcode", 0]}, ["31", "45"]]}]},
             {
               "$gt": [
                 {

--- a/distros/kubernetes/nvsentinel/values-tilt.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt.yaml
@@ -435,7 +435,7 @@ health-events-analyzer:
 
     [[rules]]
     name = "RepeatedXIDErrorOnSameGPU"
-    description = "Detect occurrence of XID errors (any XID except 31) on the same GPU 2 times within 2 minutes where the burst window is 15 seconds and sticky XIDs window is 30 seconds (test config)"
+    description = "Detect occurrence of XID errors (any XID except 31 and 45) on the same GPU 2 times within 2 minutes where the burst window is 15 seconds and sticky XIDs window is 30 seconds (test config)"
     recommended_action = "CONTACT_SUPPORT"
     evaluate_rule = true
     stage = [

--- a/distros/kubernetes/nvsentinel/values-tilt.yaml
+++ b/distros/kubernetes/nvsentinel/values-tilt.yaml
@@ -483,6 +483,10 @@ health-events-analyzer:
       ''',
       # Candidate docs must also be XID events so non-XID unhealthy events on
       # the same node are not merged into GPU burst counts.
+      #
+      # Excluded codes: 31 has its own dedicated rules; 45 is preemptive channel cleanup that
+      # the Xid catalogue resolves as "Not Solo: IGNORE (follow other Xid)", and a repeat is
+      # never solo.
       '''
       {
         "$match": {
@@ -491,7 +495,7 @@ health-events-analyzer:
           "healthevent.nodename": "this.healthevent.nodename",
           "$expr": {
           "$and": [
-            {"$ne": [{"$arrayElemAt": ["$healthevent.errorcode", 0]}, "31"]},
+            {"$not": [{"$in": [{"$arrayElemAt": ["$healthevent.errorcode", 0]}, ["31", "45"]]}]},
             {
               "$gt": [
                 {

--- a/docs/configuration/health-events-analyzer.md
+++ b/docs/configuration/health-events-analyzer.md
@@ -113,7 +113,7 @@ The following table summarises every flag, the XID or event type it covers, and 
 | Flag | Rule | Recommended Action | Description |
 |------|------|--------------------|-------------|
 | `enableMultipleRemediationsRule` | MultipleRemediations | `CONTACT_SUPPORT` | 5 or more remediations on the same node within 7 days |
-| `enableRepeatedXIDErrorOnSameGPURule` | RepeatedXIDErrorOnSameGPU | `CONTACT_SUPPORT` | Any XID except 31 five or more times within 24 hours on the same GPU (burst window 3 min, sticky XID window 3 h) |
+| `enableRepeatedXIDErrorOnSameGPURule` | RepeatedXIDErrorOnSameGPU | `CONTACT_SUPPORT` | Any XID except 31 and 45 five or more times within 24 hours on the same GPU (burst window 3 min, sticky XID window 3 h) |
 | `enableRepeatedXID31OnSameGPURule` | RepeatedXID31OnSameGPU | `RUN_DCGMEUD` | XID 31 two or more times on the same GPU within 24 hours |
 | `enableRepeatedXID31OnDifferentGPURule` | RepeatedXID31OnDifferentGPU | `NONE` | XID 31 on two or more different GPUs within 24 hours |
 | `enableRepeatedXID13OnSameGPCAndTPCRule` | RepeatedXID13OnSameGPCAndTPC | `RUN_DCGMEUD` | XID 13 two or more times on the same GPC and TPC within 24 hours |


### PR DESCRIPTION
## Summary

Fixes #1710, taking option 1 as agreed: exclude XID 45 from `RepeatedXIDErrorOnSameGPU` the
same way XID 31 already is, rather than adding a broad `isfatal` predicate.

## Why

The rule is described as detecting fatal XIDs repeating on a GPU and carries
`CONTACT_SUPPORT`. Its only code exclusion was XID 31, so XID 45 was in scope and repeats were
escalated to `CONTACT_SUPPORT` with `isFatal: true`.

The shipped `Xid-Catalog.xlsx` resolves XID 45 (`ROBUST_CHANNEL_PREEMPTIVE_REMOVAL`) as:

> **Solo: RESTART_FM / Not Solo: IGNORE (follow other Xid)**

with trigger condition "logged when the user application aborts and the kernel driver tears
down the GPU appli...". A repeat is by definition **not solo**, so the rule fired exactly where
the catalogue says to ignore. It is also inconsistent with the detector, which maps XID 45 to
`NONE` with `isFatal: false`.

Measured on a 288 node GB200 fleet: **672** `CONTACT_SUPPORT` events with `isFatal: true`
across 3 nodes in 3 hours, from 1,232 XID 45 detector events on the worst node. Over 2 days the
collection holds **168,924** XID 45 events against **10** of every other XID combined. With
fault-quarantine enabled those nodes would be cordoned and drained continuously.

## Change

One predicate, in both files that define the rule:

```diff
-{"$ne": [{"$arrayElemAt": ["$healthevent.errorcode", 0]}, "31"]},
+{"$not": [{"$in": [{"$arrayElemAt": ["$healthevent.errorcode", 0]}, ["31", "45"]]}]},
```

A `$not`/`$in` list rather than a second `$ne`, so the next per-XID decision is one list entry,
which is how you framed it on the issue. `values-tilt.yaml` gets the same change so Tilt and
e2e behaviour match production.

## Verification

- **The predicate was run against a live MongoDB**, not just reasoned about. Same match stage,
  2 days of real data: the control returns `45`, `44`, `145.RLW_SRC_TRACK`,
  `149.NETIR_BER_EVENT`; with the predicate, `45` is dropped and the rest retained. Removed
  exactly `45`. No aggregation error, so the `$not`/`$in` form is valid on the server.
- YAML parses and the edited stage is valid JSON in both files.
- Confirmed these are the only two files defining the rule and no `$ne ... "31"` copy remains.
- Confirmed `extractXidDetectorConfig` keys off a rule named `RepeatedXidError`, which does not
  exist in the shipped config, so the PostgreSQL burst-detector path is unaffected.
- Confirmed the existing e2e tests never use XID 45, so nothing there changes behaviour. The
  test at `tests/health_events_analyzer_test.go:379` already documents the XID 31 exclusion as
  precedent for this shape.

## On an e2e test

I did not add one. The natural case is sending 5 XID 45 events and asserting
`EnsureNodeConditionNotPresent`, mirroring the XID 31 note above, but `e2e-test-ci` depends on
`tilt-ci` and I have no way to run it here. I would rather not ship an e2e test I could not
execute. Happy to add it if you want it, or if CI will exercise it on this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved repeated XID event detection by excluding XID 31 and XID 45 from candidate events.
  - Reduced false positives from preemptive channel cleanup and separately handled events being flagged as repeated errors.
  - Applied consistent filtering across supported deployment configurations.

- **Documentation**
  - Updated configuration guidance to explain how XID 31 and XID 45 are handled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->