### PR TITLE
feat(janitor): make the GPU reset driverRoot configurable

### DIFF
--- a/distros/kubernetes/nvsentinel/charts/janitor/templates/configmap.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/templates/configmap.yaml
@@ -95,6 +95,9 @@ data:
         writeSysLogEvent: "{{ .Values.config.controllers.gpuReset.resetJob.writeSysLogEvent }}"
         runtimeClassName: "{{ .Values.config.controllers.gpuReset.resetJob.runtimeClassName }}"
         hostDriverRootPath: "{{ .Values.config.controllers.gpuReset.resetJob.hostDriverRootPath }}"
+        {{- with .Values.config.controllers.gpuReset.resetJob.driverRoot }}
+        driverRoot: {{ . | quote }}
+        {{- end }}
         {{- if $gpuResetUploadURL }}
         uploadURL: {{ $gpuResetUploadURL | quote }}
         {{- end }}

--- a/distros/kubernetes/nvsentinel/charts/janitor/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/janitor/values.yaml
@@ -174,6 +174,12 @@ config:
         # driver installations commonly use /run/nvidia/driver. Set this to /
         # when the NVIDIA driver is installed directly on the host.
         hostDriverRootPath: "/run/nvidia/driver"
+        # Path inside the reset container that the reset command chroots into.
+        # hostDriverRootPath is mounted here, so this path must hold a complete
+        # filesystem that can run nvidia-smi. Set this to / to run nvidia-smi
+        # from the reset container image instead. With /, hostDriverRootPath is
+        # not mounted and is not used.
+        driverRoot: "/run/nvidia/driver"
         # Optional upload endpoint for nvidia-bug-report artifacts collected after failed GPU resets.
         # When empty and global.inclusterFileServer.enabled is true, this defaults to the
         # release's incluster-file-server /upload endpoint.

--- a/docs/configuration/janitor.md
+++ b/docs/configuration/janitor.md
@@ -198,6 +198,7 @@ janitor:
           writeSysLogEvent: true
           runtimeClassName: "nvidia"
           hostDriverRootPath: "/run/nvidia/driver"
+          driverRoot: "/run/nvidia/driver"
           image:
             repository: ghcr.io/nvidia/nvsentinel/gpu-reset
             tag: ""
@@ -222,9 +223,18 @@ When `true`, the reset job writes a kernel syslog message on reset completion. U
 NVIDIA RuntimeClass name used by the GPU reset Job. Must match a RuntimeClass installed in the cluster.
 
 ### resetJob.hostDriverRootPath
-Host path containing the NVIDIA driver filesystem. It is mounted at `/run/nvidia/driver` inside the reset container, where the reset command uses it as a chroot.
+Host path containing the NVIDIA driver filesystem. The reset Job mounts it at `resetJob.driverRoot` inside the reset container.
 
 Keep the default `/run/nvidia/driver` for containerized driver installations. Set it to `/` when the driver is installed directly into the host filesystem and `nvidia-smi` is available at a path such as `/usr/bin/nvidia-smi`.
+
+### resetJob.driverRoot
+Path inside the reset container that the reset command chroots into. The reset command runs `chroot <driverRoot> nvidia-smi` for every `nvidia-smi` call, so this path must hold a complete filesystem: the `nvidia-smi` binary, its shared libraries, and a dynamic loader. The reset Job also mounts the host `/sys` at `<driverRoot>/sys`, so the chroot can read sysfs.
+
+Keep the default `/run/nvidia/driver`. The GPU Operator driver container bind-mounts its full container root to that host path, which satisfies the chroot. This default also works with `hostDriverRootPath: "/"`, because the host root filesystem is complete as well.
+
+Set `driverRoot` to `/` when the driver root holds only driver files and not a complete filesystem. A chroot into a partial driver root fails before `nvidia-smi` starts. With `/`, the chroot is a no-op and the reset command uses the `nvidia-smi` in the reset container image. The Job then does not mount `hostDriverRootPath`, and it mounts the host `/sys` at `/sys`.
+
+The value must be an absolute, clean path. The janitor rejects any other value at startup.
 
 ### resetJob.image
 Container image for the GPU reset Job. Leave `tag` empty to use the chart default.

--- a/janitor/pkg/config/config.go
+++ b/janitor/pkg/config/config.go
@@ -114,6 +114,7 @@ type ResetJobConfig struct {
 	Resources          ResourceRequirements `mapstructure:"resources" json:"resources"`
 	RuntimeClassName   string               `mapstructure:"runtimeClassName" json:"runtimeClassName"`
 	HostDriverRootPath string               `mapstructure:"hostDriverRootPath" json:"hostDriverRootPath"`
+	DriverRoot         string               `mapstructure:"driverRoot" json:"driverRoot"`
 	WriteSysLogEvent   *bool                `mapstructure:"writeSysLogEvent" json:"writeSysLogEvent"`
 	UploadURL          string               `mapstructure:"uploadURL" json:"uploadURL"`
 }
@@ -183,7 +184,8 @@ func LoadConfig(configPath string, namespace string) (*Config, error) {
 
 		jobTemplate, err := getDefaultGPUResetJobTemplate(namespace, resetJobConfig.ImageConfig.Image,
 			resetJobConfig.ImageConfig.ImagePullSecrets, resetJobConfig.Resources, resetJobConfig.HostDriverRootPath,
-			resetJobConfig.RuntimeClassName, *resetJobConfig.WriteSysLogEvent, resetJobConfig.UploadURL)
+			resetJobConfig.DriverRoot, resetJobConfig.RuntimeClassName, *resetJobConfig.WriteSysLogEvent,
+			resetJobConfig.UploadURL)
 		if err != nil {
 			return nil, err
 		}

--- a/janitor/pkg/config/config_test.go
+++ b/janitor/pkg/config/config_test.go
@@ -240,7 +240,7 @@ gpuResetController:
 		},
 	}
 	expectedJobTemplate, err := getDefaultGPUResetJobTemplate(testNamespace, "alpine:latest", imagePullSecrets,
-		resourceRequirements, "/", "nvidia", true,
+		resourceRequirements, "/", DriverRootMountPath, "nvidia", true,
 		"http://nvsentinel-incluster-file-server.nvsentinel.svc.cluster.local/upload")
 	assert.NoError(t, err)
 	assert.Equal(t, expectedJobTemplate, config.GPUReset.ResolvedJobTemplate)
@@ -343,7 +343,7 @@ gpuResetController:
 	assert.True(t, config.GPUReset.Enabled)
 
 	expectedJobTemplate, err := getDefaultGPUResetJobTemplate(testNamespace, "alpine:latest", nil,
-		ResourceRequirements{}, DefaultHostDriverRootPath, "", true, "")
+		ResourceRequirements{}, DefaultHostDriverRootPath, DriverRootMountPath, "", true, "")
 	assert.NoError(t, err)
 	assert.Equal(t, expectedJobTemplate, config.GPUReset.ResolvedJobTemplate)
 
@@ -394,7 +394,7 @@ gpuResetController:
 	assert.True(t, config.GPUReset.Enabled)
 
 	expectedJobTemplate, err := getDefaultGPUResetJobTemplate(testNamespace, "alpine:latest", nil,
-		ResourceRequirements{}, DefaultHostDriverRootPath, "", true, "")
+		ResourceRequirements{}, DefaultHostDriverRootPath, DriverRootMountPath, "", true, "")
 	assert.NoError(t, err)
 	assert.Equal(t, expectedJobTemplate, config.GPUReset.ResolvedJobTemplate)
 
@@ -483,7 +483,7 @@ gpuResetController:
 	assert.True(t, config.GPUReset.Enabled)
 
 	expectedJobTemplate, err := getDefaultGPUResetJobTemplate(testNamespace, "alpine:latest", nil,
-		ResourceRequirements{}, DefaultHostDriverRootPath, "", false, "")
+		ResourceRequirements{}, DefaultHostDriverRootPath, DriverRootMountPath, "", false, "")
 	assert.NoError(t, err)
 	assert.Equal(t, expectedJobTemplate, config.GPUReset.ResolvedJobTemplate)
 
@@ -639,4 +639,37 @@ global:
 	require.Len(t, config.RebootNode.Exclusions[1].MatchExpressions, 1)
 	assert.Equal(t, "node-role.kubernetes.io/control-plane", config.RebootNode.Exclusions[1].MatchExpressions[0].Key)
 	assert.Equal(t, metav1.LabelSelectorOpExists, config.RebootNode.Exclusions[1].MatchExpressions[0].Operator)
+}
+
+func TestLoadConfig_GPUResetDriverRootOverride(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "janitor-config.yaml")
+
+	configContent := `
+global:
+  timeout: 30m
+  cspProviderHost: janitor-provider.nvsentinel.svc.cluster.local:50051
+
+gpuResetController:
+  enabled: true
+  resetJob:
+    hostDriverRootPath: "/run/nvidia/driver"
+    driverRoot: "/"
+    imageConfig:
+      image: "alpine:latest"
+`
+
+	err := os.WriteFile(configPath, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	config, err := LoadConfig(configPath, testNamespace)
+	require.NoError(t, err)
+	require.NotNil(t, config)
+
+	assert.Equal(t, ContainerDriverRoot, config.GPUReset.ResetJob.DriverRoot)
+
+	expectedJobTemplate, err := getDefaultGPUResetJobTemplate(testNamespace, "alpine:latest", nil,
+		ResourceRequirements{}, DefaultHostDriverRootPath, ContainerDriverRoot, "", true, "")
+	require.NoError(t, err)
+	assert.Equal(t, expectedJobTemplate, config.GPUReset.ResolvedJobTemplate)
 }

--- a/janitor/pkg/config/default.go
+++ b/janitor/pkg/config/default.go
@@ -16,6 +16,8 @@ package config
 
 import (
 	"fmt"
+	"path/filepath"
+	"slices"
 	"strconv"
 	"time"
 
@@ -38,6 +40,9 @@ const (
 	WriteSyslogEventEnvVar    = "WRITE_SYSLOG_EVENT"
 	NodeNameEnvVar            = "NODE_NAME"
 	UploadURLBaseEnvVar       = "UPLOAD_URL_BASE"
+	// ContainerDriverRoot is the driverRoot that makes the reset command chroot into the reset
+	// container itself instead of into the mounted driver filesystem.
+	ContainerDriverRoot = "/"
 )
 
 func applyConfigDefaults(config *Config) {
@@ -148,6 +153,10 @@ func applyResetJobDefaults(config *ResetJobConfig) {
 	if config.HostDriverRootPath == "" {
 		config.HostDriverRootPath = DefaultHostDriverRootPath
 	}
+
+	if config.DriverRoot == "" {
+		config.DriverRoot = DriverRootMountPath
+	}
 }
 
 func getResources(resources ResourceRequirements) (*corev1.ResourceRequirements, error) {
@@ -195,12 +204,22 @@ func getImagePullSecrets(imagePullSecrets []ImagePullSecret) []corev1.LocalObjec
 
 // getDefaultGPUResetJobTemplate returns the default JobTemplateSpec for GPU reset jobs.
 func getDefaultGPUResetJobTemplate(namespace string, image string, secrets []ImagePullSecret,
-	resources ResourceRequirements, hostDriverRootPath string, runtimeClassName string, writeSyslogEvent bool,
-	uploadURL string) (*batchv1.JobTemplateSpec, error) {
+	resources ResourceRequirements, hostDriverRootPath string, driverRoot string, runtimeClassName string,
+	writeSyslogEvent bool, uploadURL string) (*batchv1.JobTemplateSpec, error) {
 	imagePullSecrets := getImagePullSecrets(secrets)
 
 	if hostDriverRootPath == "" {
 		hostDriverRootPath = DefaultHostDriverRootPath
+	}
+
+	if driverRoot == "" {
+		driverRoot = DriverRootMountPath
+	}
+
+	// Reject here, at janitor startup, rather than when a Job is created for a node that is
+	// already cordoned and drained.
+	if !filepath.IsAbs(driverRoot) {
+		return nil, fmt.Errorf("resetJob.driverRoot %q must be an absolute path", driverRoot)
 	}
 
 	containerResources, err := getResources(resources)
@@ -255,7 +274,7 @@ func getDefaultGPUResetJobTemplate(namespace string, image string, secrets []Ima
 								},
 								{
 									Name:  "DRIVER_ROOT",
-									Value: DriverRootMountPath,
+									Value: driverRoot,
 								},
 								{
 									Name:  WriteSyslogEventEnvVar,
@@ -285,11 +304,11 @@ func getDefaultGPUResetJobTemplate(namespace string, image string, secrets []Ima
 								},
 								{
 									Name:      DriverRootVolumeName,
-									MountPath: DriverRootMountPath,
+									MountPath: driverRoot,
 								},
 								{
 									Name:      HostSysVolumeName,
-									MountPath: DriverRootMountPath + HostSysPath,
+									MountPath: filepath.Join(driverRoot, HostSysPath),
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{
@@ -308,6 +327,17 @@ func getDefaultGPUResetJobTemplate(namespace string, image string, secrets []Ima
 	}
 	if len(runtimeClassName) > 0 {
 		job.Spec.Template.Spec.RuntimeClassName = &runtimeClassName
+	}
+
+	// Kubernetes cannot mount the host driver root over "/", and a chroot into "/" is a no-op,
+	// so the reset command uses the nvidia-smi of the reset container image instead.
+	if driverRoot == ContainerDriverRoot {
+		podSpec := &job.Spec.Template.Spec
+		podSpec.Volumes = slices.DeleteFunc(podSpec.Volumes, func(volume corev1.Volume) bool {
+			return volume.Name == DriverRootVolumeName
+		})
+		podSpec.Containers[0].VolumeMounts = slices.DeleteFunc(podSpec.Containers[0].VolumeMounts,
+			func(mount corev1.VolumeMount) bool { return mount.Name == DriverRootVolumeName })
 	}
 
 	return job, nil

--- a/janitor/pkg/config/default.go
+++ b/janitor/pkg/config/default.go
@@ -217,9 +217,10 @@ func getDefaultGPUResetJobTemplate(namespace string, image string, secrets []Ima
 	}
 
 	// Reject here, at janitor startup, rather than when a Job is created for a node that is
-	// already cordoned and drained.
-	if !filepath.IsAbs(driverRoot) {
-		return nil, fmt.Errorf("resetJob.driverRoot %q must be an absolute path", driverRoot)
+	// already cordoned and drained. A path such as "//" is absolute but is not ContainerDriverRoot,
+	// so it would mount the host driver root over the container root.
+	if !filepath.IsAbs(driverRoot) || filepath.Clean(driverRoot) != driverRoot {
+		return nil, fmt.Errorf("resetJob.driverRoot %q must be an absolute, clean path", driverRoot)
 	}
 
 	containerResources, err := getResources(resources)

--- a/janitor/pkg/config/default_test.go
+++ b/janitor/pkg/config/default_test.go
@@ -122,10 +122,24 @@ func TestGetDefaultGPUResetJobTemplate_DriverRoot_SetsEnvAndMounts(t *testing.T)
 	}
 }
 
-func TestGetDefaultGPUResetJobTemplate_RelativeDriverRoot_ReturnsError(t *testing.T) {
-	template, err := getDefaultGPUResetJobTemplate(testNamespace, "alpine:latest", nil,
-		ResourceRequirements{}, DefaultHostDriverRootPath, "run/nvidia/driver", "", true, "")
-	require.Error(t, err)
-	assert.Nil(t, template)
-	assert.Contains(t, err.Error(), "resetJob.driverRoot")
+func TestGetDefaultGPUResetJobTemplate_InvalidDriverRoot_ReturnsError(t *testing.T) {
+	tests := []struct {
+		name       string
+		driverRoot string
+	}{
+		{name: "relative path", driverRoot: "run/nvidia/driver"},
+		{name: "double slash", driverRoot: "//"},
+		{name: "trailing slash", driverRoot: "/run/nvidia/driver/"},
+		{name: "parent traversal", driverRoot: "/run/nvidia/../nvidia/driver"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			template, err := getDefaultGPUResetJobTemplate(testNamespace, "alpine:latest", nil,
+				ResourceRequirements{}, DefaultHostDriverRootPath, test.driverRoot, "", true, "")
+			require.Error(t, err)
+			assert.Nil(t, template)
+			assert.Contains(t, err.Error(), "resetJob.driverRoot")
+		})
+	}
 }

--- a/janitor/pkg/config/default_test.go
+++ b/janitor/pkg/config/default_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func findVolume(volumes []corev1.Volume, name string) *corev1.Volume {
+	for index := range volumes {
+		if volumes[index].Name == name {
+			return &volumes[index]
+		}
+	}
+
+	return nil
+}
+
+func findVolumeMount(mounts []corev1.VolumeMount, name string) *corev1.VolumeMount {
+	for index := range mounts {
+		if mounts[index].Name == name {
+			return &mounts[index]
+		}
+	}
+
+	return nil
+}
+
+func findEnvVar(env []corev1.EnvVar, name string) *corev1.EnvVar {
+	for index := range env {
+		if env[index].Name == name {
+			return &env[index]
+		}
+	}
+
+	return nil
+}
+
+func TestGetDefaultGPUResetJobTemplate_DriverRoot_SetsEnvAndMounts(t *testing.T) {
+	tests := []struct {
+		name                 string
+		driverRoot           string
+		expectedDriverRoot   string
+		expectDriverRootVol  bool
+		expectedSysMountPath string
+	}{
+		{
+			name:                 "empty driverRoot falls back to the containerized driver default",
+			driverRoot:           "",
+			expectedDriverRoot:   DriverRootMountPath,
+			expectDriverRootVol:  true,
+			expectedSysMountPath: DriverRootMountPath + HostSysPath,
+		},
+		{
+			name:                 "custom driverRoot moves the driver and sysfs mounts",
+			driverRoot:           "/opt/nvidia/driver",
+			expectedDriverRoot:   "/opt/nvidia/driver",
+			expectDriverRootVol:  true,
+			expectedSysMountPath: "/opt/nvidia/driver/sys",
+		},
+		{
+			name:                 "root driverRoot drops the driver volume and mounts sysfs at /sys",
+			driverRoot:           ContainerDriverRoot,
+			expectedDriverRoot:   ContainerDriverRoot,
+			expectDriverRootVol:  false,
+			expectedSysMountPath: HostSysPath,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			template, err := getDefaultGPUResetJobTemplate(testNamespace, "alpine:latest", nil,
+				ResourceRequirements{}, DefaultHostDriverRootPath, test.driverRoot, "", true, "")
+			require.NoError(t, err)
+
+			podSpec := template.Spec.Template.Spec
+			container := podSpec.Containers[0]
+
+			driverRootEnv := findEnvVar(container.Env, "DRIVER_ROOT")
+			require.NotNil(t, driverRootEnv)
+			assert.Equal(t, test.expectedDriverRoot, driverRootEnv.Value)
+
+			driverRootVolume := findVolume(podSpec.Volumes, DriverRootVolumeName)
+			driverRootMount := findVolumeMount(container.VolumeMounts, DriverRootVolumeName)
+
+			if test.expectDriverRootVol {
+				require.NotNil(t, driverRootVolume)
+				require.NotNil(t, driverRootVolume.HostPath)
+				assert.Equal(t, DefaultHostDriverRootPath, driverRootVolume.HostPath.Path)
+				require.NotNil(t, driverRootMount)
+				assert.Equal(t, test.expectedDriverRoot, driverRootMount.MountPath)
+			} else {
+				assert.Nil(t, driverRootVolume)
+				assert.Nil(t, driverRootMount)
+			}
+
+			sysMount := findVolumeMount(container.VolumeMounts, HostSysVolumeName)
+			require.NotNil(t, sysMount)
+			assert.Equal(t, test.expectedSysMountPath, sysMount.MountPath)
+
+			// /dev is mounted at /dev wherever the chroot points.
+			devMount := findVolumeMount(container.VolumeMounts, HostDevVolumeName)
+			require.NotNil(t, devMount)
+			assert.Equal(t, HostDevPath, devMount.MountPath)
+		})
+	}
+}
+
+func TestGetDefaultGPUResetJobTemplate_RelativeDriverRoot_ReturnsError(t *testing.T) {
+	template, err := getDefaultGPUResetJobTemplate(testNamespace, "alpine:latest", nil,
+		ResourceRequirements{}, DefaultHostDriverRootPath, "run/nvidia/driver", "", true, "")
+	require.Error(t, err)
+	assert.Nil(t, template)
+	assert.Contains(t, err.Error(), "resetJob.driverRoot")
+}


### PR DESCRIPTION
## Summary

`gpu_reset.sh` never calls `nvidia-smi` directly. Every call goes through `chroot "$DRIVER_ROOT" nvidia-smi`, so `DRIVER_ROOT` must point at a complete filesystem: the binary, its shared libraries, and a dynamic loader. The janitor built that path from a Go constant, `DriverRootMountPath = "/run/nvidia/driver"`, which set the container mount path of the `driver-root` volume, the `DRIVER_ROOT` environment variable, and the mount path of the host `/sys`. Only the host side of the volume was configurable, through `resetJob.hostDriverRootPath`.

That works against a GPU Operator driver container, which recursively bind-mounts its full container root to the host path. It fails against a driver root that stages only driver surfaces: the chroot fails before `nvidia-smi` starts.

This change adds the Helm value `janitor.config.controllers.gpuReset.resetJob.driverRoot`, which sets the chroot target that the reset Job uses. The default is `/run/nvidia/driver`, so the rendered pod spec does not change for any existing installation.

Set `driverRoot: "/"` when the driver root is not a complete filesystem. The chroot then becomes a no-op and the reset command uses the `nvidia-smi` of the reset container image. In that case the Job does not mount `hostDriverRootPath`, because Kubernetes cannot mount a volume over `/` and the host driver root has nothing to contribute, and it mounts the host `/sys` at `/sys`.

A `driverRoot` that is not an absolute path fails `LoadConfig`. The janitor then fails to start, instead of creating a broken reset Job for a node that is already cordoned and drained.

### Backwards compatibility

- No Helm value, proto field, metric, node label, CLI flag or CRD field is renamed or removed.
- `resetJob.hostDriverRootPath` keeps its meaning: the host side of the `driver-root` volume. It is unused when `driverRoot` is `/`.
- With the default value, `getDefaultGPUResetJobTemplate` produces the same Job as before this change.
- One caveat for reviewers: the janitor unmarshals its config with `ErrorUnused = true`. A janitor pod from the previous release that restarts after the new ConfigMap lands, but before the Deployment rolls, rejects the unknown `driverRoot` key. Every existing `resetJob` key has the same exposure, so this follows the current pattern. Say the word and I will render the key only when it differs from the default.

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Health Monitors
- [ ] Fault Management
- [x] Deployment/Config
- [ ] API/Interface
- [ ] Preflight
- [ ] Plugins
- [x] Janitor
- [x] Documentation/CI
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] No breaking changes (or documented)

`make -C janitor lint` reports 0 issues. The full `janitor` module test suite passes with `-race`, including the `envtest` controller and webhook suites. `make kubernetes-distro-lint` passes.

New tests in `janitor/pkg/config`:

- A table-driven test over `driverRoot` values. It asserts the `DRIVER_ROOT` environment variable, the `driver-root` mount path, and the `/sys` mount path for the default, for a custom path, and for `/`. The `/` case asserts that the `driver-root` volume and mount are absent and that `/sys` moves to `/sys`.
- A test that a relative `driverRoot` returns an error.
- A `LoadConfig` test that the `driverRoot` key in the ConfigMap reaches the resolved Job template.

Manual verification: `helm template` of the chart at the default, with `driverRoot=/`, and with the key set to null. The default renders `driverRoot: "/run/nvidia/driver"`, and a null value omits the key so the Go default applies.

> [!NOTE]
> `make lint-test-all` was not run. Its first step, `protos-generate`, needs `protoc`, which is not installed on the machine this was written on. `addlicense` and `gotestsum` are also missing there. No `.proto` file is touched by this change. The gate still needs a run on a machine with the full toolchain.

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [ ] Ready for review

Documentation: `resetJob.driverRoot` is documented in `docs/configuration/janitor.md` and inline in `values.yaml`.

No ADR accompanies this change. It adds a configuration value and does not alter a decision made by [019-janitor-gpu-reset.md](docs/designs/019-janitor-gpu-reset.md) or [020-nvsentinel-gpu-reset.md](docs/designs/020-nvsentinel-gpu-reset.md), neither of which specifies the chroot path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable driver root paths for GPU reset containers.
  * Supports the default mounted host driver path, custom absolute paths, or the container filesystem root.
  * GPU reset jobs now apply the selected path to environment variables and filesystem mounts.
  * Invalid driver root paths are rejected during startup.

* **Documentation**
  * Documented driver root configuration, path requirements, filesystem contents, mount behavior, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->