### PR TITLE
feat(gpu-health-monitor): debounce DCGM connectivity transitions

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/_helpers.tpl
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/_helpers.tpl
@@ -207,6 +207,30 @@ embedded-mode because the main container is responsible for starting DCGM.
     {{- toYaml $root.Values.resources | nindent 4 }}
 {{- end }}
 
+{{/* Validate runtime connectivity debounce thresholds. */}}
+{{- define "gpu-health-monitor.dcgmConnectivityFailureThreshold" -}}
+{{- $threshold := .Values.dcgmConnectivity.runtimeDebounce.failureThreshold -}}
+{{- if not (or (kindIs "float64" $threshold) (kindIs "int" $threshold) (kindIs "int64" $threshold)) -}}
+{{- fail (printf "gpu-health-monitor.dcgmConnectivity.runtimeDebounce.failureThreshold must be an integer, got %s %#v" (kindOf $threshold) $threshold) -}}
+{{- end -}}
+{{- if or (lt (int $threshold) 1) (ne (float64 $threshold) (float64 (int $threshold))) -}}
+{{- fail "gpu-health-monitor.dcgmConnectivity.runtimeDebounce.failureThreshold must be an integer greater than or equal to 1" -}}
+{{- end -}}
+{{- int $threshold -}}
+{{- end }}
+
+{{- define "gpu-health-monitor.dcgmConnectivitySuccessThreshold" -}}
+{{- $threshold := .Values.dcgmConnectivity.runtimeDebounce.successThreshold -}}
+{{- if not (or (kindIs "float64" $threshold) (kindIs "int" $threshold) (kindIs "int64" $threshold)) -}}
+{{- fail (printf "gpu-health-monitor.dcgmConnectivity.runtimeDebounce.successThreshold must be an integer, got %s %#v" (kindOf $threshold) $threshold) -}}
+{{- end -}}
+{{- if or (lt (int $threshold) 1) (ne (float64 $threshold) (float64 (int $threshold))) -}}
+{{- fail "gpu-health-monitor.dcgmConnectivity.runtimeDebounce.successThreshold must be an integer greater than or equal to 1" -}}
+{{- end -}}
+{{- int $threshold -}}
+{{- end }}
+
+
 
 {{/*
 Chart-local copies of the umbrella chart's nvsentinel.pcAuth.* helpers, so this

--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/configmap.yaml
@@ -50,6 +50,10 @@ data:
 {{- end }}
     MinConsecutivePolls = {{ join "," $debounce }}
 
+    [dcgmconnectivity]
+    FailureThreshold = {{ include "gpu-health-monitor.dcgmConnectivityFailureThreshold" . }}
+    SuccessThreshold = {{ include "gpu-health-monitor.dcgmConnectivitySuccessThreshold" . }}
+
     [eventprocessors.kubernetes]
     ConflictRetryCount = 10
 

--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/tests/dcgm_runtime_debounce_test.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/tests/dcgm_runtime_debounce_test.yaml
@@ -1,0 +1,67 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+suite: DCGM runtime connectivity debounce
+templates:
+  - templates/configmap.yaml
+tests:
+  - it: preserves fail-once recover-once defaults
+    set:
+      global.platformConnectorAuth.enabled: false
+    asserts:
+      - matchRegex:
+          path: data["config.ini"]
+          pattern: "(?s)\\[dcgmconnectivity\\].*FailureThreshold = 1.*SuccessThreshold = 1"
+
+  - it: renders custom thresholds
+    set:
+      global.platformConnectorAuth.enabled: false
+      dcgmConnectivity.runtimeDebounce.failureThreshold: 4
+      dcgmConnectivity.runtimeDebounce.successThreshold: 2
+    asserts:
+      - matchRegex:
+          path: data["config.ini"]
+          pattern: "(?s)\\[dcgmconnectivity\\].*FailureThreshold = 4.*SuccessThreshold = 2"
+
+  - it: rejects a zero failure threshold
+    set:
+      global.platformConnectorAuth.enabled: false
+      dcgmConnectivity.runtimeDebounce.failureThreshold: 0
+    asserts:
+      - failedTemplate:
+          errorMessage: gpu-health-monitor.dcgmConnectivity.runtimeDebounce.failureThreshold must be an integer greater than or equal to 1
+
+  - it: rejects a negative success threshold
+    set:
+      global.platformConnectorAuth.enabled: false
+      dcgmConnectivity.runtimeDebounce.successThreshold: -1
+    asserts:
+      - failedTemplate:
+          errorMessage: gpu-health-monitor.dcgmConnectivity.runtimeDebounce.successThreshold must be an integer greater than or equal to 1
+
+  - it: rejects a fractional failure threshold
+    set:
+      global.platformConnectorAuth.enabled: false
+      dcgmConnectivity.runtimeDebounce.failureThreshold: 1.5
+    asserts:
+      - failedTemplate:
+          errorMessage: gpu-health-monitor.dcgmConnectivity.runtimeDebounce.failureThreshold must be an integer greater than or equal to 1
+
+  - it: rejects a quoted success threshold
+    set:
+      global.platformConnectorAuth.enabled: false
+      dcgmConnectivity.runtimeDebounce.successThreshold: "2"
+    asserts:
+      - failedTemplate:
+          errorMessage: gpu-health-monitor.dcgmConnectivity.runtimeDebounce.successThreshold must be an integer, got string "2"

--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/values.yaml
@@ -72,6 +72,15 @@ dcgmConnectivity:
     # Maximum seconds allowed for one DCGM connection and discovery attempt.
     # A timed-out attempt is terminated before the next retry begins.
     connectTimeoutSeconds: 10
+  # Debounce runtime connectivity transitions after the monitor has started.
+  # Defaults preserve the existing fail-once, recover-once behavior.
+  runtimeDebounce:
+    # Example: failureThreshold: 4 and successThreshold: 2 publishes failure
+    # after four failed cycles and recovery after two successful cycles.
+    # Consecutive failed cycles required to publish an unhealthy event.
+    failureThreshold: 1
+    # Consecutive successful cycles required to clear a published failure.
+    successThreshold: 1
 
 # DCGM field-level monitoring feature flags
 dcgmFieldsMonitoring:

--- a/distros/kubernetes/nvsentinel/values-full.yaml
+++ b/distros/kubernetes/nvsentinel/values-full.yaml
@@ -1035,6 +1035,17 @@ gpu-health-monitor:
       # Maximum seconds allowed for one DCGM connection and discovery attempt.
       # A timed-out attempt is terminated before the next retry begins.
       connectTimeoutSeconds: 10
+    # Debounce runtime connectivity transitions after the monitor has started.
+    # Defaults preserve the existing fail-once, recover-once behavior.
+    runtimeDebounce:
+      # Example: failureThreshold: 4 and successThreshold: 2 publishes failure
+      # after four failed cycles and recovery after two successful cycles.
+      # Consecutive failed cycles required to publish an unhealthy event.
+      failureThreshold: 1
+      # Consecutive successful cycles required to clear a published failure.
+      successThreshold: 1
+
+
 
   # Use host networking for GPU health monitor pods
   # Required when:

--- a/docs/configuration/gpu-health-monitor.md
+++ b/docs/configuration/gpu-health-monitor.md
@@ -259,6 +259,52 @@ Alert separately when the init program itself is repeatedly failing:
     description: "The wait-for-dcgm init container in {{ $labels.namespace }}/{{ $labels.pod }} is repeatedly failing."
 ```
 
+## Runtime DCGM Connectivity Debounce
+
+After the main container has started, transient DCGM timeouts or connection errors can be debounced before they become `GpuDcgmConnectivityFailure` transitions. For example, the following configuration requires three consecutive failures:
+
+```yaml
+gpu-health-monitor:
+  dcgmConnectivity:
+    runtimeDebounce:
+      failureThreshold: 3
+      successThreshold: 1
+```
+
+`failureThreshold` is the number of consecutive failed DCGM connectivity cycles required before the unhealthy event is published. A successful cycle before the threshold resets the failure streak, so intermittent failures do not accumulate across healthy polls.
+
+`successThreshold` is the number of consecutive successful cycles required to clear an already-published connectivity failure. A failed cycle during recovery resets the success streak and keeps the existing unhealthy event active. The threshold does not delay the initial healthy baseline event emitted for a node with no prior connectivity state.
+
+Both values must be integers greater than or equal to `1`. They default to `1`, preserving the existing fail-once and recover-once behavior. Raising `failureThreshold` filters shorter connectivity interruptions at the cost of up to `failureThreshold - 1` additional poll intervals of detection latency.
+
+The debounce state belongs to the running monitor process and is not persisted. Restarting the process resets both observation streaks. The replacement process emits its normal initial healthy baseline as soon as a complete health check succeeds, allowing platform state left by the previous process to converge without waiting for `successThreshold`.
+
+The following metric exposes the current streaks:
+
+```text
+dcgm_connectivity_consecutive_observations{result="failure"}
+dcgm_connectivity_consecutive_observations{result="success"}
+```
+
+Runtime debounce and the startup gate address different phases:
+
+- `startupGate` prevents the monitor from starting and publishing connectivity failures before DCGM has been functional once.
+- `runtimeDebounce` filters short connectivity transitions after the monitor is running.
+- The probe watchdog is not delayed by `failureThreshold`: a DCGM call that has stopped returning may have no later poll from which to build a failure streak.
+
+`dcgmHealthCheck.connectivityFailureEscalationThreshold` continues to count consecutive failed observations. If its threshold is lower than the debounce failure threshold, the first published unhealthy event may already recommend `RESTART_BM`; configure escalation at or above `failureThreshold` when a preliminary `CONTACT_SUPPORT` event is desired.
+
+Example behavior for `failureThreshold: 4` and `successThreshold: 2`:
+
+```text
+failure 1-3  -> no unhealthy event
+failure 4    -> publish GpuDcgmConnectivityFailure
+success 1    -> keep the unhealthy event active
+failure      -> reset the recovery streak
+success 1    -> keep the unhealthy event active
+success 2    -> publish the healthy recovery event
+```
+
 ## Unresponsive DCGM Detection
 
 A DCGM call that stops answering never returns an error — callers park and the probe blocks forever rather than raising `DCGMError_Timeout`. Meanwhile the node can still report `Ready` with every GPU allocatable and no taint, so no other signal in the stack registers a fault. In `embedded-mode` that hang is node-local, but it is not yet proof of a kernel-driver wedge: DCGM userspace deadlock or lock contention can look the same until an independent NVML/`nvidia-smi` probe confirms the driver itself.

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/cli.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/cli.py
@@ -67,6 +67,8 @@ def _init_event_processor(
     processing_strategy: platformconnector_pb2.ProcessingStrategy,
     store_only_checks: frozenset[str],
     connectivity_failure_escalation_threshold: int,
+    connectivity_failure_threshold: int,
+    connectivity_success_threshold: int,
     platform_connector_token_path: str,
 ):
     platform_connector_config = config["eventprocessors.platformconnector"]
@@ -82,6 +84,8 @@ def _init_event_processor(
                 processing_strategy=processing_strategy,
                 store_only_checks=store_only_checks,
                 connectivity_failure_escalation_threshold=connectivity_failure_escalation_threshold,
+                connectivity_failure_threshold=connectivity_failure_threshold,
+                connectivity_success_threshold=connectivity_success_threshold,
                 token_path=platform_connector_token_path or None,
             )
         case _:
@@ -261,6 +265,8 @@ def cli(
     suppressed_error_codes = frozenset()
     connectivity_failure_escalation_threshold = 0
     health_check_min_consecutive_polls: dict[str, int] = {}
+    connectivity_failure_threshold = 1
+    connectivity_success_threshold = 1
     if config.has_section("dcgmhealthcheck"):
         health_check_config = config["dcgmhealthcheck"]
         suppressed_error_codes_raw = health_check_config.get("SuppressedErrorCodes", fallback="")
@@ -285,6 +291,26 @@ def cli(
         if health_check_min_consecutive_polls:
             log.info(f"DCGM incident debounce thresholds: {health_check_min_consecutive_polls}")
 
+    if config.has_section("dcgmconnectivity"):
+        connectivity_config = config["dcgmconnectivity"]
+        connectivity_failure_threshold = connectivity_config.getint("FailureThreshold", fallback=1)
+        connectivity_success_threshold = connectivity_config.getint("SuccessThreshold", fallback=1)
+    if connectivity_failure_threshold < 1:
+        raise click.BadParameter(
+            "must be at least 1",
+            param_hint="dcgmconnectivity.FailureThreshold",
+        )
+    if connectivity_success_threshold < 1:
+        raise click.BadParameter(
+            "must be at least 1",
+            param_hint="dcgmconnectivity.SuccessThreshold",
+        )
+    log.info(
+        "DCGM runtime connectivity debounce: failure_threshold=%d success_threshold=%d",
+        connectivity_failure_threshold,
+        connectivity_success_threshold,
+    )
+
     enabled_event_processor_names = cli_config["EnabledEventProcessors"].split(",")
     enabled_event_processors = []
     for event_processor in enabled_event_processor_names:
@@ -300,6 +326,8 @@ def cli(
                 processing_strategy_value,
                 store_only_checks,
                 connectivity_failure_escalation_threshold,
+                connectivity_failure_threshold,
+                connectivity_success_threshold,
                 platform_connector_token_path,
             )
         )

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/platform_connector/metrics.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/platform_connector/metrics.py
@@ -40,3 +40,9 @@ dcgm_health_active_events = Gauge(
     "Active health events by watch type and GPU",
     labelnames=["event_type", "gpu_id"],
 )
+
+dcgm_connectivity_consecutive_observations = Gauge(
+    "dcgm_connectivity_consecutive_observations",
+    "Consecutive DCGM connectivity observations by result",
+    labelnames=["result"],
+)

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/platform_connector/platform_connector.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/platform_connector/platform_connector.py
@@ -98,6 +98,8 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
         store_only_checks: frozenset[str] = frozenset(),
         connectivity_failure_escalation_threshold: int = 0,
         token_path: str | None = None,
+        connectivity_failure_threshold: int = 1,
+        connectivity_success_threshold: int = 1,
     ) -> None:
         self._exit = exit
         self._socket_path = socket_path
@@ -121,8 +123,13 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
         self._processing_strategy = processing_strategy
         self._store_only_checks = store_only_checks
         self._connectivity_failure_escalation_threshold = connectivity_failure_escalation_threshold
+        self._connectivity_failure_threshold = connectivity_failure_threshold
+        self._connectivity_success_threshold = connectivity_success_threshold
         self._consecutive_connectivity_failures = 0
+        self._consecutive_connectivity_successes = 0
         self._connectivity_escalated = False
+        metrics.dcgm_connectivity_consecutive_observations.labels(result="failure").set(0)
+        metrics.dcgm_connectivity_consecutive_observations.labels(result="success").set(0)
         # Strategy used for the active local-managed probe-hang event. Restored
         # from the marker so a clear after a liveness restart still matches the
         # unhealthy event even if Helm config changed in between.
@@ -213,10 +220,31 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
         check_name = "GpuDcgmConnectivityFailure"
 
         self._consecutive_connectivity_failures = 0
-        self._connectivity_escalated = False
+        metrics.dcgm_connectivity_consecutive_observations.labels(result="failure").set(0)
 
         key = self._build_cache_key(check_name, "DCGM", "ALL")
         entry = self.entity_cache.get(key)
+        if entry is not None and entry.is_healthy:
+            self._consecutive_connectivity_successes = 0
+            metrics.dcgm_connectivity_consecutive_observations.labels(result="success").set(0)
+            return
+
+        # Preserve the existing first-poll healthy baseline. The success
+        # threshold only confirms recovery after an unhealthy event has been
+        # published; it must not delay initial Condition creation.
+        if entry is not None:
+            self._consecutive_connectivity_successes += 1
+            metrics.dcgm_connectivity_consecutive_observations.labels(result="success").set(
+                self._consecutive_connectivity_successes
+            )
+            if self._consecutive_connectivity_successes < self._connectivity_success_threshold:
+                log.info(
+                    "DCGM connectivity recovery observed %d/%d consecutive successful cycles",
+                    self._consecutive_connectivity_successes,
+                    self._connectivity_success_threshold,
+                )
+                return
+
         if entry is None or not entry.is_healthy:
             event_metadata = {}
             chassis_serial = self._metadata_reader.get_chassis_serial()
@@ -248,6 +276,9 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
                     delivery_timeout_seconds=CRITICAL_EVENT_DELIVERY_TIMEOUT_SECONDS,
                 ):
                     self.entity_cache[key] = EntityCacheEntry()
+                    self._consecutive_connectivity_successes = 0
+                    self._connectivity_escalated = False
+                    metrics.dcgm_connectivity_consecutive_observations.labels(result="success").set(0)
                     log.info(f"Updated cache for key {key} with value {self.entity_cache[key]} after successful send")
                     metrics.dcgm_health_active_events.labels(event_type=check_name, gpu_id="").set(0)
             except Exception as e:
@@ -656,10 +687,25 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
         bounded critical-event budget. DCGMWatcher uses this synchronously before
         cleanup because cleanup itself can hang on an unresponsive DCGM probe.
         """
+        self._consecutive_connectivity_failures += 1
+        self._consecutive_connectivity_successes = 0
+        metrics.dcgm_connectivity_consecutive_observations.labels(result="failure").set(
+            self._consecutive_connectivity_failures
+        )
+        metrics.dcgm_connectivity_consecutive_observations.labels(result="success").set(0)
+
+        if self._consecutive_connectivity_failures < self._connectivity_failure_threshold:
+            log.warning(
+                "DCGM connectivity failure observed %d/%d consecutive cycles; suppressing health event",
+                self._consecutive_connectivity_failures,
+                self._connectivity_failure_threshold,
+            )
+            return True
+
         with metrics.dcgm_health_events_publish_time_to_grpc_channel.labels(
             "dcgm_connectivity_failure_to_grpc_channel"
         ).time():
-            log.error("DCGM connectivity failure detected, sending GpuDcgmConnectivityFailure health event")
+            log.error("DCGM connectivity failure threshold reached")
             timestamp = Timestamp()
             timestamp.GetCurrentTime()
             health_events = []
@@ -667,10 +713,9 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
             key = self._build_cache_key(check_name, "DCGM", "ALL")
             entry = self.entity_cache.get(key)
 
-            self._consecutive_connectivity_failures += 1
-            # One failed connection is worth a page. DCGM that stays unreachable
-            # cycle after cycle is a stuck driver, and the only fix for that is a
-            # reboot, so escalate the action once the operator's threshold is hit.
+            # Once the debounce threshold is met, persistent node-local
+            # unreachability may indicate a stuck driver. Escalate the action
+            # separately once the operator's escalation threshold is hit.
             escalate = (
                 self._connectivity_failure_escalation_threshold > 0
                 and self._consecutive_connectivity_failures >= self._connectivity_failure_escalation_threshold
@@ -713,6 +758,7 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
             if not health_events:
                 return True
 
+            log.error("Sending GpuDcgmConnectivityFailure health event")
             try:
                 if self.send_health_event_with_retries(
                     health_events,

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_platform_connector/test_platform_connector.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_platform_connector/test_platform_connector.py
@@ -1838,6 +1838,129 @@ class TestPlatformConnectors(unittest.TestCase):
 
             assert servicer.health_events is None
 
+    def test_connectivity_failure_waits_for_configured_threshold(self) -> None:
+        """Transient failures stay internal until the configured streak is reached."""
+        with self._running_connector(connectivity_failure_threshold=3) as (servicer, processor):
+            assert processor.dcgm_connectivity_failed() is True
+            assert processor.dcgm_connectivity_failed() is True
+            assert servicer.health_events is None
+            assert processor._consecutive_connectivity_failures == 2
+
+            assert processor.dcgm_connectivity_failed() is True
+            assert len(servicer.health_events) == 1
+            event = servicer.health_events[0]
+            assert event.checkName == "GpuDcgmConnectivityFailure"
+            assert event.isHealthy is False
+            assert event.errorCode == ["DCGM_CONNECTIVITY_ERROR"]
+
+    def test_connectivity_success_resets_a_pending_failure_streak(self) -> None:
+        """A successful cycle before the failure threshold starts a new streak."""
+        with self._running_connector(connectivity_failure_threshold=3) as (servicer, processor):
+            timestamp = Timestamp()
+            timestamp.GetCurrentTime()
+            processor.clear_dcgm_connectivity_failure(timestamp)
+            assert servicer.health_events[0].isHealthy is True
+
+            servicer.health_events = None
+            processor.dcgm_connectivity_failed()
+            processor.dcgm_connectivity_failed()
+            assert servicer.health_events is None
+
+            processor.clear_dcgm_connectivity_failure(timestamp)
+            assert processor._consecutive_connectivity_failures == 0
+            assert servicer.health_events is None
+
+            processor.dcgm_connectivity_failed()
+            processor.dcgm_connectivity_failed()
+            assert servicer.health_events is None
+            processor.dcgm_connectivity_failed()
+            assert servicer.health_events[0].isHealthy is False
+
+    def test_connectivity_recovery_waits_for_configured_threshold(self) -> None:
+        """An active failure clears only after the configured successful streak."""
+        with self._running_connector(connectivity_success_threshold=2) as (servicer, processor):
+            processor.dcgm_connectivity_failed()
+            assert servicer.health_events[0].isHealthy is False
+
+            servicer.health_events = None
+            timestamp = Timestamp()
+            timestamp.GetCurrentTime()
+            processor.clear_dcgm_connectivity_failure(timestamp)
+            assert servicer.health_events is None
+            assert processor._consecutive_connectivity_successes == 1
+
+            processor.clear_dcgm_connectivity_failure(timestamp)
+            assert len(servicer.health_events) == 1
+            assert servicer.health_events[0].isHealthy is True
+            assert processor._consecutive_connectivity_successes == 0
+
+    def test_connectivity_failure_interrupts_pending_recovery(self) -> None:
+        """A failed cycle resets recovery confirmation without duplicating the active event."""
+        with self._running_connector(connectivity_success_threshold=2) as (servicer, processor):
+            processor.dcgm_connectivity_failed()
+            servicer.health_events = None
+
+            timestamp = Timestamp()
+            timestamp.GetCurrentTime()
+            processor.clear_dcgm_connectivity_failure(timestamp)
+            assert processor._consecutive_connectivity_successes == 1
+
+            processor.dcgm_connectivity_failed()
+            assert processor._consecutive_connectivity_successes == 0
+            assert servicer.health_events is None
+
+            processor.clear_dcgm_connectivity_failure(timestamp)
+            assert servicer.health_events is None
+            processor.clear_dcgm_connectivity_failure(timestamp)
+            assert servicer.health_events[0].isHealthy is True
+
+    def test_connectivity_initial_healthy_baseline_bypasses_recovery_threshold(self) -> None:
+        """Recovery debounce must not delay initial healthy Condition creation."""
+        with self._running_connector(connectivity_success_threshold=3) as (servicer, processor):
+            timestamp = Timestamp()
+            timestamp.GetCurrentTime()
+            processor.clear_dcgm_connectivity_failure(timestamp)
+
+            assert len(servicer.health_events) == 1
+            assert servicer.health_events[0].isHealthy is True
+            assert processor._consecutive_connectivity_successes == 0
+
+    def test_connectivity_debounce_retries_failed_transition_delivery(self) -> None:
+        """A publish failure leaves the transition eligible for the next observation."""
+        with self._running_connector(connectivity_failure_threshold=2) as (servicer, processor):
+            processor.send_health_event_with_retries = unittest.mock.Mock(side_effect=[False, True])
+
+            assert processor.dcgm_connectivity_failed() is True
+            assert processor.send_health_event_with_retries.call_count == 0
+            assert processor.dcgm_connectivity_failed() is False
+            assert processor.send_health_event_with_retries.call_count == 1
+
+            assert processor.dcgm_connectivity_failed() is True
+            assert processor.send_health_event_with_retries.call_count == 2
+            key = processor._build_cache_key("GpuDcgmConnectivityFailure", "DCGM", "ALL")
+            assert processor.entity_cache[key].active_errors == {"DCGM_CONNECTIVITY_ERROR"}
+            assert servicer.health_events is None
+
+    def test_connectivity_debounce_retries_failed_recovery_delivery(self) -> None:
+        """A failed healthy publish keeps the active event and retries on the next success."""
+        with self._running_connector(connectivity_success_threshold=2) as (_servicer, processor):
+            processor.dcgm_connectivity_failed()
+            key = processor._build_cache_key("GpuDcgmConnectivityFailure", "DCGM", "ALL")
+
+            processor.send_health_event_with_retries = unittest.mock.Mock(side_effect=[False, True])
+            timestamp = Timestamp()
+            timestamp.GetCurrentTime()
+
+            processor.clear_dcgm_connectivity_failure(timestamp)
+            assert processor.send_health_event_with_retries.call_count == 0
+            processor.clear_dcgm_connectivity_failure(timestamp)
+            assert processor.send_health_event_with_retries.call_count == 1
+            assert processor.entity_cache[key].active_errors == {"DCGM_CONNECTIVITY_ERROR"}
+
+            processor.clear_dcgm_connectivity_failure(timestamp)
+            assert processor.send_health_event_with_retries.call_count == 2
+            assert processor.entity_cache[key].is_healthy
+
     def test_connectivity_failure_escalates_to_reboot_at_threshold(self):
         """DCGM unreachable cycle after cycle is a stuck driver, which needs a reboot."""
         with self._running_connector(connectivity_failure_escalation_threshold=3) as (servicer, processor):


### PR DESCRIPTION
## Summary

  This change:

  - requires consecutive DCGM connectivity failures before publishing `GpuDcgmConnectivityFailure`;
  - requires consecutive successful checks before publishing recovery;
  - resets the failure streak after a successful check;
  - resets the recovery streak after a failed check;
  - preserves the initial healthy baseline behavior;
  - exposes the current failure and success streaks through Prometheus metrics;
  - defaults to `failureThreshold: 3` and `successThreshold: 1`.

  The startup-gating portion of this work was merged separately in #1756.

  Closes #1642

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [x] Documentation/CI
- [ ] Fault Management
- [x] Health Monitors
- [ ] Janitor
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable DCGM connectivity debouncing for GPU health monitoring.
  - Connectivity failures and recoveries use configurable consecutive-observation thresholds, defaulting to one failure and one success.
  - Added Prometheus metrics for consecutive connectivity observations.
  - Added validation requiring thresholds to be positive whole numbers.
  - Added configuration examples for certification monitoring and label-based janitor behavior.

- **Documentation**
  - Documented configuration, defaults, metrics, restart behavior, and health-monitoring interactions.

- **Tests**
  - Added coverage for thresholds, invalid values, streak resets, recovery, and event-delivery retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->