### PR TITLE
fix(gpu-health-monitor): preserve all DCGM incident codes

### DIFF
--- a/health-monitors/gpu-health-monitor/README.md
+++ b/health-monitors/gpu-health-monitor/README.md
@@ -1,3 +1,10 @@
 # GPU Health Monitor
 
 Health monitor for monitoring the health of GPUs
+
+
+## Incident reporting
+
+Each GPU and watch reports every distinct error code. Repeated incidents for the same code share one event with their combined messages. Each event retains its code-specific remediation action.
+
+Suppression and debounce apply separately to each code. A healthy event clears the watch only when that GPU has no remaining reported incidents. Cache updates occur after successful delivery.

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/dcgm.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/dcgm.py
@@ -360,22 +360,20 @@ class DCGMWatcher:
             return
 
         for watch_name, details in health_status.items():
-            suppressed_gpu_ids = [
-                gpu_id
-                for gpu_id, failure in details.entity_failures.items()
-                if failure.code in self._suppressed_error_codes
-            ]
-            for gpu_id in suppressed_gpu_ids:
-                error_code = details.entity_failures[gpu_id].code
-                log.debug(
-                    f"Suppressing incident for watch={watch_name} entity={gpu_id} "
-                    f"error_code={error_code}: high-frequency non-actionable event"
-                )
-                metrics.dcgm_health_check_suppressed_incidents.labels(error_code).inc()
-                del details.entity_failures[gpu_id]
+            had_failures = bool(details.entity_failures)
+            for gpu_id, failures in list(details.entity_failures.items()):
+                remaining = [
+                    failure
+                    for failure in failures
+                    if not self._is_suppressed_error_code(watch_name, gpu_id, failure.code)
+                ]
+                if remaining:
+                    details.entity_failures[gpu_id] = remaining
+                else:
+                    del details.entity_failures[gpu_id]
 
             # A watch with no remaining failures is healthy again.
-            if suppressed_gpu_ids and not details.entity_failures:
+            if had_failures and not details.entity_failures:
                 details.status = types.HealthStatus.PASS
 
     def _is_nvlink_down_false_positive(self, watch_name: str, gpu_id: int, error_code: str) -> bool:
@@ -587,8 +585,8 @@ class DCGMWatcher:
             log.debug(f"initial health status is {health_details}")
 
             health_status = self._get_health_status_dict()
-            # Temporary dict to accumulate multiple failures per GPU
-            gpu_failures_accumulator = {}
+            # Group repeated incidents by watch, GPU and error code.
+            gpu_failures_accumulator: dict[tuple[str, int, str], list[str]] = {}
             # One debounce decision per (error code, GPU) per poll. DCGM reports an
             # incident per down link, so a GPU with several down links produces several
             # records for the same code; advancing the streak once per record would
@@ -649,23 +647,17 @@ class DCGMWatcher:
                 if debounce_decisions[debounce_key]:
                     continue
 
-                health_status[watch_name].status = types.HealthStatus(int(incident.health))
+                health_status[watch_name].status = types.HealthStatus(
+                    max(health_status[watch_name].status.value, int(incident.health))
+                )
 
-                # Create a key for accumulating failures per GPU per watch
-                accumulator_key = (watch_name, gpu_id)
+                # Keep messages with their code: each code determines its own remediation.
+                accumulator_key = (watch_name, gpu_id, error_code)
+                gpu_failures_accumulator.setdefault(accumulator_key, []).append(error_msg)
 
-                if accumulator_key not in gpu_failures_accumulator:
-                    gpu_failures_accumulator[accumulator_key] = {"code": error_code, "messages": []}
-
-                # Accumulate all error messages for this GPU and watch type
-                gpu_failures_accumulator[accumulator_key]["messages"].append(error_msg)
-
-            # Now consolidate accumulated failures into health_status
-            for (watch_name, gpu_id), failure_data in gpu_failures_accumulator.items():
-                # Combine all messages with semicolon separator
-                combined_message = "; ".join(failure_data["messages"])
-                health_status[watch_name].entity_failures[gpu_id] = types.ErrorDetails(
-                    message=combined_message, code=failure_data["code"]
+            for (watch_name, gpu_id, error_code), messages in sorted(gpu_failures_accumulator.items()):
+                health_status[watch_name].entity_failures.setdefault(gpu_id, []).append(
+                    types.ErrorDetails(message="; ".join(messages), code=error_code)
                 )
 
             self._reset_absent_incident_streaks(set(debounce_decisions))
@@ -748,10 +740,12 @@ class DCGMWatcher:
                     slowdown_threshold,
                 )
                 margin_details.status = types.HealthStatus.FAIL
-                margin_details.entity_failures[gpu_id] = types.ErrorDetails(
-                    message=f"GPU {gpu_id} thermal margin {margin_c}°C below HW slowdown T.Limit (slowdown={slowdown_threshold}°C)",
-                    code=monitor.violation_code,
-                )
+                margin_details.entity_failures[gpu_id] = [
+                    types.ErrorDetails(
+                        message=f"GPU {gpu_id} thermal margin {margin_c}°C below HW slowdown T.Limit (slowdown={slowdown_threshold}°C)",
+                        code=monitor.violation_code,
+                    )
+                ]
             else:
                 log.debug(
                     "GPU %s thermal margin %s°C at or above HW slowdown T.Limit (slowdown=%s°C) for GpuThermalMarginWatch",
@@ -858,13 +852,15 @@ class DCGMWatcher:
                     streak,
                 )
                 brake_details.status = types.HealthStatus.FAIL
-                brake_details.entity_failures[gpu_id] = types.ErrorDetails(
-                    message=(
-                        f"GPU {gpu_id} hardware power brake asserted for {streak} consecutive "
-                        f"poll(s) (clocks event reasons mask 0x{reasons_mask:x})"
-                    ),
-                    code=monitor.violation_code,
-                )
+                brake_details.entity_failures[gpu_id] = [
+                    types.ErrorDetails(
+                        message=(
+                            f"GPU {gpu_id} hardware power brake asserted for {streak} consecutive "
+                            f"poll(s) (clocks event reasons mask 0x{reasons_mask:x})"
+                        ),
+                        code=monitor.violation_code,
+                    )
+                ]
             else:
                 self._power_brake_streaks.pop(gpu_id, None)
 

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/types.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/dcgm_watcher/types.py
@@ -31,7 +31,7 @@ class ErrorDetails:
 @dataclasses.dataclass
 class HealthDetails:
     status: HealthStatus
-    entity_failures: dict[int, ErrorDetails]
+    entity_failures: dict[int, list[ErrorDetails]]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/platform_connector/platform_connector.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/platform_connector/platform_connector.py
@@ -385,83 +385,87 @@ class PlatformConnectorEventProcessor(dcgmtypes.CallbackInterface):
                 log.debug(f"length of entity_failures are {len(details.entity_failures)}")
                 for gpu_id in gpu_ids:
                     if details.entity_failures.get(gpu_id):
-                        failure_details = details.entity_failures.get(gpu_id)
-                        message = failure_details.message
-                        error_code = [f"{failure_details.code}"]
-                        entities_impacted = []
-                        entity = platformconnector_pb2.Entity(entityType=self._component_class, entityValue=str(gpu_id))
-                        entities_impacted.append(entity)
-
-                        pci_address = self._metadata_reader.get_pci_address(gpu_id)
-                        if pci_address:
-                            entities_impacted.append(
-                                platformconnector_pb2.Entity(entityType="PCI", entityValue=pci_address)
+                        for failure_details in details.entity_failures[gpu_id]:
+                            message = failure_details.message
+                            error_code = [f"{failure_details.code}"]
+                            entities_impacted = []
+                            entity = platformconnector_pb2.Entity(
+                                entityType=self._component_class, entityValue=str(gpu_id)
                             )
+                            entities_impacted.append(entity)
 
-                        gpu_uuid = self._metadata_reader.get_gpu_uuid(gpu_id)
-                        if gpu_uuid:
-                            entities_impacted.append(
-                                platformconnector_pb2.Entity(entityType="GPU_UUID", entityValue=gpu_uuid)
-                            )
-
-                        entities_impacted_supports_component_reset = pci_address and gpu_uuid
-
-                        recommended_action = self.get_recommended_action_from_dcgm_error_map(failure_details.code)
-                        isHealthy = False
-                        isFatal = recommended_action != platformconnector_pb2.NONE
-                        key = self._build_cache_key(check_name, entity.entityType, entity.entityValue)
-
-                        entry = self.entity_cache.get(key)
-                        if entry is None or failure_details.code not in entry.active_errors:
-                            existing_errors = set(entry.active_errors) if entry else set()
-                            existing_errors.add(failure_details.code)
-                            pending_cache_updates[key] = EntityCacheEntry(active_errors=existing_errors)
-
-                            # The COMPONENT_RESET recommended action requires that the GPU_UUID is present on the
-                            # unhealthy HealthEvent. Sending an event with COMPONENT_RESET that is missing the GPU_UUID
-                            # impacted entity will result in a failed partial drain in node-drainer (as well as a
-                            # failed remediation in fault-remediation). As a result, we are checking that the GPU_UUID
-                            # can be read from the MetadataReader and are falling back to the RESTART_VM action if it
-                            # is not present on the event.
-
-                            # Note that entity-specific HealthEvents require an exact match for the set of impacted
-                            # entities between the initial unhealthy event and the eventual healthy event which clears
-                            # it in fault-quarantine. To ensure that there's a consistent view of impacted
-                            # entities between healthy and unhealthy events, we will only send unhealthy HealthEvents
-                            # for COMPONENT_RESET which include the GPU index, PCI, and GPU_UUID (and the corresponding
-                            # HealthyEvent will include all of these as long as there's no failure extracting the PCI
-                            # or GPU_UUID from the MetadataReader).
-                            if (
-                                recommended_action == platformconnector_pb2.COMPONENT_RESET
-                                and not entities_impacted_supports_component_reset
-                            ):
-                                log.info(f"Overriding action from COMPONENT_RESET to RESTART_VM for {self._node_name}")
-                                recommended_action = platformconnector_pb2.RESTART_VM
-
-                            event_metadata = {}
-                            chassis_serial = self._metadata_reader.get_chassis_serial()
-                            if chassis_serial:
-                                event_metadata["chassis_serial"] = chassis_serial
-
-                            health_events.append(
-                                platformconnector_pb2.HealthEvent(
-                                    version=self._version,
-                                    agent=self._agent,
-                                    componentClass=self._component_class,
-                                    checkName=check_name,
-                                    generatedTimestamp=timestamp,
-                                    isFatal=isFatal,
-                                    isHealthy=isHealthy,
-                                    errorCode=error_code,
-                                    entitiesImpacted=entities_impacted,
-                                    message=message,
-                                    recommendedAction=recommended_action,
-                                    nodeName=self._node_name,
-                                    metadata=event_metadata,
-                                    processingStrategy=effective_strategy,
+                            pci_address = self._metadata_reader.get_pci_address(gpu_id)
+                            if pci_address:
+                                entities_impacted.append(
+                                    platformconnector_pb2.Entity(entityType="PCI", entityValue=pci_address)
                                 )
-                            )
-                            pending_metric_updates.append((check_name, gpu_id, 1))
+
+                            gpu_uuid = self._metadata_reader.get_gpu_uuid(gpu_id)
+                            if gpu_uuid:
+                                entities_impacted.append(
+                                    platformconnector_pb2.Entity(entityType="GPU_UUID", entityValue=gpu_uuid)
+                                )
+
+                            entities_impacted_supports_component_reset = pci_address and gpu_uuid
+
+                            recommended_action = self.get_recommended_action_from_dcgm_error_map(failure_details.code)
+                            isHealthy = False
+                            isFatal = recommended_action != platformconnector_pb2.NONE
+                            key = self._build_cache_key(check_name, entity.entityType, entity.entityValue)
+
+                            entry = pending_cache_updates.get(key, self.entity_cache.get(key))
+                            if entry is None or failure_details.code not in entry.active_errors:
+                                existing_errors = set(entry.active_errors) if entry else set()
+                                existing_errors.add(failure_details.code)
+                                pending_cache_updates[key] = EntityCacheEntry(active_errors=existing_errors)
+
+                                # The COMPONENT_RESET recommended action requires that the GPU_UUID is present on the
+                                # unhealthy HealthEvent. Sending an event with COMPONENT_RESET that is missing the GPU_UUID
+                                # impacted entity will result in a failed partial drain in node-drainer (as well as a
+                                # failed remediation in fault-remediation). As a result, we are checking that the GPU_UUID
+                                # can be read from the MetadataReader and are falling back to the RESTART_VM action if it
+                                # is not present on the event.
+
+                                # Note that entity-specific HealthEvents require an exact match for the set of impacted
+                                # entities between the initial unhealthy event and the eventual healthy event which clears
+                                # it in fault-quarantine. To ensure that there's a consistent view of impacted
+                                # entities between healthy and unhealthy events, we will only send unhealthy HealthEvents
+                                # for COMPONENT_RESET which include the GPU index, PCI, and GPU_UUID (and the corresponding
+                                # HealthyEvent will include all of these as long as there's no failure extracting the PCI
+                                # or GPU_UUID from the MetadataReader).
+                                if (
+                                    recommended_action == platformconnector_pb2.COMPONENT_RESET
+                                    and not entities_impacted_supports_component_reset
+                                ):
+                                    log.info(
+                                        f"Overriding action from COMPONENT_RESET to RESTART_VM for {self._node_name}"
+                                    )
+                                    recommended_action = platformconnector_pb2.RESTART_VM
+
+                                event_metadata = {}
+                                chassis_serial = self._metadata_reader.get_chassis_serial()
+                                if chassis_serial:
+                                    event_metadata["chassis_serial"] = chassis_serial
+
+                                health_events.append(
+                                    platformconnector_pb2.HealthEvent(
+                                        version=self._version,
+                                        agent=self._agent,
+                                        componentClass=self._component_class,
+                                        checkName=check_name,
+                                        generatedTimestamp=timestamp,
+                                        isFatal=isFatal,
+                                        isHealthy=isHealthy,
+                                        errorCode=error_code,
+                                        entitiesImpacted=entities_impacted,
+                                        message=message,
+                                        recommendedAction=recommended_action,
+                                        nodeName=self._node_name,
+                                        metadata=event_metadata,
+                                        processingStrategy=effective_strategy,
+                                    )
+                                )
+                                pending_metric_updates.append((check_name, gpu_id, 1))
                     else:
 
                         entity = platformconnector_pb2.Entity(entityType=self._component_class, entityValue=str(gpu_id))

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_dcgm_watcher/test_dcgm.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_dcgm_watcher/test_dcgm.py
@@ -160,7 +160,7 @@ class TestDCGMHealthChecks:
 
         assert result is not None
         assert result.status == dcgm.types.HealthStatus.FAIL
-        assert result.entity_failures[0].code == "GPU_HW_POWER_BRAKE_VIOLATION"
+        assert result.entity_failures[0][0].code == "GPU_HW_POWER_BRAKE_VIOLATION"
 
     def test_evaluate_gpu_power_brake_ignores_sw_power_cap(self) -> None:
         """SW power cap alone is normal capping under load and must not fail."""
@@ -187,7 +187,7 @@ class TestDCGMHealthChecks:
         assert first.status == dcgm.types.HealthStatus.PASS
         assert second.status == dcgm.types.HealthStatus.PASS
         assert third.status == dcgm.types.HealthStatus.FAIL
-        assert third.entity_failures[0].code == "GPU_HW_POWER_BRAKE_VIOLATION"
+        assert third.entity_failures[0][0].code == "GPU_HW_POWER_BRAKE_VIOLATION"
 
     def test_evaluate_gpu_power_brake_streak_resets_when_cleared(self) -> None:
         """A clear resets the streak, so a transient never accumulates to a failure."""
@@ -345,7 +345,7 @@ class TestDCGMHealthChecks:
         dcgm_group_mock.samples.GetLatest.return_value = MagicMock(values={0: {field_id: [MagicMock(value=-3)]}})
         triggered = watcher._evaluate_gpu_thermal_margin(dcgm_group_mock, [0])
         assert triggered.status == dcgm.types.HealthStatus.FAIL
-        assert triggered.entity_failures[0].code == violation_code
+        assert triggered.entity_failures[0][0].code == violation_code
 
         # Phase 3: Adjust threshold to clear violation → PASS
         reader._metadata["gpus"][0]["slowdown_tlimit_c"] = -4
@@ -386,7 +386,7 @@ class TestDCGMHealthChecks:
         assert result.status == dcgm.types.HealthStatus.FAIL
         assert 0 not in result.entity_failures  # GPU 0 passed
         assert 1 in result.entity_failures  # GPU 1 failed
-        assert result.entity_failures[1].code == violation_code
+        assert result.entity_failures[1][0].code == violation_code
 
     @patch("pydcgm.DcgmGroup.__new__")
     def test_dcgm_create_group(self, mock_dcgm_group):
@@ -461,10 +461,12 @@ class TestDCGMHealthChecks:
         expected_response["DCGM_HEALTH_WATCH_PCIE"] = dcgm.types.HealthDetails(
             status=dcgm.types.HealthStatus.WARN,
             entity_failures={
-                1: dcgm.types.ErrorDetails(
-                    code="DCGM_FR_PCI_REPLAY_RATE",
-                    message="Detected more than 8 PCIe replays per minute for GPU 1 : 99999 Reconnect PCIe card. Run system side PCIE diagnostic utilities to verify hops off the GPU board. If issue is on the board, run the field diagnostic.",
-                )
+                1: [
+                    dcgm.types.ErrorDetails(
+                        code="DCGM_FR_PCI_REPLAY_RATE",
+                        message="Detected more than 8 PCIe replays per minute for GPU 1 : 99999 Reconnect PCIe card. Run system side PCIE diagnostic utilities to verify hops off the GPU board. If issue is on the board, run the field diagnostic.",
+                    )
+                ]
             },
         )
         assert response == expected_response
@@ -492,14 +494,18 @@ class TestDCGMHealthChecks:
         expected_response["DCGM_HEALTH_WATCH_PCIE"] = dcgm.types.HealthDetails(
             status=dcgm.types.HealthStatus.WARN,
             entity_failures={
-                1: dcgm.types.ErrorDetails(
-                    code="DCGM_FR_PCI_REPLAY_RATE",
-                    message="Detected more than 8 PCIe replays per minute for GPU 1 : 99999 Reconnect PCIe card. Run system side PCIE diagnostic utilities to verify hops off the GPU board. If issue is on the board, run the field diagnostic.",
-                ),
-                2: dcgm.types.ErrorDetails(
-                    code="DCGM_FR_PCI_REPLAY_RATE",
-                    message="Detected more than 8 PCIe replays per minute for GPU 1 : 99999 Reconnect PCIe card. Run system side PCIE diagnostic utilities to verify hops off the GPU board. If issue is on the board, run the field diagnostic.",
-                ),
+                1: [
+                    dcgm.types.ErrorDetails(
+                        code="DCGM_FR_PCI_REPLAY_RATE",
+                        message="Detected more than 8 PCIe replays per minute for GPU 1 : 99999 Reconnect PCIe card. Run system side PCIE diagnostic utilities to verify hops off the GPU board. If issue is on the board, run the field diagnostic.",
+                    )
+                ],
+                2: [
+                    dcgm.types.ErrorDetails(
+                        code="DCGM_FR_PCI_REPLAY_RATE",
+                        message="Detected more than 8 PCIe replays per minute for GPU 1 : 99999 Reconnect PCIe card. Run system side PCIE diagnostic utilities to verify hops off the GPU board. If issue is on the board, run the field diagnostic.",
+                    )
+                ],
             },
         )
 
@@ -545,10 +551,12 @@ class TestDCGMHealthChecks:
         expected_response["DCGM_HEALTH_WATCH_POWER"] = dcgm.types.HealthDetails(
             status=dcgm.types.HealthStatus.WARN,
             entity_failures={
-                1: dcgm.types.ErrorDetails(
-                    code="DCGM_FR_CLOCK_THROTTLE_POWER",
-                    message="ErrorCode:DCGM_FR_CLOCK_THROTTLE_POWER GPU:1 Recommended Action=NONE;",
-                )
+                1: [
+                    dcgm.types.ErrorDetails(
+                        code="DCGM_FR_CLOCK_THROTTLE_POWER",
+                        message="ErrorCode:DCGM_FR_CLOCK_THROTTLE_POWER GPU:1 Recommended Action=NONE;",
+                    )
+                ]
             },
         )
         assert response == expected_response
@@ -566,10 +574,12 @@ class TestDCGMHealthChecks:
         health_status["DCGM_HEALTH_WATCH_POWER"] = dcgm.types.HealthDetails(
             status=dcgm.types.HealthStatus.WARN,
             entity_failures={
-                1: dcgm.types.ErrorDetails(
-                    code="DCGM_FR_CLOCK_THROTTLE_POWER",
-                    message="ErrorCode:DCGM_FR_CLOCK_THROTTLE_POWER GPU:1 Recommended Action=NONE;",
-                )
+                1: [
+                    dcgm.types.ErrorDetails(
+                        code="DCGM_FR_CLOCK_THROTTLE_POWER",
+                        message="ErrorCode:DCGM_FR_CLOCK_THROTTLE_POWER GPU:1 Recommended Action=NONE;",
+                    )
+                ]
             },
         )
         expected = copy.deepcopy(health_status)
@@ -592,10 +602,12 @@ class TestDCGMHealthChecks:
         health_status["DCGM_HEALTH_WATCH_POWER"] = dcgm.types.HealthDetails(
             status=dcgm.types.HealthStatus.WARN,
             entity_failures={
-                1: dcgm.types.ErrorDetails(
-                    code="DCGM_FR_CLOCK_THROTTLE_POWER",
-                    message="ErrorCode:DCGM_FR_CLOCK_THROTTLE_POWER GPU:1 Recommended Action=NONE;",
-                )
+                1: [
+                    dcgm.types.ErrorDetails(
+                        code="DCGM_FR_CLOCK_THROTTLE_POWER",
+                        message="ErrorCode:DCGM_FR_CLOCK_THROTTLE_POWER GPU:1 Recommended Action=NONE;",
+                    )
+                ]
             },
         )
 
@@ -617,19 +629,23 @@ class TestDCGMHealthChecks:
         health_status["DCGM_HEALTH_WATCH_POWER"] = dcgm.types.HealthDetails(
             status=dcgm.types.HealthStatus.WARN,
             entity_failures={
-                1: dcgm.types.ErrorDetails(
-                    code="DCGM_FR_CLOCK_THROTTLE_POWER",
-                    message="ErrorCode:DCGM_FR_CLOCK_THROTTLE_POWER GPU:1 Recommended Action=NONE;",
-                )
+                1: [
+                    dcgm.types.ErrorDetails(
+                        code="DCGM_FR_CLOCK_THROTTLE_POWER",
+                        message="ErrorCode:DCGM_FR_CLOCK_THROTTLE_POWER GPU:1 Recommended Action=NONE;",
+                    )
+                ]
             },
         )
         health_status["DCGM_HEALTH_WATCH_PCIE"] = dcgm.types.HealthDetails(
             status=dcgm.types.HealthStatus.WARN,
             entity_failures={
-                2: dcgm.types.ErrorDetails(
-                    code="DCGM_FR_PCI_REPLAY_RATE",
-                    message="Detected more than 8 PCIe replays per minute for GPU 1.",
-                )
+                2: [
+                    dcgm.types.ErrorDetails(
+                        code="DCGM_FR_PCI_REPLAY_RATE",
+                        message="Detected more than 8 PCIe replays per minute for GPU 1.",
+                    )
+                ]
             },
         )
 
@@ -639,10 +655,12 @@ class TestDCGMHealthChecks:
         expected_response["DCGM_HEALTH_WATCH_PCIE"] = dcgm.types.HealthDetails(
             status=dcgm.types.HealthStatus.WARN,
             entity_failures={
-                2: dcgm.types.ErrorDetails(
-                    code="DCGM_FR_PCI_REPLAY_RATE",
-                    message="Detected more than 8 PCIe replays per minute for GPU 1.",
-                )
+                2: [
+                    dcgm.types.ErrorDetails(
+                        code="DCGM_FR_PCI_REPLAY_RATE",
+                        message="Detected more than 8 PCIe replays per minute for GPU 1.",
+                    )
+                ]
             },
         )
         assert health_status == expected_response
@@ -662,10 +680,12 @@ class TestDCGMHealthChecks:
         health_status["DCGM_HEALTH_WATCH_THERMAL_MARGIN"] = dcgm.types.HealthDetails(
             status=dcgm.types.HealthStatus.WARN,
             entity_failures={
-                0: dcgm.types.ErrorDetails(
-                    code="GPU_TEMP_HW_SLOWDOWN_VIOLATION",
-                    message="GPU 0 thermal margin below HW slowdown T.Limit",
-                )
+                0: [
+                    dcgm.types.ErrorDetails(
+                        code="GPU_TEMP_HW_SLOWDOWN_VIOLATION",
+                        message="GPU 0 thermal margin below HW slowdown T.Limit",
+                    )
+                ]
             },
         )
 
@@ -724,10 +744,12 @@ class TestDCGMHealthChecks:
         # The surviving incident keeps its own code — the code drives remediation —
         # and the suppressed incident's message is not merged into it.
         assert details.entity_failures == {
-            0: dcgm.types.ErrorDetails(
-                code="DCGM_FR_FABRIC_PROBE_STATE",
-                message="GPU 0 fabric probe state is not complete",
-            )
+            0: [
+                dcgm.types.ErrorDetails(
+                    code="DCGM_FR_FABRIC_PROBE_STATE",
+                    message="GPU 0 fabric probe state is not complete",
+                )
+            ]
         }
 
     def test_suppressed_code_alone_leaves_the_watch_passing(self) -> None:
@@ -762,7 +784,7 @@ class TestDCGMHealthChecks:
         details = health_status["DCGM_HEALTH_WATCH_NVLINK"]
         assert details.status == dcgm.types.HealthStatus.FAIL
         assert 0 not in details.entity_failures
-        assert details.entity_failures[1].code == "DCGM_FR_NVLINK_DOWN"
+        assert details.entity_failures[1][0].code == "DCGM_FR_NVLINK_DOWN"
 
     def test_suppressed_incidents_are_counted_per_incident(self) -> None:
         """Withheld incidents stay observable: the counter advances once per suppressed
@@ -845,7 +867,7 @@ class TestDCGMHealthChecks:
 
         health_status = self._poll(watcher, MagicMock(), [self._get_nvlink_incident(0, 1, 16)])
 
-        assert health_status["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[1].code == "DCGM_FR_NVLINK_DOWN"
+        assert health_status["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[1][0].code == "DCGM_FR_NVLINK_DOWN"
         # Unconfigured codes are never tracked, so the dict stays empty.
         assert watcher._incident_streaks == {}
 
@@ -862,7 +884,7 @@ class TestDCGMHealthChecks:
 
         second = self._poll(watcher, dcgm_group_mock, incidents)
         assert second["DCGM_HEALTH_WATCH_NVLINK"].status == dcgm.types.HealthStatus.FAIL
-        assert second["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[1].code == "DCGM_FR_NVLINK_DOWN"
+        assert second["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[1][0].code == "DCGM_FR_NVLINK_DOWN"
 
     def test_incident_debounce_keeps_publishing_past_the_threshold(self) -> None:
         """A sustained fault keeps publishing once the threshold is met."""
@@ -874,7 +896,7 @@ class TestDCGMHealthChecks:
 
         for _ in range(3):
             health_status = self._poll(watcher, dcgm_group_mock, incidents)
-            assert health_status["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[1].code == "DCGM_FR_NVLINK_DOWN"
+            assert health_status["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[1][0].code == "DCGM_FR_NVLINK_DOWN"
 
     def test_incident_debounce_counts_one_streak_per_gpu_per_poll(self) -> None:
         """DCGM reports one incident per down link, so a GPU with several down links
@@ -891,7 +913,7 @@ class TestDCGMHealthChecks:
 
         # Both records are published together once the threshold is genuinely met.
         second = self._poll(watcher, dcgm_group_mock, two_links_one_gpu)
-        failure = second["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[3]
+        failure = second["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[3][0]
         assert failure.code == "DCGM_FR_NVLINK_DOWN"
         assert "link 16" in failure.message
         assert "link 17" in failure.message
@@ -935,7 +957,7 @@ class TestDCGMHealthChecks:
         )
 
         assert health_status["DCGM_HEALTH_WATCH_NVLINK"].entity_failures == {}
-        assert health_status["DCGM_HEALTH_WATCH_PCIE"].entity_failures[1].code == "DCGM_FR_PCI_REPLAY_RATE"
+        assert health_status["DCGM_HEALTH_WATCH_PCIE"].entity_failures[1][0].code == "DCGM_FR_PCI_REPLAY_RATE"
 
     def test_incident_debounce_failed_poll_does_not_reset_the_streak(self) -> None:
         """A poll that observed nothing must not clear a streak, so a fault spanning a
@@ -953,7 +975,7 @@ class TestDCGMHealthChecks:
 
         dcgm_group_mock.health.Check.side_effect = None
         health_status = self._poll(watcher, dcgm_group_mock, incidents)
-        assert health_status["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[1].code == "DCGM_FR_NVLINK_DOWN"
+        assert health_status["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[1][0].code == "DCGM_FR_NVLINK_DOWN"
 
     def test_incident_debounce_counts_withheld_incidents(self) -> None:
         """Withheld incidents are observable via the debounced counter."""
@@ -972,7 +994,7 @@ class TestDCGMHealthChecks:
 
         health_status = self._poll(watcher, MagicMock(), [self._get_nvlink_incident(0, 1, 16)])
 
-        assert health_status["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[1].code == "DCGM_FR_NVLINK_DOWN"
+        assert health_status["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[1][0].code == "DCGM_FR_NVLINK_DOWN"
         assert watcher._health_check_min_consecutive_polls == {}
 
     def test_perform_health_check_multiple_failures_same_gpu(self):
@@ -1011,10 +1033,12 @@ class TestDCGMHealthChecks:
         expected_response["DCGM_HEALTH_WATCH_NVLINK"] = dcgm.types.HealthDetails(
             status=dcgm.types.HealthStatus.FAIL,
             entity_failures={
-                0: dcgm.types.ErrorDetails(
-                    code="DCGM_FR_NVLINK_DOWN",
-                    message=expected_message,
-                )
+                0: [
+                    dcgm.types.ErrorDetails(
+                        code="DCGM_FR_NVLINK_DOWN",
+                        message=expected_message,
+                    )
+                ]
             },
         )
 
@@ -1022,13 +1046,13 @@ class TestDCGMHealthChecks:
         assert connectivity_success == True
 
         # Verify that all 4 failures are captured in the message
-        assert "link 8" in response["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[0].message
-        assert "link 9" in response["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[0].message
-        assert "link 14" in response["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[0].message
-        assert "link 15" in response["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[0].message
+        assert "link 8" in response["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[0][0].message
+        assert "link 9" in response["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[0][0].message
+        assert "link 14" in response["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[0][0].message
+        assert "link 15" in response["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[0][0].message
 
         # Verify messages are separated by semicolons
-        assert response["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[0].message.count(";") == 3
+        assert response["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[0][0].message.count(";") == 3
 
     def test_perform_health_check_multiple_gpus_multiple_failures_each(self):
         """Test that multiple failures across multiple GPUs are properly handled."""
@@ -1063,7 +1087,7 @@ class TestDCGMHealthChecks:
         assert 1 in response["DCGM_HEALTH_WATCH_NVLINK"].entity_failures
 
         # Verify GPU 0 has all 4 link failures
-        gpu0_message = response["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[0].message
+        gpu0_message = response["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[0][0].message
         assert "link 8" in gpu0_message
         assert "link 9" in gpu0_message
         assert "link 14" in gpu0_message
@@ -1071,7 +1095,7 @@ class TestDCGMHealthChecks:
         assert gpu0_message.count(";") == 3
 
         # Verify GPU 1 has all 4 link failures
-        gpu1_message = response["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[1].message
+        gpu1_message = response["DCGM_HEALTH_WATCH_NVLINK"].entity_failures[1][0].message
         assert "link 8" in gpu1_message
         assert "link 9" in gpu1_message
         assert "link 12" in gpu1_message
@@ -1274,7 +1298,7 @@ class TestDCGMHealthChecks:
         assert connectivity_success == True
         assert response["DCGM_HEALTH_WATCH_ALL"].status == dcgm.types.HealthStatus.FAIL
         assert 0 in response["DCGM_HEALTH_WATCH_ALL"].entity_failures
-        assert response["DCGM_HEALTH_WATCH_ALL"].entity_failures[0].message == "XID 95 detected on GPU 0"
+        assert response["DCGM_HEALTH_WATCH_ALL"].entity_failures[0][0].message == "XID 95 detected on GPU 0"
 
     def test_perform_health_check_unknown_error_code(self):
         """Test that incidents with unknown error codes use DCGM_FR_UNKNOWN fallback."""
@@ -1308,7 +1332,7 @@ class TestDCGMHealthChecks:
         assert connectivity_success == True
         assert response["DCGM_HEALTH_WATCH_PCIE"].status == dcgm.types.HealthStatus.WARN
         assert 1 in response["DCGM_HEALTH_WATCH_PCIE"].entity_failures
-        assert response["DCGM_HEALTH_WATCH_PCIE"].entity_failures[1].code == "DCGM_FR_UNKNOWN"
+        assert response["DCGM_HEALTH_WATCH_PCIE"].entity_failures[1][0].code == "DCGM_FR_UNKNOWN"
 
     @patch("pydcgm.DcgmHandle")
     @patch("pydcgm.DcgmGroup")
@@ -1549,7 +1573,7 @@ class TestSuppressNvlinkDownOnPcieGpus:
     def _assert_not_suppressed(self, health_status: dict[str, dcgm.types.HealthDetails]) -> None:
         details = health_status["DCGM_HEALTH_WATCH_NVLINK"]
         assert details.status == dcgm.types.HealthStatus.FAIL
-        assert details.entity_failures[0].code == "DCGM_FR_NVLINK_DOWN"
+        assert details.entity_failures[0][0].code == "DCGM_FR_NVLINK_DOWN"
 
     def test_suppress_no_nvlink_silicon_without_opt_in(self, tmp_path: Path) -> None:
         """L40-class GPU (zero hardware links): suppressed unconditionally —
@@ -1626,7 +1650,7 @@ class TestSuppressNvlinkDownOnPcieGpus:
         details = health_status["DCGM_HEALTH_WATCH_NVLINK"]
         assert details.status == dcgm.types.HealthStatus.FAIL
         assert 0 not in details.entity_failures
-        assert details.entity_failures[1].code == "DCGM_FR_NVLINK_DOWN"
+        assert details.entity_failures[1][0].code == "DCGM_FR_NVLINK_DOWN"
 
     def test_mixed_codes_same_gpu_preserves_genuine_incident(self, tmp_path: Path) -> None:
         """Regression: a genuine non-NVLINK_DOWN incident aggregated on the same
@@ -1649,9 +1673,9 @@ class TestSuppressNvlinkDownOnPcieGpus:
 
         details = health_status["DCGM_HEALTH_WATCH_NVLINK"]
         assert details.status == dcgm.types.HealthStatus.FAIL
-        assert details.entity_failures[0].code == "DCGM_FR_NVLINK_ERROR_THRESHOLD"
-        assert details.entity_failures[0].message == "GPU 0 NVLink error threshold exceeded"
-        assert "currently down" not in details.entity_failures[0].message
+        assert details.entity_failures[0][0].code == "DCGM_FR_NVLINK_ERROR_THRESHOLD"
+        assert details.entity_failures[0][0].message == "GPU 0 NVLink error threshold exceeded"
+        assert "currently down" not in details.entity_failures[0][0].message
 
     def test_no_suppress_when_metadata_unavailable(self) -> None:
         """Metadata file missing: incident NOT suppressed (fail closed)."""
@@ -1679,7 +1703,7 @@ class TestSuppressNvlinkDownOnPcieGpus:
 
         details = health_status["DCGM_HEALTH_WATCH_NVLINK"]
         assert details.status == dcgm.types.HealthStatus.FAIL
-        assert details.entity_failures[0].code == "DCGM_FR_NVLINK_ERROR_THRESHOLD"
+        assert details.entity_failures[0][0].code == "DCGM_FR_NVLINK_ERROR_THRESHOLD"
 
 
 class TestProbeWatchdog:

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_multiple_incident_codes.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_multiple_incident_codes.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Keep incident codes distinct from polling through event publication and recovery."""
+
+from pathlib import Path
+from threading import Event
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import dcgm_errors
+import dcgm_structs
+import pytest
+
+from gpu_health_monitor.dcgm_watcher import dcgm
+from gpu_health_monitor.platform_connector import platform_connector
+from gpu_health_monitor.protos import health_event_pb2 as pb
+
+WATCH = "DCGM_HEALTH_WATCH_NVLINK"
+CHECK = "GpuNvlinkWatch"
+CODES = {"DCGM_FR_IMEX_UNHEALTHY": "NONE", "DCGM_FR_FABRIC_PROBE_STATE": "RESTART_VM"}
+
+
+@pytest.fixture
+def processor(tmp_path: Path) -> platform_connector.PlatformConnectorEventProcessor:
+    """Use the real event builder and cache with an isolated, controllable transport."""
+    state = tmp_path / "state"
+    state.write_text("test-boot-id")
+    result = platform_connector.PlatformConnectorEventProcessor(
+        str(tmp_path / "connector.sock"),
+        "node1",
+        Event(),
+        CODES,
+        str(state),
+        str(tmp_path / "metadata.json"),
+        pb.EXECUTE_REMEDIATION,
+    )
+    result._metadata_reader = MagicMock()
+    result._metadata_reader.get_pci_address.return_value = "0000:17:00.0"
+    result._metadata_reader.get_gpu_uuid.return_value = "GPU-test"
+    result._metadata_reader.get_chassis_serial.return_value = "CHASSIS-test"
+    result.send_health_event_with_retries = MagicMock(return_value=True)
+    return result
+
+
+def incident(code: str, message: str, gpu_id: int = 0) -> SimpleNamespace:
+    """Construct the DCGM incident shape without a GPU or DCGM host engine."""
+    return SimpleNamespace(
+        system=dcgm_structs.DCGM_HEALTH_WATCH_NVLINK,
+        health=(
+            dcgm_structs.DCGM_HEALTH_RESULT_WARN
+            if code == "DCGM_FR_IMEX_UNHEALTHY"
+            else dcgm_structs.DCGM_HEALTH_RESULT_FAIL
+        ),
+        error=SimpleNamespace(code=getattr(dcgm_errors, code), msg=message),
+        entityInfo=SimpleNamespace(entityId=gpu_id, entityGroupId=dcgm_structs.DCGM_FE_GPU),
+    )
+
+
+def poll(watcher: dcgm.DCGMWatcher, incidents: list[SimpleNamespace]) -> dict[str, dcgm.types.HealthDetails]:
+    """Run incident suppression, debounce and accumulation in the real watcher."""
+    group = MagicMock()
+    group.health.Check.return_value = SimpleNamespace(
+        overallHealth=dcgm_structs.DCGM_HEALTH_RESULT_FAIL,
+        incidentCount=len(incidents),
+        incidents=incidents,
+    )
+    health, connected = watcher._perform_health_check(group)
+    assert connected
+    watcher._suppress_configured_error_codes(health)
+    return {WATCH: health[WATCH]}
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("send_succeeds", [False, True])
+def test_distinct_codes_survive_publication_and_recovery(processor, reverse: bool, send_succeeds: bool) -> None:
+    """Each code keeps its own message and action, including after a failed delivery."""
+    watcher = dcgm.DCGMWatcher("localhost:5555", 10, [], False)
+    incidents = [
+        incident("DCGM_FR_IMEX_UNHEALTHY", "IMEX warning"),
+        incident("DCGM_FR_FABRIC_PROBE_STATE", "fabric failure"),
+    ]
+    if reverse:
+        incidents.reverse()
+    health = poll(watcher, incidents)
+    assert health[WATCH].status == dcgm.types.HealthStatus.FAIL
+    processor.send_health_event_with_retries.return_value = send_succeeds
+    processor.health_event_occurred(health, [0])
+    events = processor.send_health_event_with_retries.call_args.args[0]
+    events = pb.HealthEvents.FromString(pb.HealthEvents(events=events).SerializeToString()).events
+    assert [(list(e.errorCode), e.message, e.recommendedAction, e.isFatal) for e in events] == [
+        (["DCGM_FR_FABRIC_PROBE_STATE"], "fabric failure", pb.RESTART_VM, True),
+        (["DCGM_FR_IMEX_UNHEALTHY"], "IMEX warning", pb.NONE, False),
+    ]
+    assert all(not e.isHealthy and e.processingStrategy == pb.EXECUTE_REMEDIATION for e in events)
+    key = processor._build_cache_key(CHECK, "GPU", "0")
+    if not send_succeeds:
+        assert key not in processor.entity_cache
+        processor.send_health_event_with_retries.reset_mock()
+        processor.send_health_event_with_retries.return_value = True
+        processor.health_event_occurred(health, [0])
+        assert len(processor.send_health_event_with_retries.call_args.args[0]) == 2
+    assert processor.entity_cache[key].active_errors == set(CODES)
+
+    processor.send_health_event_with_retries.reset_mock()
+    processor.health_event_occurred(health, [0])
+    processor.send_health_event_with_retries.assert_not_called()
+    processor.health_event_occurred(poll(watcher, incidents[:1]), [0])
+    processor.send_health_event_with_retries.assert_not_called()
+    assert processor.entity_cache[key].active_errors == set(CODES)
+
+    processor.health_event_occurred(poll(watcher, []), [0])
+    recovered = processor.send_health_event_with_retries.call_args.args[0]
+    assert len(recovered) == 1
+    assert recovered[0].isHealthy and not recovered[0].isFatal
+    assert recovered[0].recommendedAction == pb.NONE and not recovered[0].errorCode
+    assert processor.entity_cache[key].is_healthy
+    processor.send_health_event_with_retries.reset_mock()
+    processor.health_event_occurred(poll(watcher, []), [0])
+    processor.send_health_event_with_retries.assert_not_called()
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_repeated_code_combines_only_its_own_messages(processor, reverse: bool) -> None:
+    """Same-code deduplication cannot mix another code's remediation evidence."""
+    watcher = dcgm.DCGMWatcher("localhost:5555", 10, [], False)
+    incidents = [
+        incident("DCGM_FR_IMEX_UNHEALTHY", "warning one"),
+        incident("DCGM_FR_FABRIC_PROBE_STATE", "failure"),
+        incident("DCGM_FR_IMEX_UNHEALTHY", "warning two"),
+    ]
+    if reverse:
+        incidents.reverse()
+    processor.health_event_occurred(poll(watcher, incidents), [0])
+    events = processor.send_health_event_with_retries.call_args.args[0]
+    assert len(events) == 2
+    by_code = {event.errorCode[0]: event for event in events}
+    assert by_code["DCGM_FR_FABRIC_PROBE_STATE"].message == "failure"
+    assert set(by_code["DCGM_FR_IMEX_UNHEALTHY"].message.split("; ")) == {"warning one", "warning two"}
+
+
+@pytest.mark.parametrize("suppressed", list(CODES))
+@pytest.mark.parametrize("reverse", [False, True])
+def test_suppression_preserves_the_other_code(processor, suppressed: str, reverse: bool) -> None:
+    """Suppressing either code leaves the other's original message and action."""
+    watcher = dcgm.DCGMWatcher("localhost:5555", 10, [], False, suppressed_error_codes=frozenset({suppressed}))
+    incidents = [incident(code, code) for code in CODES]
+    if reverse:
+        incidents.reverse()
+    processor.health_event_occurred(poll(watcher, incidents), [0])
+    events = processor.send_health_event_with_retries.call_args.args[0]
+    expected = next(code for code in CODES if code != suppressed)
+    assert len(events) == 1 and list(events[0].errorCode) == [expected]
+    assert events[0].message == expected
+    assert events[0].recommendedAction == pb.RecommendedAction.Value(CODES[expected])
+
+
+def test_debounced_second_code_is_published_after_its_threshold(processor) -> None:
+    """A cached first code cannot conceal a later code when its debounce matures."""
+    watcher = dcgm.DCGMWatcher(
+        "localhost:5555", 10, [], False, health_check_min_consecutive_polls={"DCGM_FR_FABRIC_PROBE_STATE": 2}
+    )
+    incidents = [incident(code, code) for code in CODES]
+    processor.health_event_occurred(poll(watcher, incidents), [0])
+    first = processor.send_health_event_with_retries.call_args.args[0]
+    assert len(first) == 1 and list(first[0].errorCode) == ["DCGM_FR_IMEX_UNHEALTHY"]
+    processor.send_health_event_with_retries.reset_mock()
+    processor.health_event_occurred(poll(watcher, incidents), [0])
+    second = processor.send_health_event_with_retries.call_args.args[0]
+    assert len(second) == 1 and list(second[0].errorCode) == ["DCGM_FR_FABRIC_PROBE_STATE"]
+    key = processor._build_cache_key(CHECK, "GPU", "0")
+    assert processor.entity_cache[key].active_errors == set(CODES)

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_multiple_incident_codes.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_multiple_incident_codes.py
@@ -14,6 +14,7 @@
 
 """Keep incident codes distinct from polling through event publication and recovery."""
 
+from dataclasses import dataclass
 from pathlib import Path
 from threading import Event
 from types import SimpleNamespace
@@ -54,21 +55,41 @@ def processor(tmp_path: Path) -> platform_connector.PlatformConnectorEventProces
     return result
 
 
-def incident(code: str, message: str, gpu_id: int = 0) -> SimpleNamespace:
+@dataclass(frozen=True)
+class IncidentError:
+    code: int
+    msg: str
+
+
+@dataclass(frozen=True)
+class IncidentEntityInfo:
+    entityId: int
+    entityGroupId: int
+
+
+@dataclass(frozen=True)
+class Incident:
+    system: int
+    health: int
+    error: IncidentError
+    entityInfo: IncidentEntityInfo
+
+
+def incident(code: str, message: str, gpu_id: int = 0) -> Incident:
     """Construct the DCGM incident shape without a GPU or DCGM host engine."""
-    return SimpleNamespace(
+    return Incident(
         system=dcgm_structs.DCGM_HEALTH_WATCH_NVLINK,
         health=(
             dcgm_structs.DCGM_HEALTH_RESULT_WARN
             if code == "DCGM_FR_IMEX_UNHEALTHY"
             else dcgm_structs.DCGM_HEALTH_RESULT_FAIL
         ),
-        error=SimpleNamespace(code=getattr(dcgm_errors, code), msg=message),
-        entityInfo=SimpleNamespace(entityId=gpu_id, entityGroupId=dcgm_structs.DCGM_FE_GPU),
+        error=IncidentError(code=getattr(dcgm_errors, code), msg=message),
+        entityInfo=IncidentEntityInfo(entityId=gpu_id, entityGroupId=dcgm_structs.DCGM_FE_GPU),
     )
 
 
-def poll(watcher: dcgm.DCGMWatcher, incidents: list[SimpleNamespace]) -> dict[str, dcgm.types.HealthDetails]:
+def poll(watcher: dcgm.DCGMWatcher, incidents: list[Incident]) -> dict[str, dcgm.types.HealthDetails]:
     """Run incident suppression, debounce and accumulation in the real watcher."""
     group = MagicMock()
     group.health.Check.return_value = SimpleNamespace(
@@ -84,7 +105,9 @@ def poll(watcher: dcgm.DCGMWatcher, incidents: list[SimpleNamespace]) -> dict[st
 
 @pytest.mark.parametrize("reverse", [False, True])
 @pytest.mark.parametrize("send_succeeds", [False, True])
-def test_distinct_codes_survive_publication_and_recovery(processor, reverse: bool, send_succeeds: bool) -> None:
+def test_distinct_codes_survive_publication_and_recovery(
+    processor: platform_connector.PlatformConnectorEventProcessor, reverse: bool, send_succeeds: bool
+) -> None:
     """Each code keeps its own message and action, including after a failed delivery."""
     watcher = dcgm.DCGMWatcher("localhost:5555", 10, [], False)
     incidents = [
@@ -132,7 +155,9 @@ def test_distinct_codes_survive_publication_and_recovery(processor, reverse: boo
 
 
 @pytest.mark.parametrize("reverse", [False, True])
-def test_repeated_code_combines_only_its_own_messages(processor, reverse: bool) -> None:
+def test_repeated_code_combines_only_its_own_messages(
+    processor: platform_connector.PlatformConnectorEventProcessor, reverse: bool
+) -> None:
     """Same-code deduplication cannot mix another code's remediation evidence."""
     watcher = dcgm.DCGMWatcher("localhost:5555", 10, [], False)
     incidents = [
@@ -152,7 +177,9 @@ def test_repeated_code_combines_only_its_own_messages(processor, reverse: bool) 
 
 @pytest.mark.parametrize("suppressed", list(CODES))
 @pytest.mark.parametrize("reverse", [False, True])
-def test_suppression_preserves_the_other_code(processor, suppressed: str, reverse: bool) -> None:
+def test_suppression_preserves_the_other_code(
+    processor: platform_connector.PlatformConnectorEventProcessor, suppressed: str, reverse: bool
+) -> None:
     """Suppressing either code leaves the other's original message and action."""
     watcher = dcgm.DCGMWatcher("localhost:5555", 10, [], False, suppressed_error_codes=frozenset({suppressed}))
     incidents = [incident(code, code) for code in CODES]
@@ -166,7 +193,9 @@ def test_suppression_preserves_the_other_code(processor, suppressed: str, revers
     assert events[0].recommendedAction == pb.RecommendedAction.Value(CODES[expected])
 
 
-def test_debounced_second_code_is_published_after_its_threshold(processor) -> None:
+def test_debounced_second_code_is_published_after_its_threshold(
+    processor: platform_connector.PlatformConnectorEventProcessor,
+) -> None:
     """A cached first code cannot conceal a later code when its debounce matures."""
     watcher = dcgm.DCGMWatcher(
         "localhost:5555", 10, [], False, health_check_min_consecutive_polls={"DCGM_FR_FABRIC_PROBE_STATE": 2}

--- a/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_platform_connector/test_platform_connector.py
+++ b/health-monitors/gpu-health-monitor/gpu_health_monitor/tests/test_platform_connector/test_platform_connector.py
@@ -130,10 +130,12 @@ class TestPlatformConnectors(unittest.TestCase):
         dcgm_health_events["DCGM_HEALTH_WATCH_INFOROM"] = dcgmtypes.HealthDetails(
             status=dcgmtypes.HealthStatus.FAIL,
             entity_failures={
-                0: dcgm.types.ErrorDetails(
-                    code="DCGM_FR_CORRUPT_INFOROM",
-                    message="A corrupt InfoROM has been detected in GPU 0. Flash the InfoROM to clear this corruption.",
-                )
+                0: [
+                    dcgm.types.ErrorDetails(
+                        code="DCGM_FR_CORRUPT_INFOROM",
+                        message="A corrupt InfoROM has been detected in GPU 0. Flash the InfoROM to clear this corruption.",
+                    )
+                ]
             },
         )
 
@@ -154,10 +156,12 @@ class TestPlatformConnectors(unittest.TestCase):
         dcgm_health_events["DCGM_HEALTH_WATCH_INFOROM"] = dcgmtypes.HealthDetails(
             status=dcgmtypes.HealthStatus.FAIL,
             entity_failures={
-                0: dcgm.types.ErrorDetails(
-                    code="DCGM_FR_CORRUPT_INFOROM",
-                    message="A corrupt InfoROM has been detected in GPU 0. Flash the InfoROM to clear this corruption.",
-                )
+                0: [
+                    dcgm.types.ErrorDetails(
+                        code="DCGM_FR_CORRUPT_INFOROM",
+                        message="A corrupt InfoROM has been detected in GPU 0. Flash the InfoROM to clear this corruption.",
+                    )
+                ]
             },
         )
 
@@ -244,10 +248,12 @@ class TestPlatformConnectors(unittest.TestCase):
         dcgm_health_events["DCGM_HEALTH_WATCH_NVLINK"] = dcgmtypes.HealthDetails(
             status=dcgmtypes.HealthStatus.FAIL,
             entity_failures={
-                0: dcgm.types.ErrorDetails(
-                    code="DCGM_FR_NVLINK_DOWN",
-                    message=aggregated_message,
-                )
+                0: [
+                    dcgm.types.ErrorDetails(
+                        code="DCGM_FR_NVLINK_DOWN",
+                        message=aggregated_message,
+                    )
+                ]
             },
         )
 
@@ -358,14 +364,18 @@ class TestPlatformConnectors(unittest.TestCase):
         dcgm_health_events["DCGM_HEALTH_WATCH_NVLINK"] = dcgmtypes.HealthDetails(
             status=dcgmtypes.HealthStatus.FAIL,
             entity_failures={
-                0: dcgm.types.ErrorDetails(
-                    code="DCGM_FR_NVLINK_DOWN",
-                    message=gpu0_message,
-                ),
-                1: dcgm.types.ErrorDetails(
-                    code="DCGM_FR_NVLINK_DOWN",
-                    message=gpu1_message,
-                ),
+                0: [
+                    dcgm.types.ErrorDetails(
+                        code="DCGM_FR_NVLINK_DOWN",
+                        message=gpu0_message,
+                    )
+                ],
+                1: [
+                    dcgm.types.ErrorDetails(
+                        code="DCGM_FR_NVLINK_DOWN",
+                        message=gpu1_message,
+                    )
+                ],
             },
         )
 
@@ -430,10 +440,12 @@ class TestPlatformConnectors(unittest.TestCase):
         dcgm_health_events["DCGM_HEALTH_WATCH_NVLINK"] = dcgmtypes.HealthDetails(
             status=dcgmtypes.HealthStatus.FAIL,
             entity_failures={
-                1: dcgm.types.ErrorDetails(
-                    code="DCGM_FR_NVLINK_DOWN",
-                    message=gpu1_message,
-                ),
+                1: [
+                    dcgm.types.ErrorDetails(
+                        code="DCGM_FR_NVLINK_DOWN",
+                        message=gpu1_message,
+                    )
+                ],
             },
         )
 
@@ -558,14 +570,18 @@ class TestPlatformConnectors(unittest.TestCase):
         dcgm_health_events["DCGM_HEALTH_WATCH_NVLINK"] = dcgmtypes.HealthDetails(
             status=dcgmtypes.HealthStatus.FAIL,
             entity_failures={
-                0: dcgm.types.ErrorDetails(
-                    code="DCGM_FR_NVLINK_DOWN",
-                    message=gpu0_message,
-                ),
-                1: dcgm.types.ErrorDetails(
-                    code="DCGM_FR_NVLINK_DOWN",
-                    message=gpu1_message,
-                ),
+                0: [
+                    dcgm.types.ErrorDetails(
+                        code="DCGM_FR_NVLINK_DOWN",
+                        message=gpu0_message,
+                    )
+                ],
+                1: [
+                    dcgm.types.ErrorDetails(
+                        code="DCGM_FR_NVLINK_DOWN",
+                        message=gpu1_message,
+                    )
+                ],
             },
         )
 
@@ -778,20 +794,24 @@ class TestPlatformConnectors(unittest.TestCase):
             dcgm_health_events["DCGM_HEALTH_WATCH_MEM"] = dcgmtypes.HealthDetails(
                 status=dcgmtypes.HealthStatus.FAIL,
                 entity_failures={
-                    4: dcgm.types.ErrorDetails(
-                        code="DCGM_FR_XID_ERROR",
-                        message="ErrorCode:DCGM_FR_XID_ERROR GPU:4 PCI:0000:c4:00.0 "
-                        "Detected XID 31 for GPU 4 .Recommended Action=NONE;",
-                    )
+                    4: [
+                        dcgm.types.ErrorDetails(
+                            code="DCGM_FR_XID_ERROR",
+                            message="ErrorCode:DCGM_FR_XID_ERROR GPU:4 PCI:0000:c4:00.0 "
+                            "Detected XID 31 for GPU 4 .Recommended Action=NONE;",
+                        )
+                    ]
                 },
             )
             dcgm_health_events["DCGM_HEALTH_WATCH_THERMAL"] = dcgmtypes.HealthDetails(
                 status=dcgmtypes.HealthStatus.FAIL,
                 entity_failures={
-                    2: dcgm.types.ErrorDetails(
-                        code="DCGM_FR_TEMP_VIOLATION",
-                        message="GPU 2 temperature exceeds threshold",
-                    )
+                    2: [
+                        dcgm.types.ErrorDetails(
+                            code="DCGM_FR_TEMP_VIOLATION",
+                            message="GPU 2 temperature exceeds threshold",
+                        )
+                    ]
                 },
             )
 
@@ -936,10 +956,12 @@ class TestPlatformConnectors(unittest.TestCase):
             dcgm_health_events["DCGM_HEALTH_WATCH_POWER"] = dcgmtypes.HealthDetails(
                 status=dcgmtypes.HealthStatus.FAIL,
                 entity_failures={
-                    3: dcgm.types.ErrorDetails(
-                        code="DCGM_FR_POWER_UNREADABLE",
-                        message="GPU 3 power reading is unavailable",
-                    )
+                    3: [
+                        dcgm.types.ErrorDetails(
+                            code="DCGM_FR_POWER_UNREADABLE",
+                            message="GPU 3 power reading is unavailable",
+                        )
+                    ]
                 },
             )
 
@@ -1043,10 +1065,12 @@ class TestPlatformConnectors(unittest.TestCase):
             dcgm_health_events["DCGM_HEALTH_WATCH_POWER"] = dcgmtypes.HealthDetails(
                 status=dcgmtypes.HealthStatus.FAIL,
                 entity_failures={
-                    3: dcgm.types.ErrorDetails(
-                        code="DCGM_FR_CLOCK_THROTTLE_POWER",
-                        message="GPU 3 clock throttled due to power",
-                    )
+                    3: [
+                        dcgm.types.ErrorDetails(
+                            code="DCGM_FR_CLOCK_THROTTLE_POWER",
+                            message="GPU 3 clock throttled due to power",
+                        )
+                    ]
                 },
             )
 
@@ -1076,10 +1100,12 @@ class TestPlatformConnectors(unittest.TestCase):
             dcgm_health_events["DCGM_HEALTH_WATCH_POWER"] = dcgmtypes.HealthDetails(
                 status=dcgmtypes.HealthStatus.FAIL,
                 entity_failures={
-                    3: dcgm.types.ErrorDetails(
-                        code="DCGM_FR_POWER_UNREADABLE",
-                        message="GPU 3 power reading is unavailable",
-                    )
+                    3: [
+                        dcgm.types.ErrorDetails(
+                            code="DCGM_FR_POWER_UNREADABLE",
+                            message="GPU 3 power reading is unavailable",
+                        )
+                    ]
                 },
             )
 
@@ -1227,10 +1253,12 @@ class TestPlatformConnectors(unittest.TestCase):
             dcgm_health_events["DCGM_HEALTH_WATCH_INFOROM"] = dcgmtypes.HealthDetails(
                 status=dcgmtypes.HealthStatus.FAIL,
                 entity_failures={
-                    0: dcgm.types.ErrorDetails(
-                        code="DCGM_FR_CORRUPT_INFOROM",
-                        message="A corrupt InfoROM has been detected in GPU 0.",
-                    )
+                    0: [
+                        dcgm.types.ErrorDetails(
+                            code="DCGM_FR_CORRUPT_INFOROM",
+                            message="A corrupt InfoROM has been detected in GPU 0.",
+                        )
+                    ]
                 },
             )
             gpu_ids = [0]
@@ -1429,10 +1457,12 @@ class TestPlatformConnectors(unittest.TestCase):
             dcgm_health_events["DCGM_HEALTH_WATCH_INFOROM"] = dcgmtypes.HealthDetails(
                 status=dcgmtypes.HealthStatus.FAIL,
                 entity_failures={
-                    0: dcgm.types.ErrorDetails(
-                        code="DCGM_FR_CORRUPT_INFOROM",
-                        message="A corrupt InfoROM has been detected in GPU 0.",
-                    )
+                    0: [
+                        dcgm.types.ErrorDetails(
+                            code="DCGM_FR_CORRUPT_INFOROM",
+                            message="A corrupt InfoROM has been detected in GPU 0.",
+                        )
+                    ]
                 },
             )
 


### PR DESCRIPTION
## Summary

Fixes #1795.

Preserve every distinct error code for a GPU within a health watch. Group messages by watch, GPU and code; publish each code with its corresponding remediation; retain all pending codes in the event cache. No protobuf or configuration changes.

## Validation

- GPU health monitor make lint-test: 197 tests and 5 subtests passed.
- Seven regression cases fail on the original code. Coverage includes both arrival orders, per-code actions, repeated polls, suppression and failed-publish retries.
- Validation: https://github.com/sylvesterkaczmarek/nccl-tests/actions/runs/34522297146
- Full-repository make lint-test-all stopped because protoc was unavailable. Live GPU execution was not run.

Signed-off-by: Sylvester Kaczmarek <16242628+sylvesterkaczmarek@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPU health incidents now report and track multiple error codes independently for each GPU.
  * Repeated messages for the same error are combined, while distinct errors retain separate details and remediation actions.
  * Per-error suppression and debounce behavior allows unaffected incidents to continue reporting.
  * Incident reporting behavior is documented.

* **Bug Fixes**
  * Improved incident delivery, retry, recovery, and cache handling across multiple simultaneous GPU failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->