### PR TITLE
perf(fault-remediation): disable the Node cache to avoid a lazy cluster-wide informer

### DIFF
--- a/fault-remediation/main.go
+++ b/fault-remediation/main.go
@@ -32,6 +32,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -191,6 +192,16 @@ func createManager() (ctrl.Manager, error) {
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
+		},
+		// Nodes are only ever read by name (pkg/annotation, pkg/remediation, pkg/reconciler);
+		// the only List in this component is over Jobs. Serving those point reads from the
+		// manager's cache starts a cluster-wide Node informer on the first remediation, which
+		// retains every Node untransformed (~8.5 GB at 53k nodes) and blocks that first
+		// reconcile for ~43s while it lists and syncs. Read Nodes live instead.
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{&corev1.Node{}},
+			},
 		},
 		HealthProbeBindAddress:  healthAddr,
 		LeaderElection:          enableLeaderElection,


### PR DESCRIPTION
## Summary

fault-remediation registers no Kubernetes watches, but it reads Nodes through the manager's cached client. controller-runtime creates informers lazily on the first cached read, so the first remediation silently built a cluster-wide Node informer. Nodes are only ever fetched by name here -- the only `List` in this component is over Jobs -- so the cache buys nothing. This disables caching for Nodes, sending those point reads straight to the API server.

Measured on a 53,513-node cluster, one injected fatal health event per measurement:

| | before | after |
|---|---|---|
| Live heap (`go_memstats_heap_alloc_bytes`, post-GC trough) | 4.46 GB | **4.77 MB** |
| Container working set | 8.50 GB | **17.63 MB** |
| 1st remediation, `CR generation duration` | **43.02 s** | **0.091 s** |
| 2nd remediation, same pod | 0.048 s | 0.061 s |
| Retained bytes per Node | ~83,265 | **0** |

Before the change the pod sat at ~15 MB until its first remediation, then stepped to the 8.50 GB plateau and stayed there; the 43 s is that informer's initial LIST and sync over 53,513 Nodes, which every restart paid again for the first affected node. No `Cache.ByObject` transform was configured, so Nodes were retained whole.

API-server load drops rather than rising. Measured against a 60-second idle control, the component now issues **0** requests when idle and **5 GET + 1 POST** per remediation, with PUTs unchanged (those are leader-election lease renewals at 0.52/s, matching `RetryPeriod: 2s`). The cached version's equivalent cost was a paged LIST of all 53,513 Nodes plus a permanent WATCH carrying every Node update in the fleet. `MaxConcurrentReconciles` is unset (default 1), so the GETs serialize and a burst cannot fan them out.

A cache `Transform` was considered and would land around 450 MB at this scale, but it keeps the LIST-and-sync latency and the fleet-wide decode churn, whereas disabling the cache removes the per-node term entirely.

Numbers come from a KWOK-simulated fleet (53,513 nodes / 642,537 pods) on the scale-test cluster; heap from the pod's own `/metrics`, working set from cAdvisor via Prometheus, latency from the component's `Fault remediation CR generation duration` log field, request counts from `rest_client_requests_total` deltas. Single cluster at one scale point, `n=1`-`2` per figure -- not production percentiles.

Closes #1757

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Documentation/CI
- [ ] Fault Management
- [ ] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [ ] No breaking changes (or documented)

## Checklist
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Kubernetes Node information now reflects the latest live API state, improving the accuracy of node-related operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
