### PR TITLE
fix: publish slurm-drain-monitor image via ko build

### DIFF
--- a/.github/workflows/cleanup-untagged-images.yml
+++ b/.github/workflows/cleanup-untagged-images.yml
@@ -94,6 +94,7 @@ jobs:
           - nvsentinel/preflight-dcgm-diag
           - nvsentinel/nic-health-monitor
           - nvsentinel/preflight-nccl-allreduce
+          - nvsentinel/slurm-drain-monitor
 
     steps:
       - name: Delete untagged images for ${{ matrix.package }}

--- a/.github/workflows/container-build-test.yml
+++ b/.github/workflows/container-build-test.yml
@@ -141,6 +141,8 @@ jobs:
             path: .
           - module: health-monitors/nic-health-monitor
             path: .
+          - module: health-monitors/slurm-drain-monitor
+            path: .
           - module: event-exporter
             path: .
           - module: plugins/slinky-drainer

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -120,6 +120,7 @@ jobs:
           - component: kubernetes-object-monitor
           - component: nvcre-certification-monitor
           - component: nic-health-monitor
+          - component: slurm-drain-monitor
           - component: gpu-health-monitor
             install_dcgm: 'true'
             python_required: 'true'

--- a/scripts/build-image-list.sh
+++ b/scripts/build-image-list.sh
@@ -66,6 +66,7 @@ declare -a dynamic_images=(
   "${CONTAINER_REGISTRY}/${CONTAINER_ORG}/nvsentinel/platform-connectors:${SAFE_REF_NAME}"
   "${CONTAINER_REGISTRY}/${CONTAINER_ORG}/nvsentinel/preflight:${SAFE_REF_NAME}"
   "${CONTAINER_REGISTRY}/${CONTAINER_ORG}/nvsentinel/slinky-drainer:${SAFE_REF_NAME}"
+  "${CONTAINER_REGISTRY}/${CONTAINER_ORG}/nvsentinel/slurm-drain-monitor:${SAFE_REF_NAME}"
   "${CONTAINER_REGISTRY}/${CONTAINER_ORG}/nvsentinel/syslog-health-monitor:${SAFE_REF_NAME}"
 )
 

--- a/scripts/buildko.sh
+++ b/scripts/buildko.sh
@@ -56,7 +56,8 @@ if [ ! -f go.work ]; then
     ./platform-connectors \
     ./plugins/slinky-drainer \
     ./preflight \
-    ./lifecycle-manager
+    ./lifecycle-manager \
+    ./health-monitors/slurm-drain-monitor
 fi
 
 ko build "${KO_FLAGS[@]}" \
@@ -76,7 +77,8 @@ ko build "${KO_FLAGS[@]}" \
   ./platform-connectors \
   ./plugins/slinky-drainer \
   ./preflight \
-  ./lifecycle-manager
+  ./lifecycle-manager \
+  ./health-monitors/slurm-drain-monitor
 
 echo "built refs:"
 cat digests.txt


### PR DESCRIPTION
## Summary

`slurm-drain-monitor` has a complete `ko` build spec in `.ko.yaml` and a fully-wired local `Makefile` target (`health-monitors/Makefile`), but it was never added to the actual publish pipeline. As a result its image has never been built or pushed — `ghcr.io/nvidia/nvsentinel/slurm-drain-monitor` does not exist (confirmed via the GitHub Packages API: 404).

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] Health Monitors
- [x] Documentation/CI
- [ ] Core Services
- [ ] Fault Management
- [ ] API/Interface
- [ ] Preflight
- [ ] Plugins
- [ ] Janitor
- [ ] Other: ____________

## Changes

- `scripts/buildko.sh` — add `./health-monitors/slurm-drain-monitor` to the `go work use` and `ko build` module lists (root cause: this is the list the release publish job actually builds/pushes from)
- `scripts/build-image-list.sh` — add the image to `dynamic_images` (BOM/`versions.txt` tracking)
- `.github/workflows/lint-test.yml` — add `slurm-drain-monitor` to the `health-monitors-lint-test` matrix (CI test coverage)
- `.github/workflows/container-build-test.yml` — add `health-monitors/slurm-drain-monitor` to the `ko-build-test` matrix (PR-time build verification)
- `.github/workflows/cleanup-untagged-images.yml` — add `nvsentinel/slurm-drain-monitor` to the cleanup package matrix

## Testing
- [x] Tests pass locally (`go build ./...` in `health-monitors/slurm-drain-monitor` succeeds)
- [x] Manual testing completed (traced the gap via `buildko.sh`/`build-image-list.sh`/CI matrix diffs against sibling components `nic-health-monitor` and `nvcre-certification-monitor`, and confirmed via `gh api orgs/NVIDIA/packages/container/nvsentinel%2Fslurm-drain-monitor` returning 404 before this fix)
- [x] No breaking changes

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed) — no docs changes needed; `.ko.yaml`, `health-monitors/Makefile`, and `.github/dependabot.yml` already reference this component correctly
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added the Slurm drain monitor to automated build, lint, test, and container image workflows.
  * Included the monitor in generated image lists and workspace build targets.
  * Enabled cleanup handling for its untagged container images.
  * Removed the obsolete Slinky drainer image entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->