### PR TITLE
feat(janitor): allow replacing the GPU reset Job template

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/janitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/templates/configmap.yaml
@@ -91,12 +91,14 @@ data:
       {{- end }}
       {{- if .Values.config.controllers.gpuReset.resetJob }}
       {{- $gpuResetUploadURL := .Values.config.controllers.gpuReset.resetJob.uploadURL | default $defaultGPUResetUploadURL }}
+      {{- $gpuResetJobTemplate := .Values.config.controllers.gpuReset.resetJob.jobTemplate }}
       resetJob:
-        writeSysLogEvent: "{{ .Values.config.controllers.gpuReset.resetJob.writeSysLogEvent }}"
-        runtimeClassName: "{{ .Values.config.controllers.gpuReset.resetJob.runtimeClassName }}"
         {{- if $gpuResetUploadURL }}
         uploadURL: {{ $gpuResetUploadURL | quote }}
         {{- end }}
+        {{- if not $gpuResetJobTemplate }}
+        writeSysLogEvent: "{{ .Values.config.controllers.gpuReset.resetJob.writeSysLogEvent }}"
+        runtimeClassName: "{{ .Values.config.controllers.gpuReset.resetJob.runtimeClassName }}"
         imageConfig:
           image: "{{ .Values.config.controllers.gpuReset.resetJob.image.repository }}:{{ .Values.config.controllers.gpuReset.resetJob.image.tag | default ((.Values.global).image).tag | default .Chart.AppVersion }}"
           {{- with (.Values.config.controllers.gpuReset.resetJob.image.imagePullSecrets | default  (.Values.global).imagePullSecrets) }}
@@ -105,6 +107,11 @@ data:
           {{- end }}
         resources:
           {{- toYaml .Values.config.controllers.gpuReset.resetJob.resources | nindent 10 }}
+        {{- end }}
+        {{- with $gpuResetJobTemplate }}
+        jobTemplate: |
+{{ toYaml . | indent 10 }}
+        {{- end }}
       {{- end }}
       {{- if .Values.config.controllers.gpuReset.serviceManager }}
       serviceManager:

--- a/distros/kubernetes/nvsentinel/charts/janitor/tests/gpureset_jobtemplate_test.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/tests/gpureset_jobtemplate_test.yaml
@@ -1,0 +1,109 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+suite: gpuReset resetJob.jobTemplate
+templates:
+  - templates/configmap.yaml
+tests:
+  - it: must not emit jobTemplate when it is not set
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "jobTemplate"
+
+  # Janitor reads jobTemplate as one opaque string, so every line must be indented under it.
+  - it: must render a structured jobTemplate as an indented block scalar
+    set:
+      config.controllers.gpuReset.resetJob.jobTemplate:
+        spec:
+          backoffLimit: 1
+          template:
+            spec:
+              containers:
+                - name: gpu-reset
+                  image: registry.example.com/gpu-reset:v1
+                  volumeMounts:
+                    - name: driver-root
+                      mountPath: /home/kubernetes/bin/nvidia
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "\n    jobTemplate: \\|\n      spec:\n"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "\n        backoffLimit: 1\n"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "\n              volumeMounts:\n              - mountPath: /home/kubernetes/bin/nvidia\n"
+
+  # These four carry chart defaults, so leaving them in would make janitor's "ignoring other
+  # resetJob fields" warning fire for every operator using a jobTemplate.
+  - it: must omit the built-in template keys when a jobTemplate is set
+    set:
+      config.controllers.gpuReset.resetJob.jobTemplate:
+        spec:
+          template:
+            spec:
+              containers:
+                - name: gpu-reset
+                  image: registry.example.com/gpu-reset:v1
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "\n    writeSysLogEvent:"
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "\n    runtimeClassName:"
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "\n    imageConfig:"
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "\n    resources:"
+
+  - it: must keep the built-in template keys when no jobTemplate is set
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "\n    writeSysLogEvent:"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "\n    runtimeClassName:"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "\n    imageConfig:"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "\n    resources:"
+
+  # Parsing the ConfigMap at all proves the block scalar is well formed; serviceManager proves the
+  # keys after it land in gpuResetController rather than inside the template.
+  - it: must keep the ConfigMap parseable with a jobTemplate set
+    set:
+      config.controllers.gpuReset.resetJob.jobTemplate:
+        spec:
+          template:
+            spec:
+              containers:
+                - name: gpu-reset
+                  image: registry.example.com/gpu-reset:v1
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "^global:\n"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "\n  serviceManager:\n    name: gpu-operator\n"

--- a/distros/kubernetes/nvsentinel/charts/janitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/values.yaml
@@ -186,6 +186,12 @@ config:
           limits:
             cpu: "100m"
             memory: "128Mi"
+        # Optional batchv1.JobTemplateSpec that fully replaces the built-in GPU reset Job
+        # template. Every other key under resetJob is then ignored, so the template must supply
+        # its own image, volumes, resources and environment. Use it when the built-in template
+        # does not fit the node, for example when the host installs the driver instead of the
+        # GPU Operator. See docs/configuration/janitor.md for an example.
+        jobTemplate: {}
 
 # TTL-based cleanup of completed maintenance CRs (RebootNode / GPUReset /
 # TerminateNode). See docs/designs/037-janitor-cr-ttl-cleanup.md for details.

--- a/docs/configuration/janitor.md
+++ b/docs/configuration/janitor.md
@@ -226,6 +226,94 @@ Container image for the GPU reset Job. Leave `tag` empty to use the chart defaul
 ### resetJob.resources
 Resource requests and limits for the GPU reset Job container.
 
+### resetJob.jobTemplate
+An optional `batchv1.JobTemplateSpec` that fully replaces the built-in GPU reset Job template. It is empty by default, and the built-in template is used.
+
+Use `jobTemplate` when the built-in template does not fit the node. The built-in template mounts the GPU Operator driver root from the host path `/run/nvidia/driver`, and sets `DRIVER_ROOT` to the same path. On a cluster where the host installs the driver instead of the GPU Operator, that path does not exist and the reset job fails.
+
+The Janitor validates the template when it starts:
+
+- An unknown field is an error. A typo fails at startup, not at the first reset.
+- The template must define at least one container.
+- `metadata.namespace` must be empty or the Janitor namespace. The controller finds its jobs by that namespace.
+- `metadata.name` and `metadata.generateName` must be empty. The controller derives the job name from the `GPUReset` CR.
+- `spec.template.spec.nodeName` must be empty. The controller sets it to the node named by the `GPUReset` CR.
+
+The Janitor sets three things on each job it creates from the template: `spec.template.spec.nodeName`, the `GPU_RESETS` environment variable on every container, and the owner reference to the `GPUReset` CR. Everything else comes from the template, so the template must supply its own image, volumes, resources and environment.
+
+**A replacement inherits no defaults from the built-in template.** The built-in template sets `activeDeadlineSeconds: 300`, `backoffLimit: 2` and `ttlSecondsAfterFinished: 86400`. Your template gets none of them unless you set them. Set `activeDeadlineSeconds` in particular: without it, a reset Job that hangs runs until the Janitor timeout instead of failing, and the node stays cordoned for longer. Without `ttlSecondsAfterFinished`, completed reset Jobs are never garbage collected.
+
+The other keys under `resetJob` build the built-in template only. When you set `jobTemplate`, the chart stops emitting them and the Janitor ignores any that remain, logging a warning that names each one.
+
+#### Example: driver installed by the host
+
+This example resets GPUs on GKE, where `kube-system/nvidia-driver-installer` installs the driver at `/home/kubernetes/bin/nvidia`. It is the built-in template with the driver root moved to the host path, and it also shows that the template owns the fields the built-in path sets for you.
+
+```yaml
+janitor:
+  config:
+    controllers:
+      gpuReset:
+        resetJob:
+          jobTemplate:
+            spec:
+              activeDeadlineSeconds: 300
+              backoffLimit: 2
+              ttlSecondsAfterFinished: 86400
+              template:
+                spec:
+                  runtimeClassName: nvidia
+                  restartPolicy: OnFailure
+                  tolerations:
+                    - operator: Exists
+                  containers:
+                    - name: gpu-reset
+                      image: ghcr.io/nvidia/nvsentinel/gpu-reset:v1.20.0
+                      imagePullPolicy: Always
+                      securityContext:
+                        privileged: true
+                      env:
+                        - name: NVIDIA_VISIBLE_DEVICES
+                          value: void
+                        - name: DRIVER_ROOT
+                          value: /home/kubernetes/bin/nvidia
+                        - name: WRITE_SYSLOG_EVENT
+                          value: "true"
+                        - name: NODE_NAME
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: spec.nodeName
+                      resources:
+                        requests:
+                          cpu: 50m
+                          memory: 64Mi
+                        limits:
+                          cpu: 100m
+                          memory: 128Mi
+                      volumeMounts:
+                        - name: host-dev
+                          mountPath: /dev
+                        - name: dev-log
+                          mountPath: /run/systemd/journal/dev-log
+                        - name: driver-root
+                          mountPath: /home/kubernetes/bin/nvidia
+                        - name: host-sys
+                          mountPath: /home/kubernetes/bin/nvidia/sys
+                  volumes:
+                    - name: host-dev
+                      hostPath:
+                        path: /dev
+                    - name: dev-log
+                      hostPath:
+                        path: /run/systemd/journal/dev-log
+                    - name: driver-root
+                      hostPath:
+                        path: /home/kubernetes/bin/nvidia
+                    - name: host-sys
+                      hostPath:
+                        path: /sys
+```
+
 ## TTL-Based CR Cleanup
 
 Completed CRs are automatically deleted after the TTL expires.

--- a/docs/janitor.md
+++ b/docs/janitor.md
@@ -50,6 +50,8 @@ Issues a terminate or stop API call to the cloud provider. Used for `REPLACE_VM`
 
 Runs a privileged Kubernetes Job on the target node that performs an in-place GPU reset via `nvidia-smi`. The GPU Operator DaemonSet is paused on the node during the reset to prevent interference. On completion, the Job writes a syslog event so the Syslog Health Monitor can confirm the reset succeeded.
 
+The Janitor builds this Job from a built-in template that expects the GPU Operator to publish the driver root at `/run/nvidia/driver`. To reset GPUs on a node where that path does not apply, replace the whole template with [`resetJob.jobTemplate`](configuration/janitor.md#resetjobjobtemplate).
+
 ## Configuration
 
 Configure the Janitor and Janitor Provider through Helm values:

--- a/janitor/go.mod
+++ b/janitor/go.mod
@@ -25,6 +25,7 @@ require (
 	k8s.io/client-go v0.37.0
 	k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3
 	sigs.k8s.io/controller-runtime v0.25.0
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -120,7 +121,6 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.2 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
 // Local replacements for internal modules

--- a/janitor/pkg/config/config.go
+++ b/janitor/pkg/config/config.go
@@ -115,6 +115,9 @@ type ResetJobConfig struct {
 	RuntimeClassName string               `mapstructure:"runtimeClassName" json:"runtimeClassName"`
 	WriteSysLogEvent *bool                `mapstructure:"writeSysLogEvent" json:"writeSysLogEvent"`
 	UploadURL        string               `mapstructure:"uploadURL" json:"uploadURL"`
+	// JobTemplate replaces the built-in template entirely, ignoring the other ResetJob fields.
+	// Kept as a string because viper lowercases config keys, which would drop volumeMounts.
+	JobTemplate string `mapstructure:"jobTemplate" json:"jobTemplate,omitempty"`
 }
 
 type ResourceRequirements struct {
@@ -172,19 +175,7 @@ func LoadConfig(configPath string, namespace string) (*Config, error) {
 	applyConfigDefaults(&config)
 
 	if config.GPUReset.Enabled {
-		if len(config.GPUReset.ResetJob.ImageConfig.Image) == 0 {
-			return nil, fmt.Errorf("ResetJob.ImageConfig.Image is required but not set")
-		}
-
-		if config.GPUReset.ResetJob.WriteSysLogEvent == nil {
-			config.GPUReset.ResetJob.WriteSysLogEvent = new(true)
-		}
-
-		resetJobConfig := config.GPUReset.ResetJob
-
-		jobTemplate, err := getDefaultGPUResetJobTemplate(namespace, resetJobConfig.ImageConfig.Image,
-			resetJobConfig.ImageConfig.ImagePullSecrets, resetJobConfig.Resources, resetJobConfig.RuntimeClassName,
-			*resetJobConfig.WriteSysLogEvent, resetJobConfig.UploadURL)
+		jobTemplate, err := resolveGPUResetJobTemplate(&config.GPUReset.ResetJob, namespace)
 		if err != nil {
 			return nil, err
 		}

--- a/janitor/pkg/config/config_test.go
+++ b/janitor/pkg/config/config_test.go
@@ -22,7 +22,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 
 	"github.com/nvidia/nvsentinel/janitor/pkg/gpuservices"
 )
@@ -600,4 +603,271 @@ global:
 	require.Len(t, config.RebootNode.Exclusions[1].MatchExpressions, 1)
 	assert.Equal(t, "node-role.kubernetes.io/control-plane", config.RebootNode.Exclusions[1].MatchExpressions[0].Key)
 	assert.Equal(t, metav1.LabelSelectorOpExists, config.RebootNode.Exclusions[1].MatchExpressions[0].Operator)
+}
+
+const gpuResetDefaultTemplateConfig = `
+gpuResetController:
+  enabled: true
+  resetJob:
+    writeSysLogEvent: true
+    runtimeClassName: "nvidia"
+    uploadURL: "http://nvsentinel-incluster-file-server.nvsentinel.svc.cluster.local/upload"
+    imageConfig:
+      image: "ghcr.io/nvidia/nvsentinel/gpu-reset:1.16.0"
+      imagePullSecrets:
+      - name: pull-secret
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
+`
+
+func loadConfigFromString(t *testing.T, configContent string) (*Config, error) {
+	t.Helper()
+
+	configPath := filepath.Join(t.TempDir(), "janitor-config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0644))
+
+	return LoadConfig(configPath, testNamespace)
+}
+
+// jobTemplateConfig serialises jobTemplate into a block scalar, the way the chart renders it.
+func jobTemplateConfig(t *testing.T, jobTemplate string) string {
+	t.Helper()
+
+	out, err := yaml.Marshal(map[string]any{
+		"gpuResetController": map[string]any{
+			"enabled":  true,
+			"resetJob": map[string]any{"jobTemplate": jobTemplate},
+		},
+	})
+	require.NoError(t, err)
+
+	return string(out)
+}
+
+const gpuResetMinimalJobTemplate = `spec:
+  template:
+    spec:
+      containers:
+      - name: gpu-reset
+        image: registry.example.com/gpu-reset:v1
+`
+
+// The golden file is a copy of the built-in template taken before jobTemplate existed. Comparing
+// against getDefaultGPUResetJobTemplate instead would pass for any change to that function.
+func TestLoadConfig_NoJobTemplate_MatchesDefaultTemplateGolden(t *testing.T) {
+	config, err := loadConfigFromString(t, gpuResetDefaultTemplateConfig)
+	require.NoError(t, err)
+	require.NotNil(t, config.GPUReset.ResolvedJobTemplate)
+
+	actual, err := yaml.Marshal(config.GPUReset.ResolvedJobTemplate)
+	require.NoError(t, err)
+
+	golden, err := os.ReadFile(filepath.Join("testdata", "default-gpu-reset-job-template.yaml"))
+	require.NoError(t, err)
+
+	assert.YAMLEq(t, string(golden), string(actual))
+}
+
+func TestLoadConfig_JobTemplate_ReplacesDefaultTemplate(t *testing.T) {
+	jobTemplate := `metadata:
+  labels:
+    owner: platform
+spec:
+  backoffLimit: 1
+  template:
+    spec:
+      containers:
+      - name: gpu-reset
+        image: registry.example.com/gpu-reset:v1
+        volumeMounts:
+        - name: driver-root
+          mountPath: /home/kubernetes/bin/nvidia
+      volumes:
+      - name: driver-root
+        hostPath:
+          path: /home/kubernetes/bin/nvidia
+`
+
+	config, err := loadConfigFromString(t, jobTemplateConfig(t, jobTemplate))
+	require.NoError(t, err)
+	require.NotNil(t, config.GPUReset.ResolvedJobTemplate)
+
+	resolved := config.GPUReset.ResolvedJobTemplate
+	assert.Equal(t, testNamespace, resolved.Namespace)
+	assert.Equal(t, map[string]string{"owner": "platform"}, resolved.Labels)
+	assert.Equal(t, int32(1), *resolved.Spec.BackoffLimit)
+
+	assert.Nil(t, resolved.Spec.TTLSecondsAfterFinished)
+	assert.Nil(t, resolved.Spec.ActiveDeadlineSeconds)
+	assert.Empty(t, resolved.Spec.Template.Spec.Tolerations)
+	assert.Nil(t, resolved.Spec.Template.Spec.RuntimeClassName)
+
+	podSpec := resolved.Spec.Template.Spec
+	require.Len(t, podSpec.Containers, 1)
+	assert.Equal(t, "registry.example.com/gpu-reset:v1", podSpec.Containers[0].Image)
+	assert.Empty(t, podSpec.Containers[0].Env)
+
+	require.Len(t, podSpec.Containers[0].VolumeMounts, 1)
+	assert.Equal(t, "/home/kubernetes/bin/nvidia", podSpec.Containers[0].VolumeMounts[0].MountPath)
+	require.Len(t, podSpec.Volumes, 1)
+	require.NotNil(t, podSpec.Volumes[0].HostPath)
+	assert.Equal(t, "/home/kubernetes/bin/nvidia", podSpec.Volumes[0].HostPath.Path)
+}
+
+func TestLoadConfig_JobTemplate_ParsesResourceQuantities(t *testing.T) {
+	jobTemplate := `spec:
+  template:
+    spec:
+      containers:
+      - name: gpu-reset
+        image: registry.example.com/gpu-reset:v1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 1Gi
+`
+
+	config, err := loadConfigFromString(t, jobTemplateConfig(t, jobTemplate))
+	require.NoError(t, err)
+
+	limits := config.GPUReset.ResolvedJobTemplate.Spec.Template.Spec.Containers[0].Resources.Limits
+	assert.True(t, resource.MustParse("1Gi").Equal(limits[corev1.ResourceMemory]))
+	assert.True(t, resource.MustParse("100m").Equal(limits[corev1.ResourceCPU]))
+}
+
+func TestLoadConfig_JobTemplate_InvalidReturnsError(t *testing.T) {
+	tests := []struct {
+		name        string
+		jobTemplate string
+		expectedErr string
+	}{
+		{
+			name: "unknown field",
+			jobTemplate: `spec:
+  template:
+    spec:
+      restartPolicyy: OnFailure
+      containers:
+      - name: gpu-reset
+        image: registry.example.com/gpu-reset:v1
+`,
+			expectedErr: "restartPolicyy",
+		},
+		{
+			name: "nodeName set",
+			jobTemplate: `spec:
+  template:
+    spec:
+      nodeName: gpu-node-1
+      containers:
+      - name: gpu-reset
+        image: registry.example.com/gpu-reset:v1
+`,
+			expectedErr: "must not set spec.template.spec.nodeName",
+		},
+		{
+			name: "no containers",
+			jobTemplate: `spec:
+  template:
+    spec:
+      containers: []
+`,
+			expectedErr: "at least one container",
+		},
+		{
+			name:        "foreign namespace",
+			jobTemplate: "metadata:\n  namespace: other\n" + gpuResetMinimalJobTemplate,
+			expectedErr: `metadata.namespace "other"`,
+		},
+		{
+			name:        "name set",
+			jobTemplate: "metadata:\n  name: my-reset-job\n" + gpuResetMinimalJobTemplate,
+			expectedErr: `must not set metadata.name "my-reset-job"`,
+		},
+		{
+			name:        "generateName set",
+			jobTemplate: "metadata:\n  generateName: my-reset-job-\n" + gpuResetMinimalJobTemplate,
+			expectedErr: `must not set metadata.generateName "my-reset-job-"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, err := loadConfigFromString(t, jobTemplateConfig(t, tt.jobTemplate))
+			require.Error(t, err)
+			require.Nil(t, config)
+			assert.Contains(t, err.Error(), tt.expectedErr)
+		})
+	}
+}
+
+func TestLoadConfig_JobTemplate_NamespaceDefaultsToJanitorNamespace(t *testing.T) {
+	tests := []struct {
+		name        string
+		jobTemplate string
+	}{
+		{
+			name:        "namespace omitted",
+			jobTemplate: gpuResetMinimalJobTemplate,
+		},
+		{
+			name:        "namespace matches",
+			jobTemplate: "metadata:\n  namespace: " + testNamespace + "\n" + gpuResetMinimalJobTemplate,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, err := loadConfigFromString(t, jobTemplateConfig(t, tt.jobTemplate))
+			require.NoError(t, err)
+			assert.Equal(t, testNamespace, config.GPUReset.ResolvedJobTemplate.Namespace)
+		})
+	}
+}
+
+func TestLoadConfig_JobTemplate_ImageConfigNotRequired(t *testing.T) {
+	config, err := loadConfigFromString(t, jobTemplateConfig(t, gpuResetMinimalJobTemplate))
+	require.NoError(t, err)
+	assert.Empty(t, config.GPUReset.ResetJob.ImageConfig.Image)
+}
+
+func TestIgnoredResetJobFields_ReturnsFieldsThatAreSet(t *testing.T) {
+	tests := []struct {
+		name     string
+		resetJob ResetJobConfig
+		expected []string
+	}{
+		{
+			name:     "only jobTemplate set",
+			resetJob: ResetJobConfig{JobTemplate: gpuResetMinimalJobTemplate},
+		},
+		{
+			name: "every other field set",
+			resetJob: ResetJobConfig{
+				ImageConfig: ImageConfig{
+					Image:            "registry.example.com/gpu-reset:v1",
+					ImagePullSecrets: []ImagePullSecret{{Name: "pull-secret"}},
+				},
+				Resources:        ResourceRequirements{Limits: map[string]string{"cpu": "100m"}},
+				RuntimeClassName: "nvidia",
+				WriteSysLogEvent: new(false),
+				UploadURL:        "http://file-server/upload",
+			},
+			expected: []string{
+				"imageConfig.image", "imageConfig.imagePullSecrets", "resources",
+				"runtimeClassName", "writeSysLogEvent", "uploadURL",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ignoredResetJobFields(&tt.resetJob))
+		})
+	}
 }

--- a/janitor/pkg/config/default.go
+++ b/janitor/pkg/config/default.go
@@ -16,12 +16,14 @@ package config
 
 import (
 	"fmt"
+	"log/slog"
 	"strconv"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -137,6 +139,97 @@ func applyCSPProviderHostDefaults(config *Config) {
 	if len(config.TerminateNode.CSPProviderTokenPath) == 0 {
 		config.TerminateNode.CSPProviderTokenPath = config.Global.CSPProviderTokenPath
 	}
+}
+
+func resolveGPUResetJobTemplate(resetJob *ResetJobConfig, namespace string) (*batchv1.JobTemplateSpec, error) {
+	if resetJob.JobTemplate != "" {
+		if ignored := ignoredResetJobFields(resetJob); len(ignored) > 0 {
+			slog.Warn("resetJob.jobTemplate replaces the built-in template, ignoring other resetJob fields",
+				"fields", ignored)
+		}
+
+		return parseGPUResetJobTemplate(namespace, resetJob.JobTemplate)
+	}
+
+	if len(resetJob.ImageConfig.Image) == 0 {
+		return nil, fmt.Errorf("ResetJob.ImageConfig.Image is required but not set")
+	}
+
+	if resetJob.WriteSysLogEvent == nil {
+		resetJob.WriteSysLogEvent = new(true)
+	}
+
+	return getDefaultGPUResetJobTemplate(namespace, resetJob.ImageConfig.Image, resetJob.ImageConfig.ImagePullSecrets,
+		resetJob.Resources, resetJob.RuntimeClassName, *resetJob.WriteSysLogEvent, resetJob.UploadURL)
+}
+
+// parseGPUResetJobTemplate uses sigs.k8s.io/yaml rather than mapstructure so that decoding
+// honours the Kubernetes json tags and the resource.Quantity unmarshaller.
+func parseGPUResetJobTemplate(namespace, raw string) (*batchv1.JobTemplateSpec, error) {
+	var tmpl batchv1.JobTemplateSpec
+
+	if err := yaml.UnmarshalStrict([]byte(raw), &tmpl); err != nil {
+		return nil, fmt.Errorf("failed to parse resetJob.jobTemplate: %w", err)
+	}
+
+	switch {
+	case tmpl.Namespace == "":
+		tmpl.Namespace = namespace
+	case tmpl.Namespace != namespace:
+		return nil, fmt.Errorf("resetJob.jobTemplate metadata.namespace %q must be empty or the janitor "+
+			"namespace %q, which is where the controller looks for its jobs", tmpl.Namespace, namespace)
+	}
+
+	if len(tmpl.Spec.Template.Spec.Containers) == 0 {
+		return nil, fmt.Errorf("resetJob.jobTemplate must define at least one container")
+	}
+
+	if tmpl.Spec.Template.Spec.NodeName != "" {
+		return nil, fmt.Errorf("resetJob.jobTemplate must not set spec.template.spec.nodeName %q, "+
+			"the controller sets it from the GPUReset it is reconciling", tmpl.Spec.Template.Spec.NodeName)
+	}
+
+	if tmpl.Name != "" {
+		return nil, fmt.Errorf("resetJob.jobTemplate must not set metadata.name %q, "+
+			"the controller derives it from the GPUReset it is reconciling", tmpl.Name)
+	}
+
+	if tmpl.GenerateName != "" {
+		return nil, fmt.Errorf("resetJob.jobTemplate must not set metadata.generateName %q, "+
+			"the controller derives metadata.name from the GPUReset it is reconciling", tmpl.GenerateName)
+	}
+
+	return &tmpl, nil
+}
+
+func ignoredResetJobFields(resetJob *ResetJobConfig) []string {
+	var ignored []string
+
+	if resetJob.ImageConfig.Image != "" {
+		ignored = append(ignored, "imageConfig.image")
+	}
+
+	if len(resetJob.ImageConfig.ImagePullSecrets) > 0 {
+		ignored = append(ignored, "imageConfig.imagePullSecrets")
+	}
+
+	if len(resetJob.Resources.Limits) > 0 || len(resetJob.Resources.Requests) > 0 {
+		ignored = append(ignored, "resources")
+	}
+
+	if resetJob.RuntimeClassName != "" {
+		ignored = append(ignored, "runtimeClassName")
+	}
+
+	if resetJob.WriteSysLogEvent != nil {
+		ignored = append(ignored, "writeSysLogEvent")
+	}
+
+	if resetJob.UploadURL != "" {
+		ignored = append(ignored, "uploadURL")
+	}
+
+	return ignored
 }
 
 func getResources(resources ResourceRequirements) (*corev1.ResourceRequirements, error) {

--- a/janitor/pkg/config/testdata/default-gpu-reset-job-template.yaml
+++ b/janitor/pkg/config/testdata/default-gpu-reset-job-template.yaml
@@ -1,0 +1,63 @@
+metadata:
+  namespace: nvsentinel
+spec:
+  activeDeadlineSeconds: 300
+  backoffLimit: 2
+  template:
+    metadata: {}
+    spec:
+      containers:
+      - env:
+        - name: NVIDIA_VISIBLE_DEVICES
+          value: void
+        - name: DRIVER_ROOT
+          value: /run/nvidia/driver
+        - name: WRITE_SYSLOG_EVENT
+          value: "true"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: UPLOAD_URL_BASE
+          value: http://nvsentinel-incluster-file-server.nvsentinel.svc.cluster.local/upload
+        image: ghcr.io/nvidia/nvsentinel/gpu-reset:1.16.0
+        imagePullPolicy: Always
+        name: gpu-reset
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /dev
+          name: host-dev
+        - mountPath: /run/systemd/journal/dev-log
+          name: dev-log
+        - mountPath: /run/nvidia/driver
+          name: driver-root
+        - mountPath: /run/nvidia/driver/sys
+          name: host-sys
+      imagePullSecrets:
+      - name: pull-secret
+      restartPolicy: OnFailure
+      runtimeClassName: nvidia
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /dev
+        name: host-dev
+      - hostPath:
+          path: /run/systemd/journal/dev-log
+        name: dev-log
+      - hostPath:
+          path: /run/nvidia/driver
+        name: driver-root
+      - hostPath:
+          path: /sys
+        name: host-sys
+  ttlSecondsAfterFinished: 86400

--- a/janitor/pkg/controller/gpureset_controller.go
+++ b/janitor/pkg/controller/gpureset_controller.go
@@ -28,6 +28,7 @@ import (
 
 	"log/slog"
 
+	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1035,6 +1036,29 @@ func (r *GPUResetReconciler) getJob(ctx context.Context, gr *v1alpha1.GPUReset) 
 		job.Name, metav1.GetControllerOf(job), gr.Name)
 }
 
+func setEnvVarOnContainers(log logr.Logger, containers []corev1.Container, envVar corev1.EnvVar) {
+	for i := range containers {
+		envVarIndex := -1
+
+		for j, env := range containers[i].Env {
+			if env.Name == envVar.Name {
+				envVarIndex = j
+				break
+			}
+		}
+
+		if envVarIndex >= 0 {
+			log.V(1).Info("Overriding existing environment variable", "env_var", envVar.Name, "container",
+				containers[i].Name, "new_value", envVar.Value, "old_value", containers[i].Env[envVarIndex].Value)
+			containers[i].Env[envVarIndex] = envVar
+		} else {
+			log.V(1).Info("Adding environment variable", "env_var", envVar.Name, "container", containers[i].Name,
+				"value", envVar.Value)
+			containers[i].Env = append(containers[i].Env, envVar)
+		}
+	}
+}
+
 // newGpuResetJob constructs the Kubernetes Job object responsible for performing the GPU reset.
 func (r *GPUResetReconciler) newGpuResetJob(ctx context.Context, gr *v1alpha1.GPUReset) (*batchv1.Job, error) {
 	log := log.FromContext(ctx)
@@ -1083,28 +1107,9 @@ func (r *GPUResetReconciler) newGpuResetJob(ctx context.Context, gr *v1alpha1.GP
 		Value: gpuIDString,
 	}
 
-	for i, container := range jobSpec.Template.Spec.Containers {
-		envVarIndex := -1
-
-		for j, env := range jobSpec.Template.Spec.Containers[i].Env {
-			if env.Name == gpuResetEnvVar.Name {
-				envVarIndex = j
-				break
-			}
-		}
-
-		if envVarIndex >= 0 {
-			oldValue := jobSpec.Template.Spec.Containers[i].Env[envVarIndex]
-			log.V(1).Info("Overriding existing environment variable", "env_var", gpuResetEnvVar.Name, "job", jobName,
-				"namespace", jobNamespace, "container", container.Name, "new_value", gpuResetEnvVar.Value, "old_value",
-				oldValue.Value)
-			jobSpec.Template.Spec.Containers[i].Env[envVarIndex] = gpuResetEnvVar
-		} else {
-			log.V(1).Info("Adding environment variable", "env_var", gpuResetEnvVar.Name, "job", jobName, "namespace",
-				jobNamespace, "container", container.Name, "value", gpuResetEnvVar.Value)
-			jobSpec.Template.Spec.Containers[i].Env = append(jobSpec.Template.Spec.Containers[i].Env, gpuResetEnvVar)
-		}
-	}
+	jobLog := log.WithValues("job", jobName, "namespace", jobNamespace)
+	setEnvVarOnContainers(jobLog, jobSpec.Template.Spec.InitContainers, gpuResetEnvVar)
+	setEnvVarOnContainers(jobLog, jobSpec.Template.Spec.Containers, gpuResetEnvVar)
 
 	job := &batchv1.Job{
 		ObjectMeta: jobMeta,

--- a/janitor/pkg/controller/gpureset_controller_test.go
+++ b/janitor/pkg/controller/gpureset_controller_test.go
@@ -812,6 +812,23 @@ var _ = Describe("GPUReset Controller", func() {
 					}
 				}
 			}
+
+			// Specs here share resetName, and the finalizer makes the delete above only mark
+			// the reset terminating, which conflicts with the next spec recreating it.
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, typeNamespacedName, reset)
+				if apierrors.IsNotFound(err) {
+					return
+				}
+				g.Expect(err).NotTo(HaveOccurred())
+
+				if controllerutil.ContainsFinalizer(reset, gpuResetFinalizer) {
+					controllerutil.RemoveFinalizer(reset, gpuResetFinalizer)
+					g.Expect(k8sClient.Update(ctx, reset)).To(Succeed())
+				}
+
+				g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, typeNamespacedName, reset))).To(BeTrue())
+			}, "20s", "250ms").Should(Succeed())
 		})
 
 		It("should NOT remove pre-existing env vars when adding GPU ID env var", func() {
@@ -865,6 +882,66 @@ var _ = Describe("GPUReset Controller", func() {
 
 			By("Verifying the Job's Pod template container still has pre-existing env vars")
 			Expect(targetContainer.Env).To(ContainElement(corev1.EnvVar{Name: "PRE_EXISTING_ENV", Value: "foo"}))
+		})
+
+		It("should add the GPU ID env var to init containers", func() {
+			By("Configuring an init container that overrides the GPU ID env var")
+			customTemplate := reconciler.Config.ResolvedJobTemplate.DeepCopy()
+			customTemplate.Spec.Template.Spec.InitContainers = []corev1.Container{
+				{
+					Name:            "pre-reset-hook",
+					Image:           "nvcr.io/nv-ngc-devops/gpu-reset:latest",
+					SecurityContext: &defaultSecurityContext,
+					Resources:       defaultResources,
+					Env: []corev1.EnvVar{
+						{Name: "PRE_EXISTING_ENV", Value: "foo"},
+						{Name: "NVIDIA_GPU_RESETS", Value: "stale"},
+					},
+				},
+			}
+			reconciler.Config.ResolvedJobTemplate = customTemplate
+
+			By("Creating a new GPUReset resource")
+			reset := &v1alpha1.GPUReset{
+				Name: resetName,
+				Spec: v1alpha1.GPUResetSpec{
+					NodeName: nodeName,
+					Selector: &v1alpha1.GPUSelector{
+						UUIDs: []string{"GPU-a1b2c3d4-e5f6-a7b8-c9d0-e1f2a3b4c5d6"},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, reset)).To(Succeed())
+
+			By("Waiting for the reset job to be created")
+			var updatedReset v1alpha1.GPUReset
+			var createdJob batchv1.Job
+			Eventually(func(g Gomega) {
+				_, _ = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+				g.Expect(k8sClient.Get(ctx, typeNamespacedName, &updatedReset)).To(Succeed())
+				g.Expect(updatedReset.Status.JobRef).NotTo(BeNil())
+
+				jobKey := types.NamespacedName{Name: updatedReset.Status.JobRef.Name, Namespace: updatedReset.Status.JobRef.Namespace}
+				g.Expect(k8sClient.Get(ctx, jobKey, &createdJob)).To(Succeed())
+			}, "10s", "250ms").Should(Succeed())
+
+			Expect(createdJob.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+			initContainer := createdJob.Spec.Template.Spec.InitContainers[0]
+
+			By("Verifying the init container's GPU ID env var was replaced, not duplicated")
+			expectedEnvVar := corev1.EnvVar{
+				Name:  "NVIDIA_GPU_RESETS",
+				Value: "GPU-a1b2c3d4-e5f6-a7b8-c9d0-e1f2a3b4c5d6",
+			}
+			Expect(initContainer.Env).To(ContainElement(expectedEnvVar))
+			Expect(initContainer.Env).NotTo(ContainElement(corev1.EnvVar{Name: "NVIDIA_GPU_RESETS", Value: "stale"}))
+
+			By("Verifying the init container still has pre-existing env vars")
+			Expect(initContainer.Env).To(ContainElement(corev1.EnvVar{Name: "PRE_EXISTING_ENV", Value: "foo"}))
+
+			By("Verifying the main container also has the GPU ID env var")
+			Expect(createdJob.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(createdJob.Spec.Template.Spec.Containers[0].Env).To(ContainElement(expectedEnvVar))
 		})
 	})
 


### PR DESCRIPTION
## Summary

**DRAFT STATUS: awaiting internal testing and confirmation.**

Adds `gpuResetController.resetJob.jobTemplate`, an optional `batchv1.JobTemplateSpec` that fully replaces the built-in GPU reset Job template. Default behaviour does not change.

Refs #1782. Also resolves the GKE host-installed-driver case in #1681.

### Why

The built-in reset Job template is built in Go and is compile-time constant apart from image, resources, runtimeClass, syslog flag and upload URL. In particular it mounts the GPU Operator driver root from the host path `/run/nvidia/driver` and sets `DRIVER_ROOT` to the same value. On a cluster where the host installs the driver instead of the GPU Operator, that path does not exist and the reset job fails inside the chroot — which is exactly #1681 on GKE, where `kube-system/nvidia-driver-installer` puts the driver at `/home/kubernetes/bin/nvidia`. Today the only way to change that is to fork janitor.

### The one non-obvious part: the template is an opaque string

Viper recursively lowercases every config key it reads (`insensitiviseMap`). If the field were declared as `map[string]any` or a typed `batchv1.JobTemplateSpec` and left to viper/mapstructure, `volumeMounts` would arrive as `volumemounts` and the Kubernetes json-tag decoder would silently drop it. Viper does not touch string values.

So the field is a `string`. Helm renders the operator's structured YAML into a block scalar, and janitor decodes it with `sigs.k8s.io/yaml.UnmarshalStrict`, which uses json tags and handles `resource.Quantity` correctly. `UnmarshalStrict` also means an operator typo fails at startup rather than at the first reset. `TestLoadConfig_JobTemplate_ParsesResourceQuantities` covers the decoder path specifically.

Note also that `LoadConfig` sets `dc.ErrorUnused = true`, so the key has to exist on the struct or any config that sets it fails to load.

### Why replacement rather than a strategic merge patch

#1782 discussion landed on "the jobTemplate strategic patch should be enough", so this needs explaining. I prototyped strategic merge against the built-in template and it produces a silently broken pod spec for the #1681 case:

```yaml
volumeMounts:                                    # what strategicpatch actually returned
- mountPath: /home/kubernetes/bin/nvidia         # from the patch
  name: driver-root
- mountPath: /run/nvidia/driver                  # stale, survived the merge
  name: driver-root
- mountPath: /run/nvidia/driver/sys              # stale
  name: host-sys
```

`env` merges on `name` and `volumes` merge on `name`, so both patch cleanly. But `volumeMounts` merges on `mountPath`, which is precisely the field this fix changes, so the patch *adds* mounts instead of editing them. The driver root ends up mounted at two paths and `/sys` lands under the stale one, so the reset script chroots into `/home/kubernetes/bin/nvidia` and finds no `/sys`. That configuration passes validation and then does the wrong thing on a live GPU node.

It is recoverable with `$patch: replace` on the list, but then all four mounts get restated anyway, so the patch is ~22 lines against ~60 for full replacement — and only for operators who know a directive that appears nowhere in our docs. For code that resets GPUs on production nodes, an explicit template that is wrong loudly beats a merge that is wrong quietly.

Replacement is also the consistent choice for this repository. There are two existing customization idioms — Helm append (`extraEnv`, `additionalVolumeMounts`, `additionalHostVolumes` in `metadata-collector`, `gpu-health-monitor`, `preflight`) and whole-template replacement (the custom drain YAML from ADR-015, lifecycle-manager's job templates). Nothing deep-merges a partial Kubernetes object onto a built-in default; every `StrategicMergePatch` and `client.MergeFrom` in the tree patches a live object through the API, which is a different thing. The append idiom could not express #1681 either, because that case needs existing `hostPath` and `mountPath` values changed rather than new ones added.

Happy to revisit if maintainers prefer the patch model — the counter-evidence above is the argument, not a preference.

### Validation

`parseGPUResetJobTemplate` rejects a template that lies about what the controller controls:

- unknown fields (strict decode)
- no containers
- `metadata.namespace` other than janitor's own, which is what the controller uses for job lookup, creation and the owner index
- `metadata.name` / `metadata.generateName`, which `newGpuResetJob` overwrites
- `spec.template.spec.nodeName`, which `newGpuResetJob` overwrites from `GPUReset.spec.nodeName`

`RestartPolicy` is deliberately left alone when empty — `newGpuResetJob` already defaults it to `OnFailure`. No TTL or `backoffLimit` defaults are injected; the operator owns them, and the built-in path keeps its existing `ttlSecondsAfterFinished: 86400`. The docs call out that a replacement inherits none of the built-in template's `activeDeadlineSeconds`, `backoffLimit` or `ttlSecondsAfterFinished`, and the worked example sets all three.

### Default behaviour is unchanged

`getDefaultGPUResetJobTemplate` and its signature are untouched. `TestLoadConfig_NoJobTemplate_MatchesDefaultTemplateGolden` pins the resolved default against a golden file in `testdata/`, rather than comparing it to a fresh call of `getDefaultGPUResetJobTemplate` the way the existing tests do — that comparison passes for any change to that function, which is the opposite of what this test is for. I verified the golden detects drift by flipping `backoffLimit` in it.

On the chart side, the four `resetJob` keys that carry chart defaults are now gated on `jobTemplate` being unset, so `resetJob:` renders with `jobTemplate` as its only key and the "ignoring other resetJob fields" warning cannot fire from chart defaults alone. With `jobTemplate` unset, the rendered ConfigMap is byte-identical to `main` under default values; with `global.inclusterFileServer.enabled=true` the only difference is `uploadURL` moving position within the same mapping.

### Backwards compatibility

Additive on every surface. New Helm value defaults to `{}`, which is falsy, so the chart emits nothing new and no existing deployment changes. No proto, CRD, metric, node label or CLI flag is touched. `sigs.k8s.io/yaml` moves from indirect to direct in `janitor/go.mod`; it was already in the module graph via the Kubernetes libraries, so nothing new enters the supply chain.

One narrow edge, which the design already handles: because `LoadConfig` sets `ErrorUnused = true`, an old janitor binary reading a ConfigMap with `jobTemplate` set would fail to load. The chart renders the key with `with` rather than `if hasKey`, so a routine upgrade emits nothing new and only an operator who opts in is exposed — and they are upgrading the image anyway.

### ADRs

ADR-019 and ADR-020 describe the reset Job only as "a Kubernetes Job configured with a nodeName"; their alternatives sections weigh Job vs SSH vs DaemonSet architecture and never consider configurability. No ADR mentions `jobTemplate`, `podTemplate` or strategic merge. So this adds a decision rather than contradicting one, and nothing needs superseding. Happy to write one up as 056 if you would rather have the replace-vs-patch reasoning in the decision record instead of in this description.

### Second commit is optional

`feat(janitor): set GPU_RESETS on GPU reset init containers` is independent and can be dropped without touching the first. `newGpuResetJob` injected the GPU selector only into `Spec.Template.Spec.Containers`, so an init container in a supplied template could not see which GPUs the reset targets. It extracts the upsert loop and runs it over `InitContainers` too. It also makes the `Job Creation` `AfterEach` wait for the reset to be gone rather than only requesting deletion, because the finalizer otherwise leaves it terminating and a second spec in that block cannot recreate it. Not needed for our own migration.

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Health Monitors
- [ ] Fault Management
- [x] Deployment/Config
- [ ] API/Interface
- [ ] Preflight
- [ ] Plugins
- [x] Janitor
- [x] Documentation/CI
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

`make protos-lint`, `make license-headers-lint`, `make gomod-lint`, `make -C janitor lint-test`, `make kubernetes-distro-lint` and `make helm-test` all pass, and `make go-lint-test-all` passes across every Go module. Janitor's suite also ran uncached with `-race`, including the envtest controller specs.

Not manually tested on a GKE cluster with host-installed drivers — I do not have one. The GKE example in the docs is derived from the built-in template and the paths reported in #1681, so it is worth a check by someone who can reproduce that issue.

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review
