### PR TITLE
fix(janitor-provider/oci): add retry to transient failures

### DIFF
--- a/janitor-provider/main.go
+++ b/janitor-provider/main.go
@@ -67,6 +67,21 @@ type janitorProviderServer struct {
 	k8sClient kubernetes.Interface
 }
 
+// translateCSPError preserves provider gRPC status codes and maps unclassified
+// provider errors to Internal.
+func translateCSPError(err error, operation string) error {
+	if err == nil {
+		return nil
+	}
+
+	grpcStatus, ok := status.FromError(err)
+	if !ok || grpcStatus.Code() == codes.Unknown {
+		return status.Errorf(codes.Internal, "%s: %v", operation, err)
+	}
+
+	return status.Errorf(grpcStatus.Code(), "%s: %s", operation, grpcStatus.Message())
+}
+
 func (s *janitorProviderServer) SendRebootSignal(
 	ctx context.Context, req *cspv1alpha1.SendRebootSignalRequest,
 ) (*cspv1alpha1.SendRebootSignalResponse, error) {
@@ -94,7 +109,7 @@ func (s *janitorProviderServer) SendRebootSignal(
 		)
 		tracing.RecordError(span, err)
 
-		return nil, status.Errorf(codes.Internal, "failed to send reboot signal: %v", err)
+		return nil, translateCSPError(err, "failed to send reboot signal")
 	}
 
 	span.SetAttributes(
@@ -133,7 +148,7 @@ func (s *janitorProviderServer) IsNodeReady(
 		)
 		tracing.RecordError(span, err)
 
-		return nil, status.Errorf(codes.Internal, "failed to check if node is ready: %v", err)
+		return nil, translateCSPError(err, "failed to check if node is ready")
 	}
 
 	span.SetAttributes(attribute.Bool("janitor_provider.node_ready.ready", isReady))
@@ -170,7 +185,7 @@ func (s *janitorProviderServer) SendTerminateSignal(
 		)
 		tracing.RecordError(span, err)
 
-		return nil, status.Errorf(codes.Internal, "failed to send terminate signal: %v", err)
+		return nil, translateCSPError(err, "failed to send terminate signal")
 	}
 
 	span.SetAttributes(

--- a/janitor-provider/main_test.go
+++ b/janitor-provider/main_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestTranslateCSPError_VariousErrors_ReturnsExpectedStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode codes.Code
+		wantText string
+	}{
+		{
+			name:     "plain provider error",
+			err:      errors.New("permission denied"),
+			wantCode: codes.Internal,
+			wantText: "permission denied",
+		},
+		{
+			name:     "retryable provider error",
+			err:      status.Error(codes.Unavailable, "instance busy"),
+			wantCode: codes.Unavailable,
+			wantText: "instance busy",
+		},
+		{
+			name:     "provider deadline",
+			err:      status.Error(codes.DeadlineExceeded, "request timed out"),
+			wantCode: codes.DeadlineExceeded,
+			wantText: "request timed out",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := translateCSPError(test.err, "perform CSP operation")
+
+			require.Error(t, err)
+			assert.Equal(t, test.wantCode, status.Code(err))
+			assert.ErrorContains(t, err, "perform CSP operation")
+			assert.ErrorContains(t, err, test.wantText)
+		})
+	}
+}
+
+func TestTranslateCSPError_NilError_ReturnsNil(t *testing.T) {
+	require.NoError(t, translateCSPError(nil, "perform CSP operation"))
+}

--- a/janitor-provider/main_test.go
+++ b/janitor-provider/main_test.go
@@ -24,6 +24,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// TestTranslateCSPError_VariousErrors_ReturnsExpectedStatus verifies that CSP
+// errors retain known gRPC codes and plain errors become Internal errors.
 func TestTranslateCSPError_VariousErrors_ReturnsExpectedStatus(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -63,6 +65,8 @@ func TestTranslateCSPError_VariousErrors_ReturnsExpectedStatus(t *testing.T) {
 	}
 }
 
+// TestTranslateCSPError_NilError_ReturnsNil verifies that the translator does
+// not create an error when the provider returns nil.
 func TestTranslateCSPError_NilError_ReturnsNil(t *testing.T) {
 	require.NoError(t, translateCSPError(nil, "perform CSP operation"))
 }

--- a/janitor-provider/pkg/csp/oci/oci.go
+++ b/janitor-provider/pkg/csp/oci/oci.go
@@ -16,6 +16,7 @@ package oci
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -27,6 +28,8 @@ import (
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/common/auth"
 	"github.com/oracle/oci-go-sdk/v65/core"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/nvidia/nvsentinel/commons/pkg/auditlogger"
@@ -36,8 +39,6 @@ import (
 var (
 	_ model.CSPClient = (*Client)(nil)
 )
-
-const rebootRetryAttempts = 6
 
 // Compute provides a wrapper around a subset of the OCI Compute client interface,
 // to enable mocking/stubbing for testing.
@@ -126,22 +127,15 @@ func NewClientFromEnv(ctx context.Context) (*Client, error) {
 func (c *Client) SendRebootSignal(
 	ctx context.Context,
 	node corev1.Node,
-	_ string,
+	crName string,
 ) (model.ResetSignalRequestRef, error) {
-	retryPolicy := rebootRetryPolicy()
 	_, err := c.compute.InstanceAction(ctx, core.InstanceActionRequest{
-		InstanceId: &node.Spec.ProviderID,
-		Action:     core.InstanceActionActionSoftreset,
-		RequestMetadata: common.RequestMetadata{
-			RetryPolicy: &retryPolicy,
-		},
+		InstanceId:    &node.Spec.ProviderID,
+		Action:        core.InstanceActionActionSoftreset,
+		OpcRetryToken: rebootRetryToken(node.Spec.ProviderID, crName),
 	})
 	if err != nil {
-		return "", fmt.Errorf(
-			"send soft reset action for OCI instance %q: %w",
-			node.Spec.ProviderID,
-			err,
-		)
+		return "", translateRebootError(node.Spec.ProviderID, err)
 	}
 
 	return model.ResetSignalRequestRef(time.Now().UTC().Format(time.RFC3339)), nil
@@ -165,14 +159,25 @@ func (c *Client) IsNodeReady(ctx context.Context, node corev1.Node, requestID st
 	return true, nil
 }
 
-func rebootRetryPolicy() common.RetryPolicy {
-	return common.NewRetryPolicyWithOptions(
-		common.ReplaceWithValuesFromRetryPolicy(common.DefaultRetryPolicyWithoutEventualConsistency()),
-		common.WithMaximumNumberAttempts(rebootRetryAttempts),
-		common.WithShouldRetryOperation(func(response common.OCIOperationResponse) bool {
-			return isRetryableRebootError(response.Error)
-		}),
-	)
+// rebootRetryToken returns a stable OCI idempotency token for retries of one
+// RebootNode request. OCI retry tokens are limited to 64 characters.
+func rebootRetryToken(providerID, crName string) *string {
+	if crName == "" {
+		return nil
+	}
+
+	token := fmt.Sprintf("%x", sha256.Sum256([]byte(providerID+"\x00"+crName)))
+
+	return &token
+}
+
+func translateRebootError(providerID string, err error) error {
+	contextualErr := fmt.Errorf("send soft reset action for OCI instance %q: %w", providerID, err)
+	if isRetryableRebootError(err) {
+		return status.Error(codes.Unavailable, contextualErr.Error())
+	}
+
+	return contextualErr
 }
 
 func isRetryableRebootError(err error) bool {

--- a/janitor-provider/pkg/csp/oci/oci.go
+++ b/janitor-provider/pkg/csp/oci/oci.go
@@ -16,10 +16,12 @@ package oci
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
@@ -34,6 +36,8 @@ import (
 var (
 	_ model.CSPClient = (*Client)(nil)
 )
+
+const rebootRetryAttempts = 6
 
 // Compute provides a wrapper around a subset of the OCI Compute client interface,
 // to enable mocking/stubbing for testing.
@@ -119,13 +123,25 @@ func NewClientFromEnv(ctx context.Context) (*Client, error) {
 }
 
 // SendRebootSignal sends a reboot signal to OCI for the given node.
-func (c *Client) SendRebootSignal(ctx context.Context, node corev1.Node, _ string) (model.ResetSignalRequestRef, error) {
+func (c *Client) SendRebootSignal(
+	ctx context.Context,
+	node corev1.Node,
+	_ string,
+) (model.ResetSignalRequestRef, error) {
+	retryPolicy := rebootRetryPolicy()
 	_, err := c.compute.InstanceAction(ctx, core.InstanceActionRequest{
 		InstanceId: &node.Spec.ProviderID,
 		Action:     core.InstanceActionActionSoftreset,
+		RequestMetadata: common.RequestMetadata{
+			RetryPolicy: &retryPolicy,
+		},
 	})
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf(
+			"send soft reset action for OCI instance %q: %w",
+			node.Spec.ProviderID,
+			err,
+		)
 	}
 
 	return model.ResetSignalRequestRef(time.Now().UTC().Format(time.RFC3339)), nil
@@ -147,6 +163,31 @@ func (c *Client) IsNodeReady(ctx context.Context, node corev1.Node, requestID st
 	}
 
 	return true, nil
+}
+
+func rebootRetryPolicy() common.RetryPolicy {
+	return common.NewRetryPolicyWithOptions(
+		common.ReplaceWithValuesFromRetryPolicy(common.DefaultRetryPolicyWithoutEventualConsistency()),
+		common.WithMaximumNumberAttempts(rebootRetryAttempts),
+		common.WithShouldRetryOperation(func(response common.OCIOperationResponse) bool {
+			return isRetryableRebootError(response.Error)
+		}),
+	)
+}
+
+func isRetryableRebootError(err error) bool {
+	if common.IsErrorRetryableByDefault(err) {
+		return true
+	}
+
+	var serviceErr common.ServiceError
+	if !errors.As(err, &serviceErr) {
+		return false
+	}
+
+	return serviceErr.GetHTTPStatusCode() == http.StatusConflict &&
+		serviceErr.GetCode() == "Conflict" &&
+		strings.Contains(strings.ToLower(serviceErr.GetMessage()), "currently being modified")
 }
 
 // SendTerminateSignal is not implemented for OCI.

--- a/janitor-provider/pkg/csp/oci/oci_test.go
+++ b/janitor-provider/pkg/csp/oci/oci_test.go
@@ -1,0 +1,217 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type fakeCompute struct {
+	actionErrors   []error
+	actionRequests []core.InstanceActionRequest
+}
+
+func (f *fakeCompute) InstanceAction(
+	_ context.Context,
+	request core.InstanceActionRequest,
+) (core.InstanceActionResponse, error) {
+	index := len(f.actionRequests)
+	f.actionRequests = append(f.actionRequests, request)
+	if index < len(f.actionErrors) {
+		return core.InstanceActionResponse{}, f.actionErrors[index]
+	}
+
+	return core.InstanceActionResponse{}, nil
+}
+
+type fakeServiceError struct {
+	status  int
+	code    string
+	message string
+}
+
+func (e fakeServiceError) Error() string           { return e.message }
+func (e fakeServiceError) GetHTTPStatusCode() int  { return e.status }
+func (e fakeServiceError) GetCode() string         { return e.code }
+func (e fakeServiceError) GetMessage() string      { return e.message }
+func (e fakeServiceError) GetOpcRequestID() string { return "request-id" }
+
+func instanceBusyError() error {
+	return fakeServiceError{
+		status:  http.StatusConflict,
+		code:    "Conflict",
+		message: "instance ocid1.instance.test is currently being modified, try again later",
+	}
+}
+
+func testNode() corev1.Node {
+	return corev1.Node{Spec: corev1.NodeSpec{ProviderID: "ocid1.instance.test"}}
+}
+
+func testClient(compute Compute) *Client {
+	return &Client{compute: compute}
+}
+
+// TestSendRebootSignalSuccess verifies that a successful reboot request returns
+// a timestamp reference and configures the OCI retry policy.
+func TestSendRebootSignalSuccess(t *testing.T) {
+	compute := &fakeCompute{}
+	ref, err := testClient(compute).SendRebootSignal(context.Background(), testNode(), "")
+
+	require.NoError(t, err)
+	_, err = time.Parse(time.RFC3339, string(ref))
+	require.NoError(t, err)
+	require.Len(t, compute.actionRequests, 1)
+
+	retryPolicy := compute.actionRequests[0].RequestMetadata.RetryPolicy
+	require.NotNil(t, retryPolicy)
+	assert.Equal(t, uint(rebootRetryAttempts), retryPolicy.MaximumNumberAttempts)
+}
+
+// TestSendRebootSignalReturnsComputeError verifies that a failed OCI request
+// returns its error to the caller.
+func TestSendRebootSignalReturnsComputeError(t *testing.T) {
+	compute := &fakeCompute{actionErrors: []error{errors.New("permission denied")}}
+	_, err := testClient(compute).SendRebootSignal(context.Background(), testNode(), "")
+
+	require.ErrorContains(t, err, "permission denied")
+	assert.Len(t, compute.actionRequests, 1)
+}
+
+// TestIsRetryableRebootError verifies the OCI default retry classifications
+// and the additional instance-modification conflict.
+func TestIsRetryableRebootError(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		retryable bool
+	}{
+		{
+			name:      "instance currently being modified",
+			err:       instanceBusyError(),
+			retryable: true,
+		},
+		{
+			name: "OCI incorrect state",
+			err: fakeServiceError{
+				status: http.StatusConflict,
+				code:   "IncorrectState",
+			},
+			retryable: true,
+		},
+		{
+			name: "OCI lock conflict",
+			err: fakeServiceError{
+				status: http.StatusConflict,
+				code:   "LockConflict",
+			},
+			retryable: true,
+		},
+		{
+			name: "rate limited",
+			err: fakeServiceError{
+				status: http.StatusTooManyRequests,
+				code:   "TooManyRequests",
+			},
+			retryable: true,
+		},
+		{
+			name: "internal server error",
+			err: fakeServiceError{
+				status: http.StatusInternalServerError,
+				code:   "InternalError",
+			},
+			retryable: true,
+		},
+		{
+			name: "service unavailable",
+			err: fakeServiceError{
+				status: http.StatusServiceUnavailable,
+				code:   "ServiceUnavailable",
+			},
+			retryable: true,
+		},
+		{
+			name:      "connection closed",
+			err:       io.EOF,
+			retryable: true,
+		},
+		{
+			name: "method not implemented",
+			err: fakeServiceError{
+				status: http.StatusNotImplemented,
+				code:   "MethodNotImplemented",
+			},
+			retryable: false,
+		},
+		{
+			name: "unrelated conflict",
+			err: fakeServiceError{
+				status:  http.StatusConflict,
+				code:    "Conflict",
+				message: "instance is already stopped",
+			},
+			retryable: false,
+		},
+		{
+			name: "bad request",
+			err: fakeServiceError{
+				status: http.StatusBadRequest,
+				code:   "InvalidParameter",
+			},
+			retryable: false,
+		},
+		{
+			name:      "non-OCI error",
+			err:       errors.New("permission denied"),
+			retryable: false,
+		},
+		{
+			name:      "nil error",
+			err:       nil,
+			retryable: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.retryable, isRetryableRebootError(test.err))
+		})
+	}
+}
+
+// TestRebootRetryPolicyUsesRetryableErrorClassification verifies that the
+// request policy delegates retry decisions to the reboot error classifier.
+func TestRebootRetryPolicyUsesRetryableErrorClassification(t *testing.T) {
+	policy := rebootRetryPolicy()
+
+	assert.True(t, policy.ShouldRetryOperation(common.OCIOperationResponse{
+		Error: instanceBusyError(),
+	}))
+	assert.False(t, policy.ShouldRetryOperation(common.OCIOperationResponse{
+		Error: errors.New("permission denied"),
+	}))
+}

--- a/janitor-provider/pkg/csp/oci/oci_test.go
+++ b/janitor-provider/pkg/csp/oci/oci_test.go
@@ -75,9 +75,9 @@ func testClient(compute Compute) *Client {
 	return &Client{compute: compute}
 }
 
-// TestSendRebootSignalSuccess verifies that a successful reboot request returns
-// a timestamp reference and configures the OCI retry policy.
-func TestSendRebootSignalSuccess(t *testing.T) {
+// TestSendRebootSignal_ComputeSucceeds_ReturnsTimestampAndRetryPolicy verifies
+// that a successful reboot request returns a timestamp and configures retries.
+func TestSendRebootSignal_ComputeSucceeds_ReturnsTimestampAndRetryPolicy(t *testing.T) {
 	compute := &fakeCompute{}
 	ref, err := testClient(compute).SendRebootSignal(context.Background(), testNode(), "")
 
@@ -91,9 +91,9 @@ func TestSendRebootSignalSuccess(t *testing.T) {
 	assert.Equal(t, uint(rebootRetryAttempts), retryPolicy.MaximumNumberAttempts)
 }
 
-// TestSendRebootSignalReturnsComputeError verifies that a failed OCI request
-// returns its error to the caller.
-func TestSendRebootSignalReturnsComputeError(t *testing.T) {
+// TestSendRebootSignal_ComputeFails_ReturnsError verifies that a failed OCI
+// request returns its error to the caller.
+func TestSendRebootSignal_ComputeFails_ReturnsError(t *testing.T) {
 	compute := &fakeCompute{actionErrors: []error{errors.New("permission denied")}}
 	_, err := testClient(compute).SendRebootSignal(context.Background(), testNode(), "")
 
@@ -101,9 +101,9 @@ func TestSendRebootSignalReturnsComputeError(t *testing.T) {
 	assert.Len(t, compute.actionRequests, 1)
 }
 
-// TestIsRetryableRebootError verifies the OCI default retry classifications
-// and the additional instance-modification conflict.
-func TestIsRetryableRebootError(t *testing.T) {
+// TestIsRetryableRebootError_VariousErrors_ReturnsExpectedClassification
+// verifies the OCI defaults and the additional instance-modification conflict.
+func TestIsRetryableRebootError_VariousErrors_ReturnsExpectedClassification(t *testing.T) {
 	tests := []struct {
 		name      string
 		err       error
@@ -203,9 +203,9 @@ func TestIsRetryableRebootError(t *testing.T) {
 	}
 }
 
-// TestRebootRetryPolicyUsesRetryableErrorClassification verifies that the
-// request policy delegates retry decisions to the reboot error classifier.
-func TestRebootRetryPolicyUsesRetryableErrorClassification(t *testing.T) {
+// TestRebootRetryPolicy_RetryableAndPermanentErrors_ReturnsExpectedDecision
+// verifies that the request policy delegates to the reboot error classifier.
+func TestRebootRetryPolicy_RetryableAndPermanentErrors_ReturnsExpectedDecision(t *testing.T) {
 	policy := rebootRetryPolicy()
 
 	assert.True(t, policy.ShouldRetryOperation(common.OCIOperationResponse{

--- a/janitor-provider/pkg/csp/oci/oci_test.go
+++ b/janitor-provider/pkg/csp/oci/oci_test.go
@@ -16,12 +16,9 @@ package oci
 
 import (
 	"context"
-	"crypto/sha256"
 	"errors"
-	"io"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/oracle/oci-go-sdk/v65/core"
 	"github.com/stretchr/testify/assert"
@@ -32,21 +29,19 @@ import (
 )
 
 type fakeCompute struct {
-	actionErrors   []error
-	actionRequests []core.InstanceActionRequest
+	actionError   error
+	actionRequest core.InstanceActionRequest
+	calls         int
 }
 
 func (f *fakeCompute) InstanceAction(
 	_ context.Context,
 	request core.InstanceActionRequest,
 ) (core.InstanceActionResponse, error) {
-	index := len(f.actionRequests)
-	f.actionRequests = append(f.actionRequests, request)
-	if index < len(f.actionErrors) {
-		return core.InstanceActionResponse{}, f.actionErrors[index]
-	}
+	f.actionRequest = request
+	f.calls++
 
-	return core.InstanceActionResponse{}, nil
+	return core.InstanceActionResponse{}, f.actionError
 }
 
 type fakeServiceError struct {
@@ -73,78 +68,36 @@ func testNode() corev1.Node {
 	return corev1.Node{Spec: corev1.NodeSpec{ProviderID: "ocid1.instance.test"}}
 }
 
-func testClient(compute Compute) *Client {
-	return &Client{compute: compute}
-}
-
-// TestSendRebootSignal_ComputeSucceeds_ReturnsTimestampAndIdempotencyToken verifies
-// that a successful reboot request returns a timestamp and configures a stable retry token.
-func TestSendRebootSignal_ComputeSucceeds_ReturnsTimestampAndIdempotencyToken(t *testing.T) {
+// TestSendRebootSignal_ComputeSucceeds_UsesStableTokenWithoutSDKRetry verifies
+// that controller retries stay idempotent without enabling OCI SDK retries.
+func TestSendRebootSignal_ComputeSucceeds_UsesStableTokenWithoutSDKRetry(t *testing.T) {
 	compute := &fakeCompute{}
-	ref, err := testClient(compute).SendRebootSignal(context.Background(), testNode(), "rebootnode-test")
+	client := &Client{compute: compute}
 
+	_, err := client.SendRebootSignal(context.Background(), testNode(), "rebootnode-test")
 	require.NoError(t, err)
-	_, err = time.Parse(time.RFC3339, string(ref))
+	require.NotNil(t, compute.actionRequest.OpcRetryToken)
+	token := *compute.actionRequest.OpcRetryToken
+
+	_, err = client.SendRebootSignal(context.Background(), testNode(), "rebootnode-test")
 	require.NoError(t, err)
-	require.Len(t, compute.actionRequests, 1)
-
-	request := compute.actionRequests[0]
-	require.NotNil(t, request.OpcRetryToken)
-	assert.Len(t, *request.OpcRetryToken, sha256.Size*2)
-	assert.Nil(t, request.RequestMetadata.RetryPolicy)
+	assert.Equal(t, 2, compute.calls)
+	assert.Equal(t, token, *compute.actionRequest.OpcRetryToken)
+	assert.Nil(t, compute.actionRequest.RequestMetadata.RetryPolicy)
 }
 
-// TestSendRebootSignal_ComputeFails_ReturnsError verifies that a failed OCI
-// request returns its error to the caller.
-func TestSendRebootSignal_ComputeFails_ReturnsError(t *testing.T) {
-	compute := &fakeCompute{actionErrors: []error{errors.New("permission denied")}}
-	_, err := testClient(compute).SendRebootSignal(context.Background(), testNode(), "")
-
-	require.ErrorContains(t, err, "permission denied")
-	assert.Len(t, compute.actionRequests, 1)
-	assert.Equal(t, codes.Unknown, status.Code(err))
-}
-
-// TestSendRebootSignal_ComputeReturnsTransientError_ReturnsUnavailable verifies
-// that Janitor can identify a retryable OCI failure through its gRPC status.
-func TestSendRebootSignal_ComputeReturnsTransientError_ReturnsUnavailable(t *testing.T) {
-	compute := &fakeCompute{actionErrors: []error{instanceBusyError()}}
-	_, err := testClient(compute).SendRebootSignal(context.Background(), testNode(), "rebootnode-test")
-
-	require.Error(t, err)
-	assert.Equal(t, codes.Unavailable, status.Code(err))
-	assert.ErrorContains(t, err, "currently being modified")
-	assert.Len(t, compute.actionRequests, 1)
-}
-
-// TestIsRetryableRebootError_VariousErrors_ReturnsExpectedClassification
-// verifies the OCI defaults and the additional instance-modification conflict.
-func TestIsRetryableRebootError_VariousErrors_ReturnsExpectedClassification(t *testing.T) {
+// TestSendRebootSignal_ComputeFails_ReturnsExpectedStatus verifies the custom
+// conflict, OCI default retry, and permanent error paths.
+func TestSendRebootSignal_ComputeFails_ReturnsExpectedStatus(t *testing.T) {
 	tests := []struct {
-		name      string
-		err       error
-		retryable bool
+		name     string
+		err      error
+		wantCode codes.Code
 	}{
 		{
-			name:      "instance currently being modified",
-			err:       instanceBusyError(),
-			retryable: true,
-		},
-		{
-			name: "OCI incorrect state",
-			err: fakeServiceError{
-				status: http.StatusConflict,
-				code:   "IncorrectState",
-			},
-			retryable: true,
-		},
-		{
-			name: "OCI lock conflict",
-			err: fakeServiceError{
-				status: http.StatusConflict,
-				code:   "LockConflict",
-			},
-			retryable: true,
+			name:     "instance currently being modified",
+			err:      instanceBusyError(),
+			wantCode: codes.Unavailable,
 		},
 		{
 			name: "rate limited",
@@ -152,36 +105,7 @@ func TestIsRetryableRebootError_VariousErrors_ReturnsExpectedClassification(t *t
 				status: http.StatusTooManyRequests,
 				code:   "TooManyRequests",
 			},
-			retryable: true,
-		},
-		{
-			name: "internal server error",
-			err: fakeServiceError{
-				status: http.StatusInternalServerError,
-				code:   "InternalError",
-			},
-			retryable: true,
-		},
-		{
-			name: "service unavailable",
-			err: fakeServiceError{
-				status: http.StatusServiceUnavailable,
-				code:   "ServiceUnavailable",
-			},
-			retryable: true,
-		},
-		{
-			name:      "connection closed",
-			err:       io.EOF,
-			retryable: true,
-		},
-		{
-			name: "method not implemented",
-			err: fakeServiceError{
-				status: http.StatusNotImplemented,
-				code:   "MethodNotImplemented",
-			},
-			retryable: false,
+			wantCode: codes.Unavailable,
 		},
 		{
 			name: "unrelated conflict",
@@ -190,44 +114,25 @@ func TestIsRetryableRebootError_VariousErrors_ReturnsExpectedClassification(t *t
 				code:    "Conflict",
 				message: "instance is already stopped",
 			},
-			retryable: false,
+			wantCode: codes.Unknown,
 		},
 		{
-			name: "bad request",
-			err: fakeServiceError{
-				status: http.StatusBadRequest,
-				code:   "InvalidParameter",
-			},
-			retryable: false,
-		},
-		{
-			name:      "non-OCI error",
-			err:       errors.New("permission denied"),
-			retryable: false,
-		},
-		{
-			name:      "nil error",
-			err:       nil,
-			retryable: false,
+			name:     "permission denied",
+			err:      errors.New("permission denied"),
+			wantCode: codes.Unknown,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.retryable, isRetryableRebootError(test.err))
+			compute := &fakeCompute{actionError: test.err}
+			client := &Client{compute: compute}
+
+			_, err := client.SendRebootSignal(context.Background(), testNode(), "rebootnode-test")
+
+			require.Error(t, err)
+			assert.Equal(t, test.wantCode, status.Code(err))
+			assert.Equal(t, 1, compute.calls)
 		})
 	}
-}
-
-// TestRebootRetryToken_SameRequest_ReturnsStableToken verifies that controller
-// requeues use the same OCI idempotency token.
-func TestRebootRetryToken_SameRequest_ReturnsStableToken(t *testing.T) {
-	first := rebootRetryToken("ocid1.instance.test", "rebootnode-test")
-	second := rebootRetryToken("ocid1.instance.test", "rebootnode-test")
-
-	require.NotNil(t, first)
-	require.NotNil(t, second)
-	assert.Equal(t, *first, *second)
-	assert.NotEqual(t, *first, *rebootRetryToken("ocid1.instance.test", "another-reboot"))
-	assert.Nil(t, rebootRetryToken("ocid1.instance.test", ""))
 }

--- a/janitor-provider/pkg/csp/oci/oci_test.go
+++ b/janitor-provider/pkg/csp/oci/oci_test.go
@@ -16,16 +16,18 @@ package oci
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"io"
 	"net/http"
 	"testing"
 	"time"
 
-	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -75,20 +77,21 @@ func testClient(compute Compute) *Client {
 	return &Client{compute: compute}
 }
 
-// TestSendRebootSignal_ComputeSucceeds_ReturnsTimestampAndRetryPolicy verifies
-// that a successful reboot request returns a timestamp and configures retries.
-func TestSendRebootSignal_ComputeSucceeds_ReturnsTimestampAndRetryPolicy(t *testing.T) {
+// TestSendRebootSignal_ComputeSucceeds_ReturnsTimestampAndIdempotencyToken verifies
+// that a successful reboot request returns a timestamp and configures a stable retry token.
+func TestSendRebootSignal_ComputeSucceeds_ReturnsTimestampAndIdempotencyToken(t *testing.T) {
 	compute := &fakeCompute{}
-	ref, err := testClient(compute).SendRebootSignal(context.Background(), testNode(), "")
+	ref, err := testClient(compute).SendRebootSignal(context.Background(), testNode(), "rebootnode-test")
 
 	require.NoError(t, err)
 	_, err = time.Parse(time.RFC3339, string(ref))
 	require.NoError(t, err)
 	require.Len(t, compute.actionRequests, 1)
 
-	retryPolicy := compute.actionRequests[0].RequestMetadata.RetryPolicy
-	require.NotNil(t, retryPolicy)
-	assert.Equal(t, uint(rebootRetryAttempts), retryPolicy.MaximumNumberAttempts)
+	request := compute.actionRequests[0]
+	require.NotNil(t, request.OpcRetryToken)
+	assert.Len(t, *request.OpcRetryToken, sha256.Size*2)
+	assert.Nil(t, request.RequestMetadata.RetryPolicy)
 }
 
 // TestSendRebootSignal_ComputeFails_ReturnsError verifies that a failed OCI
@@ -98,6 +101,19 @@ func TestSendRebootSignal_ComputeFails_ReturnsError(t *testing.T) {
 	_, err := testClient(compute).SendRebootSignal(context.Background(), testNode(), "")
 
 	require.ErrorContains(t, err, "permission denied")
+	assert.Len(t, compute.actionRequests, 1)
+	assert.Equal(t, codes.Unknown, status.Code(err))
+}
+
+// TestSendRebootSignal_ComputeReturnsTransientError_ReturnsUnavailable verifies
+// that Janitor can identify a retryable OCI failure through its gRPC status.
+func TestSendRebootSignal_ComputeReturnsTransientError_ReturnsUnavailable(t *testing.T) {
+	compute := &fakeCompute{actionErrors: []error{instanceBusyError()}}
+	_, err := testClient(compute).SendRebootSignal(context.Background(), testNode(), "rebootnode-test")
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Unavailable, status.Code(err))
+	assert.ErrorContains(t, err, "currently being modified")
 	assert.Len(t, compute.actionRequests, 1)
 }
 
@@ -203,15 +219,15 @@ func TestIsRetryableRebootError_VariousErrors_ReturnsExpectedClassification(t *t
 	}
 }
 
-// TestRebootRetryPolicy_RetryableAndPermanentErrors_ReturnsExpectedDecision
-// verifies that the request policy delegates to the reboot error classifier.
-func TestRebootRetryPolicy_RetryableAndPermanentErrors_ReturnsExpectedDecision(t *testing.T) {
-	policy := rebootRetryPolicy()
+// TestRebootRetryToken_SameRequest_ReturnsStableToken verifies that controller
+// requeues use the same OCI idempotency token.
+func TestRebootRetryToken_SameRequest_ReturnsStableToken(t *testing.T) {
+	first := rebootRetryToken("ocid1.instance.test", "rebootnode-test")
+	second := rebootRetryToken("ocid1.instance.test", "rebootnode-test")
 
-	assert.True(t, policy.ShouldRetryOperation(common.OCIOperationResponse{
-		Error: instanceBusyError(),
-	}))
-	assert.False(t, policy.ShouldRetryOperation(common.OCIOperationResponse{
-		Error: errors.New("permission denied"),
-	}))
+	require.NotNil(t, first)
+	require.NotNil(t, second)
+	assert.Equal(t, *first, *second)
+	assert.NotEqual(t, *first, *rebootRetryToken("ocid1.instance.test", "another-reboot"))
+	assert.Nil(t, rebootRetryToken("ocid1.instance.test", ""))
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/NVIDIA/NVSentinel/issues/1805

This PR adds retry mechanism to OCI request, so it's tolerant of transient failures. I've met several CR failures due to timeout or conflict operations, so it's more like a bug fix rather than a feature request from my perspective.

The reason why I added retry inside of oci, which is a detailed janitor provider, instead of somewhere more high-level, is because each provider has its own (slightly) different error code and message.

## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Health Monitors
- [ ] Fault Management
- [ ] Deployment/Config
- [ ] API/Interface
- [ ] Preflight
- [ ] Plugins
- [X] Janitor
- [ ] Documentation/CI
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OCI reboot requests now use stable idempotency tokens for safer request handling.
  * Transient OCI failures are reported as temporarily unavailable, while other failures retain instance-specific context.
  * Reboot, readiness, and termination errors now preserve recognized service status codes instead of being reported uniformly as internal errors.

* **Tests**
  * Added coverage for stable request handling, transient and permanent failures, and service status translation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->