### PR TITLE
fix(chart): make DaemonSet updateStrategy configurable again

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/daemonset-dcgm-3.x.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/daemonset-dcgm-3.x.yaml
@@ -19,9 +19,11 @@ metadata:
     {{- include "gpu-health-monitor.labels" . | nindent 4 }}
 spec:
   updateStrategy:
-    type: RollingUpdate
+    type: {{ .Values.updateStrategy.type }}
+    {{- if eq .Values.updateStrategy.type "RollingUpdate" }}
     rollingUpdate:
-      maxUnavailable: 5%
+      maxUnavailable: {{ .Values.updateStrategy.rollingUpdate.maxUnavailable }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "gpu-health-monitor.selectorLabels" . | nindent 6 }}

--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/daemonset-dcgm-4.x.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/templates/daemonset-dcgm-4.x.yaml
@@ -19,9 +19,11 @@ metadata:
     {{- include "gpu-health-monitor.labels" . | nindent 4 }}
 spec:
   updateStrategy:
-    type: RollingUpdate
+    type: {{ .Values.updateStrategy.type }}
+    {{- if eq .Values.updateStrategy.type "RollingUpdate" }}
     rollingUpdate:
-      maxUnavailable: 5%
+      maxUnavailable: {{ .Values.updateStrategy.rollingUpdate.maxUnavailable }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "gpu-health-monitor.selectorLabels" . | nindent 6 }}

--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/values.yaml
@@ -190,3 +190,10 @@ processingStrategy: EXECUTE_REMEDIATION
 # present at boot. GPUs with no NVLink silicon (L40, A40) are always
 # suppressed regardless of this value.
 suppressNvlinkDownOnUnbridgedPcie: "False"
+
+# Rolling update budget for this DaemonSet. maxUnavailable counts pods stranded on
+# unreachable nodes as well, so a cluster with many nodes down may need it raised.
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 5%

--- a/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/gpu-health-monitor/values.yaml
@@ -191,8 +191,13 @@ processingStrategy: EXECUTE_REMEDIATION
 # suppressed regardless of this value.
 suppressNvlinkDownOnUnbridgedPcie: "False"
 
-# Rolling update budget for this DaemonSet. maxUnavailable counts pods stranded on
-# unreachable nodes as well, so a cluster with many nodes down may need it raised.
+# DaemonSet rolling update strategy. Shared by the dcgm-3.x and dcgm-4.x DaemonSets;
+# both are generated from this chart and only one is scheduled per node's DCGM major.
+# type: RollingUpdate or OnDelete. rollingUpdate is only rendered for RollingUpdate.
+# maxUnavailable counts pods stranded on unreachable nodes as well, so a cluster with
+# many nodes down for service may need it raised or the rollout cannot start.
+# Example, absolute count instead of a percentage:
+#   updateStrategy: {type: RollingUpdate, rollingUpdate: {maxUnavailable: 34}}
 updateStrategy:
   type: RollingUpdate
   rollingUpdate:

--- a/distros/kubernetes/nvsentinel/charts/metadata-collector/templates/daemonset.yaml
+++ b/distros/kubernetes/nvsentinel/charts/metadata-collector/templates/daemonset.yaml
@@ -20,9 +20,11 @@ metadata:
     {{- include "metadata-collector.labels" . | nindent 4 }}
 spec:
   updateStrategy:
-    type: RollingUpdate
+    type: {{ .Values.updateStrategy.type }}
+    {{- if eq .Values.updateStrategy.type "RollingUpdate" }}
     rollingUpdate:
-      maxUnavailable: 5%
+      maxUnavailable: {{ .Values.updateStrategy.rollingUpdate.maxUnavailable }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "metadata-collector.selectorLabels" . | nindent 6 }}

--- a/distros/kubernetes/nvsentinel/charts/metadata-collector/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/metadata-collector/values.yaml
@@ -74,3 +74,10 @@ kubeletHost:
 
 # Pod priority for this component. Overridden by the matching global when that is set.
 priorityClassName: ""
+
+# Rolling update budget for this DaemonSet. maxUnavailable counts pods stranded on
+# unreachable nodes as well, so a cluster with many nodes down may need it raised.
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 5%

--- a/distros/kubernetes/nvsentinel/charts/metadata-collector/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/metadata-collector/values.yaml
@@ -75,8 +75,12 @@ kubeletHost:
 # Pod priority for this component. Overridden by the matching global when that is set.
 priorityClassName: ""
 
-# Rolling update budget for this DaemonSet. maxUnavailable counts pods stranded on
-# unreachable nodes as well, so a cluster with many nodes down may need it raised.
+# DaemonSet rolling update strategy.
+# type: RollingUpdate or OnDelete. rollingUpdate is only rendered for RollingUpdate.
+# maxUnavailable counts pods stranded on unreachable nodes as well, so a cluster with
+# many nodes down for service may need it raised or the rollout cannot start.
+# Example, absolute count instead of a percentage:
+#   updateStrategy: {type: RollingUpdate, rollingUpdate: {maxUnavailable: 34}}
 updateStrategy:
   type: RollingUpdate
   rollingUpdate:

--- a/distros/kubernetes/nvsentinel/charts/nic-health-monitor/templates/daemonset.yaml
+++ b/distros/kubernetes/nvsentinel/charts/nic-health-monitor/templates/daemonset.yaml
@@ -20,9 +20,11 @@ metadata:
     {{- include "nic-health-monitor.labels" . | nindent 4 }}
 spec:
   updateStrategy:
-    type: RollingUpdate
+    type: {{ .Values.updateStrategy.type }}
+    {{- if eq .Values.updateStrategy.type "RollingUpdate" }}
     rollingUpdate:
-      maxUnavailable: 5%
+      maxUnavailable: {{ .Values.updateStrategy.rollingUpdate.maxUnavailable }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "nic-health-monitor.selectorLabels" . | nindent 6 }}

--- a/distros/kubernetes/nvsentinel/charts/nic-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/nic-health-monitor/values.yaml
@@ -209,3 +209,10 @@ logLevel: info
 # EXECUTE_REMEDIATION: normal behavior; downstream modules may update cluster state.
 # STORE_ONLY: observability-only behavior; event should be persisted/exported but should not modify cluster resources.
 processingStrategy: EXECUTE_REMEDIATION
+
+# Rolling update budget for this DaemonSet. maxUnavailable counts pods stranded on
+# unreachable nodes as well, so a cluster with many nodes down may need it raised.
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 5%

--- a/distros/kubernetes/nvsentinel/charts/nic-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/nic-health-monitor/values.yaml
@@ -210,8 +210,12 @@ logLevel: info
 # STORE_ONLY: observability-only behavior; event should be persisted/exported but should not modify cluster resources.
 processingStrategy: EXECUTE_REMEDIATION
 
-# Rolling update budget for this DaemonSet. maxUnavailable counts pods stranded on
-# unreachable nodes as well, so a cluster with many nodes down may need it raised.
+# DaemonSet rolling update strategy.
+# type: RollingUpdate or OnDelete. rollingUpdate is only rendered for RollingUpdate.
+# maxUnavailable counts pods stranded on unreachable nodes as well, so a cluster with
+# many nodes down for service may need it raised or the rollout cannot start.
+# Example, absolute count instead of a percentage:
+#   updateStrategy: {type: RollingUpdate, rollingUpdate: {maxUnavailable: 34}}
 updateStrategy:
   type: RollingUpdate
   rollingUpdate:

--- a/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/templates/_helpers.tpl
+++ b/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/templates/_helpers.tpl
@@ -56,9 +56,11 @@ metadata:
     {{- include "syslog-health-monitor.labels" $root | nindent 4 }}
 spec:
   updateStrategy:
-    type: RollingUpdate
+    type: {{ $root.Values.updateStrategy.type }}
+    {{- if eq $root.Values.updateStrategy.type "RollingUpdate" }}
     rollingUpdate:
-      maxUnavailable: 5%
+      maxUnavailable: {{ $root.Values.updateStrategy.rollingUpdate.maxUnavailable }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "syslog-health-monitor.selectorLabels" $root | nindent 6 }}

--- a/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/values.yaml
@@ -108,8 +108,13 @@ cancellations:
       - onErrorCode: "162"
         cancelErrorCodes: ["163"]
 
-# Rolling update budget for this DaemonSet. maxUnavailable counts pods stranded on
-# unreachable nodes as well, so a cluster with many nodes down may need it raised.
+# DaemonSet rolling update strategy. Shared by both generated DaemonSet variants,
+# syslog-health-monitor-regular and syslog-health-monitor-kata.
+# type: RollingUpdate or OnDelete. rollingUpdate is only rendered for RollingUpdate.
+# maxUnavailable counts pods stranded on unreachable nodes as well, so a cluster with
+# many nodes down for service may need it raised or the rollout cannot start.
+# Example, absolute count instead of a percentage:
+#   updateStrategy: {type: RollingUpdate, rollingUpdate: {maxUnavailable: 34}}
 updateStrategy:
   type: RollingUpdate
   rollingUpdate:

--- a/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/syslog-health-monitor/values.yaml
@@ -107,3 +107,10 @@ cancellations:
       # XID 162 (PSHC re-engaged) implies recovery from XID 163 (PSHC disengaged).
       - onErrorCode: "162"
         cancelErrorCodes: ["163"]
+
+# Rolling update budget for this DaemonSet. maxUnavailable counts pods stranded on
+# unreachable nodes as well, so a cluster with many nodes down may need it raised.
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 5%

--- a/distros/kubernetes/nvsentinel/templates/daemonset.yaml
+++ b/distros/kubernetes/nvsentinel/templates/daemonset.yaml
@@ -20,9 +20,11 @@ metadata:
     {{- include "nvsentinel.labels" . | nindent 4 }}
 spec:
   updateStrategy:
-    type: RollingUpdate
+    type: {{ .Values.updateStrategy.type }}
+    {{- if eq .Values.updateStrategy.type "RollingUpdate" }}
     rollingUpdate:
-      maxUnavailable: 5%
+      maxUnavailable: {{ .Values.updateStrategy.rollingUpdate.maxUnavailable }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "nvsentinel.selectorLabels" . | nindent 6 }}

--- a/distros/kubernetes/nvsentinel/values.yaml
+++ b/distros/kubernetes/nvsentinel/values.yaml
@@ -497,8 +497,12 @@ podMonitor:
   # metricsPath: "/metrics"  # Metrics path (defaults to /metrics)
   # labels: {}  # Additional labels for the PodMonitor resource
 
-# Rolling update budget for this DaemonSet. maxUnavailable counts pods stranded on
-# unreachable nodes as well, so a cluster with many nodes down may need it raised.
+# DaemonSet rolling update strategy for the platform-connectors DaemonSet.
+# type: RollingUpdate or OnDelete. rollingUpdate is only rendered for RollingUpdate.
+# maxUnavailable counts pods stranded on unreachable nodes as well, so a cluster with
+# many nodes down for service may need it raised or the rollout cannot start.
+# Example, absolute count instead of a percentage:
+#   updateStrategy: {type: RollingUpdate, rollingUpdate: {maxUnavailable: 34}}
 updateStrategy:
   type: RollingUpdate
   rollingUpdate:

--- a/distros/kubernetes/nvsentinel/values.yaml
+++ b/distros/kubernetes/nvsentinel/values.yaml
@@ -496,3 +496,10 @@ podMonitor:
   # scrapeTimeout: ""  # Scrape timeout (defaults to Prometheus default if not specified)
   # metricsPath: "/metrics"  # Metrics path (defaults to /metrics)
   # labels: {}  # Additional labels for the PodMonitor resource
+
+# Rolling update budget for this DaemonSet. maxUnavailable counts pods stranded on
+# unreachable nodes as well, so a cluster with many nodes down may need it raised.
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 5%


### PR DESCRIPTION
Fixes #1764. Restores the Helm value that #232 replaced with a literal, keeping `5%` as the default.

Per chart rather than one global, as you asked. `gpu-health-monitor`'s two DaemonSets share their chart's key, which I took to be the intent.

## Why the explicit form rather than `toYaml`

I tried `{{- toYaml .Values.updateStrategy | nindent 4 }}` first, matching the bundled `mongodb` and `postgresql` subcharts. It works, but `toYaml` sorts map keys, so it emits `rollingUpdate:` before `type:` and changes the rendered output for every existing user without changing its meaning.

Using the explicit `if eq .type "RollingUpdate"` shape instead — which is exactly what these templates had before #232 — makes the default render **byte-identical** to `main`. Happy to switch to `toYaml` if you would rather have the shorter template and do not mind the key reordering.

## Verified

- **Default render is byte-identical to `main`**, 1848 lines, across all six DaemonSets (`platform-connectors`, `gpu-health-monitor-dcgm-3.x`, `gpu-health-monitor-dcgm-4.x`, `metadata-collector`, `syslog-health-monitor-kata`, `syslog-health-monitor-regular`).
- **Each chart's override binds independently:**

```
--set updateStrategy.rollingUpdate.maxUnavailable=34                      -> platform-connectors            34
--set gpu-health-monitor.updateStrategy.rollingUpdate.maxUnavailable=40   -> both gpu-health-monitor DS      40
--set metadata-collector.updateStrategy.rollingUpdate.maxUnavailable=41   -> metadata-collector              41
--set syslog-health-monitor.updateStrategy.rollingUpdate.maxUnavailable=42 -> both syslog-health-monitor DS  42
```

- **`type: OnDelete` correctly drops the `rollingUpdate` block**, so the guard works.
- `helm lint` clean.

`nic-health-monitor` gets the same treatment for consistency; it is disabled by default here so it does not appear in the render above.

## Left open deliberately

The other half of #1764, documenting *why* 5%, I have not attempted. I do not know the answer, and writing a rationale I had inferred would be worse than writing none, so the new values comments describe only the mechanism (that `maxUnavailable` counts pods stranded on unreachable nodes). If you can say what the 5% encodes, I am glad to add it in a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable DaemonSet update strategies across GPU, NIC, metadata, syslog, and core monitoring deployments.
  * Added configurable rolling-update limits, with existing configurations retaining a 5% maximum of unavailable pods.
  * Rolling-update settings are rendered only when the RollingUpdate strategy is selected.

* **Documentation**
  * Documented supported update strategies, rolling-update behavior, unreachable-node handling, and absolute-count examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->