### PR TITLE
fix: increase UAT uncordon timeout from 5 minutes to 10 minutes

### DIFF
--- a/tests/uat/tests.sh
+++ b/tests/uat/tests.sh
@@ -252,7 +252,7 @@ wait_for_node_quarantine() {
 
 wait_for_node_unquarantine() {
     local node=$1
-    local timeout=${UAT_UNQUARANTINE_TIMEOUT:-300}
+    local timeout=${UAT_UNQUARANTINE_TIMEOUT:-600}
     local elapsed=0
 
     log "Waiting for node $node to be uncordoned..."


### PR DESCRIPTION
## Summary

Increase the UAT uncordon timeout from 5 minutes to 10 minutes. After enabling post-remediation validation in the UAT test, we hit a timeout waiting for the node to be uncordoned: https://github.com/NVIDIA/NVSentinel/actions/runs/34510035952/job/102981605274
```
[2026-09-10 18:07:39] Waiting for node gke-nvs-d34510035952-gpu-pool-4b753c83-s163 to be uncordoned...
[2026-09-10 18:08:16] Still waiting for uncordon... elapsed=30s, unschedulable=true
[2026-09-10 18:08:52] Still waiting for uncordon... elapsed=60s, unschedulable=true
[2026-09-10 18:09:28] Still waiting for uncordon... elapsed=90s, unschedulable=true
[2026-09-10 18:10:05] Still waiting for uncordon... elapsed=120s, unschedulable=true
[2026-09-10 18:10:41] Still waiting for uncordon... elapsed=150s, unschedulable=true
[2026-09-10 18:11:17] Still waiting for uncordon... elapsed=180s, unschedulable=true
[2026-09-10 18:11:53] Still waiting for uncordon... elapsed=210s, unschedulable=true
[2026-09-10 18:12:28] Still waiting for uncordon... elapsed=240s, unschedulable=true
[2026-09-10 18:13:04] Still waiting for uncordon... elapsed=270s, unschedulable=true
[2026-09-10 18:13:39] ERROR: Timeout waiting for node gke-nvs-d34510035952-gpu-pool-4b753c83-s163 to be uncordoned
```
Timeline:
- 2026-09-10T18:13:37Z: DCGM test passed 
- 2026-09-10T18:13:39Z: UAT test timed out after 5 minutes
- 2026-09-10T18:13:40Z: node was uncordoned

## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Health Monitors
- [ ] Fault Management
- [ ] Deployment/Config
- [ ] API/Interface
- [ ] Preflight
- [ ] Plugins
- [ ] Janitor
- [ ] Documentation/CI
- [X] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the default timeout for node unquarantine operations from 300 to 600 seconds in end-to-end testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->