### PR TITLE
fix(statemanager): allow direct remediation failure after drain

### DIFF
--- a/commons/pkg/statemanager/statemanager.go
+++ b/commons/pkg/statemanager/statemanager.go
@@ -90,6 +90,7 @@
 //
 //	Remediation Phase:
 //	  drain-succeeded → remediating              (fault-remediation starts remediation)
+//	  drain-succeeded → remediation-failed       (recommended action is unsupported)
 //	  remediating → remediation-succeeded        (fault-remediation: success)
 //	  remediating → remediation-failed           (fault-remediation: failure)
 //
@@ -135,13 +136,16 @@
 //  2. Failed remediation:
 //     none → quarantined → draining → drain-succeeded → remediating → remediation-failed [TERMINAL]
 //
-//  3. No pods to drain:
+//  3. Unsupported remediation:
+//     none → quarantined → draining → drain-succeeded → remediation-failed [TERMINAL]
+//
+//  4. No pods to drain:
 //     none → quarantined → drain-succeeded → remediating → remediation-succeeded → (no label)
 //
-//  4. Failed draining:
+//  5. Failed draining:
 //     none → quarantined → draining → drain-failed [TERMINAL]
 //
-//  5. Canceled drain (healthy event):
+//  6. Canceled drain (healthy event):
 //     none → quarantined → draining → (no label)
 //
 // # Validation Behavior
@@ -409,7 +413,7 @@ func validateStateTransition(nodeName, currentValue string, exists bool, targetS
 	validTransitions := map[NVSentinelStateLabelValue][]NVSentinelStateLabelValue{
 		QuarantinedLabelValue:    {DrainingLabelValue, DrainSucceededLabelValue},
 		DrainingLabelValue:       {DrainSucceededLabelValue, DrainFailedLabelValue},
-		DrainSucceededLabelValue: {RemediatingLabelValue},
+		DrainSucceededLabelValue: {RemediatingLabelValue, RemediationFailedLabelValue},
 		DrainFailedLabelValue:    {}, // Terminal state - fault-remediation doesn't consume drain-failed
 		RemediatingLabelValue:    {RemediationSucceededLabelValue, RemediationFailedLabelValue},
 		// remediation-succeeded and remediation-failed are terminal for a single failure, but a

--- a/commons/pkg/statemanager/statemanager_test.go
+++ b/commons/pkg/statemanager/statemanager_test.go
@@ -293,6 +293,9 @@ func TestStateTransitionValidProgression(t *testing.T) {
 		{"Draining to DrainSucceeded", string(DrainingLabelValue), DrainSucceededLabelValue, true, false},
 		{"Draining to DrainFailed", string(DrainingLabelValue), DrainFailedLabelValue, true, false},
 		{"DrainSucceeded to Remediating", string(DrainSucceededLabelValue), RemediatingLabelValue, true, false},
+		// Unsupported actions do not start remediation, so they transition directly to the
+		// terminal failure state to indicate that operator intervention is required.
+		{"DrainSucceeded to RemediationFailed", string(DrainSucceededLabelValue), RemediationFailedLabelValue, true, false},
 		{"Remediating to RemediationSucceeded", string(RemediatingLabelValue), RemediationSucceededLabelValue, true, false},
 		{"Remediating to RemediationFailed", string(RemediatingLabelValue), RemediationFailedLabelValue, true, false},
 		{"Quarantined to DrainSucceeded", string(QuarantinedLabelValue), DrainSucceededLabelValue, true, false},


### PR DESCRIPTION
## Summary

Closes https://github.com/NVIDIA/NVSentinel/issues/1786

As described in the issue, even for valid remediation config application still fails state transfer validation (in detail, drain successful -> remediation fails). In this PR I simply accept the state transfer as legal.

## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Health Monitors
- [ ] Fault Management
- [X] Deployment/Config
- [ ] API/Interface
- [ ] Preflight
- [ ] Plugins
- [ ] Janitor
- [ ] Documentation/CI
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [ ] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Remediation workflows now correctly allow a transition from a successfully drained state to a remediation-failed outcome.
  - State validation recognizes this terminal failure path, preventing valid remediation results from being rejected.

- **Documentation**
  - Added guidance and examples for handling unsupported remediation actions and the resulting failure state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->