### PR TITLE
fix(syslog-health-monitor): refresh GPU metadata mappings

### DIFF
--- a/health-monitors/syslog-health-monitor/pkg/metadata/reader.go
+++ b/health-monitors/syslog-health-monitor/pkg/metadata/reader.go
@@ -17,6 +17,7 @@ package metadata
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"strings"
@@ -30,6 +31,7 @@ type Reader struct {
 
 	mu     sync.Mutex
 	loaded bool
+	file   os.FileInfo
 
 	metadata *model.GPUMetadata
 
@@ -49,25 +51,42 @@ func NewReader(path string) *Reader {
 	}
 }
 
-func (r *Reader) ensureLoaded() error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+func (r *Reader) ensureFreshLocked() error {
+	if !r.loaded {
+		return r.load()
+	}
 
-	if r.loaded {
+	info, err := os.Stat(r.path)
+	if err != nil {
+		slog.Warn("Failed to refresh GPU metadata; keeping last successful snapshot", "path", r.path, "error", err)
+		return nil
+	}
+
+	if sameFileVersion(r.file, info) {
 		return nil
 	}
 
 	if err := r.load(); err != nil {
-		return err
+		slog.Warn("Failed to refresh GPU metadata; keeping last successful snapshot", "path", r.path, "error", err)
+		return nil
 	}
-
-	r.loaded = true
 
 	return nil
 }
 
 func (r *Reader) load() error {
-	data, err := os.ReadFile(r.path)
+	file, err := os.Open(r.path)
+	if err != nil {
+		return fmt.Errorf("failed to read metadata file: %w", err)
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to stat metadata file: %w", err)
+	}
+
+	data, err := io.ReadAll(file)
 	if err != nil {
 		return fmt.Errorf("failed to read metadata file: %w", err)
 	}
@@ -77,10 +96,16 @@ func (r *Reader) load() error {
 		return fmt.Errorf("failed to parse metadata JSON: %w", err)
 	}
 
+	pciToGPU, uuidToInfo, nvswitchLinks := buildMaps(&metadata)
+	wasLoaded := r.loaded
 	r.metadata = &metadata
-	r.buildMaps()
+	r.pciToGPU = pciToGPU
+	r.uuidToInfo = uuidToInfo
+	r.nvswitchLinks = nvswitchLinks
+	r.file = info
+	r.loaded = true
 
-	if r.loaded {
+	if wasLoaded {
 		slog.Debug("GPU metadata reloaded",
 			"gpus", len(metadata.GPUs),
 			"driver_version", metadata.DriverVersion)
@@ -95,34 +120,42 @@ func (r *Reader) load() error {
 	return nil
 }
 
-func (r *Reader) buildMaps() {
-	r.pciToGPU = make(map[string]*model.GPUInfo)
-	r.uuidToInfo = make(map[string]*model.GPUInfo)
-	r.nvswitchLinks = make(map[string]map[int]*gpuLinkInfo)
+func buildMaps(metadata *model.GPUMetadata) (map[string]*model.GPUInfo, map[string]*model.GPUInfo, map[string]map[int]*gpuLinkInfo) {
+	pciToGPU := make(map[string]*model.GPUInfo)
+	uuidToInfo := make(map[string]*model.GPUInfo)
+	nvswitchLinks := make(map[string]map[int]*gpuLinkInfo)
 
-	for i := range r.metadata.GPUs {
-		gpu := &r.metadata.GPUs[i]
+	for i := range metadata.GPUs {
+		gpu := &metadata.GPUs[i]
 		normPCI := normalizePCI(gpu.PCIAddress)
-		r.pciToGPU[normPCI] = gpu
-		r.uuidToInfo[gpu.UUID] = gpu
+		pciToGPU[normPCI] = gpu
+		uuidToInfo[gpu.UUID] = gpu
 
 		for _, link := range gpu.NVLinks {
 			remotePCI := normalizePCI(link.RemotePCIAddress)
 
-			if r.nvswitchLinks[remotePCI] == nil {
-				r.nvswitchLinks[remotePCI] = make(map[int]*gpuLinkInfo)
+			if nvswitchLinks[remotePCI] == nil {
+				nvswitchLinks[remotePCI] = make(map[int]*gpuLinkInfo)
 			}
 
-			r.nvswitchLinks[remotePCI][link.RemoteLinkID] = &gpuLinkInfo{
+			nvswitchLinks[remotePCI][link.RemoteLinkID] = &gpuLinkInfo{
 				GPU:         gpu,
 				LocalLinkID: link.LinkID,
 			}
 		}
 	}
+
+	return pciToGPU, uuidToInfo, nvswitchLinks
+}
+
+func sameFileVersion(previous, current os.FileInfo) bool {
+	return previous != nil && os.SameFile(previous, current) && previous.Size() == current.Size() && previous.ModTime().Equal(current.ModTime())
 }
 
 func (r *Reader) GetInfoByUUID(uuid string) (*model.GPUInfo, error) {
-	if err := r.ensureLoaded(); err != nil {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err := r.ensureFreshLocked(); err != nil {
 		return nil, fmt.Errorf("failed to load metadata for UUID lookup %s: %w", uuid, err)
 	}
 
@@ -135,7 +168,9 @@ func (r *Reader) GetInfoByUUID(uuid string) (*model.GPUInfo, error) {
 }
 
 func (r *Reader) GetGPUByPCI(pci string) (*model.GPUInfo, error) {
-	if err := r.ensureLoaded(); err != nil {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err := r.ensureFreshLocked(); err != nil {
 		return nil, fmt.Errorf("failed to load metadata for PCI lookup %s: %w", pci, err)
 	}
 
@@ -150,7 +185,9 @@ func (r *Reader) GetGPUByPCI(pci string) (*model.GPUInfo, error) {
 }
 
 func (r *Reader) GetGPUByNVSwitchLink(nvswitchPCI string, linkID int) (*model.GPUInfo, int, error) {
-	if err := r.ensureLoaded(); err != nil {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err := r.ensureFreshLocked(); err != nil {
 		return nil, -1, fmt.Errorf("failed to load metadata for NVSwitch lookup %s link %d: %w", nvswitchPCI, linkID, err)
 	}
 
@@ -171,7 +208,9 @@ func (r *Reader) GetGPUByNVSwitchLink(nvswitchPCI string, linkID int) (*model.GP
 }
 
 func (r *Reader) GetChassisSerial() *string {
-	if err := r.ensureLoaded(); err != nil {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err := r.ensureFreshLocked(); err != nil {
 		return nil
 	}
 
@@ -180,27 +219,19 @@ func (r *Reader) GetChassisSerial() *string {
 
 // GetDriverVersion returns the GPU driver version from the metadata file.
 //
-// Unlike the other accessors, the driver version is typically consumed early
-// (e.g. when constructing the XID parser) and may still be empty if the
-// metadata-collector has not finished writing the file yet. Permanently caching
-// that empty value is dangerous: the XID sidecar would keep receiving an empty
-// driver_version and silently fall back to the wrong (V1) NVL5 decode table for
-// R575+ drivers, mis-classifying errors. To avoid that, re-attempt a load
-// whenever the cached driver version is still empty. Once a non-empty value is
-// observed it is cached like every other field.
+// The reader checks for metadata replacement on every accessor, including this
+// one, so an early empty driver version can be refreshed when the collector
+// publishes its next snapshot.
 func (r *Reader) GetDriverVersion() string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if !r.loaded || r.metadata == nil || r.metadata.DriverVersion == "" {
-		if err := r.load(); err != nil {
+	if err := r.ensureFreshLocked(); err != nil {
+		if !r.loaded || r.metadata == nil {
 			slog.Warn("Failed to load GPU metadata for driver version",
 				"path", r.path, "error", err)
-
 			return ""
 		}
-
-		r.loaded = true
 	}
 
 	return r.metadata.DriverVersion

--- a/health-monitors/syslog-health-monitor/pkg/metadata/reader.go
+++ b/health-monitors/syslog-health-monitor/pkg/metadata/reader.go
@@ -120,7 +120,11 @@ func (r *Reader) load() error {
 	return nil
 }
 
-func buildMaps(metadata *model.GPUMetadata) (map[string]*model.GPUInfo, map[string]*model.GPUInfo, map[string]map[int]*gpuLinkInfo) {
+func buildMaps(metadata *model.GPUMetadata) (
+	map[string]*model.GPUInfo,
+	map[string]*model.GPUInfo,
+	map[string]map[int]*gpuLinkInfo,
+) {
 	pciToGPU := make(map[string]*model.GPUInfo)
 	uuidToInfo := make(map[string]*model.GPUInfo)
 	nvswitchLinks := make(map[string]map[int]*gpuLinkInfo)
@@ -149,12 +153,16 @@ func buildMaps(metadata *model.GPUMetadata) (map[string]*model.GPUInfo, map[stri
 }
 
 func sameFileVersion(previous, current os.FileInfo) bool {
-	return previous != nil && os.SameFile(previous, current) && previous.Size() == current.Size() && previous.ModTime().Equal(current.ModTime())
+	return previous != nil &&
+		os.SameFile(previous, current) &&
+		previous.Size() == current.Size() &&
+		previous.ModTime().Equal(current.ModTime())
 }
 
 func (r *Reader) GetInfoByUUID(uuid string) (*model.GPUInfo, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
 	if err := r.ensureFreshLocked(); err != nil {
 		return nil, fmt.Errorf("failed to load metadata for UUID lookup %s: %w", uuid, err)
 	}
@@ -170,6 +178,7 @@ func (r *Reader) GetInfoByUUID(uuid string) (*model.GPUInfo, error) {
 func (r *Reader) GetGPUByPCI(pci string) (*model.GPUInfo, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
 	if err := r.ensureFreshLocked(); err != nil {
 		return nil, fmt.Errorf("failed to load metadata for PCI lookup %s: %w", pci, err)
 	}
@@ -187,6 +196,7 @@ func (r *Reader) GetGPUByPCI(pci string) (*model.GPUInfo, error) {
 func (r *Reader) GetGPUByNVSwitchLink(nvswitchPCI string, linkID int) (*model.GPUInfo, int, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
 	if err := r.ensureFreshLocked(); err != nil {
 		return nil, -1, fmt.Errorf("failed to load metadata for NVSwitch lookup %s link %d: %w", nvswitchPCI, linkID, err)
 	}
@@ -210,6 +220,7 @@ func (r *Reader) GetGPUByNVSwitchLink(nvswitchPCI string, linkID int) (*model.GP
 func (r *Reader) GetChassisSerial() *string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
 	if err := r.ensureFreshLocked(); err != nil {
 		return nil
 	}
@@ -230,6 +241,7 @@ func (r *Reader) GetDriverVersion() string {
 		if !r.loaded || r.metadata == nil {
 			slog.Warn("Failed to load GPU metadata for driver version",
 				"path", r.path, "error", err)
+
 			return ""
 		}
 	}

--- a/health-monitors/syslog-health-monitor/pkg/metadata/reader_test.go
+++ b/health-monitors/syslog-health-monitor/pkg/metadata/reader_test.go
@@ -15,8 +15,10 @@
 package metadata
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -84,6 +86,21 @@ const testMetadataNoChassisSerial = `{
   "nvswitches": []
 }`
 
+func atomicReplace(t *testing.T, path string, data []byte) {
+	t.Helper()
+	tmp := path + ".next"
+	require.NoError(t, os.WriteFile(tmp, data, 0600))
+	require.NoError(t, os.Rename(tmp, path))
+}
+
+func metadataWithGPU0UUID(uuid string) string {
+	return strings.Replace(testMetadataJSON, "GPU-00000000-0000-0000-0000-000000000000", uuid, 1)
+}
+
+func metadataWithDriverVersion(version string) string {
+	return strings.Replace(testMetadataJSON, `"node_name": "test-node",`, `"node_name": "test-node",`+"\n  \"driver_version\": \""+version+"\",", 1)
+}
+
 func TestReaderLazyLoading(t *testing.T) {
 	tmpDir := t.TempDir()
 	metadataFile := filepath.Join(tmpDir, "gpu_metadata.json")
@@ -115,6 +132,110 @@ func TestReaderConcurrentAccess(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestReaderRefreshesPCIToUUIDAfterAtomicReplacement(t *testing.T) {
+	tmpDir := t.TempDir()
+	metadataFile := filepath.Join(tmpDir, "gpu_metadata.json")
+	require.NoError(t, os.WriteFile(metadataFile, []byte(testMetadataJSON), 0600))
+
+	reader := NewReader(metadataFile)
+	gpu, err := reader.GetGPUByPCI("0000:17:00.0")
+	require.NoError(t, err)
+	require.Equal(t, "GPU-00000000-0000-0000-0000-000000000000", gpu.UUID)
+
+	atomicReplace(t, metadataFile, []byte(metadataWithGPU0UUID("GPU-refreshed")))
+	gpu, err = reader.GetGPUByPCI("0000:17:00.0")
+	require.NoError(t, err)
+	require.Equal(t, "GPU-refreshed", gpu.UUID)
+	_, err = reader.GetInfoByUUID("GPU-00000000-0000-0000-0000-000000000000")
+	require.Error(t, err)
+}
+
+func TestReaderMalformedReplacementKeepsLastSuccessfulSnapshot(t *testing.T) {
+	tmpDir := t.TempDir()
+	metadataFile := filepath.Join(tmpDir, "gpu_metadata.json")
+	require.NoError(t, os.WriteFile(metadataFile, []byte(testMetadataJSON), 0600))
+
+	reader := NewReader(metadataFile)
+	_, err := reader.GetGPUByPCI("0000:17:00.0")
+	require.NoError(t, err)
+
+	atomicReplace(t, metadataFile, []byte("{malformed"))
+	gpu, err := reader.GetGPUByPCI("0000:17:00.0")
+	require.NoError(t, err)
+	require.Equal(t, "GPU-00000000-0000-0000-0000-000000000000", gpu.UUID)
+
+	atomicReplace(t, metadataFile, []byte(metadataWithGPU0UUID("GPU-recovered")))
+	gpu, err = reader.GetGPUByPCI("0000:17:00.0")
+	require.NoError(t, err)
+	require.Equal(t, "GPU-recovered", gpu.UUID)
+}
+
+func TestGetDriverVersionRefreshesEmptyValueAfterAtomicReplacement(t *testing.T) {
+	tmpDir := t.TempDir()
+	metadataFile := filepath.Join(tmpDir, "gpu_metadata.json")
+	require.NoError(t, os.WriteFile(metadataFile, []byte(testMetadataJSON), 0600))
+
+	reader := NewReader(metadataFile)
+	require.Empty(t, reader.GetDriverVersion())
+
+	atomicReplace(t, metadataFile, []byte(metadataWithDriverVersion("575.57.08")))
+	require.Equal(t, "575.57.08", reader.GetDriverVersion())
+}
+
+func TestGetDriverVersionMalformedReplacementKeepsLastSuccessfulValue(t *testing.T) {
+	tmpDir := t.TempDir()
+	metadataFile := filepath.Join(tmpDir, "gpu_metadata.json")
+	require.NoError(t, os.WriteFile(metadataFile, []byte(metadataWithDriverVersion("575.57.08")), 0600))
+
+	reader := NewReader(metadataFile)
+	require.Equal(t, "575.57.08", reader.GetDriverVersion())
+
+	atomicReplace(t, metadataFile, []byte("{malformed"))
+	require.Equal(t, "575.57.08", reader.GetDriverVersion())
+}
+
+func TestReaderConcurrentLookupsDuringAtomicReplacement(t *testing.T) {
+	tmpDir := t.TempDir()
+	metadataFile := filepath.Join(tmpDir, "gpu_metadata.json")
+	require.NoError(t, os.WriteFile(metadataFile, []byte(testMetadataJSON), 0600))
+
+	reader := NewReader(metadataFile)
+	_, err := reader.GetGPUByPCI("0000:17:00.0")
+	require.NoError(t, err)
+
+	errCh := make(chan error, 8)
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				gpu, lookupErr := reader.GetGPUByPCI("0000:17:00.0")
+				if lookupErr != nil {
+					errCh <- lookupErr
+					return
+				}
+				if gpu.UUID != "GPU-00000000-0000-0000-0000-000000000000" && gpu.UUID != "GPU-refreshed" {
+					errCh <- fmt.Errorf("unexpected UUID %q", gpu.UUID)
+					return
+				}
+			}
+		}()
+	}
+	for i := range 50 {
+		uuid := "GPU-00000000-0000-0000-0000-000000000000"
+		if i%2 == 0 {
+			uuid = "GPU-refreshed"
+		}
+		atomicReplace(t, metadataFile, []byte(metadataWithGPU0UUID(uuid)))
+	}
+	wg.Wait()
+	close(errCh)
+	for concurrentErr := range errCh {
+		require.NoError(t, concurrentErr)
+	}
 }
 
 func TestGetGPUByPCI(t *testing.T) {


### PR DESCRIPTION
## Problem

`syslog-health-monitor` caches GPU metadata after its first successful read. When `metadata-collector` atomically replaces the metadata file, later syslog events can still resolve a PCI address with the stale GPU UUID mapping.

## Root cause

The metadata reader only reloaded after an initial load failure or, for the driver version, while the cached value was empty. It did not detect successful metadata file replacements.

## Change

- Detect metadata file replacement or version changes before each lookup.
- Build a complete replacement snapshot before swapping metadata and lookup maps under the reader mutex.
- Keep the last successful snapshot when a refresh cannot be read or parsed.
- Cover PCI-to-UUID refresh, malformed replacements, driver-version refresh, and concurrent lookups.

## Validation

- `go test ./pkg/metadata`
- `go test -race ./pkg/metadata`
- `git diff --check`

All checks pass locally with Go 1.27.0.

## Risk and rollback

The change adds one file metadata check per lookup and serializes refresh and lookup through the existing mutex. A continuously missing or malformed replacement may cause repeated refresh warnings while the reader continues serving its last valid snapshot. Revert this commit to roll back.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Metadata lookups now refresh automatically when the metadata file changes.
  * GPU UUID and driver-version information remain available when replacement data is malformed.
  * Metadata recovers automatically after valid data becomes available again.
  * Improved reliability during concurrent lookups and file updates.

* **Tests**
  * Added coverage for file replacement, malformed data recovery, refresh behavior, and concurrent access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->