### PR TITLE
feat(fault-quarantine): add an absolute max-nodes bound to the circuit breaker

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-quarantine/templates/configmap.yaml
@@ -25,6 +25,7 @@ data:
     
     [circuitBreaker]
     percentage = {{ .Values.circuitBreaker.percentage }}
+    maxNodes = {{ .Values.circuitBreaker.maxNodes | default 0 }}
     duration = {{ .Values.circuitBreaker.duration | quote }}
     
     {{- range .Values.ruleSets }}

--- a/distros/kubernetes/nvsentinel/charts/fault-quarantine/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/fault-quarantine/values.yaml
@@ -65,6 +65,15 @@ circuitBreaker:
   # before the circuit breaker trips.
   # Example: 50 means if 50% or more GPU nodes are cordoned, no new quarantines will be allowed
   percentage: 50
+  # Optional absolute cap on cordoned nodes within the window, independent of fleet size.
+  # 0 disables it. When both are set the lower bound binds, so "percentage: 5, maxNodes: 10"
+  # means 5% but never more than 10 nodes.
+  #
+  # Prefer this when the blast radius you care about is a number of machines rather than a
+  # share of the fleet, since a percentage silently changes meaning as the fleet grows. Note
+  # it is per cluster by nature: an operator running many clusters of differing size will
+  # need to tune it per cluster, or leave it 0 and rely on percentage alone.
+  maxNodes: 0
   # Time window for the sliding window circuit breaker
   # The circuit breaker counts cordon events within this time window
   # Example: "5m" means if 50% of GPU nodes are cordoned within any 5-minute window, the circuit breaker trips

--- a/distros/kubernetes/nvsentinel/values-full.yaml
+++ b/distros/kubernetes/nvsentinel/values-full.yaml
@@ -491,7 +491,15 @@ fault-quarantine:
     # Example: 50 means if 50% or more GPU nodes are already cordoned,
     # no new quarantines will be allowed
     # Range: 1-100
+    # Set to 0 to bound by maxNodes alone.
     percentage: 50
+    # Absolute ceiling on cordoned nodes within the window, independent of cluster size.
+    # 0 disables this bound. When both are set the lower one binds, so percentage: 5 with
+    # maxNodes: 10 means 5% but never more than 10 nodes. Prefer it when the blast radius
+    # you care about is a number of machines rather than a share of the fleet, since a
+    # percentage silently changes meaning as the fleet grows. At least one of percentage
+    # and maxNodes must be positive.
+    maxNodes: 0
     # Cooldown period after circuit breaker trips
     # Circuit breaker waits this long before attempting to close again
     # Even if node count drops below threshold during cooldown, it stays open

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -63,6 +63,7 @@ This document outlines all Prometheus metrics exposed by NVSentinel components.
 |------------|------|--------|-------------|
 | `fault_quarantine_breaker_state` | Gauge | `state` | State of the fault quarantine breaker |
 | `fault_quarantine_breaker_utilization` | Gauge | - | Fraction of GPU nodes cordoned within the circuit breaker's sliding window |
+| `fault_quarantine_breaker_threshold_nodes` | Gauge | `bound` | Cordoned-node count that trips the circuit breaker, and which configured bound produced it (`percentage`, `maxNodes`, or `fleetSize` when clamped) |
 | `fault_quarantine_get_total_nodes_duration_seconds` | Histogram | `result` | Duration of getTotalNodesWithRetry calls in seconds |
 | `fault_quarantine_get_total_nodes_errors_total` | Counter | `error_type` | Total number of errors from getTotalNodesWithRetry |
 | `fault_quarantine_get_total_nodes_retry_attempts` | Histogram | - | Number of retry attempts needed for getTotalNodesWithRetry (buckets: 0, 1, 2, 3, 5, 10) |

--- a/docs/circuit-breaker.md
+++ b/docs/circuit-breaker.md
@@ -46,6 +46,7 @@ fault-quarantine:
   circuitBreaker:
     enabled: true      # Enable or disable the protection
     percentage: 50     # Percentage of GPU nodes that can be cordoned
+    maxNodes: 0        # Absolute node ceiling; 0 disables this bound
     duration: "5m"     # Time window to monitor
 ```
 
@@ -53,9 +54,12 @@ Only nodes labeled `nvidia.com/gpu.present=true` are included when calculating t
 
 **Example:** With `percentage: 50` and `duration: "5m"`, if 50% or more of your GPU nodes are cordoned within any 5-minute period, the circuit breaker will trip.
 
+`maxNodes` bounds the same window by an absolute count instead. When both are set the lower one binds, so `percentage: 10` with `maxNodes: 20` trips at 20 nodes on a 300 node cluster and at 10% on a 100 node one. Use it when a percentage chosen for one cluster size would become too permissive as the fleet grows. At least one of the two must be positive.
+
 **Recommended Settings:**
 - For production clusters with 10+ GPU nodes: Keep enabled with 50% threshold
 - For small clusters (< 10 GPU nodes): Consider disabling or using a higher percentage
+- For a fleet of differently sized clusters: set both, so one config bounds every cluster
 
 ## Monitoring the Circuit Breaker
 

--- a/docs/configuration/fault-quarantine.md
+++ b/docs/configuration/fault-quarantine.md
@@ -101,6 +101,7 @@ fault-quarantine:
   circuitBreaker:
     enabled: true
     percentage: 50
+    maxNodes: 0
     duration: "5m"
 ```
 
@@ -110,10 +111,21 @@ fault-quarantine:
 Enables or disables circuit breaker protection. When disabled, unlimited nodes can be quarantined.
 
 #### percentage
-Maximum percentage of total cluster nodes that can be quarantined within the time window. When exceeded, the circuit breaker trips and blocks all new quarantine actions.
+Maximum percentage of GPU nodes that can be quarantined within the time window. When reached, the circuit breaker trips and blocks all new quarantine actions. Rounds up, so `1` on a 288-node cluster is 3 nodes, not 2. Set to `0` to bound by `maxNodes` alone.
+
+#### maxNodes
+Maximum absolute number of nodes that can be quarantined within the time window, independent of cluster size. Defaults to `0`, which disables this bound and preserves the percentage-only behaviour.
+
+When both bounds are set, **the lower one binds**. This is the point of the setting: a percentage silently tracks fleet growth, so a limit chosen for a 100 node cluster becomes three times as permissive at 300 nodes, while an absolute bound does not move. Fleet-wide operators can therefore express "no more than X% *and* never more than N nodes" in one config that stays correct as clusters grow.
+
+At least one of `percentage` and `maxNodes` must be positive, and a negative value for either is rejected rather than ignored. The breaker refuses to start otherwise, so it cannot be silently reduced to a no-op while `enabled: true`. For the same reason, a threshold above the fleet size is clamped to the fleet size rather than being left unreachable, and the `bound` label described below reports `fleetSize` when that happens. To turn the breaker off, use `enabled: false` rather than an unreachable threshold.
 
 #### duration
 Time window for tracking cordon events. The circuit breaker counts unique node cordons within this sliding window.
+
+### Observability
+
+`fault_quarantine_breaker_threshold_nodes{bound}` reports the effective threshold in nodes, with `bound` naming what produced it: `percentage`, `maxNodes`, or `fleetSize` when a configured bound exceeded the cluster size and was clamped. `fault_quarantine_breaker_utilization` keeps its existing meaning, the recent cordon count as a fraction of GPU nodes, so existing dashboards and alerts are unaffected.
 
 ### Configuration Examples
 
@@ -131,6 +143,24 @@ circuitBreaker:
   enabled: true
   percentage: 75
   duration: "3m"
+```
+
+Percentage with an absolute ceiling, for a fleet whose clusters vary in size:
+```yaml
+circuitBreaker:
+  enabled: true
+  percentage: 10
+  maxNodes: 20
+  duration: "5m"
+```
+
+Absolute bound only, for "never cordon more than 2 nodes regardless of cluster size":
+```yaml
+circuitBreaker:
+  enabled: true
+  percentage: 0
+  maxNodes: 2
+  duration: "5m"
 ```
 
 Disabled:

--- a/fault-quarantine/pkg/breaker/breaker.go
+++ b/fault-quarantine/pkg/breaker/breaker.go
@@ -226,8 +226,8 @@ func (b *slidingWindowBreaker) tripThreshold(totalNodes int) (int, string) {
 // It returns true if:
 // 1. The breaker is already in TRIPPED state, OR
 // 2. Recent cordon events reach the configured threshold
-// The threshold is the lower of TripPercentage * GPU nodes and TripMaxNodes, whichever
-// bounds are configured. The method automatically trips the breaker if it is exceeded.
+// The threshold is the lower of the configured percentage of GPU nodes and TripMaxNodes,
+// clamped to the fleet size. The breaker trips when the recent-cordon count reaches it.
 func (b *slidingWindowBreaker) IsTripped(ctx context.Context) (bool, error) {
 	b.mu.RLock()
 

--- a/fault-quarantine/pkg/breaker/breaker.go
+++ b/fault-quarantine/pkg/breaker/breaker.go
@@ -45,6 +45,10 @@ var (
 // It prevents cordoning more than a specified percentage of nodes within a time window.
 // The breaker uses a ring buffer with 1-second granularity to track unique cordoned nodes.
 func NewSlidingWindowBreaker(ctx context.Context, cfg Config) (CircuitBreaker, error) {
+	if err := cfg.validateBounds(); err != nil {
+		return nil, fmt.Errorf("validate circuit breaker bounds: %w", err)
+	}
+
 	numBuckets := int((cfg.Window + time.Second - 1) / time.Second)
 	b := &slidingWindowBreaker{
 		cfg:          cfg,
@@ -176,11 +180,54 @@ func (b *slidingWindowBreaker) sumBuckets() int {
 	return sum
 }
 
+// Names for the configured bounds, used in logs and the binding-bound metric.
+const (
+	boundPercentage = "percentage"
+	boundMaxNodes   = "maxNodes"
+	// Reported when the configured bound exceeds the fleet size and was clamped to it.
+	boundFleetSize = "fleetSize"
+)
+
+// tripThreshold returns the recent-cordon count that trips the breaker for the given GPU
+// node count, along with the bound that produced it. When both bounds are configured the
+// lower one binds, so growing the fleet cannot silently raise the effective limit.
+func (b *slidingWindowBreaker) tripThreshold(totalNodes int) (int, string) {
+	threshold, bound := 0, ""
+
+	if b.cfg.TripPercentage > 0 {
+		// Compared as a float before converting: a percentage large enough to exceed
+		// math.MaxInt makes the int conversion implementation-defined per the Go spec, and
+		// a negative result would slip past the clamp below and trip on every evaluation.
+		scaled := math.Ceil(float64(totalNodes) * b.cfg.TripPercentage / 100)
+		if scaled > float64(totalNodes) {
+			threshold, bound = totalNodes, boundFleetSize
+		} else {
+			threshold, bound = int(scaled), boundPercentage
+		}
+	}
+
+	if b.cfg.TripMaxNodes > 0 && (threshold == 0 || b.cfg.TripMaxNodes < threshold) {
+		threshold = b.cfg.TripMaxNodes
+		bound = boundMaxNodes
+	}
+
+	// A threshold above the fleet size can never be reached, which would turn either
+	// bound into an off switch for the breaker. Clamp so a too-large value degrades to
+	// "every node" instead of "never trip"; the bound label reports when this happens.
+	if threshold > totalNodes {
+		threshold = totalNodes
+		bound = boundFleetSize
+	}
+
+	return threshold, bound
+}
+
 // IsTripped checks if the circuit breaker should prevent further node cordoning.
 // It returns true if:
 // 1. The breaker is already in TRIPPED state, OR
-// 2. Recent cordon events reach the configured threshold (TripPercentage * GPU nodes)
-// The method automatically trips the breaker if the threshold is exceeded.
+// 2. Recent cordon events reach the configured threshold
+// The threshold is the lower of TripPercentage * GPU nodes and TripMaxNodes, whichever
+// bounds are configured. The method automatically trips the breaker if it is exceeded.
 func (b *slidingWindowBreaker) IsTripped(ctx context.Context) (bool, error) {
 	b.mu.RLock()
 
@@ -210,7 +257,7 @@ func (b *slidingWindowBreaker) IsTripped(ctx context.Context) (bool, error) {
 
 	b.slideWindow(now)
 	recentCordonedNodes := b.sumBuckets()
-	threshold := int(math.Ceil(float64(totalNodes) * b.cfg.TripPercentage / 100))
+	threshold, bindingBound := b.tripThreshold(totalNodes)
 	shouldTrip := recentCordonedNodes >= threshold
 
 	b.mu.Unlock()
@@ -218,9 +265,13 @@ func (b *slidingWindowBreaker) IsTripped(ctx context.Context) (bool, error) {
 	slog.DebugContext(ctx, "Recent cordoned nodes status",
 		"recentCordonedNodes", recentCordonedNodes,
 		"totalNodes", totalNodes,
-		"tripPercentage", b.cfg.TripPercentage)
+		"tripPercentage", b.cfg.TripPercentage,
+		"tripMaxNodes", b.cfg.TripMaxNodes,
+		"threshold", threshold,
+		"bindingBound", bindingBound)
 
 	metrics.SetFaultQuarantineBreakerUtilization(float64(recentCordonedNodes) / float64(totalNodes))
+	metrics.SetFaultQuarantineBreakerThresholdNodes(float64(threshold), bindingBound)
 
 	if shouldTrip {
 		err := b.ForceState(ctx, StateTripped)

--- a/fault-quarantine/pkg/breaker/breaker.go
+++ b/fault-quarantine/pkg/breaker/breaker.go
@@ -180,19 +180,25 @@ func (b *slidingWindowBreaker) sumBuckets() int {
 	return sum
 }
 
-// Names for the configured bounds, used in logs and the binding-bound metric.
+// Bound names the configured limit that produced the effective threshold. It appears in
+// logs and as the label on fault_quarantine_breaker_threshold_nodes.
+type Bound string
+
 const (
-	boundPercentage = "percentage"
-	boundMaxNodes   = "maxNodes"
-	// Reported when the configured bound exceeds the fleet size and was clamped to it.
-	boundFleetSize = "fleetSize"
+	// boundNone is the zero value, reported when no bound is configured.
+	boundNone       Bound = ""
+	boundPercentage Bound = "percentage"
+	boundMaxNodes   Bound = "maxNodes"
+	// boundFleetSize is reported when a configured bound exceeded the fleet size and was
+	// clamped to it.
+	boundFleetSize Bound = "fleetSize"
 )
 
 // tripThreshold returns the recent-cordon count that trips the breaker for the given GPU
 // node count, along with the bound that produced it. When both bounds are configured the
 // lower one binds, so growing the fleet cannot silently raise the effective limit.
-func (b *slidingWindowBreaker) tripThreshold(totalNodes int) (int, string) {
-	threshold, bound := 0, ""
+func (b *slidingWindowBreaker) tripThreshold(totalNodes int) (int, Bound) {
+	threshold, bound := 0, boundNone
 
 	if b.cfg.TripPercentage > 0 {
 		// Compared as a float before converting: a percentage large enough to exceed
@@ -271,7 +277,7 @@ func (b *slidingWindowBreaker) IsTripped(ctx context.Context) (bool, error) {
 		"bindingBound", bindingBound)
 
 	metrics.SetFaultQuarantineBreakerUtilization(float64(recentCordonedNodes) / float64(totalNodes))
-	metrics.SetFaultQuarantineBreakerThresholdNodes(float64(threshold), bindingBound)
+	metrics.SetFaultQuarantineBreakerThresholdNodes(float64(threshold), string(bindingBound))
 
 	if shouldTrip {
 		err := b.ForceState(ctx, StateTripped)

--- a/fault-quarantine/pkg/breaker/breaker_test.go
+++ b/fault-quarantine/pkg/breaker/breaker_test.go
@@ -19,6 +19,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"log"
+	"math"
 	"math/big"
 	"os"
 	"testing"
@@ -486,4 +487,217 @@ func getHistogramVecCount(t *testing.T, histogramVec *prometheus.HistogramVec, l
 	}
 
 	return 0
+}
+
+func TestTripThreshold_ConfiguredBounds_ReturnsEffectiveThreshold(t *testing.T) {
+	tests := []struct {
+		name          string
+		percentage    float64
+		maxNodes      int
+		totalNodes    int
+		wantThreshold int
+		wantBound     string
+	}{
+		{
+			name:          "percentage only, unchanged from previous behaviour",
+			percentage:    50,
+			totalNodes:    10,
+			wantThreshold: 5,
+			wantBound:     boundPercentage,
+		},
+		{
+			name:          "percentage rounds up, so 1 percent of 288 is 3 not 2",
+			percentage:    1,
+			totalNodes:    288,
+			wantThreshold: 3,
+			wantBound:     boundPercentage,
+		},
+		{
+			name:          "maxNodes only, independent of fleet size",
+			maxNodes:      5,
+			totalNodes:    288,
+			wantThreshold: 5,
+			wantBound:     boundMaxNodes,
+		},
+		{
+			name:          "both set, maxNodes is lower so it binds",
+			percentage:    50,
+			maxNodes:      10,
+			totalNodes:    288,
+			wantThreshold: 10,
+			wantBound:     boundMaxNodes,
+		},
+		{
+			name:          "both set, percentage is lower so it binds",
+			percentage:    1,
+			maxNodes:      100,
+			totalNodes:    288,
+			wantThreshold: 3,
+			wantBound:     boundPercentage,
+		},
+		{
+			name:          "both set and equal, percentage binds",
+			percentage:    50,
+			maxNodes:      5,
+			totalNodes:    10,
+			wantThreshold: 5,
+			wantBound:     boundPercentage,
+		},
+		{
+			// The motivating case: a percentage silently tracks fleet growth, an absolute
+			// bound does not.
+			name:          "fleet growth cannot raise the effective limit past maxNodes",
+			percentage:    5,
+			maxNodes:      10,
+			totalNodes:    1000,
+			wantThreshold: 10,
+			wantBound:     boundMaxNodes,
+		},
+		{
+			// The initializer rejects this config; asserted here so the reason the guard
+			// exists stays visible.
+			name:          "neither bound set yields no threshold",
+			totalNodes:    288,
+			wantThreshold: 0,
+			wantBound:     "",
+		},
+		{
+			// Without the clamp this would be unreachable and disable the breaker.
+			name:          "maxNodes above the fleet size is clamped to it",
+			maxNodes:      1000,
+			totalNodes:    288,
+			wantThreshold: 288,
+			wantBound:     boundFleetSize,
+		},
+		{
+			name:          "percentage above 100 is clamped to the fleet size",
+			percentage:    150,
+			totalNodes:    288,
+			wantThreshold: 288,
+			wantBound:     boundFleetSize,
+		},
+		{
+			// A percentage this large makes the float-to-int conversion
+			// implementation-defined, so the comparison happens in float space.
+			name:          "percentage large enough to overflow int still clamps",
+			percentage:    3.3e18,
+			totalNodes:    288,
+			wantThreshold: 288,
+			wantBound:     boundFleetSize,
+		},
+		{
+			name:          "maxNodes equal to the fleet size still binds as maxNodes",
+			maxNodes:      288,
+			totalNodes:    288,
+			wantThreshold: 288,
+			wantBound:     boundMaxNodes,
+		},
+		{
+			name:          "percentage of 100 is exactly the fleet size and is not clamped",
+			percentage:    100,
+			totalNodes:    288,
+			wantThreshold: 288,
+			wantBound:     boundPercentage,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &slidingWindowBreaker{
+				cfg: Config{TripPercentage: tc.percentage, TripMaxNodes: tc.maxNodes},
+			}
+
+			threshold, bound := b.tripThreshold(tc.totalNodes)
+
+			assert.Equal(t, tc.wantThreshold, threshold, "threshold")
+			assert.Equal(t, tc.wantBound, bound, "binding bound")
+		})
+	}
+}
+
+func TestValidateBounds_RejectsConfigsThatCannotLimit(t *testing.T) {
+	tests := []struct {
+		name       string
+		percentage float64
+		maxNodes   int
+		wantErr    string
+	}{
+		{
+			name:       "percentage only is valid",
+			percentage: 50,
+		},
+		{
+			name:     "maxNodes only is valid",
+			maxNodes: 5,
+		},
+		{
+			name:       "both set is valid",
+			percentage: 10,
+			maxNodes:   20,
+		},
+		{
+			// Would leave threshold 0, and IsTripped compares with >=, so the breaker
+			// would trip immediately with no cordons.
+			name:    "neither bound set is rejected",
+			wantErr: "requires percentage or maxNodes",
+		},
+		{
+			// NaN passes every ordinary comparison, then becomes int(NaN) == 0, which trips
+			// the breaker at startup with no cordons.
+			name:       "NaN percentage is rejected",
+			percentage: math.NaN(),
+			wantErr:    "must be a finite number",
+		},
+		{
+			name:       "infinite percentage is rejected",
+			percentage: math.Inf(1),
+			wantErr:    "must be a finite number",
+		},
+		{
+			name:       "negative percentage is rejected rather than ignored",
+			percentage: -10,
+			wantErr:    "percentage must not be negative",
+		},
+		{
+			name:     "negative maxNodes is rejected rather than ignored",
+			maxNodes: -10,
+			wantErr:  "maxNodes must not be negative",
+		},
+		{
+			// A negative alongside a usable bound is still a config error, not a typo to
+			// silently drop.
+			name:       "negative maxNodes is rejected even with a valid percentage",
+			percentage: 50,
+			maxNodes:   -1,
+			wantErr:    "maxNodes must not be negative",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Config{TripPercentage: tc.percentage, TripMaxNodes: tc.maxNodes}.validateBounds()
+
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestNewSlidingWindowBreaker_NoBoundsConfigured_ReturnsError(t *testing.T) {
+	b, err := NewSlidingWindowBreaker(context.Background(), Config{
+		Window:             time.Second,
+		K8sClient:          setupTestClient(t),
+		ConfigMapName:      "test-breaker-unbounded",
+		ConfigMapNamespace: "default",
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, b)
+	assert.Contains(t, err.Error(), "requires percentage or maxNodes")
 }

--- a/fault-quarantine/pkg/breaker/breaker_test.go
+++ b/fault-quarantine/pkg/breaker/breaker_test.go
@@ -496,7 +496,7 @@ func TestTripThreshold_ConfiguredBounds_ReturnsEffectiveThreshold(t *testing.T) 
 		maxNodes      int
 		totalNodes    int
 		wantThreshold int
-		wantBound     string
+		wantBound     Bound
 	}{
 		{
 			name:          "percentage only, unchanged from previous behaviour",
@@ -559,7 +559,7 @@ func TestTripThreshold_ConfiguredBounds_ReturnsEffectiveThreshold(t *testing.T) 
 			name:          "neither bound set yields no threshold",
 			totalNodes:    288,
 			wantThreshold: 0,
-			wantBound:     "",
+			wantBound:     boundNone,
 		},
 		{
 			// Without the clamp this would be unreachable and disable the breaker.

--- a/fault-quarantine/pkg/breaker/types.go
+++ b/fault-quarantine/pkg/breaker/types.go
@@ -17,6 +17,9 @@ package breaker
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"math"
 	"sync"
 	"time"
 )
@@ -79,8 +82,14 @@ type Config struct {
 
 	// TripPercentage is the percentage of GPU nodes that, if reached by recent
 	// cordon events within Window, will trip the breaker (e.g., 50 for 50%).
-	// Default: 50 (50% of GPU nodes).
+	// Default: 50 (50% of GPU nodes). Zero disables the percentage bound.
 	TripPercentage float64
+
+	// TripMaxNodes is an absolute node count that, if reached by recent cordon
+	// events within Window, will trip the breaker regardless of fleet size. Zero
+	// disables it. When both bounds are set the lower one binds, so a fleet that
+	// grows cannot silently raise the effective limit.
+	TripMaxNodes int
 
 	// K8sClient provides operations for node counts and ConfigMap state persistence
 	K8sClient K8sClientOperations
@@ -102,6 +111,36 @@ type Config struct {
 	// MaxRetryDelay caps the maximum delay between retry attempts
 	// Default: 5 seconds (prevents excessive delays)
 	MaxRetryDelay time.Duration
+}
+
+// validateBounds rejects a configuration that cannot act as a limit. It lives here rather
+// than in the initializer so every caller is covered, including tests that build a Config
+// directly.
+//
+// Neither bound set leaves the threshold at 0, and IsTripped compares with >=, so the
+// breaker would trip on its first evaluation with no cordons at all. A negative value is
+// ignored by tripThreshold, so it silently does nothing rather than what it looks like.
+func (c Config) validateBounds() error {
+	// NaN passes every comparison below and survives into tripThreshold as int(NaN), which
+	// is 0, leaving the breaker tripped from startup with no cordons at all. Infinities are
+	// caught by the fleet-size clamp, but rejecting them here is explicit rather than lucky.
+	if math.IsNaN(c.TripPercentage) || math.IsInf(c.TripPercentage, 0) {
+		return fmt.Errorf("circuit breaker percentage must be a finite number, got %v", c.TripPercentage)
+	}
+
+	if c.TripPercentage < 0 {
+		return fmt.Errorf("circuit breaker percentage must not be negative, got %v", c.TripPercentage)
+	}
+
+	if c.TripMaxNodes < 0 {
+		return fmt.Errorf("circuit breaker maxNodes must not be negative, got %d", c.TripMaxNodes)
+	}
+
+	if c.TripPercentage == 0 && c.TripMaxNodes == 0 {
+		return errors.New("circuit breaker requires percentage or maxNodes to be set to a positive value")
+	}
+
+	return nil
 }
 
 // slidingWindowBreaker implements CircuitBreaker using a ring buffer approach.

--- a/fault-quarantine/pkg/config/config.go
+++ b/fault-quarantine/pkg/config/config.go
@@ -48,6 +48,7 @@ type Cordon struct {
 
 type CircuitBreaker struct {
 	Percentage int    `toml:"percentage"`
+	MaxNodes   int    `toml:"maxNodes"`
 	Duration   string `toml:"duration"`
 }
 

--- a/fault-quarantine/pkg/initializer/init.go
+++ b/fault-quarantine/pkg/initializer/init.go
@@ -184,15 +184,20 @@ func initializeCircuitBreaker(
 		return nil, fmt.Errorf("invalid circuit breaker duration %q: %w", cbConfig.Duration, err)
 	}
 
+	// Bounds are validated by NewSlidingWindowBreaker below, so a caller that builds the
+	// config directly cannot bypass the check.
+
 	slog.InfoContext(ctx, "Initializing circuit breaker",
 		"configMap", circuitBreakerName,
 		"namespace", namespace,
 		"percentage", cbConfig.Percentage,
+		"maxNodes", cbConfig.MaxNodes,
 		"duration", cbConfig.Duration)
 
 	cb, err := breaker.NewSlidingWindowBreaker(ctx, breaker.Config{
 		Window:             duration,
 		TripPercentage:     float64(cbConfig.Percentage),
+		TripMaxNodes:       cbConfig.MaxNodes,
 		K8sClient:          k8sClient,
 		ConfigMapName:      circuitBreakerName,
 		ConfigMapNamespace: namespace,

--- a/fault-quarantine/pkg/metrics/metrics.go
+++ b/fault-quarantine/pkg/metrics/metrics.go
@@ -199,6 +199,13 @@ var (
 			Help: "Utilization of the fault quarantine breaker.",
 		},
 	)
+	FaultQuarantineBreakerThresholdNodes = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "fault_quarantine_breaker_threshold_nodes",
+			Help: "Effective trip threshold of the fault quarantine breaker in nodes, by binding bound.",
+		},
+		[]string{"bound"},
+	)
 	FaultQuarantineGetTotalNodesDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "fault_quarantine_get_total_nodes_duration_seconds",
@@ -225,6 +232,13 @@ var (
 
 func SetFaultQuarantineBreakerUtilization(utilization float64) {
 	FaultQuarantineBreakerUtilization.Set(utilization)
+}
+
+// SetFaultQuarantineBreakerThresholdNodes reports the effective threshold and which bound
+// produced it. Reset first so a change of binding bound leaves no stale series behind.
+func SetFaultQuarantineBreakerThresholdNodes(threshold float64, bound string) {
+	FaultQuarantineBreakerThresholdNodes.Reset()
+	FaultQuarantineBreakerThresholdNodes.WithLabelValues(bound).Set(threshold)
 }
 
 func SetFaultQuarantineBreakerState(state string) {


### PR DESCRIPTION
## Summary

Fixes #1686. The circuit breaker threshold could only be expressed as a percentage of GPU
nodes. Adds an optional absolute `maxNodes` bound alongside it.

## Why

On a 288 node cluster, `Percentage` being an `int` means 1% is the floor, roughly 3 nodes, and
each further step is another 3, so "never quarantine more than 5 nodes in a window" is not
expressible. A percentage is also a moving target: 5% is 14 nodes today and a different number
after the next expansion, silently. For a control whose job is bounding blast radius, an
operator generally wants to reason in absolute terms.

## Semantics

- Both bounds optional; `maxNodes: 0` disables the new one, so existing configs are unchanged.
- **When both are set the lower one binds**, so `percentage: 5, maxNodes: 10` reads as "5% but
  never more than 10 nodes", and growing the fleet cannot silently raise the effective limit.
- The initializer now **rejects a config with neither bound set**. Previously that computed a
  threshold of 0 and tripped on the first cordon, which is a silent halt rather than a safety
  control.

## Observability

You asked on the issue whether the utilisation metric should gain a label or report the binding
constraint. I went with neither, to avoid changing an existing metric's meaning:

- `fault_quarantine_breaker_utilization` keeps its current definition, recent cordons over GPU
  nodes, so existing dashboards and alerts are untouched.
- A new gauge `fault_quarantine_breaker_threshold_nodes{bound="percentage|maxNodes"}` reports
  the effective threshold in nodes, labelled by the bound that produced it.

That gives strictly more information than a label on the old metric: utilisation against the
actual limit is now derivable as `fault_quarantine_breaker_utilization * <gpu nodes> /
fault_quarantine_breaker_threshold_nodes`, and the label shows which constraint is active. The
setter resets before setting so a change of binding bound leaves no stale series. Happy to
change this if you would rather it were a label on the existing metric.

## Documentation

Per your note about multi-cluster operators, `values.yaml` states that an absolute bound is per
cluster by nature, so an operator running many clusters of differing size will need to tune it
per cluster or leave it unset and rely on percentage alone.

## Verification

- New table-driven `TestTripThreshold` covers 8 cases: percentage-only (unchanged behaviour),
  the ceiling rounding, maxNodes-only, both-set in each direction, both-equal, the
  fleet-growth case that motivated the issue, and neither-set returning no threshold so the
  reason for the initializer guard stays visible.
- Full `fault-quarantine` module test suite passes, including the existing breaker,
  reconciler, evaluator and informer suites.
- `golangci-lint` v2.13.1 with the repo config: **0 issues**.
- Helm renders correctly through the umbrella chart, both at the default and with an override:

  ```
  [circuitBreaker]
  percentage = 50
  maxNodes = 10
  duration = "5m"
  ```

## Unrelated tooling note

`make install-golangci-lint` fails on macOS arm64 with a checksum error. It is not a corrupt
download. The Makefile pipes `install.sh` from golangci-lint `master`, and that script's
checksum lookup matches `golangci-lint-<v>-darwin-arm64.tar.gz.sbom.json` as well as
`...tar.gz`, then compares the SBOM's hash against the tarball. Verifying the tarball against
the release's own `checksums.txt` with an exact filename match passes. Mentioning it in case it
bites others; happy to raise it separately if useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional absolute node limit for the fault-quarantine circuit breaker.
  * When percentage and node limits are configured, the lower applicable threshold is used, with percentage values rounded up.
  * Added metrics reporting the effective threshold and the limit that determined it.

* **Bug Fixes**
  * Invalid threshold configurations are now rejected, and thresholds are capped at the fleet size.

* **Documentation**
  * Updated configuration and metrics documentation with new options, behavior, validation rules, and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->