### PR TITLE
feat(gpu-health-monitor): add DCGM startup gate

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/_helpers.tpl
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/_helpers.tpl
@@ -151,6 +151,62 @@ namespace. An endpoint override does not change this networking contract.
 {{- if or .Values.useHostNetworking (eq (include "gpu-health-monitor.dcgmMode" .) "external-hostengine") -}}true{{- end -}}
 {{- end }}
 
+{{/*
+Validate and render the optional DCGM startup gate. The gate cannot be used in
+embedded-mode because the main container is responsible for starting DCGM.
+*/}}
+{{- define "gpu-health-monitor.dcgmStartupGateEnabled" -}}
+{{- $enabled := .Values.dcgmConnectivity.startupGate.enabled -}}
+{{- if not (kindIs "bool" $enabled) -}}
+{{- fail (printf "gpu-health-monitor.dcgmConnectivity.startupGate.enabled must be a boolean, got %s %#v" (kindOf $enabled) $enabled) -}}
+{{- end -}}
+{{- if and $enabled (eq (include "gpu-health-monitor.dcgmMode" .) "embedded-mode") -}}
+{{- fail "gpu-health-monitor.dcgmConnectivity.startupGate.enabled cannot be true in embedded-mode because the main container starts DCGM" -}}
+{{- end -}}
+{{- if $enabled -}}true{{- end -}}
+{{- end }}
+
+{{- define "gpu-health-monitor.dcgmStartupGateRetryInterval" -}}
+{{- $interval := .Values.dcgmConnectivity.startupGate.retryIntervalSeconds -}}
+{{- if not (or (kindIs "float64" $interval) (kindIs "int" $interval) (kindIs "int64" $interval)) -}}
+{{- fail (printf "gpu-health-monitor.dcgmConnectivity.startupGate.retryIntervalSeconds must be a number, got %s %#v" (kindOf $interval) $interval) -}}
+{{- end -}}
+{{- if le (float64 $interval) 0.0 -}}
+{{- fail "gpu-health-monitor.dcgmConnectivity.startupGate.retryIntervalSeconds must be greater than zero" -}}
+{{- end -}}
+{{- $interval -}}
+{{- end }}
+
+{{- define "gpu-health-monitor.dcgmStartupGateConnectTimeout" -}}
+{{- $timeout := .Values.dcgmConnectivity.startupGate.connectTimeoutSeconds -}}
+{{- if not (or (kindIs "float64" $timeout) (kindIs "int" $timeout) (kindIs "int64" $timeout)) -}}
+{{- fail (printf "gpu-health-monitor.dcgmConnectivity.startupGate.connectTimeoutSeconds must be a number, got %s %#v" (kindOf $timeout) $timeout) -}}
+{{- end -}}
+{{- if le (float64 $timeout) 0.0 -}}
+{{- fail "gpu-health-monitor.dcgmConnectivity.startupGate.connectTimeoutSeconds must be greater than zero" -}}
+{{- end -}}
+{{- $timeout -}}
+{{- end }}
+
+{{- define "gpu-health-monitor.dcgmStartupGate" -}}
+{{- $root := .root -}}
+- name: wait-for-dcgm
+  command: ["gpu_health_monitor_wait_for_dcgm"]
+  args:
+    - --dcgm-addr
+    - {{ include "gpu-health-monitor.dcgmAddr" $root | quote }}
+    - --retry-interval-seconds
+    - {{ include "gpu-health-monitor.dcgmStartupGateRetryInterval" $root | quote }}
+    - --connect-timeout-seconds
+    - {{ include "gpu-health-monitor.dcgmStartupGateConnectTimeout" $root | quote }}
+  securityContext:
+    runAsUser: 0
+  image: "{{ $root.Values.image.repository }}:{{ $root.Values.image.tag | default (($root.Values.global).image).tag | default $root.Chart.AppVersion }}-dcgm-{{ .dcgmVersion }}"
+  imagePullPolicy: {{ $root.Values.image.pullPolicy }}
+  resources:
+    {{- toYaml $root.Values.resources | nindent 4 }}
+{{- end }}
+
 
 {{/*
 Chart-local copies of the umbrella chart's nvsentinel.pcAuth.* helpers, so this

--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/daemonset-dcgm-3.x.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/daemonset-dcgm-3.x.yaml
@@ -39,6 +39,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if include "gpu-health-monitor.dcgmStartupGateEnabled" . }}
+      initContainers:
+        {{- include "gpu-health-monitor.dcgmStartupGate" (dict "root" . "dcgmVersion" "3.x") | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           command: ["gpu_health_monitor"]

--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/daemonset-dcgm-4.x.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/daemonset-dcgm-4.x.yaml
@@ -39,6 +39,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if include "gpu-health-monitor.dcgmStartupGateEnabled" . }}
+      initContainers:
+        {{- include "gpu-health-monitor.dcgmStartupGate" (dict "root" . "dcgmVersion" "4.x") | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           command: ["gpu_health_monitor"]

--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/tests/dcgm_startup_gate_test.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/tests/dcgm_startup_gate_test.yaml
@@ -71,6 +71,9 @@ tests:
           path: spec.template.spec.initContainers[0].image
           value: ghcr.io/nvidia/nvsentinel/gpu-health-monitor:test-dcgm-3.x
 
+      - equal:
+          path: spec.template.spec.initContainers[0].args[5]
+          value: "10"
   - it: rejects the startup gate in embedded mode
     template: templates/daemonset-dcgm-4.x.yaml
     set:

--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/tests/dcgm_startup_gate_test.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/tests/dcgm_startup_gate_test.yaml
@@ -1,0 +1,111 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+suite: DCGM startup gate
+templates:
+  - templates/daemonset-dcgm-4.x.yaml
+  - templates/daemonset-dcgm-3.x.yaml
+  - templates/configmap.yaml
+tests:
+  - it: is disabled by default
+    template: templates/daemonset-dcgm-4.x.yaml
+    set:
+      global.platformConnectorAuth.enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+
+  - it: waits for operator-service DCGM with the 4.x image
+    template: templates/daemonset-dcgm-4.x.yaml
+    set:
+      global.platformConnectorAuth.enabled: false
+      dcgmConnectivity.startupGate.enabled: true
+      dcgmConnectivity.startupGate.retryIntervalSeconds: 7
+      dcgmConnectivity.startupGate.connectTimeoutSeconds: 9
+      image.tag: test
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-dcgm
+      - equal:
+          path: spec.template.spec.initContainers[0].command[0]
+          value: gpu_health_monitor_wait_for_dcgm
+      - equal:
+          path: spec.template.spec.initContainers[0].args
+          value:
+            - --dcgm-addr
+            - nvidia-dcgm.gpu-operator.svc:5555
+            - --retry-interval-seconds
+            - "7"
+            - --connect-timeout-seconds
+            - "9"
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: ghcr.io/nvidia/nvsentinel/gpu-health-monitor:test-dcgm-4.x
+
+  - it: uses the external hostengine endpoint with the 3.x image
+    template: templates/daemonset-dcgm-3.x.yaml
+    set:
+      global.platformConnectorAuth.enabled: false
+      dcgm.mode: external-hostengine
+      dcgm.externalHostengine.endpoint: 192.0.2.10
+      dcgm.externalHostengine.port: 6666
+      dcgmConnectivity.startupGate.enabled: true
+      image.tag: test
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].args[1]
+          value: 192.0.2.10:6666
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: ghcr.io/nvidia/nvsentinel/gpu-health-monitor:test-dcgm-3.x
+
+  - it: rejects the startup gate in embedded mode
+    template: templates/daemonset-dcgm-4.x.yaml
+    set:
+      global.platformConnectorAuth.enabled: false
+      dcgm.mode: embedded-mode
+      dcgmConnectivity.startupGate.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: gpu-health-monitor.dcgmConnectivity.startupGate.enabled cannot be true in embedded-mode because the main container starts DCGM
+
+  - it: rejects a non-positive retry interval
+    template: templates/daemonset-dcgm-4.x.yaml
+    set:
+      global.platformConnectorAuth.enabled: false
+      dcgmConnectivity.startupGate.enabled: true
+      dcgmConnectivity.startupGate.retryIntervalSeconds: 0
+    asserts:
+      - failedTemplate:
+          errorMessage: gpu-health-monitor.dcgmConnectivity.startupGate.retryIntervalSeconds must be greater than zero
+
+  - it: rejects a non-positive connection timeout
+    template: templates/daemonset-dcgm-4.x.yaml
+    set:
+      global.platformConnectorAuth.enabled: false
+      dcgmConnectivity.startupGate.enabled: true
+      dcgmConnectivity.startupGate.connectTimeoutSeconds: 0
+    asserts:
+      - failedTemplate:
+          errorMessage: gpu-health-monitor.dcgmConnectivity.startupGate.connectTimeoutSeconds must be greater than zero
+
+  - it: rejects a quoted enabled value
+    template: templates/daemonset-dcgm-4.x.yaml
+    set:
+      global.platformConnectorAuth.enabled: false
+      dcgmConnectivity.startupGate.enabled: "true"
+    asserts:
+      - failedTemplate:
+          errorMessage: gpu-health-monitor.dcgmConnectivity.startupGate.enabled must be a boolean, got string "true"

--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/values.yaml
@@ -71,7 +71,7 @@ dcgmConnectivity:
     retryIntervalSeconds: 5
     # Maximum seconds allowed for one DCGM connection and discovery attempt.
     # A timed-out attempt is terminated before the next retry begins.
-    connectTimeoutSeconds: 5
+    connectTimeoutSeconds: 10
 
 # DCGM field-level monitoring feature flags
 dcgmFieldsMonitoring:

--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/values.yaml
@@ -59,6 +59,16 @@ dcgm:
   # Set to false only after validating embedded-mode detections on your fleet.
   probeStoreOnly: true
 
+# DCGM connection lifecycle configuration
+dcgmConnectivity:
+  # Optional startup gate for remote DCGM modes. When enabled, an init
+  # container retries until it can connect to DCGM and complete GPU discovery.
+  # Disabled by default to preserve the existing startup behavior.
+  startupGate:
+    enabled: false
+    retryIntervalSeconds: 5
+    connectTimeoutSeconds: 5
+
 # DCGM field-level monitoring feature flags
 dcgmFieldsMonitoring:
   # Enable GpuThermalMarginWatch (DCGM field 153 / GPU T.Limit margin monitoring)

--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/values.yaml
@@ -65,8 +65,12 @@ dcgmConnectivity:
   # container retries until it can connect to DCGM and complete GPU discovery.
   # Disabled by default to preserve the existing startup behavior.
   startupGate:
+    # Enables the startup gate. This value must be a YAML boolean.
     enabled: false
+    # Seconds to wait between failed readiness attempts.
     retryIntervalSeconds: 5
+    # Maximum seconds allowed for one DCGM connection and discovery attempt.
+    # A timed-out attempt is terminated before the next retry begins.
     connectTimeoutSeconds: 5
 
 # DCGM field-level monitoring feature flags

--- a/distros/kubernetes/nvsentinel/values-full.yaml
+++ b/distros/kubernetes/nvsentinel/values-full.yaml
@@ -982,8 +982,12 @@ gpu-health-monitor:
     # indefinitely until a functional DCGM API request succeeds. It is disabled
     # by default for backward compatibility and cannot be used in embedded-mode.
     startupGate:
+      # Enables the startup gate. This value must be a YAML boolean.
       enabled: false
+      # Seconds to wait between failed readiness attempts.
       retryIntervalSeconds: 5
+      # Maximum seconds allowed for one DCGM connection and discovery attempt.
+      # A timed-out attempt is terminated before the next retry begins.
       connectTimeoutSeconds: 5
 
   # Use host networking for GPU health monitor pods

--- a/distros/kubernetes/nvsentinel/values-full.yaml
+++ b/distros/kubernetes/nvsentinel/values-full.yaml
@@ -988,7 +988,7 @@ gpu-health-monitor:
       retryIntervalSeconds: 5
       # Maximum seconds allowed for one DCGM connection and discovery attempt.
       # A timed-out attempt is terminated before the next retry begins.
-      connectTimeoutSeconds: 5
+      connectTimeoutSeconds: 10
 
   # Use host networking for GPU health monitor pods
   # Required when:

--- a/distros/kubernetes/nvsentinel/values-full.yaml
+++ b/distros/kubernetes/nvsentinel/values-full.yaml
@@ -976,6 +976,16 @@ gpu-health-monitor:
     # Set to false only after validating embedded-mode detections on your fleet.
     probeStoreOnly: true
 
+  # DCGM connection lifecycle configuration
+  dcgmConnectivity:
+    # Optional startup gate for remote DCGM modes. The init container waits
+    # indefinitely until a functional DCGM API request succeeds. It is disabled
+    # by default for backward compatibility and cannot be used in embedded-mode.
+    startupGate:
+      enabled: false
+      retryIntervalSeconds: 5
+      connectTimeoutSeconds: 5
+
   # Use host networking for GPU health monitor pods
   # Required when:
   # - DCGM is running as hostProcess (not as service)

--- a/docs/configuration/gpu-health-monitor.md
+++ b/docs/configuration/gpu-health-monitor.md
@@ -215,10 +215,12 @@ gpu-health-monitor:
     startupGate:
       enabled: true
       retryIntervalSeconds: 5
-      connectTimeoutSeconds: 5
+      connectTimeoutSeconds: 10
 ```
 
 When enabled, the chart adds a `wait-for-dcgm` init container. Each attempt creates a DCGM handle and performs supported-GPU discovery; opening the TCP port alone is not considered ready. Failed attempts are retried indefinitely at `retryIntervalSeconds`. Each attempt runs in a child process bounded by `connectTimeoutSeconds`, so a blocked native DCGM call can be terminated without restarting the init container. The init container does not publish health events, so an unavailable DCGM endpoint during installation or restart cannot create node conditions, quarantine nodes, or trigger remediation before the monitor has established its first connection.
+
+The default 10-second hard timeout leaves time for DCGM's own 5-second connection timeout to return and log a specific connection error first; the parent timeout remains a backstop for a genuinely stuck native call.
 
 The gate is disabled by default for backward compatibility and supports `operator-service` and `external-hostengine`. It cannot be enabled in `embedded-mode`, because the main GPU health monitor container starts the embedded hostengine; Helm rejects that combination rather than creating a pod that can never leave init.
 

--- a/docs/configuration/gpu-health-monitor.md
+++ b/docs/configuration/gpu-health-monitor.md
@@ -205,6 +205,58 @@ Dry run. When true, this check's events are emitted with `processingStrategy=STO
 
 Consecutive polls with the bit set before the GPU is failed. A brake asserted for a single poll can be a load transient; a sustained assertion is the actionable case. A clear resets the counter, so a flapping brake never accumulates to a failure. `1` fails on first observation. A GPU with no usable sample is skipped and keeps its counter, so a gap in DCGM data neither raises nor clears a finding. This includes DCGM's int64 "no data" sentinels, whose low byte has the brake bit set and which would otherwise read as an assertion.
 
+## DCGM Startup Gate
+
+For remote DCGM modes, the GPU health monitor can wait for a functional DCGM API before its main container starts:
+
+```yaml
+gpu-health-monitor:
+  dcgmConnectivity:
+    startupGate:
+      enabled: true
+      retryIntervalSeconds: 5
+      connectTimeoutSeconds: 5
+```
+
+When enabled, the chart adds a `wait-for-dcgm` init container. Each attempt creates a DCGM handle and performs supported-GPU discovery; opening the TCP port alone is not considered ready. Failed attempts are retried indefinitely at `retryIntervalSeconds`. Each attempt runs in a child process bounded by `connectTimeoutSeconds`, so a blocked native DCGM call can be terminated without restarting the init container. The init container does not publish health events, so an unavailable DCGM endpoint during installation or restart cannot create node conditions, quarantine nodes, or trigger remediation before the monitor has established its first connection.
+
+The gate is disabled by default for backward compatibility and supports `operator-service` and `external-hostengine`. It cannot be enabled in `embedded-mode`, because the main GPU health monitor container starts the embedded hostengine; Helm rejects that combination rather than creating a pod that can never leave init.
+
+While DCGM remains unavailable, the pod stays in `Init:0/1`; ordinary readiness failures do not restart the init container. This state should be monitored with the deployment's existing pod-state alerts (for example, kube-state-metrics). An `Init:CrashLoopBackOff` instead indicates an image, configuration, or implementation failure. After startup, runtime DCGM failures are still handled by the GPU health monitor's connectivity checks; the startup gate does not replace runtime failure handling or debouncing.
+
+For example, alert when the startup gate has been waiting for more than five minutes:
+
+```yaml
+- alert: NVSentinelGPUHealthMonitorWaitingForDCGM
+  expr: |
+    kube_pod_init_container_status_running{
+      container="wait-for-dcgm"
+    } == 1
+  for: 5m
+  labels:
+    severity: warning
+  annotations:
+    summary: "gpu-health-monitor is waiting for DCGM"
+    description: "Pod {{ $labels.namespace }}/{{ $labels.pod }} has been waiting for DCGM for more than 5 minutes."
+```
+
+Alert separately when the init program itself is repeatedly failing:
+
+```yaml
+- alert: NVSentinelGPUHealthMonitorDCGMInitFailed
+  expr: |
+    kube_pod_init_container_status_waiting_reason{
+      container="wait-for-dcgm",
+      reason="CrashLoopBackOff"
+    } == 1
+  for: 2m
+  labels:
+    severity: critical
+  annotations:
+    summary: "gpu-health-monitor DCGM startup gate is failing"
+    description: "The wait-for-dcgm init container in {{ $labels.namespace }}/{{ $labels.pod }} is repeatedly failing."
+```
+
 ## Unresponsive DCGM Detection
 
 A DCGM call that stops answering never returns an error — callers park and the probe blocks forever rather than raising `DCGMError_Timeout`. Meanwhile the node can still report `Ready` with every GPU allocatable and no taint, so no other signal in the stack registers a fault. In `embedded-mode` that hang is node-local, but it is not yet proof of a kernel-driver wedge: DCGM userspace deadlock or lock contention can look the same until an independent NVML/`nvidia-smi` probe confirms the driver itself.

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_wait_for_dcgm.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_wait_for_dcgm.py
@@ -127,6 +127,34 @@ def test_wait_for_dcgm_retries_until_ready(is_ready: MagicMock) -> None:
     assert sleep.call_args_list == [call(2.5), call(2.5)]
 
 
+@patch("gpu_health_monitor.wait_for_dcgm.wait_for_dcgm")
+def test_cli_uses_documented_timeout_defaults(wait_for_dcgm_mock: MagicMock) -> None:
+    """The CLI defaults leave time for DCGM's own connection error to surface."""
+    result = CliRunner().invoke(cli, ["--dcgm-addr", "dcgm.example:5555"])
+
+    assert result.exit_code == 0
+    wait_for_dcgm_mock.assert_called_once_with("dcgm.example:5555", 5.0, 10.0)
+
+
+@patch("gpu_health_monitor.wait_for_dcgm.wait_for_dcgm")
+def test_cli_accepts_positive_subsecond_intervals(wait_for_dcgm_mock: MagicMock) -> None:
+    """Any value greater than zero is accepted for both timing options."""
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--dcgm-addr",
+            "dcgm.example:5555",
+            "--retry-interval-seconds",
+            "0.01",
+            "--connect-timeout-seconds",
+            "0.02",
+        ],
+    )
+
+    assert result.exit_code == 0
+    wait_for_dcgm_mock.assert_called_once_with("dcgm.example:5555", 0.01, 0.02)
+
+
 def test_cli_rejects_non_positive_retry_interval() -> None:
     """The CLI rejects retry intervals that could create a busy loop."""
     result = CliRunner().invoke(

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_wait_for_dcgm.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_wait_for_dcgm.py
@@ -21,7 +21,8 @@ from gpu_health_monitor.wait_for_dcgm import cli, dcgm_is_ready, dcgm_is_ready_w
 
 
 @patch("gpu_health_monitor.wait_for_dcgm.pydcgm.DcgmHandle")
-def test_dcgm_is_ready_requires_gpu_discovery(dcgm_handle_factory):
+def test_dcgm_is_ready_requires_gpu_discovery(dcgm_handle_factory: MagicMock) -> None:
+    """Readiness requires a functional supported-GPU discovery request."""
     dcgm_handle = MagicMock()
     dcgm_handle.GetSystem.return_value.discovery.GetEntityGroupEntities.return_value = [0, 1]
     dcgm_handle_factory.return_value = dcgm_handle
@@ -36,7 +37,8 @@ def test_dcgm_is_ready_requires_gpu_discovery(dcgm_handle_factory):
 
 
 @patch("gpu_health_monitor.wait_for_dcgm.pydcgm.DcgmHandle")
-def test_dcgm_is_ready_accepts_an_empty_supported_gpu_list(dcgm_handle_factory):
+def test_dcgm_is_ready_accepts_an_empty_supported_gpu_list(dcgm_handle_factory: MagicMock) -> None:
+    """A successful discovery request is ready even when it returns no GPUs."""
     dcgm_handle = MagicMock()
     dcgm_handle.GetSystem.return_value.discovery.GetEntityGroupEntities.return_value = []
     dcgm_handle_factory.return_value = dcgm_handle
@@ -46,7 +48,8 @@ def test_dcgm_is_ready_accepts_an_empty_supported_gpu_list(dcgm_handle_factory):
 
 
 @patch("gpu_health_monitor.wait_for_dcgm.pydcgm.DcgmHandle")
-def test_dcgm_is_ready_returns_false_and_closes_handle_after_discovery_failure(dcgm_handle_factory):
+def test_dcgm_is_ready_returns_false_and_closes_handle_after_discovery_failure(dcgm_handle_factory: MagicMock) -> None:
+    """A failed discovery closes its DCGM handle and reports not ready."""
     dcgm_handle = MagicMock()
     dcgm_handle.GetSystem.return_value.discovery.GetEntityGroupEntities.side_effect = RuntimeError("not ready")
     dcgm_handle_factory.return_value = dcgm_handle
@@ -56,7 +59,8 @@ def test_dcgm_is_ready_returns_false_and_closes_handle_after_discovery_failure(d
 
 
 @patch("gpu_health_monitor.wait_for_dcgm.dcgm_is_ready", side_effect=[False, False, True])
-def test_probe_process_entrypoint_uses_readiness_result(is_ready):
+def test_probe_process_entrypoint_uses_readiness_result(is_ready: MagicMock) -> None:
+    """The child process exit code reflects the DCGM readiness result."""
     from gpu_health_monitor.wait_for_dcgm import _probe_process_entrypoint
 
     with patch("gpu_health_monitor.wait_for_dcgm.sys.exit", side_effect=SystemExit) as exit_mock:
@@ -69,7 +73,8 @@ def test_probe_process_entrypoint_uses_readiness_result(is_ready):
 
 
 @patch("gpu_health_monitor.wait_for_dcgm.multiprocessing.get_context")
-def test_dcgm_is_ready_with_timeout_returns_child_result(get_context):
+def test_dcgm_is_ready_with_timeout_returns_child_result(get_context: MagicMock) -> None:
+    """A completed child result is returned and its process is closed."""
     process = MagicMock(pid=123, exitcode=0)
     process.is_alive.return_value = False
     get_context.return_value.Process.return_value = process
@@ -82,9 +87,10 @@ def test_dcgm_is_ready_with_timeout_returns_child_result(get_context):
 
 
 @patch("gpu_health_monitor.wait_for_dcgm.multiprocessing.get_context")
-def test_dcgm_is_ready_with_timeout_terminates_a_hung_probe(get_context):
+def test_dcgm_is_ready_with_timeout_terminates_a_hung_probe(get_context: MagicMock) -> None:
+    """A timed-out probe is terminated before another attempt can begin."""
     process = MagicMock(pid=123)
-    process.is_alive.side_effect = [True, True, False]
+    process.is_alive.side_effect = [True, True, False, False]
     get_context.return_value.Process.return_value = process
 
     assert dcgm_is_ready_with_timeout("dcgm.example:5555", 4) is False
@@ -95,8 +101,24 @@ def test_dcgm_is_ready_with_timeout_terminates_a_hung_probe(get_context):
     process.close.assert_called_once_with()
 
 
+@patch("gpu_health_monitor.wait_for_dcgm.multiprocessing.get_context")
+def test_dcgm_is_ready_with_timeout_bounds_cleanup_after_kill(get_context: MagicMock) -> None:
+    """Cleanup remains bounded and does not close a child that is still alive."""
+    process = MagicMock(pid=123)
+    process.is_alive.side_effect = [True, True, True, True]
+    get_context.return_value.Process.return_value = process
+
+    assert dcgm_is_ready_with_timeout("dcgm.example:5555", 4) is False
+
+    process.terminate.assert_called_once_with()
+    process.kill.assert_called_once_with()
+    process.join.assert_has_calls([call(timeout=4), call(timeout=1), call(timeout=1)])
+    process.close.assert_not_called()
+
+
 @patch("gpu_health_monitor.wait_for_dcgm.dcgm_is_ready_with_timeout", side_effect=[False, False, True])
-def test_wait_for_dcgm_retries_until_ready(is_ready):
+def test_wait_for_dcgm_retries_until_ready(is_ready: MagicMock) -> None:
+    """The gate retries failed probes and returns after the first success."""
     sleep = MagicMock()
 
     wait_for_dcgm("dcgm.example:5555", 2.5, 4, sleep=sleep)
@@ -105,7 +127,8 @@ def test_wait_for_dcgm_retries_until_ready(is_ready):
     assert sleep.call_args_list == [call(2.5), call(2.5)]
 
 
-def test_cli_rejects_non_positive_retry_interval():
+def test_cli_rejects_non_positive_retry_interval() -> None:
+    """The CLI rejects retry intervals that could create a busy loop."""
     result = CliRunner().invoke(
         cli,
         ["--dcgm-addr", "dcgm.example:5555", "--retry-interval-seconds", "0"],
@@ -115,7 +138,8 @@ def test_cli_rejects_non_positive_retry_interval():
     assert "not in the range" in result.output
 
 
-def test_cli_rejects_non_positive_connect_timeout():
+def test_cli_rejects_non_positive_connect_timeout() -> None:
+    """The CLI rejects non-positive per-attempt timeouts."""
     result = CliRunner().invoke(
         cli,
         ["--dcgm-addr", "dcgm.example:5555", "--connect-timeout-seconds", "0"],

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_wait_for_dcgm.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_wait_for_dcgm.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock, call, patch
+
+import dcgm_fields
+from click.testing import CliRunner
+
+from gpu_health_monitor.wait_for_dcgm import cli, dcgm_is_ready, dcgm_is_ready_with_timeout, wait_for_dcgm
+
+
+@patch("gpu_health_monitor.wait_for_dcgm.pydcgm.DcgmHandle")
+def test_dcgm_is_ready_requires_gpu_discovery(dcgm_handle_factory):
+    dcgm_handle = MagicMock()
+    dcgm_handle.GetSystem.return_value.discovery.GetEntityGroupEntities.return_value = [0, 1]
+    dcgm_handle_factory.return_value = dcgm_handle
+
+    assert dcgm_is_ready("dcgm.example:5555") is True
+
+    dcgm_handle_factory.assert_called_once()
+    dcgm_handle.GetSystem.return_value.discovery.GetEntityGroupEntities.assert_called_once_with(
+        dcgm_fields.DCGM_FE_GPU, True
+    )
+    dcgm_handle.Shutdown.assert_called_once_with()
+
+
+@patch("gpu_health_monitor.wait_for_dcgm.pydcgm.DcgmHandle")
+def test_dcgm_is_ready_accepts_an_empty_supported_gpu_list(dcgm_handle_factory):
+    dcgm_handle = MagicMock()
+    dcgm_handle.GetSystem.return_value.discovery.GetEntityGroupEntities.return_value = []
+    dcgm_handle_factory.return_value = dcgm_handle
+
+    assert dcgm_is_ready("dcgm.example:5555") is True
+    dcgm_handle.Shutdown.assert_called_once_with()
+
+
+@patch("gpu_health_monitor.wait_for_dcgm.pydcgm.DcgmHandle")
+def test_dcgm_is_ready_returns_false_and_closes_handle_after_discovery_failure(dcgm_handle_factory):
+    dcgm_handle = MagicMock()
+    dcgm_handle.GetSystem.return_value.discovery.GetEntityGroupEntities.side_effect = RuntimeError("not ready")
+    dcgm_handle_factory.return_value = dcgm_handle
+
+    assert dcgm_is_ready("dcgm.example:5555") is False
+    dcgm_handle.Shutdown.assert_called_once_with()
+
+
+@patch("gpu_health_monitor.wait_for_dcgm.dcgm_is_ready", side_effect=[False, False, True])
+def test_probe_process_entrypoint_uses_readiness_result(is_ready):
+    from gpu_health_monitor.wait_for_dcgm import _probe_process_entrypoint
+
+    with patch("gpu_health_monitor.wait_for_dcgm.sys.exit", side_effect=SystemExit) as exit_mock:
+        for expected_exit_code in [1, 1, 0]:
+            try:
+                _probe_process_entrypoint("dcgm.example:5555")
+            except SystemExit:
+                pass
+            exit_mock.assert_called_with(expected_exit_code)
+
+
+@patch("gpu_health_monitor.wait_for_dcgm.multiprocessing.get_context")
+def test_dcgm_is_ready_with_timeout_returns_child_result(get_context):
+    process = MagicMock(pid=123, exitcode=0)
+    process.is_alive.return_value = False
+    get_context.return_value.Process.return_value = process
+
+    assert dcgm_is_ready_with_timeout("dcgm.example:5555", 4) is True
+
+    get_context.assert_called_once_with("spawn")
+    process.join.assert_called_once_with(timeout=4)
+    process.close.assert_called_once_with()
+
+
+@patch("gpu_health_monitor.wait_for_dcgm.multiprocessing.get_context")
+def test_dcgm_is_ready_with_timeout_terminates_a_hung_probe(get_context):
+    process = MagicMock(pid=123)
+    process.is_alive.side_effect = [True, True, False]
+    get_context.return_value.Process.return_value = process
+
+    assert dcgm_is_ready_with_timeout("dcgm.example:5555", 4) is False
+
+    process.terminate.assert_called_once_with()
+    process.join.assert_has_calls([call(timeout=4), call(timeout=1)])
+    process.kill.assert_not_called()
+    process.close.assert_called_once_with()
+
+
+@patch("gpu_health_monitor.wait_for_dcgm.dcgm_is_ready_with_timeout", side_effect=[False, False, True])
+def test_wait_for_dcgm_retries_until_ready(is_ready):
+    sleep = MagicMock()
+
+    wait_for_dcgm("dcgm.example:5555", 2.5, 4, sleep=sleep)
+
+    assert is_ready.call_args_list == [call("dcgm.example:5555", 4)] * 3
+    assert sleep.call_args_list == [call(2.5), call(2.5)]
+
+
+def test_cli_rejects_non_positive_retry_interval():
+    result = CliRunner().invoke(
+        cli,
+        ["--dcgm-addr", "dcgm.example:5555", "--retry-interval-seconds", "0"],
+    )
+
+    assert result.exit_code == 2
+    assert "not in the range" in result.output
+
+
+def test_cli_rejects_non_positive_connect_timeout():
+    result = CliRunner().invoke(
+        cli,
+        ["--dcgm-addr", "dcgm.example:5555", "--connect-timeout-seconds", "0"],
+    )
+
+    assert result.exit_code == 2
+    assert "not in the range" in result.output

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/wait_for_dcgm.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/wait_for_dcgm.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging as log
+import multiprocessing
+import signal
+import sys
+import time
+from collections.abc import Callable
+
+import click
+import dcgm_fields
+import dcgm_structs
+import pydcgm
+
+_LOG_FORMAT = "%(asctime)s %(levelname)s %(message)s"
+
+
+def _configure_logging() -> None:
+    log.basicConfig(level=log.INFO, format=_LOG_FORMAT)
+
+
+def dcgm_is_ready(dcgm_addr: str) -> bool:
+    """Return true after a DCGM connection and GPU discovery both succeed."""
+    dcgm_handle = None
+    try:
+        dcgm_handle = pydcgm.DcgmHandle(
+            ipAddress=dcgm_addr,
+            opMode=dcgm_structs.DCGM_OPERATION_MODE_AUTO,
+        )
+        dcgm_system = dcgm_handle.GetSystem()
+        gpu_ids = dcgm_system.discovery.GetEntityGroupEntities(dcgm_fields.DCGM_FE_GPU, True)
+        log.info("DCGM is ready at %s; discovered %d supported GPU(s)", dcgm_addr, len(gpu_ids))
+        return True
+    except Exception as error:
+        log.warning("DCGM is not ready at %s: %s", dcgm_addr, error)
+        return False
+    finally:
+        if dcgm_handle is not None:
+            try:
+                dcgm_handle.Shutdown()
+            except Exception as error:
+                log.warning("Failed to close DCGM readiness handle: %s", error)
+
+
+def _probe_process_entrypoint(dcgm_addr: str) -> None:
+    """Run one DCGM readiness attempt in an independently killable process."""
+    _configure_logging()
+    sys.exit(0 if dcgm_is_ready(dcgm_addr) else 1)
+
+
+def _stop_process(process: multiprocessing.Process) -> None:
+    """Stop a probe process without allowing cleanup to block the init gate."""
+    if process.pid is None:
+        return
+    if process.is_alive():
+        process.terminate()
+        process.join(timeout=1)
+    if process.is_alive():
+        process.kill()
+        process.join()
+    process.close()
+
+
+def dcgm_is_ready_with_timeout(dcgm_addr: str, connect_timeout_seconds: float) -> bool:
+    """Run a functional DCGM readiness check with a hard process timeout."""
+    process = multiprocessing.get_context("spawn").Process(
+        target=_probe_process_entrypoint,
+        args=(dcgm_addr,),
+        name="dcgm-readiness-probe",
+    )
+    try:
+        process.start()
+        process.join(timeout=connect_timeout_seconds)
+        if process.is_alive():
+            log.warning(
+                "DCGM readiness check at %s exceeded %.1f seconds",
+                dcgm_addr,
+                connect_timeout_seconds,
+            )
+            return False
+        return process.exitcode == 0
+    except Exception as error:
+        log.warning("Failed to run DCGM readiness check at %s: %s", dcgm_addr, error)
+        return False
+    finally:
+        _stop_process(process)
+
+
+def wait_for_dcgm(
+    dcgm_addr: str,
+    retry_interval_seconds: float,
+    connect_timeout_seconds: float,
+    sleep: Callable[[float], None] = time.sleep,
+) -> None:
+    """Wait indefinitely for DCGM to accept a functional API request."""
+    while not dcgm_is_ready_with_timeout(dcgm_addr, connect_timeout_seconds):
+        sleep(retry_interval_seconds)
+
+
+def _exit_on_sigterm(_signum, _frame) -> None:
+    """Allow finally blocks to terminate an active probe during pod shutdown."""
+    raise SystemExit(0)
+
+
+@click.command()
+@click.option("--dcgm-addr", required=True, help="Host:Port where DCGM is running")
+@click.option(
+    "--retry-interval-seconds",
+    type=click.FloatRange(min=0.1),
+    default=5.0,
+    show_default=True,
+    help="Seconds to wait between DCGM readiness attempts.",
+)
+@click.option(
+    "--connect-timeout-seconds",
+    type=click.FloatRange(min=0.1),
+    default=5.0,
+    show_default=True,
+    help="Maximum seconds allowed for one functional DCGM readiness check.",
+)
+def cli(dcgm_addr: str, retry_interval_seconds: float, connect_timeout_seconds: float) -> None:
+    """Block startup until the configured DCGM endpoint is functional."""
+    _configure_logging()
+    signal.signal(signal.SIGTERM, _exit_on_sigterm)
+    log.info(
+        "Waiting for DCGM at %s (retry interval %.1fs, connection timeout %.1fs)",
+        dcgm_addr,
+        retry_interval_seconds,
+        connect_timeout_seconds,
+    )
+    wait_for_dcgm(dcgm_addr, retry_interval_seconds, connect_timeout_seconds)

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/wait_for_dcgm.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/wait_for_dcgm.py
@@ -125,15 +125,15 @@ def _exit_on_sigterm(_signum: int, _frame: FrameType | None) -> NoReturn:
 @click.option("--dcgm-addr", required=True, help="Host:Port where DCGM is running")
 @click.option(
     "--retry-interval-seconds",
-    type=click.FloatRange(min=0.1),
+    type=click.FloatRange(min=0.0, min_open=True),
     default=5.0,
     show_default=True,
     help="Seconds to wait between DCGM readiness attempts.",
 )
 @click.option(
     "--connect-timeout-seconds",
-    type=click.FloatRange(min=0.1),
-    default=5.0,
+    type=click.FloatRange(min=0.0, min_open=True),
+    default=10.0,
     show_default=True,
     help="Maximum seconds allowed for one functional DCGM readiness check.",
 )

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/wait_for_dcgm.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/wait_for_dcgm.py
@@ -18,6 +18,8 @@ import signal
 import sys
 import time
 from collections.abc import Callable
+from types import FrameType
+from typing import NoReturn
 
 import click
 import dcgm_fields
@@ -28,6 +30,7 @@ _LOG_FORMAT = "%(asctime)s %(levelname)s %(message)s"
 
 
 def _configure_logging() -> None:
+    """Configure logging for the init process and readiness probe children."""
     log.basicConfig(level=log.INFO, format=_LOG_FORMAT)
 
 
@@ -69,7 +72,11 @@ def _stop_process(process: multiprocessing.Process) -> None:
         process.join(timeout=1)
     if process.is_alive():
         process.kill()
-        process.join()
+        process.join(timeout=1)
+    if process.is_alive():
+        log.error("DCGM readiness probe process %s did not stop after terminate and kill", process.pid)
+        return
+
     process.close()
 
 
@@ -109,7 +116,7 @@ def wait_for_dcgm(
         sleep(retry_interval_seconds)
 
 
-def _exit_on_sigterm(_signum, _frame) -> None:
+def _exit_on_sigterm(_signum: int, _frame: FrameType | None) -> NoReturn:
     """Allow finally blocks to terminate an active probe during pod shutdown."""
     raise SystemExit(0)
 

--- a/health-monitors/gpu-health-monitor/pyproject.toml
+++ b/health-monitors/gpu-health-monitor/pyproject.toml
@@ -26,6 +26,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 gpu_health_monitor = "gpu_health_monitor.cli:cli"
+gpu_health_monitor_wait_for_dcgm = "gpu_health_monitor.wait_for_dcgm:cli"
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
## Summary

Add an optional init container that waits for a functional remote DCGM endpoint before starting the GPU health monitor.

The startup gate:

- Is disabled by default to preserve existing behavior.
- Supports `operator-service` and `external-hostengine` modes.
- Requires both a successful DCGM connection and supported GPU discovery.
- Runs each readiness attempt in a separate process with a configurable hard timeout.
- Bounds process termination and only closes a probe after it has exited.
- Cleans up the DCGM handle after every completed attempt.
- Retries indefinitely without publishing health events.
- Prevents `GpuDcgmConnectivityFailure` events before DCGM has been available at least once.
- Rejects `embedded-mode`, because DCGM is started by the main container in that mode.
- Documents recommended alerts for pods waiting in the init phase.

Configuration example:

```yaml
gpu-health-monitor:
  dcgmConnectivity:
    startupGate:
      enabled: true
      retryIntervalSeconds: 5
      connectTimeoutSeconds: 10
```

This PR implements the startup-gating part of #1642. Runtime connectivity debouncing will be submitted separately.

Related to #1642.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected

- [ ] Core Services
- [x] Documentation/CI
- [ ] Fault Management
- [x] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing

- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

Validation completed:

- GPU health monitor Python tests: 174 passed, 5 subtests passed
- GPU health monitor Helm tests: 22 passed
- Black formatting check passed

## Checklist

- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional DCGM startup gate for GPU health monitoring.
  - The gate verifies DCGM connectivity and GPU discovery before monitoring begins, with configurable retry intervals and connection timeouts.
  - Supports operator-service and external-hostengine modes; disabled by default and unavailable in embedded mode.
  - Added validation for invalid settings and safe handling of stalled connection attempts.

- **Documentation**
  - Documented configuration, behavior, troubleshooting guidance, and Prometheus alert examples.

- **Tests**
  - Added coverage for connectivity, retries, timeouts, validation, and startup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->