### PR TITLE
feat(gpu-health-monitor): debounce health check incidents across consecutive polls

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/configmap.yaml
@@ -44,6 +44,11 @@ data:
     [dcgmhealthcheck]
     SuppressedErrorCodes = {{ .Values.dcgmHealthCheck.suppressedErrorCodes | join "," }}
     ConnectivityFailureEscalationThreshold = {{ .Values.dcgmHealthCheck.connectivityFailureEscalationThreshold }}
+{{- $debounce := list }}
+{{- range $code, $polls := .Values.dcgmHealthCheck.minConsecutivePolls }}
+{{- $debounce = append $debounce (printf "%s=%d" $code (int $polls)) }}
+{{- end }}
+    MinConsecutivePolls = {{ join "," $debounce }}
 
     [eventprocessors.kubernetes]
     ConflictRetryCount = 10

--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/values.yaml
@@ -99,6 +99,13 @@ dcgmHealthCheck:
   # wedged driver; a shared service or network outage is not fixed by rebooting
   # this node. 0 disables escalation and keeps failures at CONTACT_SUPPORT.
   connectivityFailureEscalationThreshold: 0
+  # Consecutive polls an incident must persist, per error code and GPU, before it is
+  # published. Codes left out publish on first observation. Motivating case: SXM
+  # DCGM_FR_NVLINK_DOWN is briefly asserted after every boot while links train.
+  # Example:
+  #   minConsecutivePolls:
+  #     DCGM_FR_NVLINK_DOWN: 2
+  minConsecutivePolls: {}
 
 # Use host networking for GPU health monitor pods. external-hostengine mode
 # enables host networking automatically because the configured endpoint is

--- a/distros/kubernetes/nvsentinel/values-full.yaml
+++ b/distros/kubernetes/nvsentinel/values-full.yaml
@@ -994,6 +994,14 @@ gpu-health-monitor:
     # 0 disables escalation.
     connectivityFailureEscalationThreshold: 0
 
+    # Consecutive polls an incident must persist, per error code and GPU, before it
+    # is published. Codes left out publish on first observation. Motivating case:
+    # SXM DCGM_FR_NVLINK_DOWN is briefly asserted after every boot while links train.
+    # Example:
+    #   minConsecutivePolls:
+    #     DCGM_FR_NVLINK_DOWN: 2
+    minConsecutivePolls: {}
+
   # Additional volume mounts for GPU health monitor
   # Use when monitor needs access to host files
   # Example:

--- a/docs/configuration/gpu-health-monitor.md
+++ b/docs/configuration/gpu-health-monitor.md
@@ -247,6 +247,25 @@ Defaults to `0`, which disables escalation and keeps every connectivity failure 
 
 > **Note**: Both settings recommend `RESTART_BM`, which fault-remediation maps to a `RebootNode` CR. A reboot is the practical recovery when an on-node DCGM probe will not return — whether the underlying cause is a wedged driver or DCGM userspace holding driver locks. Nodes are drained before the reboot by node-drainer. Note that `probeStoreOnly` gates this for `GpuDcgmUnresponsive`, while `connectivityFailureEscalationThreshold` is opt-in by being `0` by default.
 
+### minConsecutivePolls
+
+Number of consecutive polls a health check incident must persist, per error code and GPU, before it is published. Codes absent from the map publish on their first observation, which is the default behaviour.
+
+```yaml
+gpu-health-monitor:
+  dcgmHealthCheck:
+    minConsecutivePolls:
+      DCGM_FR_NVLINK_DOWN: 2
+```
+
+Use this for a code whose single-poll occurrences are transients rather than faults. `DCGM_FR_NVLINK_DOWN` is the motivating case: on SXM systems the NVLink links are briefly down after every node boot while they train, so a routine maintenance reboot otherwise produces a FATAL event carrying `RESTART_VM`. `_is_nvlink_down_false_positive` cannot cover this, because it is metadata-based and deliberately fails closed on SXM where an untrained link is indistinguishable from a dead one. A time-based threshold separates them: an untrained link trains, a dead one does not.
+
+The streak is keyed on `(error code, GPU)` and resets whenever the code is absent for that GPU in a poll, so a code that appears on alternate polls for a GPU never accumulates and is never published. Note the key is the code and GPU, not the individual link: a GPU reporting one down link on one poll and a different one on the next keeps its streak, because that GPU has had a link down continuously. A streak also survives a failed poll, since a DCGM timeout observes nothing and must not clear it.
+
+**Tradeoff**: a threshold of `N` delays a genuinely sustained fault by up to `N-1` poll intervals. At the default `pollIntervalSeconds: 15`, a threshold of `2` costs at most 15 seconds of detection latency. Prefer the smallest threshold that suppresses the transient; permanently suppressing the code via `suppressedErrorCodes` would also mask genuine failures, which this avoids.
+
+Withheld incidents are counted by `dcgm_health_check_debounced_incidents{error_code, gpu_id}`, so suppression stays observable per GPU. It increments once per poll per `(error code, GPU)`, not once per incident record.
+
 ## Additional Volumes
 
 Extension point for mounting additional host paths required by DCGM in specific environments.

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/cli.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/cli.py
@@ -27,6 +27,35 @@ from gpu_health_monitor.protos import health_event_pb2 as platformconnector_pb2
 from gpu_health_monitor.logger import set_default_structured_logger_with_level
 
 
+def _parse_min_consecutive_polls(raw: str) -> dict[str, int]:
+    """Parse ``CODE=N`` pairs from the INI value into a per-error-code threshold map.
+
+    INI has no nested sections, so the chart renders the values map as a comma
+    separated list. A malformed entry is logged and skipped rather than taken as a
+    reason to refuse to start, since the fail-open outcome is today's behaviour for
+    that one code.
+    """
+    thresholds: dict[str, int] = {}
+
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+
+        code, separator, polls = entry.partition("=")
+        code, polls = code.strip(), polls.strip()
+
+        # isascii guards the isdigit/int mismatch: "²".isdigit() is True but int("²")
+        # raises, which would crash startup instead of skipping the entry.
+        if not separator or not code or not (polls.isascii() and polls.isdigit()):
+            log.warning(f"Ignoring malformed MinConsecutivePolls entry {entry!r}; expected CODE=N")
+            continue
+
+        thresholds[code] = int(polls)
+
+    return thresholds
+
+
 def _init_event_processor(
     event_processor_name: str,
     config: configparser.ConfigParser,
@@ -231,6 +260,7 @@ def cli(
 
     suppressed_error_codes = frozenset()
     connectivity_failure_escalation_threshold = 0
+    health_check_min_consecutive_polls: dict[str, int] = {}
     if config.has_section("dcgmhealthcheck"):
         health_check_config = config["dcgmhealthcheck"]
         suppressed_error_codes_raw = health_check_config.get("SuppressedErrorCodes", fallback="")
@@ -248,6 +278,12 @@ def cli(
                 "DCGM connectivity failures escalate to RESTART_BM after %d consecutive cycles",
                 connectivity_failure_escalation_threshold,
             )
+
+        health_check_min_consecutive_polls = _parse_min_consecutive_polls(
+            health_check_config.get("MinConsecutivePolls", fallback="")
+        )
+        if health_check_min_consecutive_polls:
+            log.info(f"DCGM incident debounce thresholds: {health_check_min_consecutive_polls}")
 
     enabled_event_processor_names = cli_config["EnabledEventProcessors"].split(",")
     enabled_event_processors = []
@@ -300,6 +336,7 @@ def cli(
         probe_deadline_seconds=probe_deadline_seconds,
         power_brake_enabled=power_brake_enabled,
         power_brake_min_consecutive_polls=power_brake_min_consecutive_polls,
+        health_check_min_consecutive_polls=health_check_min_consecutive_polls,
     )
     dcgm_watcher.start([], exit)
 

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/dcgm.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/dcgm.py
@@ -208,6 +208,7 @@ class DCGMWatcher:
         probe_deadline_seconds: float = 0.0,
         power_brake_enabled: bool = False,
         power_brake_min_consecutive_polls: int = 1,
+        health_check_min_consecutive_polls: dict[str, int] | None = None,
     ) -> None:
         self._addr = addr
         self._poll_interval_seconds = poll_interval_seconds
@@ -240,6 +241,24 @@ class DCGMWatcher:
                 DCGM_FIELDS_MONITORING["gpupowerbrakemonitoringenabled"].field_id,
                 HW_POWER_BRAKE_REASON_BIT,
                 self._power_brake_min_consecutive_polls,
+            )
+        # An incident published from a single poll can be a transient: SXM NVLink
+        # links are briefly down after every boot while they train. Codes listed
+        # here must persist for N consecutive polls per GPU; anything unlisted
+        # keeps today's behaviour of publishing on the first observation.
+        # A threshold of 1 or less is today's behaviour, so those are dropped here
+        # and no streak is ever tracked for them.
+        self._health_check_min_consecutive_polls = {
+            code: polls for code, polls in (health_check_min_consecutive_polls or {}).items() if polls > 1
+        }
+        self._incident_streaks: dict[tuple[str, int], int] = {}
+        if self._health_check_min_consecutive_polls:
+            log.info(
+                "DCGM health check incident debounce: %s",
+                ", ".join(
+                    f"{code}={polls} consecutive poll(s)"
+                    for code, polls in sorted(self._health_check_min_consecutive_polls.items())
+                ),
             )
         self._metadata_reader = metadata_reader
         self._suppress_unbridged_pcie_nvlink_down = suppress_unbridged_pcie_nvlink_down
@@ -400,6 +419,55 @@ class DCGMWatcher:
 
         return True
 
+    def _is_incident_debounced(self, error_code: str, gpu_id: int) -> bool:
+        """Return True when this incident has not yet persisted for the configured
+        number of consecutive polls, so it must be withheld this cycle.
+
+        The streak is keyed on ``(error_code, gpu_id)`` so a debounced code on one
+        GPU never delays a different code, or the same code on another GPU.
+        """
+        threshold = self._health_check_min_consecutive_polls.get(error_code)
+        if threshold is None:
+            return False
+
+        key = (error_code, gpu_id)
+        streak = self._incident_streaks.get(key, 0) + 1
+        self._incident_streaks[key] = streak
+
+        if streak >= threshold:
+            log.debug(
+                "Incident %s on GPU %s has persisted %d consecutive poll(s); publishing",
+                error_code,
+                gpu_id,
+                streak,
+            )
+            return False
+
+        log.debug(
+            "Incident %s on GPU %s seen %d/%d consecutive polls; withholding",
+            error_code,
+            gpu_id,
+            streak,
+            threshold,
+        )
+        metrics.dcgm_health_check_debounced_incidents.labels(error_code, str(gpu_id)).inc()
+
+        return True
+
+    def _reset_absent_incident_streaks(self, seen_this_poll: set[tuple[str, int]]) -> None:
+        """Drop the streak for every tracked incident absent from this poll.
+
+        A code that appears for a GPU on alternate polls therefore restarts from zero
+        each time and never reaches its threshold. The key is the code and GPU, not the
+        individual link, so a GPU reporting one link on one poll and another link on the
+        next keeps its streak: that GPU has had a link down continuously.
+
+        Only called after a successful health check, since a failed poll observed
+        nothing and must not clear a streak.
+        """
+        for key in [key for key in self._incident_streaks if key not in seen_this_poll]:
+            del self._incident_streaks[key]
+
     def _fire_callback_funcs(self, func_name: str, args: list[any]):
         def done_callback(class_name: str, func_name: str, future):
             e = future.exception()
@@ -510,6 +578,12 @@ class DCGMWatcher:
             health_status = self._get_health_status_dict()
             # Temporary dict to accumulate multiple failures per GPU
             gpu_failures_accumulator = {}
+            # One debounce decision per (error code, GPU) per poll. DCGM reports an
+            # incident per down link, so a GPU with several down links produces several
+            # records for the same code; advancing the streak once per record would
+            # reach the threshold inside a single poll. Keys also record presence,
+            # which is what keeps a streak alive.
+            debounce_decisions: dict[tuple[str, int], bool] = {}
 
             log.debug(
                 f"Health check returned: overallHealth={health_details.overallHealth}, "
@@ -550,6 +624,17 @@ class DCGMWatcher:
                 if self._is_nvlink_down_false_positive(watch_name, gpu_id, error_code):
                     continue
 
+                # Evaluated after suppression: a suppressed incident is not an
+                # observation, so it must not build a streak.
+                debounce_key = (error_code, gpu_id)
+                if debounce_key not in debounce_decisions:
+                    debounce_decisions[debounce_key] = self._is_incident_debounced(error_code, gpu_id)
+
+                # A debounced incident must neither degrade the watch status nor
+                # land in the accumulator, exactly like a suppressed one.
+                if debounce_decisions[debounce_key]:
+                    continue
+
                 health_status[watch_name].status = types.HealthStatus(int(incident.health))
 
                 # Create a key for accumulating failures per GPU per watch
@@ -568,6 +653,8 @@ class DCGMWatcher:
                 health_status[watch_name].entity_failures[gpu_id] = types.ErrorDetails(
                     message=combined_message, code=failure_data["code"]
                 )
+
+            self._reset_absent_incident_streaks(set(debounce_decisions))
 
             log.debug(f"filled in health details is {health_status}")
             return health_status, True

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/metrics.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/metrics.py
@@ -44,6 +44,12 @@ dcgm_health_check_suppressed_incidents = Counter(
     "Number of DCGM health check incidents suppressed due to a non-actionable error code",
     labelnames=["error_code"],
 )
+dcgm_health_check_debounced_incidents = Counter(
+    "dcgm_health_check_debounced_incidents",
+    "Number of DCGM health check polls where an error code was withheld for a GPU because it "
+    "had not yet persisted for its configured minimum consecutive polls",
+    labelnames=["error_code", "gpu_id"],
+)
 dcgm_probe_hangs = Counter(
     "dcgm_probe_hangs",
     "Number of DCGM probes that exceeded the watchdog deadline without returning",

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_cli.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_cli.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from gpu_health_monitor.cli import _parse_min_consecutive_polls
+
+
+class TestParseMinConsecutivePolls:
+    @pytest.mark.parametrize("raw", ["", "   ", ",", " , "])
+    def test_empty_value_yields_no_thresholds(self, raw: str) -> None:
+        assert _parse_min_consecutive_polls(raw) == {}
+
+    def test_single_pair(self) -> None:
+        assert _parse_min_consecutive_polls("DCGM_FR_NVLINK_DOWN=2") == {"DCGM_FR_NVLINK_DOWN": 2}
+
+    def test_multiple_pairs_with_surrounding_whitespace(self) -> None:
+        raw = " DCGM_FR_NVLINK_DOWN = 2 , DCGM_FR_PCI_REPLAY_RATE=3 "
+
+        assert _parse_min_consecutive_polls(raw) == {
+            "DCGM_FR_NVLINK_DOWN": 2,
+            "DCGM_FR_PCI_REPLAY_RATE": 3,
+        }
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "DCGM_FR_NVLINK_DOWN",  # no separator
+            "DCGM_FR_NVLINK_DOWN=",  # no value
+            "=2",  # no code
+            "DCGM_FR_NVLINK_DOWN=two",  # not a number
+            "DCGM_FR_NVLINK_DOWN=2.5",  # not an integer
+            "DCGM_FR_NVLINK_DOWN=-2",  # negative
+        ],
+    )
+    def test_malformed_entry_is_skipped_rather_than_fatal(self, raw: str) -> None:
+        assert _parse_min_consecutive_polls(raw) == {}
+
+    def test_malformed_entry_does_not_discard_the_valid_ones(self) -> None:
+        raw = "DCGM_FR_NVLINK_DOWN=2,garbage,DCGM_FR_PCI_REPLAY_RATE=3"
+
+        assert _parse_min_consecutive_polls(raw) == {
+            "DCGM_FR_NVLINK_DOWN": 2,
+            "DCGM_FR_PCI_REPLAY_RATE": 3,
+        }
+
+    def test_last_value_wins_on_a_duplicated_code(self) -> None:
+        assert _parse_min_consecutive_polls("DCGM_FR_NVLINK_DOWN=2,DCGM_FR_NVLINK_DOWN=5") == {"DCGM_FR_NVLINK_DOWN": 5}

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_dcgm_watcher/test_dcgm.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_dcgm_watcher/test_dcgm.py
@@ -690,6 +690,172 @@ class TestDCGMHealthChecks:
         incident.entityInfo.entityId = entity_id
         return incident
 
+    def _make_debounce_watcher(self, thresholds: dict[str, int]) -> dcgm.DCGMWatcher:
+        return dcgm.DCGMWatcher(
+            addr="localhost:5555",
+            poll_interval_seconds=10,
+            callbacks=[],
+            dcgm_k8s_service_enabled=False,
+            health_check_min_consecutive_polls=thresholds,
+        )
+
+    @staticmethod
+    def _health_response(incidents: list) -> dcgm_structs.c_dcgmHealthResponse_v4:
+        """Build a health check response carrying the given incidents."""
+        response = dcgm_structs.c_dcgmHealthResponse_v4()
+        response.version = dcgm_structs.dcgmHealthResponse_version4
+        response.overallHealth = (
+            dcgm_structs.DCGM_HEALTH_RESULT_FAIL if incidents else dcgm_structs.DCGM_DIAG_RESULT_PASS
+        )
+        response.incidentCount = len(incidents)
+        # Allocated per response rather than on the class, so one test cannot leak
+        # incidents into the next.
+        response.incidents = (dcgm_structs.c_dcgmIncidentInfo_t * dcgm_structs.DCGM_HEALTH_WATCH_MAX_INCIDENTS)()
+        for index, incident in enumerate(incidents):
+            response.incidents[index] = incident
+        return response
+
+    def _poll(self, watcher: dcgm.DCGMWatcher, dcgm_group_mock: MagicMock, incidents: list) -> dict:
+        dcgm_group_mock.health.Check.return_value = self._health_response(incidents)
+        health_status, _ = watcher._perform_health_check(dcgm_group_mock)
+        return health_status
+
+    def test_incident_debounce_publishes_first_observation_by_default(self) -> None:
+        """With no thresholds configured, an incident is published on the poll it appears."""
+        watcher = self._make_debounce_watcher({})
+
+        health_status = self._poll(watcher, MagicMock(), [self._get_nvlink_incident(0, 1, 16)])
+
+        assert health_status["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[1].code == "DCGM_FR_NVLINK_DOWN"
+        # Unconfigured codes are never tracked, so the dict stays empty.
+        assert watcher._incident_streaks == {}
+
+    def test_incident_debounce_withholds_until_threshold_is_reached(self) -> None:
+        """A threshold of 2 withholds the first observation and publishes the second."""
+        watcher = self._make_debounce_watcher({"DCGM_FR_NVLINK_DOWN": 2})
+        dcgm_group_mock = MagicMock()
+        incidents = [self._get_nvlink_incident(0, 1, 16)]
+
+        first = self._poll(watcher, dcgm_group_mock, incidents)
+        assert first["DCGM_HEALTH_WATCH_NVLINK"] == dcgm.types.HealthDetails(
+            status=dcgm.types.HealthStatus.PASS, entity_failures={}
+        )
+
+        second = self._poll(watcher, dcgm_group_mock, incidents)
+        assert second["DCGM_HEALTH_WATCH_NVLINK"].status == dcgm.types.HealthStatus.FAIL
+        assert second["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[1].code == "DCGM_FR_NVLINK_DOWN"
+
+    def test_incident_debounce_keeps_publishing_past_the_threshold(self) -> None:
+        """A sustained fault keeps publishing once the threshold is met."""
+        watcher = self._make_debounce_watcher({"DCGM_FR_NVLINK_DOWN": 2})
+        dcgm_group_mock = MagicMock()
+        incidents = [self._get_nvlink_incident(0, 1, 16)]
+
+        self._poll(watcher, dcgm_group_mock, incidents)
+
+        for _ in range(3):
+            health_status = self._poll(watcher, dcgm_group_mock, incidents)
+            assert health_status["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[1].code == "DCGM_FR_NVLINK_DOWN"
+
+    def test_incident_debounce_counts_one_streak_per_gpu_per_poll(self) -> None:
+        """DCGM reports one incident per down link, so a GPU with several down links
+        yields several records for the same code in a single poll. The streak must
+        advance once per poll, or the threshold is reached within the first poll and
+        the debounce is defeated."""
+        watcher = self._make_debounce_watcher({"DCGM_FR_NVLINK_DOWN": 2})
+        dcgm_group_mock = MagicMock()
+        two_links_one_gpu = [self._get_nvlink_incident(0, 3, 16), self._get_nvlink_incident(0, 3, 17)]
+
+        first = self._poll(watcher, dcgm_group_mock, two_links_one_gpu)
+        assert first["DCGM_HEALTH_WATCH_NVLINK"].entity_failures == {}
+        assert watcher._incident_streaks == {("DCGM_FR_NVLINK_DOWN", 3): 1}
+
+        # Both records are published together once the threshold is genuinely met.
+        second = self._poll(watcher, dcgm_group_mock, two_links_one_gpu)
+        failure = second["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[3]
+        assert failure.code == "DCGM_FR_NVLINK_DOWN"
+        assert "link 16" in failure.message
+        assert "link 17" in failure.message
+
+    def test_incident_debounce_streak_resets_when_incident_is_absent(self) -> None:
+        """A link down on alternate polls never reaches its threshold."""
+        watcher = self._make_debounce_watcher({"DCGM_FR_NVLINK_DOWN": 2})
+        dcgm_group_mock = MagicMock()
+        down = [self._get_nvlink_incident(0, 1, 16)]
+
+        for incidents in (down, [], down, [], down):
+            health_status = self._poll(watcher, dcgm_group_mock, incidents)
+            assert health_status["DCGM_HEALTH_WATCH_NVLINK"].entity_failures == {}
+
+        assert watcher._incident_streaks == {("DCGM_FR_NVLINK_DOWN", 1): 1}
+
+    def test_incident_debounce_is_tracked_per_gpu(self) -> None:
+        """Reaching the threshold on one GPU does not publish another GPU's first observation."""
+        watcher = self._make_debounce_watcher({"DCGM_FR_NVLINK_DOWN": 2})
+        dcgm_group_mock = MagicMock()
+
+        self._poll(watcher, dcgm_group_mock, [self._get_nvlink_incident(0, 1, 16)])
+        health_status = self._poll(
+            watcher,
+            dcgm_group_mock,
+            [self._get_nvlink_incident(0, 1, 16), self._get_nvlink_incident(0, 2, 16)],
+        )
+
+        failures = health_status["DCGM_HEALTH_WATCH_NVLINK"].entity_failures
+        assert 1 in failures
+        assert 2 not in failures
+
+    def test_incident_debounce_only_applies_to_configured_codes(self) -> None:
+        """An unconfigured code in the same poll is published immediately."""
+        watcher = self._make_debounce_watcher({"DCGM_FR_NVLINK_DOWN": 2})
+
+        health_status = self._poll(
+            watcher,
+            MagicMock(),
+            [self._get_nvlink_incident(0, 1, 16), self._get_pcie_incident(0, 1)],
+        )
+
+        assert health_status["DCGM_HEALTH_WATCH_NVLINK"].entity_failures == {}
+        assert health_status["DCGM_HEALTH_WATCH_PCIE"].entity_failures[1].code == "DCGM_FR_PCI_REPLAY_RATE"
+
+    def test_incident_debounce_failed_poll_does_not_reset_the_streak(self) -> None:
+        """A poll that observed nothing must not clear a streak, so a fault spanning a
+        DCGM timeout still publishes on its next observation."""
+        watcher = self._make_debounce_watcher({"DCGM_FR_NVLINK_DOWN": 2})
+        dcgm_group_mock = MagicMock()
+        incidents = [self._get_nvlink_incident(0, 1, 16)]
+
+        self._poll(watcher, dcgm_group_mock, incidents)
+
+        dcgm_group_mock.health.Check.side_effect = dcgm_structs.DCGMError_Timeout()
+        _, connectivity_success = watcher._perform_health_check(dcgm_group_mock)
+        assert connectivity_success is False
+        assert watcher._incident_streaks == {("DCGM_FR_NVLINK_DOWN", 1): 1}
+
+        dcgm_group_mock.health.Check.side_effect = None
+        health_status = self._poll(watcher, dcgm_group_mock, incidents)
+        assert health_status["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[1].code == "DCGM_FR_NVLINK_DOWN"
+
+    def test_incident_debounce_counts_withheld_incidents(self) -> None:
+        """Withheld incidents are observable via the debounced counter."""
+        watcher = self._make_debounce_watcher({"DCGM_FR_NVLINK_DOWN": 2})
+        counter = dcgm.metrics.dcgm_health_check_debounced_incidents.labels("DCGM_FR_NVLINK_DOWN", "1")
+        before = counter._value.get()
+
+        # Two links on GPU 1 in one poll must count once, not twice.
+        self._poll(watcher, MagicMock(), [self._get_nvlink_incident(0, 1, 16), self._get_nvlink_incident(0, 1, 17)])
+
+        assert counter._value.get() == before + 1
+
+    def test_incident_debounce_threshold_of_one_is_not_tracked(self) -> None:
+        """A configured threshold of 1 is today's behaviour, so no streak is kept."""
+        watcher = self._make_debounce_watcher({"DCGM_FR_NVLINK_DOWN": 1})
+
+        health_status = self._poll(watcher, MagicMock(), [self._get_nvlink_incident(0, 1, 16)])
+
+        assert health_status["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[1].code == "DCGM_FR_NVLINK_DOWN"
+        assert watcher._health_check_min_consecutive_polls == {}
+
     def test_perform_health_check_multiple_failures_same_gpu(self):
         """Test that multiple failures for the same GPU are aggregated into a single error message."""
         watcher = dcgm.DCGMWatcher(


### PR DESCRIPTION
Closes #1701, following the approach you approved there.

## Problem

`DCGM_FR_NVLINK_DOWN` is published from a single poll observation. On SXM systems the NVLink links are briefly down after every node boot while they train, so a routine maintenance reboot produces a FATAL event carrying `RESTART_VM`.

Measured on a 288 node GB200 NVL72 fleet in detection-only mode: 214 nodes emitted the code over three and a half weeks, **none** with an NVLink fault. The evidence that these are single-poll transients rather than faults:

- median span from first to last event within a node day is **0.0 minutes**, i.e. every affected GPU reports at one identical timestamp and nothing follows
- median events per node day is 3, one per affected GPU rather than one per poll
- affected nodes arrive in whole **racks of 18** on discrete dates matching the planned reboot schedule
- in the eight days after the last reboot: zero occurrences, while the same watch reported 30 genuine `DCGM_FR_NVLINK_ERROR_THRESHOLD` (BER) events on 3 nodes

With remediation enabled, `RESTART_VM` maps to `RebootNode`, so NVSentinel would reboot nodes an operator had just deliberately rebooted: 63 nodes on one day, which also exceeds the default 50%-in-5-minutes circuit breaker on a 288 node fleet and suppresses genuine fault detection during that window.

## Why the existing protections do not cover it

- **`_is_nvlink_down_false_positive` (#1481) excludes SXM by design.** Its docstring says it fails closed on "an SXM system whose links may simply not have trained yet". That guard is metadata based and cannot distinguish an untrained link from a dead one. A time based mechanism can: an untrained link trains, a dead one does not.
- **`suppressedErrorCodes` is not acceptable here**, since it would mask genuine NVLink failures.
- **The labeler bootstrap gate protects only a node's first join** (`dcgm-bootstrap-completed` is set once and never deleted), so subsequent reboots get no protection.

## Change

Adds `dcgmHealthCheck.minConsecutivePolls`, a per-error-code map, mirroring the `power_brake_min_consecutive_polls` pattern from #1668:

```yaml
gpu-health-monitor:
  dcgmHealthCheck:
    minConsecutivePolls:
      DCGM_FR_NVLINK_DOWN: 2
```

- **Off by default.** `minConsecutivePolls: {}`; a code absent from the map publishes on first observation, exactly as today. A configured threshold of 1 or less is normalized away so no streak is tracked for it.
- **Keyed on `(error_code, gpu_id)`**, so a debounced code never delays a different code or the same code on another GPU.
- **Resets on absence**, so a link that is down on alternate polls never reaches its threshold, which is the intended behaviour for a link that is not stably down.
- **Does not reset on a failed poll.** A DCGM timeout observed nothing, so clearing the streak there would let a fault spanning a timeout restart from zero. Mirrors the power brake's treatment of a blank sample.
- A debounced incident neither degrades the watch status nor enters `gpu_failures_accumulator`, matching how a suppressed incident is handled.
- Withheld incidents are counted by `dcgm_health_check_debounced_incidents{error_code}`, following the `dcgm_health_check_suppressed_incidents` convention.

INI has no nested sections, so the chart renders the values map as comma separated `CODE=N` pairs. A malformed entry is logged and skipped rather than refusing to start, since fail-open for that one code is today's behaviour.

## Tradeoff, documented

A threshold of N delays a genuinely sustained fault by up to N-1 poll intervals. At the default `pollIntervalSeconds: 15` a threshold of 2 costs at most 15 seconds. Noted in `docs/configuration/gpu-health-monitor.md`.

## Verification

- **9 new tests** covering the default, the threshold, continued publishing past the threshold, reset on absence, per-GPU isolation, non-interference with unconfigured codes, streak survival across a DCGM timeout, and the counter.
- **7 new tests** for the config parser, including each malformed shape.
- Full `gpu-health-monitor` suite green: **161 passed, 5 subtests passed**. Note these tests are skipped by `make test` on non-Linux; I ran them against the DCGM python bindings extracted from the `nvcr.io/nvidia/cloud-native/dcgm` image, so they are genuinely executed rather than assumed.
- `black --check` clean, `helm lint` clean.
- Rendered the configmap at the default (`MinConsecutivePolls =` empty), with `values-full.yaml`, and with two codes set, which yields `DCGM_FR_NVLINK_DOWN=2,DCGM_FR_XID_ERROR=3` in deterministic sorted order.

## Acceptance criteria from #1701

All met, except that I did not add an e2e test: `e2e-test-ci` needs a full cluster via `tilt-ci`, so I could not run one and did not want to ship an unexecuted test. Happy to add one if you would like it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable consecutive-poll thresholds for GPU health incidents by error code and GPU.
  * Added Helm configuration support and Prometheus metrics for incidents delayed by debouncing.

* **Bug Fixes**
  * Improved handling of transient and startup NVLink events.
  * Ensured incidents reset correctly, remain isolated per GPU, and are excluded while debounced.
  * Prevented duplicate events in a single poll from advancing thresholds multiple times.

* **Documentation**
  * Documented configuration, reset behavior, failed-poll handling, latency, and monitoring.

* **Tests**
  * Added coverage for parsing, validation, thresholds, resets, duplicates, and metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->