### PR TITLE
fix(janitor): avoid hardcoded host driver root path

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/janitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/templates/configmap.yaml
@@ -94,6 +94,7 @@ data:
       resetJob:
         writeSysLogEvent: "{{ .Values.config.controllers.gpuReset.resetJob.writeSysLogEvent }}"
         runtimeClassName: "{{ .Values.config.controllers.gpuReset.resetJob.runtimeClassName }}"
+        hostDriverRootPath: {{ .Values.config.controllers.gpuReset.resetJob.hostDriverRootPath | default "/run/nvidia/driver" | quote }}
         {{- if $gpuResetUploadURL }}
         uploadURL: {{ $gpuResetUploadURL | quote }}
         {{- end }}

--- a/distros/kubernetes/nvsentinel/charts/janitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/templates/configmap.yaml
@@ -94,7 +94,7 @@ data:
       resetJob:
         writeSysLogEvent: "{{ .Values.config.controllers.gpuReset.resetJob.writeSysLogEvent }}"
         runtimeClassName: "{{ .Values.config.controllers.gpuReset.resetJob.runtimeClassName }}"
-        hostDriverRootPath: {{ .Values.config.controllers.gpuReset.resetJob.hostDriverRootPath | default "/run/nvidia/driver" | quote }}
+        hostDriverRootPath: {{ .Values.config.controllers.gpuReset.resetJob.hostDriverRootPath | quote }}
         {{- if $gpuResetUploadURL }}
         uploadURL: {{ $gpuResetUploadURL | quote }}
         {{- end }}

--- a/distros/kubernetes/nvsentinel/charts/janitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/templates/configmap.yaml
@@ -94,7 +94,7 @@ data:
       resetJob:
         writeSysLogEvent: "{{ .Values.config.controllers.gpuReset.resetJob.writeSysLogEvent }}"
         runtimeClassName: "{{ .Values.config.controllers.gpuReset.resetJob.runtimeClassName }}"
-        hostDriverRootPath: {{ .Values.config.controllers.gpuReset.resetJob.hostDriverRootPath | quote }}
+        hostDriverRootPath: "{{ .Values.config.controllers.gpuReset.resetJob.hostDriverRootPath }}"
         {{- if $gpuResetUploadURL }}
         uploadURL: {{ $gpuResetUploadURL | quote }}
         {{- end }}

--- a/distros/kubernetes/nvsentinel/charts/janitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/values.yaml
@@ -170,6 +170,10 @@ config:
       resetJob:
         writeSysLogEvent: true
         runtimeClassName: "nvidia"
+        # Host path that contains the NVIDIA driver filesystem. Containerized
+        # driver installations commonly use /run/nvidia/driver. Set this to /
+        # when the NVIDIA driver is installed directly on the host.
+        hostDriverRootPath: "/run/nvidia/driver"
         # Optional upload endpoint for nvidia-bug-report artifacts collected after failed GPU resets.
         # When empty and global.inclusterFileServer.enabled is true, this defaults to the
         # release's incluster-file-server /upload endpoint.

--- a/docs/configuration/janitor.md
+++ b/docs/configuration/janitor.md
@@ -197,6 +197,7 @@ janitor:
         resetJob:
           writeSysLogEvent: true
           runtimeClassName: "nvidia"
+          hostDriverRootPath: "/run/nvidia/driver"
           image:
             repository: ghcr.io/nvidia/nvsentinel/gpu-reset
             tag: ""
@@ -219,6 +220,11 @@ When `true`, the reset job writes a kernel syslog message on reset completion. U
 
 ### resetJob.runtimeClassName
 NVIDIA RuntimeClass name used by the GPU reset Job. Must match a RuntimeClass installed in the cluster.
+
+### resetJob.hostDriverRootPath
+Host path containing the NVIDIA driver filesystem. It is mounted at `/run/nvidia/driver` inside the reset container, where the reset command uses it as a chroot.
+
+Keep the default `/run/nvidia/driver` for containerized driver installations. Set it to `/` when the driver is installed directly into the host filesystem and `nvidia-smi` is available at a path such as `/usr/bin/nvidia-smi`.
 
 ### resetJob.image
 Container image for the GPU reset Job. Leave `tag` empty to use the chart default.

--- a/janitor/pkg/config/config.go
+++ b/janitor/pkg/config/config.go
@@ -110,12 +110,12 @@ type GPUResetControllerConfig struct {
 }
 
 type ResetJobConfig struct {
-	ImageConfig      ImageConfig          `mapstructure:"imageConfig" json:"imageConfig"`
-	Resources        ResourceRequirements `mapstructure:"resources" json:"resources"`
-	RuntimeClassName string               `mapstructure:"runtimeClassName" json:"runtimeClassName"`
-	HostDriverRootPath string `mapstructure:"hostDriverRootPath" json:"hostDriverRootPath"`
-	WriteSysLogEvent   *bool  `mapstructure:"writeSysLogEvent" json:"writeSysLogEvent"`
-	UploadURL          string `mapstructure:"uploadURL" json:"uploadURL"`
+	ImageConfig        ImageConfig          `mapstructure:"imageConfig" json:"imageConfig"`
+	Resources          ResourceRequirements `mapstructure:"resources" json:"resources"`
+	RuntimeClassName   string               `mapstructure:"runtimeClassName" json:"runtimeClassName"`
+	HostDriverRootPath string               `mapstructure:"hostDriverRootPath" json:"hostDriverRootPath"`
+	WriteSysLogEvent   *bool                `mapstructure:"writeSysLogEvent" json:"writeSysLogEvent"`
+	UploadURL          string               `mapstructure:"uploadURL" json:"uploadURL"`
 }
 
 type ResourceRequirements struct {

--- a/janitor/pkg/config/config.go
+++ b/janitor/pkg/config/config.go
@@ -113,8 +113,10 @@ type ResetJobConfig struct {
 	ImageConfig      ImageConfig          `mapstructure:"imageConfig" json:"imageConfig"`
 	Resources        ResourceRequirements `mapstructure:"resources" json:"resources"`
 	RuntimeClassName string               `mapstructure:"runtimeClassName" json:"runtimeClassName"`
-	WriteSysLogEvent *bool                `mapstructure:"writeSysLogEvent" json:"writeSysLogEvent"`
-	UploadURL        string               `mapstructure:"uploadURL" json:"uploadURL"`
+	// HostDriverRootPath is mounted at DriverRootMountPath in the reset container.
+	HostDriverRootPath string `mapstructure:"hostDriverRootPath" json:"hostDriverRootPath"`
+	WriteSysLogEvent   *bool  `mapstructure:"writeSysLogEvent" json:"writeSysLogEvent"`
+	UploadURL          string `mapstructure:"uploadURL" json:"uploadURL"`
 }
 
 type ResourceRequirements struct {
@@ -176,15 +178,13 @@ func LoadConfig(configPath string, namespace string) (*Config, error) {
 			return nil, fmt.Errorf("ResetJob.ImageConfig.Image is required but not set")
 		}
 
-		if config.GPUReset.ResetJob.WriteSysLogEvent == nil {
-			config.GPUReset.ResetJob.WriteSysLogEvent = new(true)
-		}
+		applyResetJobDefaults(&config.GPUReset.ResetJob)
 
 		resetJobConfig := config.GPUReset.ResetJob
 
 		jobTemplate, err := getDefaultGPUResetJobTemplate(namespace, resetJobConfig.ImageConfig.Image,
-			resetJobConfig.ImageConfig.ImagePullSecrets, resetJobConfig.Resources, resetJobConfig.RuntimeClassName,
-			*resetJobConfig.WriteSysLogEvent, resetJobConfig.UploadURL)
+			resetJobConfig.ImageConfig.ImagePullSecrets, resetJobConfig.Resources, resetJobConfig.HostDriverRootPath,
+			resetJobConfig.RuntimeClassName, *resetJobConfig.WriteSysLogEvent, resetJobConfig.UploadURL)
 		if err != nil {
 			return nil, err
 		}

--- a/janitor/pkg/config/config.go
+++ b/janitor/pkg/config/config.go
@@ -113,7 +113,6 @@ type ResetJobConfig struct {
 	ImageConfig      ImageConfig          `mapstructure:"imageConfig" json:"imageConfig"`
 	Resources        ResourceRequirements `mapstructure:"resources" json:"resources"`
 	RuntimeClassName string               `mapstructure:"runtimeClassName" json:"runtimeClassName"`
-	// HostDriverRootPath is mounted at DriverRootMountPath in the reset container.
 	HostDriverRootPath string `mapstructure:"hostDriverRootPath" json:"hostDriverRootPath"`
 	WriteSysLogEvent   *bool  `mapstructure:"writeSysLogEvent" json:"writeSysLogEvent"`
 	UploadURL          string `mapstructure:"uploadURL" json:"uploadURL"`

--- a/janitor/pkg/config/config_test.go
+++ b/janitor/pkg/config/config_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/nvidia/nvsentinel/janitor/pkg/gpuservices"
@@ -149,6 +150,7 @@ gpuResetController:
   resetJob:
     writeSysLogEvent: true
     runtimeClassName: "nvidia"
+    hostDriverRootPath: "/"
     uploadURL: "http://nvsentinel-incluster-file-server.nvsentinel.svc.cluster.local/upload"
     imageConfig:
       image: "alpine:latest"
@@ -216,6 +218,7 @@ gpuResetController:
 	assert.False(t, *config.GPUReset.ManualMode)
 	assert.Equal(t, "http://nvsentinel-incluster-file-server.nvsentinel.svc.cluster.local/upload",
 		config.GPUReset.ResetJob.UploadURL)
+	assert.Equal(t, "/", config.GPUReset.ResetJob.HostDriverRootPath)
 	assert.Len(t, config.GPUReset.Exclusions, 1)
 	assert.Equal(t, "qa", config.GPUReset.Exclusions[0].MatchLabels["environment"])
 	assert.Equal(t, "true", config.GPUReset.Exclusions[0].MatchLabels["critical"])
@@ -237,9 +240,45 @@ gpuResetController:
 		},
 	}
 	expectedJobTemplate, err := getDefaultGPUResetJobTemplate(testNamespace, "alpine:latest", imagePullSecrets,
-		resourceRequirements, "nvidia", true, "http://nvsentinel-incluster-file-server.nvsentinel.svc.cluster.local/upload")
+		resourceRequirements, "/", "nvidia", true,
+		"http://nvsentinel-incluster-file-server.nvsentinel.svc.cluster.local/upload")
 	assert.NoError(t, err)
 	assert.Equal(t, expectedJobTemplate, config.GPUReset.ResolvedJobTemplate)
+
+	var driverRootVolume *corev1.Volume
+	for index := range config.GPUReset.ResolvedJobTemplate.Spec.Template.Spec.Volumes {
+		volume := &config.GPUReset.ResolvedJobTemplate.Spec.Template.Spec.Volumes[index]
+		if volume.Name == DriverRootVolumeName {
+			driverRootVolume = volume
+			break
+		}
+	}
+	require.NotNil(t, driverRootVolume)
+	require.NotNil(t, driverRootVolume.HostPath)
+	assert.Equal(t, "/", driverRootVolume.HostPath.Path)
+
+	container := config.GPUReset.ResolvedJobTemplate.Spec.Template.Spec.Containers[0]
+	var driverRootMount *corev1.VolumeMount
+	for index := range container.VolumeMounts {
+		mount := &container.VolumeMounts[index]
+		if mount.Name == DriverRootVolumeName {
+			driverRootMount = mount
+			break
+		}
+	}
+	require.NotNil(t, driverRootMount)
+	assert.Equal(t, DriverRootMountPath, driverRootMount.MountPath)
+
+	var driverRootEnv *corev1.EnvVar
+	for index := range container.Env {
+		env := &container.Env[index]
+		if env.Name == "DRIVER_ROOT" {
+			driverRootEnv = env
+			break
+		}
+	}
+	require.NotNil(t, driverRootEnv)
+	assert.Equal(t, DriverRootMountPath, driverRootEnv.Value)
 
 	expectedServiceManager := gpuservices.Manager{
 		Name: "gpu-operator",
@@ -304,7 +343,7 @@ gpuResetController:
 	assert.True(t, config.GPUReset.Enabled)
 
 	expectedJobTemplate, err := getDefaultGPUResetJobTemplate(testNamespace, "alpine:latest", nil,
-		ResourceRequirements{}, "", true, "")
+		ResourceRequirements{}, DefaultHostDriverRootPath, "", true, "")
 	assert.NoError(t, err)
 	assert.Equal(t, expectedJobTemplate, config.GPUReset.ResolvedJobTemplate)
 
@@ -355,7 +394,7 @@ gpuResetController:
 	assert.True(t, config.GPUReset.Enabled)
 
 	expectedJobTemplate, err := getDefaultGPUResetJobTemplate(testNamespace, "alpine:latest", nil,
-		ResourceRequirements{}, "", true, "")
+		ResourceRequirements{}, DefaultHostDriverRootPath, "", true, "")
 	assert.NoError(t, err)
 	assert.Equal(t, expectedJobTemplate, config.GPUReset.ResolvedJobTemplate)
 
@@ -444,7 +483,7 @@ gpuResetController:
 	assert.True(t, config.GPUReset.Enabled)
 
 	expectedJobTemplate, err := getDefaultGPUResetJobTemplate(testNamespace, "alpine:latest", nil,
-		ResourceRequirements{}, "", false, "")
+		ResourceRequirements{}, DefaultHostDriverRootPath, "", false, "")
 	assert.NoError(t, err)
 	assert.Equal(t, expectedJobTemplate, config.GPUReset.ResolvedJobTemplate)
 

--- a/janitor/pkg/config/default.go
+++ b/janitor/pkg/config/default.go
@@ -25,18 +25,19 @@ import (
 )
 
 const (
-	GPUResetContainerName  = "gpu-reset"
-	HostDevVolumeName      = "host-dev"
-	HostDevPath            = "/dev"
-	HostDevLogVolumeName   = "dev-log"
-	HostDevLogPath         = "/run/systemd/journal/dev-log"
-	DriverRootVolumeName   = "driver-root"
-	DriverRootPath         = "/run/nvidia/driver"
-	HostSysVolumeName      = "host-sys"
-	HostSysPath            = "/sys"
-	WriteSyslogEventEnvVar = "WRITE_SYSLOG_EVENT"
-	NodeNameEnvVar         = "NODE_NAME"
-	UploadURLBaseEnvVar    = "UPLOAD_URL_BASE"
+	GPUResetContainerName     = "gpu-reset"
+	HostDevVolumeName         = "host-dev"
+	HostDevPath               = "/dev"
+	HostDevLogVolumeName      = "dev-log"
+	HostDevLogPath            = "/run/systemd/journal/dev-log"
+	DriverRootVolumeName      = "driver-root"
+	DefaultHostDriverRootPath = "/run/nvidia/driver"
+	DriverRootMountPath       = "/run/nvidia/driver"
+	HostSysVolumeName         = "host-sys"
+	HostSysPath               = "/sys"
+	WriteSyslogEventEnvVar    = "WRITE_SYSLOG_EVENT"
+	NodeNameEnvVar            = "NODE_NAME"
+	UploadURLBaseEnvVar       = "UPLOAD_URL_BASE"
 )
 
 func applyConfigDefaults(config *Config) {
@@ -139,6 +140,16 @@ func applyCSPProviderHostDefaults(config *Config) {
 	}
 }
 
+func applyResetJobDefaults(config *ResetJobConfig) {
+	if config.WriteSysLogEvent == nil {
+		config.WriteSysLogEvent = new(true)
+	}
+
+	if config.HostDriverRootPath == "" {
+		config.HostDriverRootPath = DefaultHostDriverRootPath
+	}
+}
+
 func getResources(resources ResourceRequirements) (*corev1.ResourceRequirements, error) {
 	limits, err := parseResourceList(resources.Limits)
 	if err != nil {
@@ -184,9 +195,13 @@ func getImagePullSecrets(imagePullSecrets []ImagePullSecret) []corev1.LocalObjec
 
 // getDefaultGPUResetJobTemplate returns the default JobTemplateSpec for GPU reset jobs.
 func getDefaultGPUResetJobTemplate(namespace string, image string, secrets []ImagePullSecret,
-	resources ResourceRequirements, runtimeClassName string, writeSyslogEvent bool,
+	resources ResourceRequirements, hostDriverRootPath string, runtimeClassName string, writeSyslogEvent bool,
 	uploadURL string) (*batchv1.JobTemplateSpec, error) {
 	imagePullSecrets := getImagePullSecrets(secrets)
+
+	if hostDriverRootPath == "" {
+		hostDriverRootPath = DefaultHostDriverRootPath
+	}
 
 	containerResources, err := getResources(resources)
 	if err != nil {
@@ -217,7 +232,7 @@ func getDefaultGPUResetJobTemplate(namespace string, image string, secrets []Ima
 						{
 							Name: DriverRootVolumeName,
 							HostPath: &corev1.HostPathVolumeSource{
-								Path: DriverRootPath,
+								Path: hostDriverRootPath,
 							},
 						},
 						{
@@ -240,7 +255,7 @@ func getDefaultGPUResetJobTemplate(namespace string, image string, secrets []Ima
 								},
 								{
 									Name:  "DRIVER_ROOT",
-									Value: DriverRootPath,
+									Value: DriverRootMountPath,
 								},
 								{
 									Name:  WriteSyslogEventEnvVar,
@@ -270,11 +285,11 @@ func getDefaultGPUResetJobTemplate(namespace string, image string, secrets []Ima
 								},
 								{
 									Name:      DriverRootVolumeName,
-									MountPath: DriverRootPath,
+									MountPath: DriverRootMountPath,
 								},
 								{
 									Name:      HostSysVolumeName,
-									MountPath: DriverRootPath + HostSysPath,
+									MountPath: DriverRootMountPath + HostSysPath,
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{


### PR DESCRIPTION
## Summary

Closes https://github.com/NVIDIA/NVSentinel/issues/1784

Currently the GPU reset driver root is hard-coded to be `/run/nvidia/driver`, which is not the case for all host machines obviously; in this PR I make it configurable meanwhile keep the default behavior unchanged.

## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Health Monitors
- [ ] Fault Management
- [X] Deployment/Config
- [ ] API/Interface
- [ ] Preflight
- [ ] Plugins
- [ ] Janitor
- [ ] Documentation/CI
- [ ] Other: ____________

## Testing
- [ ] Tests pass locally
- [ ] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable host driver root path support for GPU reset jobs.
  - GPU reset jobs now mount the configured NVIDIA driver directory and use it for driver-related operations.
  - A default path is provided for environments using the standard NVIDIA driver location.

- **Documentation**
  - Added guidance for host-installed and containerized NVIDIA drivers, including mount and path requirements.

- **Tests**
  - Added coverage for custom and default driver paths, generated mounts, and environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->