### PR TITLE
feat(store-client): idempotency keys, unique partial index and idempotent inserts for deployment platform connector

### DIFF
--- a/health-events-analyzer/pkg/reconciler/reconciler_test.go
+++ b/health-events-analyzer/pkg/reconciler/reconciler_test.go
@@ -56,6 +56,24 @@ func (m *mockDatabaseClient) InsertMany(ctx context.Context, documents []any) (*
 	return args.Get(0).(*client.InsertManyResult), args.Error(1)
 }
 
+func (m *mockDatabaseClient) InsertManyIdempotent(ctx context.Context, documents []any) (*client.InsertManyResult, error) {
+	args := m.Called(ctx, documents)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*client.InsertManyResult), args.Error(1)
+}
+
+func (m *mockDatabaseClient) EnsureHealthEventIdempotencyIndex(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *mockDatabaseClient) VerifyHealthEventIdempotencyIndex(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
 func (m *mockDatabaseClient) UpdateDocumentStatus(ctx context.Context, documentID string, statusPath string, status any) error {
 	args := m.Called(ctx, documentID, statusPath, status)
 	return args.Error(0)

--- a/platform-connectors/pkg/connectors/store/store_connector_test.go
+++ b/platform-connectors/pkg/connectors/store/store_connector_test.go
@@ -109,6 +109,24 @@ func (m *mockDatabaseClient) Ping(ctx context.Context) error {
 	return args.Error(0)
 }
 
+func (m *mockDatabaseClient) InsertManyIdempotent(ctx context.Context, documents []any) (*client.InsertManyResult, error) {
+	args := m.Called(ctx, documents)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*client.InsertManyResult), args.Error(1)
+}
+
+func (m *mockDatabaseClient) EnsureHealthEventIdempotencyIndex(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *mockDatabaseClient) VerifyHealthEventIdempotencyIndex(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
 func TestInsertHealthEvents(t *testing.T) {
 	ringBuffer := ringbuffer.NewRingBuffer("testRingBuffer", context.Background())
 	nodeName := "testNode"

--- a/store-client/pkg/client/interfaces.go
+++ b/store-client/pkg/client/interfaces.go
@@ -23,6 +23,13 @@ import (
 type DatabaseClient interface {
 	// Document operations
 	InsertMany(ctx context.Context, documents []any) (*InsertManyResult, error)
+	// InsertManyIdempotent inserts documents in order and continues past a
+	// document that already exists under the idempotency index, so a resent
+	// batch stores only its missing events and a monitor's events land in the
+	// order it sent them. Such duplicates are counted in the result's
+	// DuplicateCount; any other per-document failure stops the insert and is
+	// reported as a *datastore.BulkWriteFailure error.
+	InsertManyIdempotent(ctx context.Context, documents []any) (*InsertManyResult, error)
 	UpdateDocumentStatus(ctx context.Context, documentID string, statusPath string, status any) error
 	UpdateDocumentStatusFields(ctx context.Context, documentID string, fields map[string]any) error
 	UpdateDocument(ctx context.Context, filter any, update any) (*UpdateResult, error)
@@ -36,6 +43,17 @@ type DatabaseClient interface {
 
 	// Aggregation
 	Aggregate(ctx context.Context, pipeline any) (Cursor, error)
+
+	// Idempotency index management
+	// EnsureHealthEventIdempotencyIndex idempotently creates the unique partial
+	// index (datastore.HealthEventIdempotencyIndexName) that enforces per-event
+	// idempotency keys on health events.
+	EnsureHealthEventIdempotencyIndex(ctx context.Context) error
+	// VerifyHealthEventIdempotencyIndex returns nil only when the index exists
+	// with the expected name, key path, uniqueness, partial predicate, and a
+	// completed build; otherwise it returns datastore.ErrIndexMissing or
+	// datastore.ErrIndexMismatch wrapped with detail.
+	VerifyHealthEventIdempotencyIndex(ctx context.Context) error
 
 	// Health checks
 	Ping(ctx context.Context) error
@@ -117,6 +135,10 @@ type TokenConfig struct {
 // InsertManyResult represents the result of an insert many operation
 type InsertManyResult struct {
 	InsertedIDs []any
+	// DuplicateCount is the number of documents InsertManyIdempotent skipped
+	// because they were already stored under the idempotency index (a resend).
+	// Always 0 for InsertMany.
+	DuplicateCount int
 }
 
 // UpdateResult represents the result of an update operation

--- a/store-client/pkg/client/mongodb_client.go
+++ b/store-client/pkg/client/mongodb_client.go
@@ -388,6 +388,17 @@ type MongoDBCollectionClient struct {
 	*MongoDBClient
 }
 
+// mongoMaxPoolSize is the shared connection pool bound as the driver option
+// takes it; zero keeps the driver default of 100.
+func mongoMaxPoolSize() uint64 {
+	size := datastore.MaxConnections(nil)
+	if size <= 0 {
+		return 0
+	}
+
+	return uint64(size)
+}
+
 // NewMongoDBClient creates a new MongoDB client from database configuration
 func NewMongoDBClient(ctx context.Context, dbConfig config.DatabaseConfig) (*MongoDBClient, error) {
 	// Convert to the existing MongoDBConfig format for backward compatibility
@@ -407,6 +418,7 @@ func NewMongoDBClient(ctx context.Context, dbConfig config.DatabaseConfig) (*Mon
 		ChangeStreamRetryDeadlineSeconds: dbConfig.GetTimeoutConfig().GetChangeStreamRetryDeadlineSeconds(),
 		ChangeStreamRetryIntervalSeconds: dbConfig.GetTimeoutConfig().GetChangeStreamRetryIntervalSeconds(),
 		AppName:                          dbConfig.GetAppName(),
+		MaxPoolSize:                      mongoMaxPoolSize(),
 	}
 
 	// Initialize certificate watcher if rotation is enabled

--- a/store-client/pkg/client/mongodb_idempotency.go
+++ b/store-client/pkg/client/mongodb_idempotency.go
@@ -1,0 +1,418 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"github.com/nvidia/nvsentinel/store-client/pkg/datastore"
+)
+
+// healthEventIdempotencyKeyDocumentPath is the dotted document path of the
+// idempotency key inside a stored health event document.
+const healthEventIdempotencyKeyDocumentPath = "healthevent.metadata." +
+	datastore.HealthEventIdempotencyKeyMetadataField
+
+// mongoDuplicateKeyErrorCode is the MongoDB server error code for a unique
+// index violation (E11000).
+const mongoDuplicateKeyErrorCode = 11000
+
+// mongoDuplicateIndexNameRegex extracts the violated index name from a
+// duplicate-key error message, e.g.
+// "E11000 duplicate key error collection: db.coll index: <name> dup key: {...}".
+// The server does not expose the index name as a structured field on write
+// errors (only keyPattern/keyValue), so message parsing is the primary source.
+var mongoDuplicateIndexNameRegex = regexp.MustCompile(`index: (\S+)`)
+
+// InsertManyIdempotent inserts the documents in order, so a monitor's events
+// land in the order it sent them, and continues past a document that already
+// exists under the idempotency index. MongoDB keeps array order only for
+// ordered inserts, and an ordered insert stops at its first failure; when that
+// failure is such a duplicate (a resent batch) the insert resumes with the
+// documents after it. Any other per-document failure ends the insert and is
+// reported as a *datastore.BulkWriteFailure with the server's answer; the
+// resends skipped are counted in the result, so the caller can tell a resend
+// from a failure.
+func (c *MongoDBClient) InsertManyIdempotent(ctx context.Context, documents []any) (*InsertManyResult, error) {
+	return insertOrderedResumingDuplicates(ctx, documents,
+		func(ctx context.Context, documents []any) (*mongo.InsertManyResult, error) {
+			return c.mongoCol.InsertMany(ctx, documents)
+		})
+}
+
+// orderedInsert is one ordered InsertMany call; the driver stops at the first
+// failing document and reports it in a mongo.BulkWriteException.
+type orderedInsert func(ctx context.Context, documents []any) (*mongo.InsertManyResult, error)
+
+func insertOrderedResumingDuplicates(
+	ctx context.Context, documents []any, insert orderedInsert,
+) (*InsertManyResult, error) {
+	result := &InsertManyResult{InsertedIDs: make([]any, 0, len(documents))}
+
+	for offset := 0; offset < len(documents); {
+		res, err := insert(ctx, documents[offset:])
+		if err == nil {
+			result.InsertedIDs = append(result.InsertedIDs, res.InsertedIDs...)
+
+			return result, nil
+		}
+
+		failed, ok := classifyMongoBulkWriteError(err)
+		if !ok {
+			return nil, datastore.NewInsertError(
+				datastore.ProviderMongoDB,
+				"failed to insert documents",
+				err,
+			).WithMetadata("count", len(documents))
+		}
+
+		// Ordered: the driver stops at the first failing document, and the
+		// documents before it were inserted; their ids lead the driver's list.
+		if res != nil && len(res.InsertedIDs) >= failed.DocumentIndex {
+			result.InsertedIDs = append(result.InsertedIDs, res.InsertedIDs[:failed.DocumentIndex]...)
+		}
+
+		failed.DocumentIndex += offset
+
+		if !failed.DuplicateOn(datastore.HealthEventIdempotencyIndexName) {
+			// A real failure: the documents after it were not attempted, and
+			// the caller's retry will find the inserted ones as duplicates.
+			return nil, &datastore.BulkWriteFailure{
+				InsertedCount:  len(result.InsertedIDs),
+				DuplicateCount: result.DuplicateCount,
+				Failed:         failed,
+			}
+		}
+
+		result.DuplicateCount++
+		offset = failed.DocumentIndex + 1
+	}
+
+	return result, nil
+}
+
+// classifyMongoBulkWriteError converts a mongo.BulkWriteException into the
+// datastore.BulkDocumentError of the document the ordered insert stopped at.
+// It returns false when the error is not a per-document bulk write failure
+// (for example a write concern error, which affects the whole batch).
+func classifyMongoBulkWriteError(err error) (datastore.BulkDocumentError, bool) {
+	bwe, ok := errors.AsType[mongo.BulkWriteException](err)
+	if !ok {
+		return datastore.BulkDocumentError{}, false
+	}
+
+	if bwe.WriteConcernError != nil || len(bwe.WriteErrors) == 0 {
+		return datastore.BulkDocumentError{}, false
+	}
+
+	// Ordered insert: the driver reports the one document it stopped at.
+	writeErr := bwe.WriteErrors[0]
+	failed := datastore.BulkDocumentError{
+		DocumentIndex: writeErr.Index,
+		Message:       writeErr.Message,
+	}
+
+	if writeErr.Code == mongoDuplicateKeyErrorCode {
+		failed.Duplicate = true
+		failed.IndexName = extractMongoDuplicateIndexName(writeErr.WriteError)
+	}
+
+	return failed, true
+}
+
+// extractMongoDuplicateIndexName determines which index a duplicate-key write
+// error violated. The message is parsed first (the server does not return the
+// index name as a structured field); the structured keyPattern is used as a
+// fallback for the idempotency index specifically.
+func extractMongoDuplicateIndexName(writeErr mongo.WriteError) string {
+	if match := mongoDuplicateIndexNameRegex.FindStringSubmatch(writeErr.Message); len(match) == 2 {
+		return match[1]
+	}
+
+	// Fallback: a single-field keyPattern on the idempotency key path can only
+	// come from the idempotency index.
+	if len(writeErr.Raw) == 0 {
+		return ""
+	}
+
+	value, err := writeErr.Raw.LookupErr("keyPattern")
+	if err != nil {
+		return ""
+	}
+
+	doc, ok := value.DocumentOK()
+	if !ok {
+		return ""
+	}
+
+	elements, err := doc.Elements()
+	if err != nil || len(elements) != 1 || elements[0].Key() != healthEventIdempotencyKeyDocumentPath {
+		return ""
+	}
+
+	return datastore.HealthEventIdempotencyIndexName
+}
+
+// EnsureHealthEventIdempotencyIndex makes sure the unique partial index that
+// enforces per-event idempotency keys exists with the expected definition. The
+// partial filter covers only documents that carry the key, so existing records
+// need no backfill. An index of the same name with another definition, which
+// CreateOne would refuse with an options conflict, is dropped and recreated:
+// the name is ours, and the index Job is how an operator repairs the index.
+func (c *MongoDBClient) EnsureHealthEventIdempotencyIndex(ctx context.Context) error {
+	switch err := c.VerifyHealthEventIdempotencyIndex(ctx); {
+	case err == nil:
+		return nil
+	case errors.Is(err, datastore.ErrIndexMissing):
+	case errors.Is(err, datastore.ErrIndexBuilding):
+		// Dropping it would abort another session's build; wait for it.
+		return fmt.Errorf("idempotency index %s on collection %s is still being built by another session; retry later: %w",
+			datastore.HealthEventIdempotencyIndexName, c.collection, err)
+	case errors.Is(err, datastore.ErrIndexMismatch):
+		if err := c.mongoCol.Indexes().DropOne(ctx, datastore.HealthEventIdempotencyIndexName); err != nil {
+			return fmt.Errorf("failed to drop mismatched idempotency index %s on collection %s: %w",
+				datastore.HealthEventIdempotencyIndexName, c.collection, err)
+		}
+	default:
+		return err
+	}
+
+	indexModel := mongo.IndexModel{
+		Keys: bson.D{{Key: healthEventIdempotencyKeyDocumentPath, Value: 1}},
+		Options: options.Index().
+			SetName(datastore.HealthEventIdempotencyIndexName).
+			SetUnique(true).
+			SetPartialFilterExpression(bson.D{{
+				Key:   healthEventIdempotencyKeyDocumentPath,
+				Value: bson.D{{Key: "$exists", Value: true}},
+			}}),
+	}
+
+	if _, err := c.mongoCol.Indexes().CreateOne(ctx, indexModel); err != nil {
+		return fmt.Errorf("failed to ensure idempotency index %s on collection %s: %w",
+			datastore.HealthEventIdempotencyIndexName, c.collection, err)
+	}
+
+	return nil
+}
+
+// VerifyHealthEventIdempotencyIndex returns nil only when the idempotency index
+// exists with the expected name, key path, uniqueness, partial predicate, and a
+// completed build. A missing index yields datastore.ErrIndexMissing; any other
+// deviation yields datastore.ErrIndexMismatch, both wrapped with detail.
+func (c *MongoDBClient) VerifyHealthEventIdempotencyIndex(ctx context.Context) error {
+	cursor, err := c.mongoCol.Indexes().List(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list indexes on collection %s: %w", c.collection, err)
+	}
+
+	var specs []bson.M
+	if err := cursor.All(ctx, &specs); err != nil {
+		return fmt.Errorf("failed to decode index specifications: %w", err)
+	}
+
+	var indexSpec bson.M
+
+	for _, spec := range specs {
+		if name, _ := spec["name"].(string); name == datastore.HealthEventIdempotencyIndexName {
+			indexSpec = spec
+			break
+		}
+	}
+
+	if indexSpec == nil {
+		return fmt.Errorf("%w: index %s not found on collection %s",
+			datastore.ErrIndexMissing, datastore.HealthEventIdempotencyIndexName, c.collection)
+	}
+
+	// The build check comes first: an index another session is still building
+	// is reported as such whatever its definition, so Ensure waits for that
+	// build instead of aborting it as a mismatch.
+	if err := c.verifyMongoIdempotencyIndexBuildComplete(ctx); err != nil {
+		return err
+	}
+
+	return verifyMongoIdempotencyIndexSpec(indexSpec)
+}
+
+// asPlainMap normalizes a decoded BSON sub-document (bson.M or bson.D) into a
+// plain map for structural comparison.
+func asPlainMap(value any) (map[string]any, bool) {
+	switch v := normalizeValue(value).(type) {
+	case bson.M:
+		return v, true
+	case map[string]any:
+		return v, true
+	default:
+		return nil, false
+	}
+}
+
+// verifyMongoIdempotencyIndexSpec checks the key path, uniqueness, and partial
+// filter expression of a listIndexes specification document.
+func verifyMongoIdempotencyIndexSpec(indexSpec bson.M) error {
+	key, ok := asPlainMap(indexSpec["key"])
+	if !ok || len(key) != 1 || !isNumericOne(key[healthEventIdempotencyKeyDocumentPath]) {
+		return fmt.Errorf("%w: index %s does not index exactly {%s: 1}",
+			datastore.ErrIndexMismatch, datastore.HealthEventIdempotencyIndexName,
+			healthEventIdempotencyKeyDocumentPath)
+	}
+
+	if unique, _ := indexSpec["unique"].(bool); !unique {
+		return fmt.Errorf("%w: index %s is not unique",
+			datastore.ErrIndexMismatch, datastore.HealthEventIdempotencyIndexName)
+	}
+
+	if err := verifyMongoIdempotencyPartialFilter(indexSpec["partialFilterExpression"]); err != nil {
+		return err
+	}
+
+	// A collation (a collection default, for example) would make keys that
+	// differ only in case equal, and the client key alphabet is mixed case: a
+	// distinct batch would then be dropped as a duplicate.
+	if _, has := indexSpec["collation"]; has {
+		return fmt.Errorf("%w: index %s has a collation",
+			datastore.ErrIndexMismatch, datastore.HealthEventIdempotencyIndexName)
+	}
+
+	return nil
+}
+
+// verifyMongoIdempotencyPartialFilter checks that the partial filter covers
+// exactly the documents carrying a key: {path: {$exists: true}}.
+func verifyMongoIdempotencyPartialFilter(expression any) error {
+	partialFilter, ok := asPlainMap(expression)
+	if !ok || len(partialFilter) != 1 {
+		return fmt.Errorf("%w: index %s is missing the expected partial filter expression",
+			datastore.ErrIndexMismatch, datastore.HealthEventIdempotencyIndexName)
+	}
+
+	keyPredicate, ok := asPlainMap(partialFilter[healthEventIdempotencyKeyDocumentPath])
+	if !ok || len(keyPredicate) != 1 {
+		return fmt.Errorf("%w: index %s partial filter does not cover %s",
+			datastore.ErrIndexMismatch, datastore.HealthEventIdempotencyIndexName,
+			healthEventIdempotencyKeyDocumentPath)
+	}
+
+	if exists, _ := keyPredicate["$exists"].(bool); !exists {
+		return fmt.Errorf("%w: index %s partial filter is not {%s: {$exists: true}}",
+			datastore.ErrIndexMismatch, datastore.HealthEventIdempotencyIndexName,
+			healthEventIdempotencyKeyDocumentPath)
+	}
+
+	return nil
+}
+
+// verifyMongoIdempotencyIndexBuildComplete checks that the index is not still
+// being built. listIndexes reports an index while its build is in progress,
+// and a resend stored during a unique index build could be inserted twice and
+// then fail the build at its end. $collStats with storageStats lists the
+// builds in progress and works with the read role the chart grants (unlike
+// $indexStats, which needs clusterMonitor). A service without the stage keeps
+// the specification check alone, and says so.
+func (c *MongoDBClient) verifyMongoIdempotencyIndexBuildComplete(ctx context.Context) error {
+	pipeline := mongo.Pipeline{bson.D{{Key: "$collStats", Value: bson.D{{Key: "storageStats", Value: bson.D{}}}}}}
+
+	cursor, err := c.mongoCol.Aggregate(ctx, pipeline)
+	if err != nil {
+		if isUnsupportedStageError(err) {
+			slog.Warn("Cannot confirm the idempotency index build is complete: $collStats is not supported "+
+				"by this datastore; relying on the index specification alone", "error", err)
+
+			return nil
+		}
+
+		return fmt.Errorf("failed to read collection statistics for %s: %w", c.collection, err)
+	}
+
+	var stats []bson.M
+	if err := cursor.All(ctx, &stats); err != nil {
+		return fmt.Errorf("failed to decode collection statistics: %w", err)
+	}
+
+	if indexBuildInProgress(stats, datastore.HealthEventIdempotencyIndexName) {
+		return fmt.Errorf("%w: index %s", datastore.ErrIndexBuilding, datastore.HealthEventIdempotencyIndexName)
+	}
+
+	return nil
+}
+
+// indexBuildInProgress reports whether the $collStats documents (one per
+// shard) list the named index under storageStats.indexBuilds, the builds in
+// progress. Sub-documents are read whether the driver decoded them as bson.D
+// or bson.M.
+func indexBuildInProgress(stats []bson.M, name string) bool {
+	for _, stat := range stats {
+		storage, ok := asPlainMap(stat["storageStats"])
+		if !ok {
+			continue
+		}
+
+		builds, _ := normalizeValue(storage["indexBuilds"]).([]any)
+		for _, build := range builds {
+			if building, _ := build.(string); building == name {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// mongoUnrecognizedStageCode is the server error for a pipeline stage it does
+// not know.
+const mongoUnrecognizedStageCode = 40324
+
+// isUnsupportedStageError reports whether an aggregation failed because the
+// datastore does not support the stage (MongoDB-compatible services): the
+// server's own code, or a message saying so. The stage name alone is not
+// evidence: an authorization failure quotes the whole command, stage
+// included, and must not pass as "unsupported".
+func isUnsupportedStageError(err error) bool {
+	if cmdErr, ok := errors.AsType[mongo.CommandError](err); ok && cmdErr.Code == mongoUnrecognizedStageCode {
+		return true
+	}
+
+	message := strings.ToLower(err.Error())
+
+	return strings.Contains(message, "unrecognized pipeline stage") ||
+		(strings.Contains(message, "not supported") && strings.Contains(message, "$collstats"))
+}
+
+// isNumericOne reports whether an index key direction value equals 1,
+// tolerating the numeric types BSON decoding can produce.
+func isNumericOne(value any) bool {
+	switch v := value.(type) {
+	case int:
+		return v == 1
+	case int32:
+		return v == 1
+	case int64:
+		return v == 1
+	case float64:
+		return v == 1
+	default:
+		return false
+	}
+}

--- a/store-client/pkg/client/mongodb_idempotency_test.go
+++ b/store-client/pkg/client/mongodb_idempotency_test.go
@@ -1,0 +1,376 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+
+	"github.com/nvidia/nvsentinel/store-client/pkg/datastore"
+)
+
+const testDuplicateKeyMessage = "E11000 duplicate key error collection: nvsentinel.HealthEvents " +
+	"index: healthevent_idempotency_key_unique dup key: " +
+	`{ healthevent.metadata.idempotencyKey: "pod-uid#key#0" }`
+
+func TestClassifyMongoBulkWriteError(t *testing.T) {
+	t.Run("duplicate key errors are classified with the index name", func(t *testing.T) {
+		bwe := mongo.BulkWriteException{
+			WriteErrors: []mongo.BulkWriteError{
+				{WriteError: mongo.WriteError{
+					Index:   1,
+					Code:    mongoDuplicateKeyErrorCode,
+					Message: testDuplicateKeyMessage,
+				}},
+			},
+		}
+
+		failed, ok := classifyMongoBulkWriteError(bwe)
+		require.True(t, ok)
+		assert.Equal(t, 1, failed.DocumentIndex)
+		assert.True(t, failed.Duplicate)
+		assert.Equal(t, datastore.HealthEventIdempotencyIndexName, failed.IndexName)
+		assert.True(t, failed.DuplicateOn(datastore.HealthEventIdempotencyIndexName))
+	})
+
+	t.Run("wrapped exception is classified", func(t *testing.T) {
+		bwe := mongo.BulkWriteException{
+			WriteErrors: []mongo.BulkWriteError{
+				{WriteError: mongo.WriteError{Index: 0, Code: mongoDuplicateKeyErrorCode, Message: testDuplicateKeyMessage}},
+			},
+		}
+		wrapped := fmt.Errorf("insert failed: %w", error(bwe))
+
+		failed, ok := classifyMongoBulkWriteError(wrapped)
+		require.True(t, ok)
+		assert.Equal(t, 0, failed.DocumentIndex)
+	})
+
+	t.Run("non duplicate write errors keep the server's message", func(t *testing.T) {
+		bwe := mongo.BulkWriteException{
+			WriteErrors: []mongo.BulkWriteError{
+				{WriteError: mongo.WriteError{Index: 0, Code: 121, Message: "Document failed validation"}},
+			},
+		}
+
+		failed, ok := classifyMongoBulkWriteError(bwe)
+		require.True(t, ok)
+		assert.False(t, failed.Duplicate)
+		assert.Empty(t, failed.IndexName)
+		assert.Equal(t, "Document failed validation", failed.Message)
+	})
+
+	t.Run("write concern errors are not per-document failures", func(t *testing.T) {
+		bwe := mongo.BulkWriteException{
+			WriteConcernError: &mongo.WriteConcernError{Code: 64, Message: "waiting for replication timed out"},
+			WriteErrors: []mongo.BulkWriteError{
+				{WriteError: mongo.WriteError{Index: 0, Code: mongoDuplicateKeyErrorCode, Message: testDuplicateKeyMessage}},
+			},
+		}
+
+		_, ok := classifyMongoBulkWriteError(bwe)
+		assert.False(t, ok)
+	})
+
+	t.Run("non bulk write errors are not classified", func(t *testing.T) {
+		_, ok := classifyMongoBulkWriteError(errors.New("connection reset"))
+		assert.False(t, ok)
+	})
+}
+
+func TestExtractMongoDuplicateIndexName(t *testing.T) {
+	t.Run("index name parsed from message", func(t *testing.T) {
+		writeErr := mongo.WriteError{Code: mongoDuplicateKeyErrorCode, Message: testDuplicateKeyMessage}
+		assert.Equal(t, datastore.HealthEventIdempotencyIndexName, extractMongoDuplicateIndexName(writeErr))
+	})
+
+	t.Run("falls back to keyPattern for the idempotency path", func(t *testing.T) {
+		raw, err := bson.Marshal(bson.D{{
+			Key:   "keyPattern",
+			Value: bson.D{{Key: healthEventIdempotencyKeyDocumentPath, Value: 1}},
+		}})
+		require.NoError(t, err)
+
+		writeErr := mongo.WriteError{
+			Code:    mongoDuplicateKeyErrorCode,
+			Message: "duplicate key error without the usual format",
+			Raw:     raw,
+		}
+		assert.Equal(t, datastore.HealthEventIdempotencyIndexName, extractMongoDuplicateIndexName(writeErr))
+	})
+
+	t.Run("unknown format yields empty name", func(t *testing.T) {
+		writeErr := mongo.WriteError{Code: mongoDuplicateKeyErrorCode, Message: "duplicate key"}
+		assert.Empty(t, extractMongoDuplicateIndexName(writeErr))
+	})
+}
+
+func TestVerifyMongoIdempotencyIndexSpec(t *testing.T) {
+	validSpec := func() bson.M {
+		return bson.M{
+			"name":   datastore.HealthEventIdempotencyIndexName,
+			"key":    bson.M{healthEventIdempotencyKeyDocumentPath: int32(1)},
+			"unique": true,
+			"partialFilterExpression": bson.M{
+				healthEventIdempotencyKeyDocumentPath: bson.M{"$exists": true},
+			},
+		}
+	}
+
+	t.Run("valid spec passes", func(t *testing.T) {
+		assert.NoError(t, verifyMongoIdempotencyIndexSpec(validSpec()))
+	})
+
+	t.Run("valid spec with bson.D sub-documents passes", func(t *testing.T) {
+		spec := bson.M{
+			"name":   datastore.HealthEventIdempotencyIndexName,
+			"key":    bson.D{{Key: healthEventIdempotencyKeyDocumentPath, Value: int32(1)}},
+			"unique": true,
+			"partialFilterExpression": bson.D{{
+				Key:   healthEventIdempotencyKeyDocumentPath,
+				Value: bson.D{{Key: "$exists", Value: true}},
+			}},
+		}
+		assert.NoError(t, verifyMongoIdempotencyIndexSpec(spec))
+	})
+
+	t.Run("wrong key path is a mismatch", func(t *testing.T) {
+		spec := validSpec()
+		spec["key"] = bson.M{"healthevent.nodename": int32(1)}
+
+		err := verifyMongoIdempotencyIndexSpec(spec)
+		assert.ErrorIs(t, err, datastore.ErrIndexMismatch)
+	})
+
+	t.Run("compound key is a mismatch", func(t *testing.T) {
+		spec := validSpec()
+		spec["key"] = bson.M{
+			healthEventIdempotencyKeyDocumentPath: int32(1),
+			"healthevent.nodename":                int32(1),
+		}
+
+		err := verifyMongoIdempotencyIndexSpec(spec)
+		assert.ErrorIs(t, err, datastore.ErrIndexMismatch)
+	})
+
+	t.Run("non unique index is a mismatch", func(t *testing.T) {
+		spec := validSpec()
+		spec["unique"] = false
+
+		err := verifyMongoIdempotencyIndexSpec(spec)
+		assert.ErrorIs(t, err, datastore.ErrIndexMismatch)
+	})
+
+	t.Run("missing partial filter is a mismatch", func(t *testing.T) {
+		spec := validSpec()
+		delete(spec, "partialFilterExpression")
+
+		err := verifyMongoIdempotencyIndexSpec(spec)
+		assert.ErrorIs(t, err, datastore.ErrIndexMismatch)
+	})
+
+	t.Run("wrong partial filter predicate is a mismatch", func(t *testing.T) {
+		spec := validSpec()
+		spec["partialFilterExpression"] = bson.M{
+			healthEventIdempotencyKeyDocumentPath: bson.M{"$exists": false},
+		}
+
+		err := verifyMongoIdempotencyIndexSpec(spec)
+		assert.ErrorIs(t, err, datastore.ErrIndexMismatch)
+	})
+}
+
+func TestIsNumericOne(t *testing.T) {
+	assert.True(t, isNumericOne(1))
+	assert.True(t, isNumericOne(int32(1)))
+	assert.True(t, isNumericOne(int64(1)))
+	assert.True(t, isNumericOne(float64(1)))
+	assert.False(t, isNumericOne(int32(-1)))
+	assert.False(t, isNumericOne("1"))
+	assert.False(t, isNumericOne(nil))
+}
+
+// scriptedOrderedInsert plays the driver for insertOrderedResumingDuplicates:
+// each call inserts documents in order until the scripted failure for one of
+// them, reported the way an ordered InsertMany reports it.
+type scriptedOrderedInsert struct {
+	failures map[string]mongo.WriteError // document -> write error
+	calls    [][]any
+}
+
+func (s *scriptedOrderedInsert) insert(_ context.Context, documents []any) (*mongo.InsertManyResult, error) {
+	s.calls = append(s.calls, documents)
+
+	res := &mongo.InsertManyResult{}
+
+	for i, doc := range documents {
+		if writeErr, failed := s.failures[doc.(string)]; failed {
+			writeErr.Index = i
+
+			return res, mongo.BulkWriteException{WriteErrors: []mongo.BulkWriteError{{WriteError: writeErr}}}
+		}
+
+		res.InsertedIDs = append(res.InsertedIDs, doc)
+	}
+
+	return res, nil
+}
+
+func idempotencyDuplicate() mongo.WriteError {
+	return mongo.WriteError{
+		Code:    mongoDuplicateKeyErrorCode,
+		Message: "E11000 duplicate key error collection: db.health_events index: " + datastore.HealthEventIdempotencyIndexName + " dup key: {}",
+	}
+}
+
+// TestInsertOrderedResumingDuplicates_ResendStoresMissingEventsInOrder: a
+// resend whose first and third events already exist inserts the others, in
+// order, and counts both duplicates in the result.
+func TestInsertOrderedResumingDuplicates_ResendStoresMissingEventsInOrder(t *testing.T) {
+	driver := &scriptedOrderedInsert{failures: map[string]mongo.WriteError{"a": idempotencyDuplicate(), "c": idempotencyDuplicate()}}
+
+	result, err := insertOrderedResumingDuplicates(context.Background(), []any{"a", "b", "c", "d"}, driver.insert)
+	require.NoError(t, err, "a resend is a success, not a failure")
+	require.Equal(t, 2, result.DuplicateCount)
+	require.Equal(t, []any{"b", "d"}, result.InsertedIDs)
+	require.Equal(t, [][]any{{"a", "b", "c", "d"}, {"b", "c", "d"}, {"d"}}, driver.calls,
+		"each duplicate stops the ordered insert, which resumes right after it")
+}
+
+// TestInsertOrderedResumingDuplicates_RealFailureStops: a failure that is not
+// an idempotency duplicate ends the insert; the documents after it are not
+// attempted and the failure is not a clean resend.
+func TestInsertOrderedResumingDuplicates_RealFailureStops(t *testing.T) {
+	driver := &scriptedOrderedInsert{failures: map[string]mongo.WriteError{
+		"b": {Code: 121, Message: "Document failed validation"},
+	}}
+
+	_, err := insertOrderedResumingDuplicates(context.Background(), []any{"a", "b", "c"}, driver.insert)
+
+	failure, ok := datastore.AsBulkWriteFailure(err)
+	require.True(t, ok)
+	require.Equal(t, 1, failure.InsertedCount)
+	require.Equal(t, 1, failure.Failed.DocumentIndex)
+	require.False(t, failure.Failed.Duplicate)
+	require.Contains(t, err.Error(), "Document failed validation", "the server's answer survives into the error")
+	require.Len(t, driver.calls, 1, "nothing after a real failure is attempted")
+}
+
+// TestInsertOrderedResumingDuplicates_OtherIndexDuplicateAfterResumeStops: a
+// duplicate on another unique index, met after an idempotency duplicate was
+// resumed past, ends the insert like any real failure.
+func TestInsertOrderedResumingDuplicates_OtherIndexDuplicateAfterResumeStops(t *testing.T) {
+	driver := &scriptedOrderedInsert{failures: map[string]mongo.WriteError{
+		"a": idempotencyDuplicate(),
+		"c": {Code: mongoDuplicateKeyErrorCode, Message: "E11000 duplicate key error collection: db.health_events index: _id_ dup key: {}"},
+	}}
+
+	_, err := insertOrderedResumingDuplicates(context.Background(), []any{"a", "b", "c", "d"}, driver.insert)
+
+	failure, ok := datastore.AsBulkWriteFailure(err)
+	require.True(t, ok)
+	require.Equal(t, 1, failure.InsertedCount, "only b was stored")
+	require.Equal(t, 1, failure.DuplicateCount, "a was a resend")
+	require.Equal(t, 2, failure.Failed.DocumentIndex)
+	require.True(t, failure.Failed.Duplicate)
+	require.Equal(t, "_id_", failure.Failed.IndexName)
+	require.Contains(t, err.Error(), `duplicate on index "_id_"`)
+	require.Equal(t, [][]any{{"a", "b", "c", "d"}, {"b", "c", "d"}}, driver.calls, "nothing after the real failure is attempted")
+}
+
+// TestInsertOrderedResumingDuplicates_LastDocumentDuplicate: a duplicate at
+// the end costs no extra round trip and the batch counts as a clean resend.
+func TestInsertOrderedResumingDuplicates_LastDocumentDuplicate(t *testing.T) {
+	driver := &scriptedOrderedInsert{failures: map[string]mongo.WriteError{"c": idempotencyDuplicate()}}
+
+	result, err := insertOrderedResumingDuplicates(context.Background(), []any{"a", "b", "c"}, driver.insert)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.DuplicateCount)
+	require.Equal(t, []any{"a", "b"}, result.InsertedIDs)
+	require.Len(t, driver.calls, 1)
+}
+
+// TestInsertOrderedResumingDuplicates_AllStored: no failure, one round trip.
+func TestInsertOrderedResumingDuplicates_AllStored(t *testing.T) {
+	driver := &scriptedOrderedInsert{}
+
+	result, err := insertOrderedResumingDuplicates(context.Background(), []any{"a", "b"}, driver.insert)
+	require.NoError(t, err)
+	require.Equal(t, []any{"a", "b"}, result.InsertedIDs)
+	require.Len(t, driver.calls, 1)
+}
+
+// TestIsUnsupportedStageError: a datastore without $collStats keeps the
+// specification check alone; any other failure of the build check is reported.
+func TestIsUnsupportedStageError(t *testing.T) {
+	assert.True(t, isUnsupportedStageError(mongo.CommandError{
+		Code: mongoUnrecognizedStageCode, Message: "Unrecognized pipeline stage name: '$collStats'",
+	}))
+	assert.True(t, isUnsupportedStageError(errors.New("Unrecognized pipeline stage name: '$collStats'")))
+	assert.True(t, isUnsupportedStageError(errors.New("$collStats is not supported by this service")))
+	assert.False(t, isUnsupportedStageError(mongo.CommandError{Code: 13, Message: "not authorized on nvsentinel"}))
+	assert.False(t, isUnsupportedStageError(mongo.CommandError{
+		Code: 13,
+		Message: "not authorized on nvsentinel to execute command { aggregate: \"HealthEvents\", " +
+			"pipeline: [ { $collStats: { storageStats: {} } } ], cursor: {} }",
+	}), "an authorization failure quoting the command is not an unsupported stage")
+	assert.False(t, isUnsupportedStageError(errors.New("connection reset by peer")))
+}
+
+// TestIndexBuildInProgress: the build list is read whether the driver decoded
+// the sub-documents as bson.D or bson.M, across the documents of a sharded
+// collection; a missing list means no build.
+func TestIndexBuildInProgress(t *testing.T) {
+	name := datastore.HealthEventIdempotencyIndexName
+
+	assert.True(t, indexBuildInProgress([]bson.M{
+		{"storageStats": bson.D{{Key: "indexBuilds", Value: bson.A{"other", name}}}},
+	}, name), "bson.D sub-document")
+	assert.True(t, indexBuildInProgress([]bson.M{
+		{"storageStats": bson.M{"indexBuilds": bson.A{}}},
+		{"storageStats": bson.M{"indexBuilds": []any{name}}},
+	}, name), "second shard")
+	assert.False(t, indexBuildInProgress([]bson.M{
+		{"storageStats": bson.M{"indexBuilds": bson.A{"other"}}},
+	}, name))
+	assert.False(t, indexBuildInProgress([]bson.M{{"storageStats": bson.M{}}}, name), "no build list")
+	assert.False(t, indexBuildInProgress(nil, name))
+}
+
+// TestVerifyMongoIdempotencyIndexSpec_RejectsCollation: an otherwise matching
+// index under a collation is a mismatch.
+func TestVerifyMongoIdempotencyIndexSpec_RejectsCollation(t *testing.T) {
+	spec := bson.M{
+		"name":   datastore.HealthEventIdempotencyIndexName,
+		"key":    bson.M{healthEventIdempotencyKeyDocumentPath: int32(1)},
+		"unique": true,
+		"partialFilterExpression": bson.M{
+			healthEventIdempotencyKeyDocumentPath: bson.M{"$exists": true},
+		},
+	}
+	require.NoError(t, verifyMongoIdempotencyIndexSpec(spec))
+
+	spec["collation"] = bson.M{"locale": "en", "strength": int32(2)}
+	err := verifyMongoIdempotencyIndexSpec(spec)
+	require.ErrorIs(t, err, datastore.ErrIndexMismatch)
+	assert.Contains(t, err.Error(), "collation")
+}

--- a/store-client/pkg/client/postgresql_idempotency.go
+++ b/store-client/pkg/client/postgresql_idempotency.go
@@ -40,9 +40,6 @@ const (
 	healthEventIdempotencyKeyJSONPath = "{healthevent,metadata," +
 		datastore.HealthEventIdempotencyKeyMetadataField + "}"
 
-	// pqUniqueViolationCode is the SQLSTATE code for unique_violation.
-	pqUniqueViolationCode = "23505"
-
 	// dropIdempotencyIndexStatement removes a leftover INVALID build, or a
 	// mismatched definition, of the idempotency index without blocking
 	// writers. It must run outside a transaction block, like the CONCURRENTLY
@@ -52,8 +49,15 @@ const (
 )
 
 // InsertManyIdempotent inserts documents one at a time, in order, through
-// InsertManyIdempotentWith.
+// InsertManyIdempotentWith. The idempotency index lives on the health events
+// table, so a client configured for any other table is refused: there a
+// resend would be stored again and reported as new.
 func (c *PostgreSQLClient) InsertManyIdempotent(ctx context.Context, documents []any) (*InsertManyResult, error) {
+	if c.table != healthEventsTableName {
+		return nil, fmt.Errorf("idempotent inserts are defined for the %s table only, which carries the idempotency index; "+
+			"this client writes to %s", healthEventsTableName, c.table)
+	}
+
 	//nolint:gosec // G201: table name from config, values are parameterized
 	query := fmt.Sprintf("INSERT INTO %s (document) VALUES ($1) RETURNING id", c.table)
 
@@ -146,7 +150,7 @@ func ClassifyPostgresDocumentError(documentIndex int, err error) (datastore.Bulk
 
 	docErr := datastore.BulkDocumentError{DocumentIndex: documentIndex, Message: pqErr.Message}
 
-	if string(pqErr.Code) == pqUniqueViolationCode {
+	if pqErr.Code == pqerror.UniqueViolation {
 		docErr.IndexName = pqErr.Constraint
 		docErr.Duplicate = true
 	}

--- a/store-client/pkg/client/postgresql_idempotency.go
+++ b/store-client/pkg/client/postgresql_idempotency.go
@@ -1,0 +1,400 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/lib/pq"
+	"github.com/lib/pq/pqerror"
+
+	"github.com/nvidia/nvsentinel/store-client/pkg/datastore"
+)
+
+const (
+	// healthEventsTableName is the PostgreSQL table health events are stored in.
+	// Health events always land in this table (see the health event insert path),
+	// so the idempotency index is managed on it regardless of the configured table.
+	healthEventsTableName = "health_events"
+
+	// healthEventIdempotencyKeyJSONPath is the PostgreSQL text-array path of the
+	// idempotency key inside the JSONB document column, for use with the #>>
+	// operator. It mirrors healthEventIdempotencyKeyDocumentPath for MongoDB.
+	healthEventIdempotencyKeyJSONPath = "{healthevent,metadata," +
+		datastore.HealthEventIdempotencyKeyMetadataField + "}"
+
+	// pqUniqueViolationCode is the SQLSTATE code for unique_violation.
+	pqUniqueViolationCode = "23505"
+
+	// dropIdempotencyIndexStatement removes a leftover INVALID build, or a
+	// mismatched definition, of the idempotency index without blocking
+	// writers. It must run outside a transaction block, like the CONCURRENTLY
+	// create it makes room for.
+	dropIdempotencyIndexStatement = "DROP INDEX CONCURRENTLY IF EXISTS " +
+		datastore.HealthEventIdempotencyIndexName
+)
+
+// InsertManyIdempotent inserts documents one at a time, in order, through
+// InsertManyIdempotentWith.
+func (c *PostgreSQLClient) InsertManyIdempotent(ctx context.Context, documents []any) (*InsertManyResult, error) {
+	//nolint:gosec // G201: table name from config, values are parameterized
+	query := fmt.Sprintf("INSERT INTO %s (document) VALUES ($1) RETURNING id", c.table)
+
+	return InsertManyIdempotentWith(ctx, documents, func(ctx context.Context, doc any) (string, error) {
+		docJSON, err := json.Marshal(doc)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal document: %w", err)
+		}
+
+		var id string
+		if err := c.db.QueryRowContext(ctx, query, docJSON).Scan(&id); err != nil {
+			return "", err
+		}
+
+		return id, nil
+	})
+}
+
+// InsertManyIdempotentWith inserts documents one at a time, in order, with
+// insertOne. A duplicate on the idempotency index is a resend of an event
+// already stored: it is counted in the result and the insert goes on, so the
+// rest of a partly stored batch is still stored. Any other answer from the
+// server about a document (a constraint the batch violates) stops the insert
+// there, so the documents after it are stored in order by the client's retry
+// of the whole batch, as with MongoDB's ordered insert; that answer is
+// returned as a *datastore.BulkWriteFailure. A failure that is not an answer
+// about a document (a lost connection, a cancelled context, an undecodable
+// document) fails the whole batch, as it does for MongoDB.
+func InsertManyIdempotentWith(
+	ctx context.Context, documents []any, insertOne func(ctx context.Context, doc any) (string, error),
+) (*InsertManyResult, error) {
+	if len(documents) == 0 {
+		return &InsertManyResult{InsertedIDs: []any{}}, nil
+	}
+
+	result := &InsertManyResult{InsertedIDs: make([]any, 0, len(documents))}
+
+	for i, doc := range documents {
+		id, err := insertOne(ctx, doc)
+		if err == nil {
+			result.InsertedIDs = append(result.InsertedIDs, id)
+
+			continue
+		}
+
+		docErr, answered := ClassifyPostgresDocumentError(i, err)
+		if !answered {
+			return nil, datastore.NewInsertError(
+				datastore.ProviderPostgreSQL,
+				"failed to insert documents",
+				err,
+			).WithMetadata("count", len(documents)).WithMetadata("insertedCount", len(result.InsertedIDs))
+		}
+
+		if docErr.DuplicateOn(datastore.HealthEventIdempotencyIndexName) {
+			result.DuplicateCount++
+
+			continue
+		}
+
+		return nil, &datastore.BulkWriteFailure{
+			InsertedCount:  len(result.InsertedIDs),
+			DuplicateCount: result.DuplicateCount,
+			Failed:         docErr,
+		}
+	}
+
+	return result, nil
+}
+
+// pqDocumentErrorClasses are the SQLSTATE classes that answer a question about
+// the document itself: 22 (data exception) and 23 (integrity constraint
+// violation). Every other class says something about the connection or the
+// server instead, for example 08 (connection exception), 57 (operator
+// intervention, such as 57P01 admin_shutdown), 53 (insufficient resources) or
+// 40 (transaction rollback), and must fail the whole batch as a datastore
+// failure, so the caller retries it.
+var pqDocumentErrorClasses = map[pqerror.Class]bool{"22": true, "23": true}
+
+// ClassifyPostgresDocumentError converts the server's answer about one
+// document into a BulkDocumentError, marking a unique violation as a duplicate
+// on the named constraint. It reports false for anything that is not such an
+// answer: not a PostgreSQL error at all, or a PostgreSQL error whose SQLSTATE
+// class concerns the connection or the server rather than the document.
+func ClassifyPostgresDocumentError(documentIndex int, err error) (datastore.BulkDocumentError, bool) {
+	pqErr, ok := errors.AsType[*pq.Error](err)
+	if !ok || !pqDocumentErrorClasses[pqErr.Code.Class()] {
+		return datastore.BulkDocumentError{}, false
+	}
+
+	docErr := datastore.BulkDocumentError{DocumentIndex: documentIndex, Message: pqErr.Message}
+
+	if string(pqErr.Code) == pqUniqueViolationCode {
+		docErr.IndexName = pqErr.Constraint
+		docErr.Duplicate = true
+	}
+
+	return docErr, true
+}
+
+// EnsureHealthEventIdempotencyIndex makes sure the partial unique expression
+// index that enforces per-event idempotency keys exists with the expected
+// definition. The predicate covers only documents that carry the key, so
+// existing rows need no backfill.
+//
+// The index is built CONCURRENTLY so the build never blocks writers: every
+// health event in the fleet lands in this table, and it may already hold
+// millions of rows. CONCURRENTLY cannot run inside a transaction block, and
+// c.db is the pool handle, so each statement below runs autocommitted on its
+// own connection. Since a concurrent build takes many times longer than a
+// locking one, callers must not treat a nil return as "index ready"; that is
+// what VerifyHealthEventIdempotencyIndex is for.
+//
+// An index of this name that does not enforce the key, either another
+// definition or the invalid leftover of a failed build (which IF NOT EXISTS
+// would otherwise skip forever), is dropped (also CONCURRENTLY) and rebuilt:
+// the name is ours, and the index Job is how an operator repairs the index.
+// An index that another session is still building is left alone, because
+// dropping it would block behind that build and then discard its result.
+func (c *PostgreSQLClient) EnsureHealthEventIdempotencyIndex(ctx context.Context) error {
+	switch verifyErr := c.VerifyHealthEventIdempotencyIndex(ctx); {
+	case verifyErr == nil:
+		return nil
+	case errors.Is(verifyErr, datastore.ErrIndexMissing):
+	case errors.Is(verifyErr, datastore.ErrIndexMismatch):
+		building, err := c.idempotencyIndexBuildInProgress(ctx)
+		if err != nil {
+			return err
+		}
+
+		if building {
+			return fmt.Errorf("idempotency index %s on table %s is still being built by another session; retry later: %w",
+				datastore.HealthEventIdempotencyIndexName, healthEventsTableName, verifyErr)
+		}
+
+		if _, err := c.db.ExecContext(ctx, dropIdempotencyIndexStatement); err != nil {
+			return fmt.Errorf("failed to drop mismatched idempotency index %s on table %s: %w",
+				datastore.HealthEventIdempotencyIndexName, healthEventsTableName, err)
+		}
+	default:
+		return fmt.Errorf("failed to check idempotency index %s on table %s: %w",
+			datastore.HealthEventIdempotencyIndexName, healthEventsTableName, verifyErr)
+	}
+
+	//nolint:gosec // G201: all operands are package-level constants, no external input
+	createStatement := fmt.Sprintf(
+		"CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS %s ON %s ((document #>> '%s')) "+
+			"WHERE (document #>> '%s') IS NOT NULL",
+		datastore.HealthEventIdempotencyIndexName,
+		healthEventsTableName,
+		healthEventIdempotencyKeyJSONPath,
+		healthEventIdempotencyKeyJSONPath,
+	)
+
+	if _, err := c.db.ExecContext(ctx, createStatement); err != nil {
+		return fmt.Errorf("failed to ensure idempotency index %s on table %s: %w",
+			datastore.HealthEventIdempotencyIndexName, healthEventsTableName, err)
+	}
+
+	// IF NOT EXISTS skips an existing index without error even when that
+	// index is a leftover INVALID build or another session's build still in
+	// progress; the verification reports it so the caller retries later.
+	if err := c.VerifyHealthEventIdempotencyIndex(ctx); err != nil {
+		return fmt.Errorf("idempotency index %s on table %s is not usable after the build: %w",
+			datastore.HealthEventIdempotencyIndexName, healthEventsTableName, err)
+	}
+
+	return nil
+}
+
+// idempotencyIndexBuildInProgress reports whether another session is still
+// building an index of our name.
+func (c *PostgreSQLClient) idempotencyIndexBuildInProgress(ctx context.Context) (bool, error) {
+	query := `
+		SELECT EXISTS (
+		    SELECT 1
+		    FROM pg_stat_progress_create_index p
+		    JOIN pg_class idx ON idx.oid = p.index_relid
+		    WHERE idx.relname = $1 AND p.relid = to_regclass($2))`
+
+	var building bool
+
+	if err := c.db.QueryRowContext(ctx, query,
+		datastore.HealthEventIdempotencyIndexName, healthEventsTableName).Scan(&building); err != nil {
+		return false, fmt.Errorf("failed to check whether idempotency index %s on table %s is being built: %w",
+			datastore.HealthEventIdempotencyIndexName, healthEventsTableName, err)
+	}
+
+	return building, nil
+}
+
+// VerifyHealthEventIdempotencyIndex returns nil only when the idempotency index
+// exists with the expected name, key expression, uniqueness, partial predicate,
+// and a valid (completed) build per pg_index.indisvalid. A missing index yields
+// datastore.ErrIndexMissing; any other deviation yields datastore.ErrIndexMismatch,
+// both wrapped with detail.
+//
+// The CONCURRENTLY build started by EnsureHealthEventIdempotencyIndex keeps
+// indisvalid false until it completes, so this also returns
+// datastore.ErrIndexMismatch while that build is still running (or after it
+// failed). Callers that gate readiness on this check therefore keep waiting
+// until the index actually enforces uniqueness.
+func (c *PostgreSQLClient) VerifyHealthEventIdempotencyIndex(ctx context.Context) error {
+	// to_regclass resolves the table through the current search_path, so a
+	// same-named table in another (invisible) schema cannot satisfy the check;
+	// an absent or invisible table yields no rows and thus ErrIndexMissing.
+	query := `
+		SELECT i.indisunique,
+		       i.indisvalid,
+		       i.indnatts,
+		       pg_get_indexdef(i.indexrelid),
+		       COALESCE(pg_get_expr(i.indpred, i.indrelid), '')
+		FROM pg_index i
+		JOIN pg_class idx ON idx.oid = i.indexrelid
+		WHERE idx.relname = $1 AND i.indrelid = to_regclass($2)`
+
+	var (
+		unique    bool
+		valid     bool
+		indnatts  int
+		indexDef  string
+		predicate string
+	)
+
+	row := c.db.QueryRowContext(ctx, query,
+		datastore.HealthEventIdempotencyIndexName, healthEventsTableName)
+
+	if err := row.Scan(&unique, &valid, &indnatts, &indexDef, &predicate); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("%w: index %s not found on table %s",
+				datastore.ErrIndexMissing, datastore.HealthEventIdempotencyIndexName,
+				healthEventsTableName)
+		}
+
+		return fmt.Errorf("failed to query index definition for %s: %w",
+			datastore.HealthEventIdempotencyIndexName, err)
+	}
+
+	return verifyPostgresIdempotencyIndexDefinition(unique, valid, indnatts, indexDef, predicate)
+}
+
+// normalizeIndexSQL strips what pg_get_indexdef and pg_get_expr add around
+// the expression we created (parentheses, the text[] cast, whitespace) so an
+// expression can be compared whole: another rendering of the same expression
+// compares equal, a wrapped expression or an extra predicate term does not.
+// Single-quoted literals are kept verbatim, so a JSON path that differs only
+// inside its quotes (extra parentheses or spaces) does not compare equal. Case
+// is kept too: PostgreSQL renders keywords in upper case, as the expected
+// strings do, and the quoted JSON path is case-sensitive.
+func normalizeIndexSQL(sql string) string {
+	sql = strings.ReplaceAll(sql, "::text[]", "")
+
+	var out strings.Builder
+
+	inLiteral := false
+
+	for i := range len(sql) {
+		c := sql[i]
+
+		switch {
+		case c == '\'':
+			// A doubled quote inside a literal toggles twice and stays inside.
+			inLiteral = !inLiteral
+
+			out.WriteByte(c)
+		case inLiteral:
+			out.WriteByte(c)
+		case c == '(' || c == ')' || c == ' ' || c == '\t' || c == '\n':
+		default:
+			out.WriteByte(c)
+		}
+	}
+
+	return out.String()
+}
+
+// indexKeyList extracts the indexed key list from a pg_get_indexdef result:
+// what follows the access method (or the table, when no USING clause is
+// present) up to the WHERE clause.
+func indexKeyList(indexDef string) string {
+	keys := indexDef
+	if i := strings.Index(keys, " WHERE "); i >= 0 {
+		keys = keys[:i]
+	}
+
+	marker := " USING "
+	if !strings.Contains(keys, marker) {
+		marker = " ON "
+	}
+
+	if i := strings.Index(keys, marker); i >= 0 {
+		keys = keys[i+len(marker):]
+		// Skip the access method (or the table name).
+		if j := strings.Index(keys, " "); j >= 0 {
+			keys = keys[j+1:]
+		}
+	}
+
+	return keys
+}
+
+// verifyPostgresIdempotencyIndexDefinition checks the catalog view of the
+// idempotency index against the definition Ensure creates: exactly one key,
+// the bare idempotency key expression (not wrapped in another expression),
+// unique, and a predicate of exactly "key IS NOT NULL" (no extra terms, which
+// would leave rows outside the index).
+func verifyPostgresIdempotencyIndexDefinition(unique, valid bool, indnatts int, indexDef, predicate string) error {
+	expectedKey := normalizeIndexSQL(fmt.Sprintf("(document #>> '%s')", healthEventIdempotencyKeyJSONPath))
+	expectedPredicate := normalizeIndexSQL(
+		fmt.Sprintf("(document #>> '%s') IS NOT NULL", healthEventIdempotencyKeyJSONPath))
+
+	if !unique {
+		return fmt.Errorf("%w: index %s is not unique",
+			datastore.ErrIndexMismatch, datastore.HealthEventIdempotencyIndexName)
+	}
+
+	if indnatts != 1 {
+		return fmt.Errorf("%w: index %s indexes %d columns instead of exactly the idempotency key",
+			datastore.ErrIndexMismatch, datastore.HealthEventIdempotencyIndexName, indnatts)
+	}
+
+	if normalizeIndexSQL(indexKeyList(indexDef)) != expectedKey {
+		return fmt.Errorf("%w: index %s does not index exactly the idempotency key path %s",
+			datastore.ErrIndexMismatch, datastore.HealthEventIdempotencyIndexName,
+			healthEventIdempotencyKeyJSONPath)
+	}
+
+	if predicate == "" {
+		return fmt.Errorf("%w: index %s is not a partial index",
+			datastore.ErrIndexMismatch, datastore.HealthEventIdempotencyIndexName)
+	}
+
+	if normalizeIndexSQL(predicate) != expectedPredicate {
+		return fmt.Errorf("%w: index %s partial predicate is not exactly the idempotency key IS NOT NULL",
+			datastore.ErrIndexMismatch, datastore.HealthEventIdempotencyIndexName)
+	}
+
+	if !valid {
+		return fmt.Errorf("%w: index %s is not valid (concurrent build still running or failed)",
+			datastore.ErrIndexMismatch, datastore.HealthEventIdempotencyIndexName)
+	}
+
+	return nil
+}

--- a/store-client/pkg/client/postgresql_idempotency_test.go
+++ b/store-client/pkg/client/postgresql_idempotency_test.go
@@ -1,0 +1,559 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nvidia/nvsentinel/store-client/pkg/datastore"
+)
+
+func TestClassifyPostgresDocumentError(t *testing.T) {
+	t.Run("unique violation is a duplicate with the constraint name", func(t *testing.T) {
+		pqErr := &pq.Error{
+			Code:       pqUniqueViolationCode,
+			Constraint: datastore.HealthEventIdempotencyIndexName,
+			Message:    "duplicate key value violates unique constraint",
+		}
+
+		docErr, answered := ClassifyPostgresDocumentError(3, pqErr)
+		require.True(t, answered)
+		assert.Equal(t, 3, docErr.DocumentIndex)
+		assert.True(t, docErr.Duplicate)
+		assert.Equal(t, datastore.HealthEventIdempotencyIndexName, docErr.IndexName)
+		assert.Equal(t, pqErr.Message, docErr.Message)
+	})
+
+	t.Run("wrapped unique violation is classified", func(t *testing.T) {
+		pqErr := &pq.Error{Code: pqUniqueViolationCode, Constraint: "some_index"}
+		wrapped := fmt.Errorf("failed to insert document: %w", pqErr)
+
+		docErr, answered := ClassifyPostgresDocumentError(0, wrapped)
+		require.True(t, answered)
+		assert.True(t, docErr.Duplicate)
+		assert.Equal(t, "some_index", docErr.IndexName)
+	})
+
+	t.Run("an error that is not the server's answer about the document is not classified", func(t *testing.T) {
+		_, answered := ClassifyPostgresDocumentError(0, errors.New("connection reset"))
+		assert.False(t, answered)
+	})
+
+	t.Run("other SQLSTATE codes are not duplicates", func(t *testing.T) {
+		pqErr := &pq.Error{Code: "23502", Message: "null value in column"}
+
+		docErr, answered := ClassifyPostgresDocumentError(1, pqErr)
+		require.True(t, answered)
+		assert.False(t, docErr.Duplicate)
+		assert.Empty(t, docErr.IndexName)
+	})
+
+	t.Run("a data exception is an answer about the document", func(t *testing.T) {
+		pqErr := &pq.Error{Code: "22P02", Message: "invalid input syntax for type json"}
+
+		docErr, answered := ClassifyPostgresDocumentError(2, pqErr)
+		require.True(t, answered)
+		assert.Equal(t, 2, docErr.DocumentIndex)
+		assert.False(t, docErr.Duplicate)
+	})
+
+	t.Run("a server shutdown is not an answer about the document", func(t *testing.T) {
+		pqErr := &pq.Error{Code: "57P01", Message: "terminating connection due to administrator command"}
+
+		_, answered := ClassifyPostgresDocumentError(0, pqErr)
+		assert.False(t, answered, "SQLSTATE class 57 concerns the server, so the whole batch must fail")
+	})
+
+	t.Run("a connection failure is not an answer about the document", func(t *testing.T) {
+		pqErr := &pq.Error{Code: "08006", Message: "connection failure"}
+
+		_, answered := ClassifyPostgresDocumentError(0, pqErr)
+		assert.False(t, answered, "SQLSTATE class 08 concerns the connection, so the whole batch must fail")
+	})
+}
+
+// TestInsertManyIdempotentWith_ServerShutdownFailsTheBatch: a server that goes
+// away in the middle of a batch has answered nothing about the document it was
+// asked to store, so the batch fails as a datastore failure rather than as a
+// per-document one: the caller retries the whole batch instead of treating
+// the shutdown as a constraint violation.
+func TestInsertManyIdempotentWith_ServerShutdownFailsTheBatch(t *testing.T) {
+	calls := 0
+	insertOne := func(_ context.Context, _ any) (string, error) {
+		calls++
+		if calls == 2 {
+			return "", &pq.Error{Code: "57P01", Message: "terminating connection due to administrator command"}
+		}
+
+		return fmt.Sprintf("id-%d", calls), nil
+	}
+
+	_, err := InsertManyIdempotentWith(context.Background(), []any{"a", "b", "c"}, insertOne)
+	require.Error(t, err)
+
+	_, perDocument := datastore.AsBulkWriteFailure(err)
+	assert.False(t, perDocument, "a shutdown is a datastore failure, not a per-document answer")
+	assert.Equal(t, 2, calls, "the insert stops at the failure")
+}
+
+// TestNormalizeIndexSQL_KeepsLiterals: only SQL syntax outside single-quoted
+// literals is normalized away, so a JSON path that differs inside its quotes
+// stays different.
+func TestNormalizeIndexSQL_KeepsLiterals(t *testing.T) {
+	assert.Equal(t, "document#>>'{a,b (c)}'", normalizeIndexSQL("((document #>> '{a,b (c)}'::text[]))"))
+	assert.Equal(t, "'it''s ( x )'ISNOTNULL", normalizeIndexSQL("('it''s ( x )') IS NOT NULL"))
+	assert.NotEqual(t, normalizeIndexSQL("(document #>> '{a,b}')"), normalizeIndexSQL("(document #>> '{a,(b)}')"))
+}
+
+func TestPostgreSQLClientInsertManyIdempotent(t *testing.T) {
+	newClient := func(t *testing.T) (*PostgreSQLClient, sqlmock.Sqlmock) {
+		t.Helper()
+
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		t.Cleanup(func() { db.Close() })
+
+		return NewPostgreSQLClientFromDB(db, healthEventsTableName), mock
+	}
+
+	insertQuery := "INSERT INTO health_events (document) VALUES ($1) RETURNING id"
+
+	t.Run("empty input returns empty result", func(t *testing.T) {
+		client, _ := newClient(t)
+
+		result, err := client.InsertManyIdempotent(context.Background(), []any{})
+		require.NoError(t, err)
+		assert.Empty(t, result.InsertedIDs)
+	})
+
+	t.Run("all documents inserted", func(t *testing.T) {
+		client, mock := newClient(t)
+		mock.ExpectQuery(insertQuery).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("id-1"))
+		mock.ExpectQuery(insertQuery).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("id-2"))
+
+		result, err := client.InsertManyIdempotent(context.Background(),
+			[]any{map[string]any{"a": 1}, map[string]any{"b": 2}})
+		require.NoError(t, err)
+		assert.Equal(t, []any{"id-1", "id-2"}, result.InsertedIDs)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("duplicate does not stop the remaining inserts", func(t *testing.T) {
+		client, mock := newClient(t)
+		mock.ExpectQuery(insertQuery).WillReturnError(&pq.Error{
+			Code:       pqUniqueViolationCode,
+			Constraint: datastore.HealthEventIdempotencyIndexName,
+			Message:    "duplicate key value violates unique constraint",
+		})
+		mock.ExpectQuery(insertQuery).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("id-2"))
+
+		result, err := client.InsertManyIdempotent(context.Background(),
+			[]any{map[string]any{"a": 1}, map[string]any{"b": 2}})
+		require.NoError(t, err, "a resend is a success, not a failure")
+		assert.Equal(t, []any{"id-2"}, result.InsertedIDs)
+		assert.Equal(t, 1, result.DuplicateCount)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("a server answer that is not a duplicate stops the insert so the retry stores the rest in order",
+		func(t *testing.T) {
+			client, mock := newClient(t)
+			mock.ExpectQuery(insertQuery).WillReturnError(&pq.Error{
+				Code:       pqUniqueViolationCode,
+				Constraint: datastore.HealthEventIdempotencyIndexName,
+			})
+			mock.ExpectQuery(insertQuery).WillReturnError(&pq.Error{Code: "23514", Message: "check constraint violated"})
+			// No expectation for the third document: it must not be attempted.
+
+			_, err := client.InsertManyIdempotent(context.Background(),
+				[]any{map[string]any{"a": 1}, map[string]any{"b": 2}, map[string]any{"c": 3}})
+			require.Error(t, err)
+
+			failure, ok := datastore.AsBulkWriteFailure(err)
+			require.True(t, ok)
+			assert.Equal(t, 0, failure.InsertedCount)
+			assert.Equal(t, 1, failure.DuplicateCount)
+			assert.Equal(t, 1, failure.Failed.DocumentIndex)
+			assert.False(t, failure.Failed.Duplicate)
+			assert.Contains(t, err.Error(), "check constraint violated", "the server's answer survives into the error")
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+
+	t.Run("a transport failure fails the whole batch, as it does for MongoDB", func(t *testing.T) {
+		client, mock := newClient(t)
+		mock.ExpectQuery(insertQuery).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("id-1"))
+		mock.ExpectQuery(insertQuery).WillReturnError(errors.New("connection reset"))
+		// No expectation for the third document: it must not be attempted.
+
+		_, err := client.InsertManyIdempotent(context.Background(),
+			[]any{map[string]any{"a": 1}, map[string]any{"b": 2}, map[string]any{"c": 3}})
+		require.Error(t, err)
+
+		_, perDocument := datastore.AsBulkWriteFailure(err)
+		assert.False(t, perDocument, "not an answer about a document")
+		assert.Contains(t, err.Error(), "connection reset")
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("a duplicate on another unique index stops the insert", func(t *testing.T) {
+		client, mock := newClient(t)
+		mock.ExpectQuery(insertQuery).WillReturnError(&pq.Error{
+			Code:       pqUniqueViolationCode,
+			Constraint: "health_events_pkey",
+		})
+
+		_, err := client.InsertManyIdempotent(context.Background(),
+			[]any{map[string]any{"a": 1}, map[string]any{"b": 2}})
+		require.Error(t, err)
+
+		failure, ok := datastore.AsBulkWriteFailure(err)
+		require.True(t, ok)
+		assert.True(t, failure.Failed.Duplicate)
+		assert.Equal(t, "health_events_pkey", failure.Failed.IndexName)
+		assert.Contains(t, err.Error(), `duplicate on index "health_events_pkey"`)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestPostgreSQLClientEnsureHealthEventIdempotencyIndex(t *testing.T) {
+	createStatement := regexp.QuoteMeta(
+		"CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS healthevent_idempotency_key_unique ON health_events " +
+			"((document #>> '{healthevent,metadata,idempotencyKey}')) " +
+			"WHERE (document #>> '{healthevent,metadata,idempotencyKey}') IS NOT NULL")
+	dropStatement := regexp.QuoteMeta("DROP INDEX CONCURRENTLY IF EXISTS healthevent_idempotency_key_unique")
+	progressQuery := "pg_stat_progress_create_index"
+	progressColumns := []string{"building"}
+
+	verifyQuery := "SELECT i.indisunique"
+	verifyColumns := []string{"indisunique", "indisvalid", "indnatts", "indexdef", "predicate"}
+	validIndexDef := "CREATE UNIQUE INDEX healthevent_idempotency_key_unique ON public.health_events " +
+		"USING btree (((document #>> '{healthevent,metadata,idempotencyKey}'::text[]))) " +
+		"WHERE ((document #>> '{healthevent,metadata,idempotencyKey}'::text[]) IS NOT NULL)"
+	validPredicate := "((document #>> '{healthevent,metadata,idempotencyKey}'::text[]) IS NOT NULL)"
+
+	expectIndex := func(mock sqlmock.Sqlmock, valid bool, predicate string) {
+		mock.ExpectQuery(verifyQuery).
+			WithArgs(datastore.HealthEventIdempotencyIndexName, healthEventsTableName).
+			WillReturnRows(sqlmock.NewRows(verifyColumns).AddRow(true, valid, 1, validIndexDef, predicate))
+	}
+	expectMissing := func(mock sqlmock.Sqlmock) {
+		mock.ExpectQuery(verifyQuery).
+			WithArgs(datastore.HealthEventIdempotencyIndexName, healthEventsTableName).
+			WillReturnRows(sqlmock.NewRows(verifyColumns))
+	}
+	expectBuilding := func(mock sqlmock.Sqlmock, building bool) {
+		mock.ExpectQuery(progressQuery).
+			WithArgs(datastore.HealthEventIdempotencyIndexName, healthEventsTableName).
+			WillReturnRows(sqlmock.NewRows(progressColumns).AddRow(building))
+	}
+
+	newClient := func(t *testing.T) (*PostgreSQLClient, sqlmock.Sqlmock) {
+		t.Helper()
+
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		t.Cleanup(func() { db.Close() })
+
+		return NewPostgreSQLClientFromDB(db, healthEventsTableName), mock
+	}
+
+	t.Run("missing index is created concurrently", func(t *testing.T) {
+		client, mock := newClient(t)
+		expectMissing(mock)
+		mock.ExpectExec(createStatement).WillReturnResult(sqlmock.NewResult(0, 0))
+		expectIndex(mock, true, validPredicate)
+
+		require.NoError(t, client.EnsureHealthEventIdempotencyIndex(context.Background()))
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("index with the expected definition is left alone", func(t *testing.T) {
+		client, mock := newClient(t)
+		expectIndex(mock, true, validPredicate)
+
+		require.NoError(t, client.EnsureHealthEventIdempotencyIndex(context.Background()))
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("invalid leftover index is dropped concurrently and recreated", func(t *testing.T) {
+		client, mock := newClient(t)
+		expectIndex(mock, false, validPredicate)
+		expectBuilding(mock, false)
+		mock.ExpectExec(dropStatement).WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec(createStatement).WillReturnResult(sqlmock.NewResult(0, 0))
+		expectIndex(mock, true, validPredicate)
+
+		require.NoError(t, client.EnsureHealthEventIdempotencyIndex(context.Background()))
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("index still being built by another session is left alone", func(t *testing.T) {
+		client, mock := newClient(t)
+		expectIndex(mock, false, validPredicate)
+		expectBuilding(mock, true)
+
+		err := client.EnsureHealthEventIdempotencyIndex(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "still being built")
+		assert.ErrorIs(t, err, datastore.ErrIndexMismatch)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("valid index with another definition is replaced", func(t *testing.T) {
+		client, mock := newClient(t)
+		expectIndex(mock, true, "(((document #>> '{healthevent,metadata,idempotencyKey}'::text[]) IS NOT NULL) AND (node_name = 'node-a'::text))")
+		expectBuilding(mock, false)
+		mock.ExpectExec(dropStatement).WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec(createStatement).WillReturnResult(sqlmock.NewResult(0, 0))
+		expectIndex(mock, true, validPredicate)
+
+		require.NoError(t, client.EnsureHealthEventIdempotencyIndex(context.Background()))
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("failed drop is returned and the create is not attempted", func(t *testing.T) {
+		client, mock := newClient(t)
+		expectIndex(mock, false, validPredicate)
+		expectBuilding(mock, false)
+		mock.ExpectExec(dropStatement).WillReturnError(errors.New("lock timeout"))
+
+		err := client.EnsureHealthEventIdempotencyIndex(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to drop mismatched idempotency index")
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("aborted concurrent build is reported so the caller retries", func(t *testing.T) {
+		client, mock := newClient(t)
+		expectMissing(mock)
+		mock.ExpectExec(createStatement).WillReturnResult(sqlmock.NewResult(0, 0))
+		expectIndex(mock, false, validPredicate)
+
+		err := client.EnsureHealthEventIdempotencyIndex(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not usable after the build")
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("datastore failure during the check is returned", func(t *testing.T) {
+		client, mock := newClient(t)
+		mock.ExpectQuery(verifyQuery).
+			WithArgs(datastore.HealthEventIdempotencyIndexName, healthEventsTableName).
+			WillReturnError(errors.New("connection refused"))
+
+		err := client.EnsureHealthEventIdempotencyIndex(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to check idempotency index")
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestPostgreSQLClientVerifyHealthEventIdempotencyIndex(t *testing.T) {
+	validIndexDef := "CREATE UNIQUE INDEX healthevent_idempotency_key_unique ON public.health_events " +
+		"USING btree (((document #>> '{healthevent,metadata,idempotencyKey}'::text[]))) " +
+		"WHERE ((document #>> '{healthevent,metadata,idempotencyKey}'::text[]) IS NOT NULL)"
+	validPredicate := "((document #>> '{healthevent,metadata,idempotencyKey}'::text[]) IS NOT NULL)"
+
+	newClient := func(t *testing.T) (*PostgreSQLClient, sqlmock.Sqlmock) {
+		t.Helper()
+
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		t.Cleanup(func() { db.Close() })
+
+		return NewPostgreSQLClientFromDB(db, healthEventsTableName), mock
+	}
+
+	columns := []string{"indisunique", "indisvalid", "indnatts", "indexdef", "predicate"}
+
+	t.Run("matching index passes", func(t *testing.T) {
+		client, mock := newClient(t)
+		mock.ExpectQuery("SELECT i.indisunique").
+			WithArgs(datastore.HealthEventIdempotencyIndexName, healthEventsTableName).
+			WillReturnRows(
+				sqlmock.NewRows(columns).AddRow(true, true, 1, validIndexDef, validPredicate))
+
+		assert.NoError(t, client.VerifyHealthEventIdempotencyIndex(context.Background()))
+	})
+
+	t.Run("table is resolved through the search_path via to_regclass", func(t *testing.T) {
+		client, mock := newClient(t)
+		mock.ExpectQuery(`i\.indrelid = to_regclass\(\$2\)`).
+			WithArgs(datastore.HealthEventIdempotencyIndexName, healthEventsTableName).
+			WillReturnRows(
+				sqlmock.NewRows(columns).AddRow(true, true, 1, validIndexDef, validPredicate))
+
+		assert.NoError(t, client.VerifyHealthEventIdempotencyIndex(context.Background()))
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("missing index yields ErrIndexMissing", func(t *testing.T) {
+		client, mock := newClient(t)
+		mock.ExpectQuery("SELECT i.indisunique").WillReturnRows(sqlmock.NewRows(columns))
+
+		err := client.VerifyHealthEventIdempotencyIndex(context.Background())
+		assert.ErrorIs(t, err, datastore.ErrIndexMissing)
+	})
+
+	t.Run("invalid index yields ErrIndexMismatch", func(t *testing.T) {
+		client, mock := newClient(t)
+		mock.ExpectQuery("SELECT i.indisunique").WillReturnRows(
+			sqlmock.NewRows(columns).AddRow(true, false, 1, validIndexDef, validPredicate))
+
+		err := client.VerifyHealthEventIdempotencyIndex(context.Background())
+		assert.ErrorIs(t, err, datastore.ErrIndexMismatch)
+	})
+
+	t.Run("composite index containing the expression yields ErrIndexMismatch", func(t *testing.T) {
+		client, mock := newClient(t)
+		compositeIndexDef := "CREATE UNIQUE INDEX healthevent_idempotency_key_unique ON public.health_events " +
+			"USING btree (((document #>> '{healthevent,metadata,idempotencyKey}'::text[])), node_name) " +
+			"WHERE ((document #>> '{healthevent,metadata,idempotencyKey}'::text[]) IS NOT NULL)"
+		mock.ExpectQuery("SELECT i.indisunique").WillReturnRows(
+			sqlmock.NewRows(columns).AddRow(true, true, 2, compositeIndexDef, validPredicate))
+
+		err := client.VerifyHealthEventIdempotencyIndex(context.Background())
+		assert.ErrorIs(t, err, datastore.ErrIndexMismatch)
+	})
+}
+
+func TestVerifyPostgresIdempotencyIndexDefinition(t *testing.T) {
+	validIndexDef := "CREATE UNIQUE INDEX healthevent_idempotency_key_unique ON public.health_events " +
+		"USING btree (((document #>> '{healthevent,metadata,idempotencyKey}'::text[]))) " +
+		"WHERE ((document #>> '{healthevent,metadata,idempotencyKey}'::text[]) IS NOT NULL)"
+	validPredicate := "((document #>> '{healthevent,metadata,idempotencyKey}'::text[]) IS NOT NULL)"
+
+	tests := []struct {
+		name      string
+		unique    bool
+		valid     bool
+		indnatts  int
+		indexDef  string
+		predicate string
+		wantErr   error
+	}{
+		{
+			name:   "matching definition",
+			unique: true, valid: true, indnatts: 1, indexDef: validIndexDef, predicate: validPredicate,
+			wantErr: nil,
+		},
+		{
+			name:   "not unique",
+			unique: false, valid: true, indnatts: 1, indexDef: validIndexDef, predicate: validPredicate,
+			wantErr: datastore.ErrIndexMismatch,
+		},
+		{
+			name:   "composite index containing the key expression",
+			unique: true, valid: true, indnatts: 2,
+			indexDef:  validIndexDef,
+			predicate: validPredicate,
+			wantErr:   datastore.ErrIndexMismatch,
+		},
+		{
+			name:   "wrong key expression",
+			unique: true, valid: true, indnatts: 1,
+			indexDef:  "CREATE UNIQUE INDEX healthevent_idempotency_key_unique ON health_events (node_name)",
+			predicate: validPredicate,
+			wantErr:   datastore.ErrIndexMismatch,
+		},
+		{
+			name:   "not partial",
+			unique: true, valid: true, indnatts: 1, indexDef: validIndexDef, predicate: "",
+			wantErr: datastore.ErrIndexMismatch,
+		},
+		{
+			name:   "wrapped key expression",
+			unique: true, valid: true, indnatts: 1,
+			indexDef: "CREATE UNIQUE INDEX healthevent_idempotency_key_unique ON public.health_events " +
+				"USING btree (\"left\"((document #>> '{healthevent,metadata,idempotencyKey}'::text[]), 1)) " +
+				"WHERE ((document #>> '{healthevent,metadata,idempotencyKey}'::text[]) IS NOT NULL)",
+			predicate: validPredicate,
+			wantErr:   datastore.ErrIndexMismatch,
+		},
+		{
+			name:   "extra predicate term",
+			unique: true, valid: true, indnatts: 1, indexDef: validIndexDef,
+			predicate: "(((document #>> '{healthevent,metadata,idempotencyKey}'::text[]) IS NOT NULL) " +
+				"AND (node_name = 'node-a'::text))",
+			wantErr: datastore.ErrIndexMismatch,
+		},
+		{
+			name:   "wrong-case key path",
+			unique: true, valid: true, indnatts: 1,
+			indexDef: "CREATE UNIQUE INDEX healthevent_idempotency_key_unique ON public.health_events " +
+				"USING btree (((document #>> '{healthevent,metadata,idempotencykey}'::text[]))) " +
+				"WHERE ((document #>> '{healthevent,metadata,idempotencykey}'::text[]) IS NOT NULL)",
+			predicate: "((document #>> '{healthevent,metadata,idempotencykey}'::text[]) IS NOT NULL)",
+			wantErr:   datastore.ErrIndexMismatch,
+		},
+		{
+			name:   "parentheses inside the key literal",
+			unique: true, valid: true, indnatts: 1,
+			indexDef: "CREATE UNIQUE INDEX healthevent_idempotency_key_unique ON public.health_events " +
+				"USING btree (((document #>> '{healthevent,metadata,idempotency(Key)}'::text[]))) " +
+				"WHERE ((document #>> '{healthevent,metadata,idempotency(Key)}'::text[]) IS NOT NULL)",
+			predicate: "((document #>> '{healthevent,metadata,idempotency(Key)}'::text[]) IS NOT NULL)",
+			wantErr:   datastore.ErrIndexMismatch,
+		},
+		{
+			name:   "whitespace inside the key literal",
+			unique: true, valid: true, indnatts: 1,
+			indexDef: "CREATE UNIQUE INDEX healthevent_idempotency_key_unique ON public.health_events " +
+				"USING btree (((document #>> '{healthevent,metadata,idempotency Key}'::text[]))) " +
+				"WHERE ((document #>> '{healthevent,metadata,idempotency Key}'::text[]) IS NOT NULL)",
+			predicate: "((document #>> '{healthevent,metadata,idempotency Key}'::text[]) IS NOT NULL)",
+			wantErr:   datastore.ErrIndexMismatch,
+		},
+		{
+			name:   "same definition rendered without casts",
+			unique: true, valid: true, indnatts: 1,
+			indexDef: "CREATE UNIQUE INDEX healthevent_idempotency_key_unique ON health_events " +
+				"((document #>> '{healthevent,metadata,idempotencyKey}')) " +
+				"WHERE (document #>> '{healthevent,metadata,idempotencyKey}') IS NOT NULL",
+			predicate: "(document #>> '{healthevent,metadata,idempotencyKey}') IS NOT NULL",
+		},
+		{
+			name:   "wrong predicate",
+			unique: true, valid: true, indnatts: 1, indexDef: validIndexDef,
+			predicate: "(node_name IS NOT NULL)",
+			wantErr:   datastore.ErrIndexMismatch,
+		},
+		{
+			name:   "invalid build",
+			unique: true, valid: false, indnatts: 1, indexDef: validIndexDef, predicate: validPredicate,
+			wantErr: datastore.ErrIndexMismatch,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := verifyPostgresIdempotencyIndexDefinition(tt.unique, tt.valid, tt.indnatts, tt.indexDef, tt.predicate)
+			if tt.wantErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/store-client/pkg/client/postgresql_idempotency_test.go
+++ b/store-client/pkg/client/postgresql_idempotency_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/lib/pq"
+	"github.com/lib/pq/pqerror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -32,7 +33,7 @@ import (
 func TestClassifyPostgresDocumentError(t *testing.T) {
 	t.Run("unique violation is a duplicate with the constraint name", func(t *testing.T) {
 		pqErr := &pq.Error{
-			Code:       pqUniqueViolationCode,
+			Code:       pqerror.UniqueViolation,
 			Constraint: datastore.HealthEventIdempotencyIndexName,
 			Message:    "duplicate key value violates unique constraint",
 		}
@@ -46,7 +47,7 @@ func TestClassifyPostgresDocumentError(t *testing.T) {
 	})
 
 	t.Run("wrapped unique violation is classified", func(t *testing.T) {
-		pqErr := &pq.Error{Code: pqUniqueViolationCode, Constraint: "some_index"}
+		pqErr := &pq.Error{Code: pqerror.UniqueViolation, Constraint: "some_index"}
 		wrapped := fmt.Errorf("failed to insert document: %w", pqErr)
 
 		docErr, answered := ClassifyPostgresDocumentError(0, wrapped)
@@ -139,6 +140,18 @@ func TestPostgreSQLClientInsertManyIdempotent(t *testing.T) {
 
 	insertQuery := "INSERT INTO health_events (document) VALUES ($1) RETURNING id"
 
+	t.Run("a client for another table is refused before any insert", func(t *testing.T) {
+		db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+		require.NoError(t, err)
+		t.Cleanup(func() { db.Close() })
+
+		_, err = NewPostgreSQLClientFromDB(db, "maintenance_events").InsertManyIdempotent(context.Background(),
+			[]any{map[string]any{"a": 1}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), healthEventsTableName, "the index lives on the health events table")
+		assert.NoError(t, mock.ExpectationsWereMet(), "nothing was sent to the database")
+	})
+
 	t.Run("empty input returns empty result", func(t *testing.T) {
 		client, _ := newClient(t)
 
@@ -162,7 +175,7 @@ func TestPostgreSQLClientInsertManyIdempotent(t *testing.T) {
 	t.Run("duplicate does not stop the remaining inserts", func(t *testing.T) {
 		client, mock := newClient(t)
 		mock.ExpectQuery(insertQuery).WillReturnError(&pq.Error{
-			Code:       pqUniqueViolationCode,
+			Code:       pqerror.UniqueViolation,
 			Constraint: datastore.HealthEventIdempotencyIndexName,
 			Message:    "duplicate key value violates unique constraint",
 		})
@@ -180,7 +193,7 @@ func TestPostgreSQLClientInsertManyIdempotent(t *testing.T) {
 		func(t *testing.T) {
 			client, mock := newClient(t)
 			mock.ExpectQuery(insertQuery).WillReturnError(&pq.Error{
-				Code:       pqUniqueViolationCode,
+				Code:       pqerror.UniqueViolation,
 				Constraint: datastore.HealthEventIdempotencyIndexName,
 			})
 			mock.ExpectQuery(insertQuery).WillReturnError(&pq.Error{Code: "23514", Message: "check constraint violated"})
@@ -219,7 +232,7 @@ func TestPostgreSQLClientInsertManyIdempotent(t *testing.T) {
 	t.Run("a duplicate on another unique index stops the insert", func(t *testing.T) {
 		client, mock := newClient(t)
 		mock.ExpectQuery(insertQuery).WillReturnError(&pq.Error{
-			Code:       pqUniqueViolationCode,
+			Code:       pqerror.UniqueViolation,
 			Constraint: "health_events_pkey",
 		})
 

--- a/store-client/pkg/client/resume_token_test.go
+++ b/store-client/pkg/client/resume_token_test.go
@@ -38,6 +38,18 @@ func (m *mockResumeTokenDBClient) InsertMany(context.Context, []any) (*InsertMan
 	return nil, nil
 }
 
+func (m *mockResumeTokenDBClient) InsertManyIdempotent(context.Context, []any) (*InsertManyResult, error) {
+	return nil, nil
+}
+
+func (m *mockResumeTokenDBClient) EnsureHealthEventIdempotencyIndex(context.Context) error {
+	return nil
+}
+
+func (m *mockResumeTokenDBClient) VerifyHealthEventIdempotencyIndex(context.Context) error {
+	return nil
+}
+
 func (m *mockResumeTokenDBClient) UpdateDocumentStatus(context.Context, string, string, any) error {
 	return nil
 }

--- a/store-client/pkg/config/env_loader_test.go
+++ b/store-client/pkg/config/env_loader_test.go
@@ -102,3 +102,24 @@ func TestNewPostgreSQLCompatibleConfig_PasswordWithExplicitCA_QuotesCAAndExclude
 		t.Errorf("expected explicit CA-only password authentication not to infer client certificates, got: %s", uri)
 	}
 }
+
+// TestNewDatabaseConfigFromEnv_AppName locks the seam the platform connector
+// write path depends on: APP_NAME must surface through GetAppName so the
+// MongoDB driver appName identifies the client (daemonset and deployment
+// platform connector alike) in currentOp and server logs.
+func TestNewDatabaseConfigFromEnv_AppName(t *testing.T) {
+	t.Setenv("DATASTORE_PROVIDER", "mongodb")
+	t.Setenv("MONGODB_URI", "mongodb://example.invalid:27017/")
+	t.Setenv("MONGODB_DATABASE_NAME", "testdb")
+	t.Setenv("MONGODB_COLLECTION_NAME", "HealthEvents")
+	t.Setenv("APP_NAME", "platform-connector-deployment")
+
+	cfg, err := NewDatabaseConfigFromEnvWithDefaults("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := cfg.GetAppName(); got != "platform-connector-deployment" {
+		t.Errorf("expected GetAppName to surface APP_NAME, got: %q", got)
+	}
+}

--- a/store-client/pkg/datastore/config.go
+++ b/store-client/pkg/datastore/config.go
@@ -196,6 +196,31 @@ func setGenericPort(config *DataStoreConfig) {
 	}
 }
 
+// MaxConnections resolves the connection pool bound both providers apply: the
+// maxConnections option when it is set (LoadDatastoreConfig fills it from
+// DATASTORE_MAX_CONNECTIONS), otherwise DATASTORE_MAX_CONNECTIONS read
+// directly, for the paths that build a client without a DataStoreConfig. Zero
+// means unset, and the provider keeps its own default. A value that is not a
+// positive integer is ignored with a warning.
+func MaxConnections(options map[string]string) int {
+	for _, raw := range []string{options["maxConnections"], os.Getenv("DATASTORE_MAX_CONNECTIONS")} {
+		if raw == "" {
+			continue
+		}
+
+		size, err := strconv.Atoi(raw)
+		if err != nil || size <= 0 {
+			slog.Warn("Ignoring invalid max connections value", "value", raw)
+
+			continue
+		}
+
+		return size
+	}
+
+	return 0
+}
+
 // loadOptionsFromEnv loads options from environment variables
 func loadOptionsFromEnv(config *DataStoreConfig) {
 	config.Options = make(map[string]string)

--- a/store-client/pkg/datastore/config_test.go
+++ b/store-client/pkg/datastore/config_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadDatastoreConfigPoolOptions(t *testing.T) {
+	t.Run("max connections environment variable populates Options", func(t *testing.T) {
+		t.Setenv("DATASTORE_PROVIDER", string(ProviderMongoDB))
+		t.Setenv("DATASTORE_MAX_CONNECTIONS", "30")
+
+		config, err := LoadDatastoreConfig()
+		require.NoError(t, err)
+		assert.Equal(t, "30", config.Options["maxConnections"])
+	})
+
+	t.Run("unset max connections leaves Options empty", func(t *testing.T) {
+		t.Setenv("DATASTORE_PROVIDER", string(ProviderPostgreSQL))
+		t.Setenv("DATASTORE_MAX_CONNECTIONS", "")
+
+		config, err := LoadDatastoreConfig()
+		require.NoError(t, err)
+		assert.NotContains(t, config.Options, "maxConnections")
+	})
+}
+
+func TestMaxConnections(t *testing.T) {
+	t.Run("nothing configured means the provider default", func(t *testing.T) {
+		t.Setenv("DATASTORE_MAX_CONNECTIONS", "")
+		assert.Equal(t, 0, MaxConnections(nil))
+		assert.Equal(t, 0, MaxConnections(map[string]string{}))
+	})
+
+	t.Run("the option wins over the environment", func(t *testing.T) {
+		t.Setenv("DATASTORE_MAX_CONNECTIONS", "40")
+		assert.Equal(t, 10, MaxConnections(map[string]string{"maxConnections": "10"}))
+	})
+
+	t.Run("the environment is the fallback", func(t *testing.T) {
+		t.Setenv("DATASTORE_MAX_CONNECTIONS", "40")
+		assert.Equal(t, 40, MaxConnections(nil))
+	})
+
+	t.Run("invalid values fall through", func(t *testing.T) {
+		t.Setenv("DATASTORE_MAX_CONNECTIONS", "40")
+		assert.Equal(t, 40, MaxConnections(map[string]string{"maxConnections": "abc"}))
+
+		t.Setenv("DATASTORE_MAX_CONNECTIONS", "-5")
+		assert.Equal(t, 0, MaxConnections(map[string]string{"maxConnections": "0"}))
+	})
+}

--- a/store-client/pkg/datastore/config_test.go
+++ b/store-client/pkg/datastore/config_test.go
@@ -21,48 +21,61 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLoadDatastoreConfigPoolOptions(t *testing.T) {
-	t.Run("max connections environment variable populates Options", func(t *testing.T) {
-		t.Setenv("DATASTORE_PROVIDER", string(ProviderMongoDB))
-		t.Setenv("DATASTORE_MAX_CONNECTIONS", "30")
+func TestLoadDatastoreConfig_MaxConnectionsEnv_PopulatesOptions(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider DataStoreProvider
+		env      string
+		wantSet  bool
+		want     string
+	}{
+		{name: "set value lands in the maxConnections option", provider: ProviderMongoDB, env: "30", wantSet: true, want: "30"},
+		{name: "unset leaves the option absent", provider: ProviderPostgreSQL, env: "", wantSet: false},
+	}
 
-		config, err := LoadDatastoreConfig()
-		require.NoError(t, err)
-		assert.Equal(t, "30", config.Options["maxConnections"])
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("DATASTORE_PROVIDER", string(tt.provider))
+			t.Setenv("DATASTORE_MAX_CONNECTIONS", tt.env)
 
-	t.Run("unset max connections leaves Options empty", func(t *testing.T) {
-		t.Setenv("DATASTORE_PROVIDER", string(ProviderPostgreSQL))
-		t.Setenv("DATASTORE_MAX_CONNECTIONS", "")
+			config, err := LoadDatastoreConfig()
+			require.NoError(t, err)
 
-		config, err := LoadDatastoreConfig()
-		require.NoError(t, err)
-		assert.NotContains(t, config.Options, "maxConnections")
-	})
+			got, set := config.Options["maxConnections"]
+			assert.Equal(t, tt.wantSet, set)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
-func TestMaxConnections(t *testing.T) {
-	t.Run("nothing configured means the provider default", func(t *testing.T) {
-		t.Setenv("DATASTORE_MAX_CONNECTIONS", "")
-		assert.Equal(t, 0, MaxConnections(nil))
-		assert.Equal(t, 0, MaxConnections(map[string]string{}))
-	})
+func TestMaxConnections_Precedence_OptionThenEnvironmentThenZero(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     string
+		options map[string]string
+		want    int
+	}{
+		{name: "nothing configured is zero, the provider default", env: "", options: nil, want: 0},
+		{name: "empty options and no environment is zero", env: "", options: map[string]string{}, want: 0},
+		{
+			name: "the option wins over the environment",
+			env:  "40", options: map[string]string{"maxConnections": "10"}, want: 10,
+		},
+		{name: "the environment is the fallback", env: "40", options: nil, want: 40},
+		{
+			name: "an invalid option falls through to the environment",
+			env:  "40", options: map[string]string{"maxConnections": "abc"}, want: 40,
+		},
+		{
+			name: "invalid values everywhere fall through to zero",
+			env:  "-5", options: map[string]string{"maxConnections": "0"}, want: 0,
+		},
+	}
 
-	t.Run("the option wins over the environment", func(t *testing.T) {
-		t.Setenv("DATASTORE_MAX_CONNECTIONS", "40")
-		assert.Equal(t, 10, MaxConnections(map[string]string{"maxConnections": "10"}))
-	})
-
-	t.Run("the environment is the fallback", func(t *testing.T) {
-		t.Setenv("DATASTORE_MAX_CONNECTIONS", "40")
-		assert.Equal(t, 40, MaxConnections(nil))
-	})
-
-	t.Run("invalid values fall through", func(t *testing.T) {
-		t.Setenv("DATASTORE_MAX_CONNECTIONS", "40")
-		assert.Equal(t, 40, MaxConnections(map[string]string{"maxConnections": "abc"}))
-
-		t.Setenv("DATASTORE_MAX_CONNECTIONS", "-5")
-		assert.Equal(t, 0, MaxConnections(map[string]string{"maxConnections": "0"}))
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("DATASTORE_MAX_CONNECTIONS", tt.env)
+			assert.Equal(t, tt.want, MaxConnections(tt.options))
+		})
+	}
 }

--- a/store-client/pkg/datastore/idempotency.go
+++ b/store-client/pkg/datastore/idempotency.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastore
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	// HealthEventIdempotencyKeyMetadataField is the health event metadata key that
+	// carries the server-derived per-event idempotency key. Documents that contain
+	// this field are covered by the partial unique idempotency index.
+	HealthEventIdempotencyKeyMetadataField = "idempotencyKey"
+
+	// HealthEventIdempotencyIndexName is the name of the unique partial index that
+	// enforces per-event idempotency keys on the health events collection/table.
+	HealthEventIdempotencyIndexName = "healthevent_idempotency_key_unique"
+)
+
+// Sentinel errors returned by VerifyHealthEventIdempotencyIndex. They are wrapped
+// with provider-specific detail, so callers must match them with errors.Is.
+var (
+	// ErrIndexMissing indicates the idempotency index does not exist.
+	ErrIndexMissing = errors.New("idempotency index missing")
+
+	// ErrIndexBuilding indicates the index exists but another session is still
+	// building it (reported by the MongoDB verification; PostgreSQL's Ensure
+	// checks the build progress itself); it wraps ErrIndexMismatch, because
+	// the index does not enforce anything yet, and lets callers wait instead
+	// of replacing it.
+	ErrIndexBuilding = fmt.Errorf("%w: build in progress", ErrIndexMismatch)
+
+	// ErrIndexMismatch indicates an index with the expected name exists but its
+	// definition or build state does not match the expected one.
+	ErrIndexMismatch = errors.New("idempotency index definition mismatch")
+)
+
+// BulkDocumentError describes the failure of a single document within an
+// idempotent insert.
+type BulkDocumentError struct {
+	// DocumentIndex is the position of the failed document in the slice passed
+	// to InsertManyIdempotent.
+	DocumentIndex int
+
+	// IndexName is the name of the violated index for duplicate-key errors,
+	// empty when it could not be determined or the error is not a duplicate.
+	IndexName string
+
+	// Duplicate is true when the failure is a duplicate-key violation.
+	Duplicate bool
+
+	// Message is the provider error message for this document.
+	Message string
+}
+
+// DuplicateOn reports whether the failure is a duplicate-key violation of the
+// named index, that is, a resend of a document already stored under it.
+func (e BulkDocumentError) DuplicateOn(indexName string) bool {
+	return e.Duplicate && e.IndexName == indexName
+}
+
+// maxFailureMessageLength bounds the provider message quoted by
+// BulkWriteFailure.Error, so a verbose server answer cannot flood a log line.
+const maxFailureMessageLength = 256
+
+// BulkWriteFailure is the error type returned by InsertManyIdempotent when a
+// document fails for a reason other than being a resend already stored under
+// the idempotency index (those are skipped and counted in the result). The
+// insert is ordered and stops at that document: InsertedCount documents before
+// it were stored, DuplicateCount were resends skipped, and the documents after
+// it were not attempted; the caller's retry of the whole batch stores them in
+// order and meets the stored ones as duplicates. Failed carries the server's
+// answer about the document, so the reason survives into logs.
+//
+//nolint:errname // cross-module API name, consumed outside this module; mirrors mongo.BulkWriteException
+type BulkWriteFailure struct {
+	InsertedCount  int
+	DuplicateCount int
+	Failed         BulkDocumentError
+}
+
+// Error implements the error interface with the failed document's position,
+// the violated index when it is a duplicate, and the provider's message.
+func (f *BulkWriteFailure) Error() string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "bulk write failure at document %d", f.Failed.DocumentIndex)
+
+	if f.Failed.Duplicate {
+		fmt.Fprintf(&b, " (duplicate on index %q)", f.Failed.IndexName)
+	}
+
+	if msg := f.Failed.Message; msg != "" {
+		if len(msg) > maxFailureMessageLength {
+			msg = msg[:maxFailureMessageLength] + "..."
+		}
+
+		b.WriteString(": " + msg)
+	}
+
+	fmt.Fprintf(&b, "; %d documents inserted, %d already stored", f.InsertedCount, f.DuplicateCount)
+
+	return b.String()
+}
+
+// AsBulkWriteFailure extracts a *BulkWriteFailure from an error chain.
+func AsBulkWriteFailure(err error) (*BulkWriteFailure, bool) {
+	return errors.AsType[*BulkWriteFailure](err)
+}

--- a/store-client/pkg/datastore/idempotency_test.go
+++ b/store-client/pkg/datastore/idempotency_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastore
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdempotencyConstants(t *testing.T) {
+	// These values are part of the wire and schema contract with the
+	// deployment platform connector and the index migration Job; they must
+	// not drift.
+	assert.Equal(t, "idempotencyKey", HealthEventIdempotencyKeyMetadataField)
+	assert.Equal(t, "healthevent_idempotency_key_unique", HealthEventIdempotencyIndexName)
+}
+
+func TestBulkWriteFailureError(t *testing.T) {
+	t.Run("a duplicate on another index names the index and keeps the server's message", func(t *testing.T) {
+		failure := &BulkWriteFailure{
+			InsertedCount:  3,
+			DuplicateCount: 1,
+			Failed: BulkDocumentError{
+				DocumentIndex: 4, Duplicate: true, IndexName: "some_other_unique_index",
+				Message: "E11000 duplicate key error collection: db.HealthEvents index: some_other_unique_index",
+			},
+		}
+
+		assert.Equal(t, `bulk write failure at document 4 (duplicate on index "some_other_unique_index"): `+
+			`E11000 duplicate key error collection: db.HealthEvents index: some_other_unique_index; `+
+			`3 documents inserted, 1 already stored`, failure.Error())
+	})
+
+	t.Run("a document the server refused keeps its message", func(t *testing.T) {
+		failure := &BulkWriteFailure{Failed: BulkDocumentError{DocumentIndex: 0, Message: "Document failed validation"}}
+
+		assert.Equal(t, "bulk write failure at document 0: Document failed validation; 0 documents inserted, 0 already stored",
+			failure.Error())
+	})
+
+	t.Run("a long server message is cut, an empty one is left out", func(t *testing.T) {
+		long := &BulkWriteFailure{Failed: BulkDocumentError{Message: strings.Repeat("x", maxFailureMessageLength+50)}}
+		assert.Contains(t, long.Error(), strings.Repeat("x", maxFailureMessageLength)+"...")
+		assert.NotContains(t, long.Error(), strings.Repeat("x", maxFailureMessageLength+1))
+
+		empty := &BulkWriteFailure{Failed: BulkDocumentError{DocumentIndex: 2}}
+		assert.Equal(t, "bulk write failure at document 2; 0 documents inserted, 0 already stored", empty.Error())
+	})
+}
+
+func TestBulkDocumentErrorDuplicateOn(t *testing.T) {
+	tests := []struct {
+		name     string
+		docErr   BulkDocumentError
+		expected bool
+	}{
+		{"duplicate on the idempotency index", BulkDocumentError{Duplicate: true, IndexName: HealthEventIdempotencyIndexName}, true},
+		{"duplicate on a different index", BulkDocumentError{Duplicate: true, IndexName: "some_other_unique_index"}, false},
+		{"not a duplicate", BulkDocumentError{Duplicate: false, Message: "document too large"}, false},
+		{"duplicate with unknown index name", BulkDocumentError{Duplicate: true, IndexName: ""}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.docErr.DuplicateOn(HealthEventIdempotencyIndexName))
+		})
+	}
+}
+
+func TestAsBulkWriteFailure(t *testing.T) {
+	failure := &BulkWriteFailure{
+		InsertedCount: 1,
+		Failed:        BulkDocumentError{DocumentIndex: 1, Duplicate: true, IndexName: "some_other_unique_index"},
+	}
+
+	t.Run("direct failure", func(t *testing.T) {
+		extracted, ok := AsBulkWriteFailure(failure)
+		require.True(t, ok)
+		assert.Same(t, failure, extracted)
+	})
+
+	t.Run("wrapped failure", func(t *testing.T) {
+		wrapped := fmt.Errorf("store connector failed: %w", failure)
+
+		extracted, ok := AsBulkWriteFailure(wrapped)
+		require.True(t, ok)
+		assert.Same(t, failure, extracted)
+	})
+
+	t.Run("unrelated error", func(t *testing.T) {
+		extracted, ok := AsBulkWriteFailure(errors.New("connection refused"))
+		assert.False(t, ok)
+		assert.Nil(t, extracted)
+	})
+
+	t.Run("nil error", func(t *testing.T) {
+		extracted, ok := AsBulkWriteFailure(nil)
+		assert.False(t, ok)
+		assert.Nil(t, extracted)
+	})
+}

--- a/store-client/pkg/datastore/providers/mongodb/health_store_test.go
+++ b/store-client/pkg/datastore/providers/mongodb/health_store_test.go
@@ -66,6 +66,21 @@ func (m *MockDatabaseClient) InsertMany(ctx context.Context, documents []any) (*
 	return args.Get(0).(*client.InsertManyResult), args.Error(1)
 }
 
+func (m *MockDatabaseClient) InsertManyIdempotent(ctx context.Context, documents []any) (*client.InsertManyResult, error) {
+	args := m.Called(ctx, documents)
+	return args.Get(0).(*client.InsertManyResult), args.Error(1)
+}
+
+func (m *MockDatabaseClient) EnsureHealthEventIdempotencyIndex(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockDatabaseClient) VerifyHealthEventIdempotencyIndex(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
 func (m *MockDatabaseClient) FindOne(ctx context.Context, filter any, options *client.FindOneOptions) (client.SingleResult, error) {
 	args := m.Called(ctx, filter, options)
 	return args.Get(0).(client.SingleResult), args.Error(1)

--- a/store-client/pkg/datastore/providers/mongodb/watcher/watch_store.go
+++ b/store-client/pkg/datastore/providers/mongodb/watcher/watch_store.go
@@ -91,6 +91,9 @@ type MongoDBConfig struct {
 	CertWatcher *certwatcher.CertWatcher
 	// AppName is used to identify the client in MongoDB connection tracking
 	AppName string
+	// MaxPoolSize caps the driver connection pool when greater than zero;
+	// zero keeps the driver default (100).
+	MaxPoolSize uint64
 }
 
 // TokenConfig holds the token-specific configuration.
@@ -852,6 +855,11 @@ func constructMongoClientOptions(
 	// Set AppName for MongoDB connection tracking if provided
 	if mongoConfig.AppName != "" {
 		clientOpts.SetAppName(mongoConfig.AppName)
+	}
+
+	// Cap the connection pool when configured; zero keeps the driver default (100)
+	if mongoConfig.MaxPoolSize > 0 {
+		clientOpts.SetMaxPoolSize(mongoConfig.MaxPoolSize)
 	}
 
 	// Only set TLS when TLS config was successfully built.

--- a/store-client/pkg/datastore/providers/mongodb/watcher/watch_store_test.go
+++ b/store-client/pkg/datastore/providers/mongodb/watcher/watch_store_test.go
@@ -370,6 +370,30 @@ func TestConstructMongoClientOptions_NoTLS(t *testing.T) {
 	}
 }
 
+// TestConstructMongoClientOptions_MaxPoolSize pins the pool cap contract: a
+// configured MaxPoolSize must reach the driver options, and zero must leave
+// the option unset so the driver default (100) applies.
+func TestConstructMongoClientOptions_MaxPoolSize(t *testing.T) {
+	mongoConfig := MongoDBConfig{
+		URI:                      "mongodb://localhost:27017",
+		Database:                 "test",
+		Collection:               "test",
+		TotalPingTimeoutSeconds:  5,
+		TotalPingIntervalSeconds: 1,
+		MaxPoolSize:              8,
+	}
+
+	opts, err := constructMongoClientOptions(mongoConfig)
+	require.NoError(t, err)
+	require.NotNil(t, opts.MaxPoolSize, "configured pool size must be applied")
+	require.Equal(t, uint64(8), *opts.MaxPoolSize)
+
+	mongoConfig.MaxPoolSize = 0
+	opts, err = constructMongoClientOptions(mongoConfig)
+	require.NoError(t, err)
+	require.Nil(t, opts.MaxPoolSize, "zero must keep the driver default")
+}
+
 // TestConstructMongoClientOptions_BSONOptions_PreserveV1DecodeShape guards the two
 // driver v1 -> v2 decode behaviour changes this package depends on:
 //

--- a/store-client/pkg/datastore/providers/postgresql/database_client.go
+++ b/store-client/pkg/datastore/providers/postgresql/database_client.go
@@ -193,55 +193,12 @@ func (c *PostgreSQLDatabaseClient) insertHealthEvents(
 	insertedIDs := make([]any, 0, len(documents))
 
 	for _, doc := range documents {
-		modelEvent, ok := doc.(model.HealthEventWithStatus)
-		if !ok {
-			slog.Error("Type assertion failed in insertHealthEvents",
-				"expectedType", "model.HealthEventWithStatus",
-				"actualType", fmt.Sprintf("%T", doc))
-
-			return nil, fmt.Errorf("expected HealthEventWithStatus but got %T", doc)
-		}
-
-		// CRITICAL: Extract index fields from the protobuf BEFORE JSON marshaling
-		// After JSON marshal/unmarshal, the protobuf is converted to a map and we lose type info
-		var indexFields healthEventIndexFields
-		if modelEvent.HealthEvent != nil {
-			indexFields = healthEventIndexFields{
-				nodeName:          modelEvent.HealthEvent.NodeName,
-				eventType:         modelEvent.HealthEvent.CheckName,
-				severity:          modelEvent.HealthEvent.ComponentClass,
-				recommendedAction: modelEvent.HealthEvent.RecommendedAction.String(),
-			}
-
-			slog.Debug("Extracted index fields from protobuf", "nodeName", indexFields.nodeName)
-		} else {
-			slog.Debug("modelEvent.HealthEvent is nil, using empty index fields")
-		}
-
-		// Convert model.HealthEventWithStatus to datastore.HealthEventWithStatus
-		// by marshaling to JSON and unmarshaling to the datastore type
-		modelJSON, err := json.Marshal(modelEvent)
+		id, err := c.insertSingleHealthEvent(ctx, healthStore, doc)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal model health event: %w", err)
+			return nil, err
 		}
 
-		var datastoreEvent datastore.HealthEventWithStatus
-		if err := json.Unmarshal(modelJSON, &datastoreEvent); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal to datastore health event: %w", err)
-		}
-
-		// Use the PostgreSQL health event store to insert with proper schema
-		// Pass the index fields we extracted from the protobuf
-		err = healthStore.InsertHealthEventsWithIndexFields(ctx, &datastoreEvent, indexFields)
-		if err != nil {
-			slog.Error("InsertHealthEventsWithIndexFields failed", "error", err)
-
-			return nil, fmt.Errorf("[postgresql:insert] failed to insert documents: %w", err)
-		}
-
-		// For now, use a placeholder ID since InsertHealthEvents doesn't return the ID
-		// In the future, we could modify InsertHealthEvents to return the generated UUID
-		insertedIDs = append(insertedIDs, "inserted")
+		insertedIDs = append(insertedIDs, id)
 	}
 
 	slog.Debug("insertHealthEvents complete", "insertedCount", len(insertedIDs))
@@ -249,6 +206,121 @@ func (c *PostgreSQLDatabaseClient) insertHealthEvents(
 	return &client.InsertManyResult{
 		InsertedIDs: insertedIDs,
 	}, nil
+}
+
+// insertSingleHealthEvent inserts one health event using the PostgreSQL-specific schema
+func (c *PostgreSQLDatabaseClient) insertSingleHealthEvent(
+	ctx context.Context, healthStore *PostgreSQLHealthEventStore, doc any,
+) (any, error) {
+	modelEvent, ok := doc.(model.HealthEventWithStatus)
+	if !ok {
+		slog.Error("Type assertion failed in insertSingleHealthEvent",
+			"expectedType", "model.HealthEventWithStatus",
+			"actualType", fmt.Sprintf("%T", doc))
+
+		return nil, fmt.Errorf("expected HealthEventWithStatus but got %T", doc)
+	}
+
+	// CRITICAL: Extract index fields from the protobuf BEFORE JSON marshaling
+	// After JSON marshal/unmarshal, the protobuf is converted to a map and we lose type info
+	var indexFields healthEventIndexFields
+	if modelEvent.HealthEvent != nil {
+		indexFields = healthEventIndexFields{
+			nodeName:          modelEvent.HealthEvent.NodeName,
+			eventType:         modelEvent.HealthEvent.CheckName,
+			severity:          modelEvent.HealthEvent.ComponentClass,
+			recommendedAction: modelEvent.HealthEvent.RecommendedAction.String(),
+		}
+
+		slog.Debug("Extracted index fields from protobuf", "nodeName", indexFields.nodeName)
+	} else {
+		slog.Debug("modelEvent.HealthEvent is nil, using empty index fields")
+	}
+
+	// Convert model.HealthEventWithStatus to datastore.HealthEventWithStatus
+	// by marshaling to JSON and unmarshaling to the datastore type
+	modelJSON, err := json.Marshal(modelEvent)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal model health event: %w", err)
+	}
+
+	var datastoreEvent datastore.HealthEventWithStatus
+	if err := json.Unmarshal(modelJSON, &datastoreEvent); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal to datastore health event: %w", err)
+	}
+
+	// Use the PostgreSQL health event store to insert with proper schema
+	// Pass the index fields we extracted from the protobuf
+	// Not logged here: a duplicate on the idempotency index is the expected
+	// answer to a resend, and the caller classifies and reports the rest.
+	err = healthStore.InsertHealthEventsWithIndexFields(ctx, &datastoreEvent, indexFields)
+	if err != nil {
+		return nil, fmt.Errorf("[postgresql:insert] failed to insert documents: %w", err)
+	}
+
+	// For now, use a placeholder ID since InsertHealthEvents doesn't return the ID
+	// In the future, we could modify InsertHealthEvents to return the generated UUID
+	return "inserted", nil
+}
+
+// InsertManyIdempotent inserts documents one at a time, in order, resuming
+// past duplicates on the idempotency index and stopping at any other failure;
+// see client.InsertManyIdempotentWith.
+func (c *PostgreSQLDatabaseClient) InsertManyIdempotent(
+	ctx context.Context, documents []any,
+) (*client.InsertManyResult, error) {
+	slog.Debug("InsertManyIdempotent called", "documentCount", len(documents), "tableName", c.tableName)
+
+	healthStore := NewPostgreSQLHealthEventStore(c.db)
+
+	return client.InsertManyIdempotentWith(ctx, documents, func(ctx context.Context, doc any) (string, error) {
+		return c.insertSingleDocument(ctx, healthStore, doc)
+	})
+}
+
+// insertSingleDocument inserts one document on its own, outside a transaction,
+// so a failure on one document leaves the ones before it stored: a health
+// event goes through the health event store with its index fields, anything
+// else as JSON, like InsertMany. The datastore's error is returned unwrapped
+// beyond the store's own wrapping, so the caller can read its SQLSTATE.
+func (c *PostgreSQLDatabaseClient) insertSingleDocument(
+	ctx context.Context, healthStore *PostgreSQLHealthEventStore, doc any,
+) (string, error) {
+	if _, ok := doc.(model.HealthEventWithStatus); ok {
+		id, err := c.insertSingleHealthEvent(ctx, healthStore, doc)
+		if err != nil {
+			return "", err
+		}
+
+		return fmt.Sprint(id), nil
+	}
+
+	jsonData, err := json.Marshal(doc)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal document: %w", err)
+	}
+
+	//nolint:gosec // G201: table name from config, values are parameterized
+	query := fmt.Sprintf("INSERT INTO %s (data) VALUES ($1) RETURNING id", c.tableName)
+
+	var id string
+	if err := c.db.QueryRowContext(ctx, query, jsonData).Scan(&id); err != nil {
+		return "", err
+	}
+
+	return id, nil
+}
+
+// EnsureHealthEventIdempotencyIndex idempotently creates the partial unique
+// expression index that enforces per-event idempotency keys on health events.
+func (c *PostgreSQLDatabaseClient) EnsureHealthEventIdempotencyIndex(ctx context.Context) error {
+	return client.NewPostgreSQLClientFromDB(c.db, c.tableName).EnsureHealthEventIdempotencyIndex(ctx)
+}
+
+// VerifyHealthEventIdempotencyIndex checks the full idempotency index definition,
+// returning datastore.ErrIndexMissing or datastore.ErrIndexMismatch on deviation.
+func (c *PostgreSQLDatabaseClient) VerifyHealthEventIdempotencyIndex(ctx context.Context) error {
+	return client.NewPostgreSQLClientFromDB(c.db, c.tableName).VerifyHealthEventIdempotencyIndex(ctx)
 }
 
 // UpdateDocumentStatus updates a specific status field in a document

--- a/store-client/pkg/datastore/providers/postgresql/database_client_idempotency_test.go
+++ b/store-client/pkg/datastore/providers/postgresql/database_client_idempotency_test.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgresql
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nvidia/nvsentinel/data-models/pkg/model"
+	"github.com/nvidia/nvsentinel/data-models/pkg/protos"
+	"github.com/nvidia/nvsentinel/store-client/pkg/datastore"
+)
+
+func TestPostgreSQLDatabaseClientInsertManyIdempotentTransportFailure(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+
+	defer db.Close()
+
+	dbClient := NewPostgreSQLDatabaseClientWithConnString(db, "HealthEvents", "")
+	pgClient, ok := dbClient.(*PostgreSQLDatabaseClient)
+	require.True(t, ok)
+
+	insertQuery := "INSERT INTO health_events (data) VALUES ($1) RETURNING id"
+	mock.ExpectQuery(insertQuery).WillReturnError(errors.New("connection reset"))
+	// No expectation for the second document: it must not be attempted.
+
+	_, err = pgClient.InsertManyIdempotent(context.Background(),
+		[]any{map[string]any{"a": 1}, map[string]any{"b": 2}})
+	require.Error(t, err)
+
+	_, perDocument := datastore.AsBulkWriteFailure(err)
+	assert.False(t, perDocument, "a lost connection is not an answer about a document; the whole batch failed")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPostgreSQLDatabaseClientInsertManyIdempotent(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+
+	defer db.Close()
+
+	dbClient := NewPostgreSQLDatabaseClientWithConnString(db, "HealthEvents", "")
+	pgClient, ok := dbClient.(*PostgreSQLDatabaseClient)
+	require.True(t, ok)
+
+	insertQuery := "INSERT INTO health_events (data) VALUES ($1) RETURNING id"
+	mock.ExpectQuery(insertQuery).WillReturnError(&pq.Error{
+		Code:       "23505",
+		Constraint: datastore.HealthEventIdempotencyIndexName,
+	})
+	mock.ExpectQuery(insertQuery).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("id-2"))
+
+	result, err := pgClient.InsertManyIdempotent(context.Background(),
+		[]any{map[string]any{"a": 1}, map[string]any{"b": 2}})
+	require.NoError(t, err, "a resend is a success, not a failure")
+	assert.Equal(t, []any{"id-2"}, result.InsertedIDs)
+	assert.Equal(t, 1, result.DuplicateCount)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// Duplicate classification must survive the health-event route
+// (insertSingleHealthEvent -> InsertHealthEventsWithIndexFields -> the
+// health_events columnar INSERT), whose errors reach the classifier only
+// through %w wrap sites — not just the generic JSONB route above.
+func TestPostgreSQLDatabaseClientInsertManyIdempotentHealthEventDuplicate(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	defer db.Close()
+
+	dbClient := NewPostgreSQLDatabaseClientWithConnString(db, "HealthEvents", "")
+	pgClient, ok := dbClient.(*PostgreSQLDatabaseClient)
+	require.True(t, ok)
+
+	mock.ExpectExec("INSERT INTO health_events").WillReturnError(&pq.Error{
+		Code:       "23505",
+		Constraint: datastore.HealthEventIdempotencyIndexName,
+		Message:    "duplicate key value violates unique constraint",
+	})
+
+	result, err := pgClient.InsertManyIdempotent(context.Background(), []any{
+		model.HealthEventWithStatus{
+			HealthEvent: &protos.HealthEvent{
+				NodeName:  "node-1",
+				CheckName: "GpuXidError",
+			},
+		},
+	})
+	require.NoError(t, err, "the duplicate reached the classifier through the wrap sites and counts as a resend")
+	assert.Empty(t, result.InsertedIDs)
+	assert.Equal(t, 1, result.DuplicateCount)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestResolveMaxOpenConns(t *testing.T) {
+	t.Run("default when nothing configured", func(t *testing.T) {
+		t.Setenv("DATASTORE_MAX_CONNECTIONS", "")
+		assert.Equal(t, defaultMaxOpenConns, resolveMaxOpenConns(map[string]string{}))
+	})
+
+	t.Run("options value wins", func(t *testing.T) {
+		t.Setenv("DATASTORE_MAX_CONNECTIONS", "40")
+		assert.Equal(t, 10, resolveMaxOpenConns(map[string]string{"maxConnections": "10"}))
+	})
+
+	t.Run("environment fallback", func(t *testing.T) {
+		t.Setenv("DATASTORE_MAX_CONNECTIONS", "40")
+		assert.Equal(t, 40, resolveMaxOpenConns(map[string]string{}))
+	})
+
+	t.Run("invalid values fall through to the default", func(t *testing.T) {
+		t.Setenv("DATASTORE_MAX_CONNECTIONS", "-5")
+		assert.Equal(t, defaultMaxOpenConns, resolveMaxOpenConns(map[string]string{"maxConnections": "abc"}))
+	})
+}
+
+func TestConfigureConnectionPool(t *testing.T) {
+	t.Setenv("DATASTORE_MAX_CONNECTIONS", "7")
+
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+
+	defer db.Close()
+
+	ConfigureConnectionPool(db, nil)
+	assert.Equal(t, 7, db.Stats().MaxOpenConnections)
+}

--- a/store-client/pkg/datastore/providers/postgresql/datastore.go
+++ b/store-client/pkg/datastore/providers/postgresql/datastore.go
@@ -80,9 +80,7 @@ func NewPostgreSQLStore(ctx context.Context, config datastore.DataStoreConfig) (
 	}
 
 	// Set connection pool settings
-	db.SetMaxOpenConns(25)
-	db.SetMaxIdleConns(10)
-	db.SetConnMaxLifetime(time.Hour)
+	ConfigureConnectionPool(db, config.Options)
 
 	if _, err := otelsql.RegisterDBStatsMetrics(db,
 		otelsql.WithAttributes(semconv.DBSystemPostgreSQL),
@@ -107,6 +105,38 @@ func NewPostgreSQLStore(ctx context.Context, config datastore.DataStoreConfig) (
 	slog.Info("Successfully connected to PostgreSQL database", "host", config.Connection.Host)
 
 	return store, nil
+}
+
+// defaultMaxOpenConns preserves the previously hardcoded connection pool limit.
+const defaultMaxOpenConns = 25
+
+// defaultMaxIdleConns and defaultConnMaxLifetime are the shared idle-connection
+// and connection-lifetime defaults applied to every PostgreSQL pool.
+const (
+	defaultMaxIdleConns    = 10
+	defaultConnMaxLifetime = time.Hour
+)
+
+// ConfigureConnectionPool applies the shared PostgreSQL connection pool
+// settings to db: the max open connections resolved by resolveMaxOpenConns
+// plus the default idle-connection count and connection lifetime. It is used
+// by NewPostgreSQLStore and by the client factory so both paths honor the
+// same pool configuration.
+func ConfigureConnectionPool(db *sql.DB, options map[string]string) {
+	db.SetMaxOpenConns(resolveMaxOpenConns(options))
+	db.SetMaxIdleConns(defaultMaxIdleConns)
+	db.SetConnMaxLifetime(defaultConnMaxLifetime)
+}
+
+// resolveMaxOpenConns returns the connection pool limit: the shared
+// datastore.MaxConnections resolution (the maxConnections option, then the
+// DATASTORE_MAX_CONNECTIONS environment variable) or the default of 25.
+func resolveMaxOpenConns(options map[string]string) int {
+	if size := datastore.MaxConnections(options); size > 0 {
+		return size
+	}
+
+	return defaultMaxOpenConns
 }
 
 // MaintenanceEventStore returns the maintenance event store

--- a/store-client/pkg/factory/client_factory.go
+++ b/store-client/pkg/factory/client_factory.go
@@ -102,6 +102,11 @@ func (f *ClientFactory) CreateDatabaseClient(ctx context.Context) (client.Databa
 			)
 		}
 
+		// Bound the connection pool so DATASTORE_MAX_CONNECTIONS takes effect
+		// on this path too, with the
+		// same idle and lifetime defaults NewPostgreSQLStore applies.
+		providers_postgresql.ConfigureConnectionPool(db, nil)
+
 		// Return the provider's PostgreSQL database client which has health event field extraction
 		tableName := f.dbConfig.GetCollectionName() // In PostgreSQL context, collection = table
 


### PR DESCRIPTION
## Summary

Part of ADR 052, the deployment platform connector. This PR adds the datastore side of the design and nothing else: a per-event idempotency key, the unique partial index that enforces it, inserts that treat a resend as already done, and the index management the connector's index Job and readiness check will call. No component uses the new methods yet; the platform connector adopts them in a later PR. It is independent of #1796 and can merge before or after it.

### What changes

- `datastore` gains the contract both providers share: the metadata field `idempotencyKey`, the index name `healthevent_idempotency_key_unique`, the errors `ErrIndexMissing`, `ErrIndexMismatch` and `ErrIndexBuilding`, and the failure type `BulkWriteFailure`, which names the one document an insert stopped at, with its position, the violated index when it is a duplicate, and the server's message, so the reason reaches the logs.
- `DatabaseClient` gains three methods: `InsertManyIdempotent`, `EnsureHealthEventIdempotencyIndex` and `VerifyHealthEventIdempotencyIndex`. `InsertManyResult` gains `DuplicateCount`, the number of documents skipped because they were already stored under the key. A resend is therefore a success result, not an error; only a real failure is an error.
- MongoDB: `InsertManyIdempotent` is an ordered insert that resumes after a duplicate on the idempotency index, so a resent batch stores only its missing events and a monitor's events land in the order it sent them. A duplicate on any other unique index, or any other per-document failure, stops the insert and is returned as `BulkWriteFailure`. The index is a unique partial index on the key field, covering only documents that carry it, so existing records need no backfill. An index of the same name with another definition is dropped and recreated. Verification checks the name, key path, uniqueness, partial predicate and a completed build.
- PostgreSQL: `InsertManyIdempotent` inserts one row at a time, in order, each outside a transaction, skipping duplicates on the idempotency index and stopping at any other constraint answer. SQLSTATE classes 22 and 23 count as answers about a document; anything else fails the whole batch. The index is created `CONCURRENTLY` outside a transaction so the build never blocks writers; a leftover invalid build or a mismatched definition is dropped concurrently and rebuilt. Verification checks the normalised definition and `pg_index.indisvalid`.
- Connection pool bound: one resolver, `datastore.MaxConnections`, reads the `maxConnections` option first and the existing `DATASTORE_MAX_CONNECTIONS` variable second. PostgreSQL applies it on both the store and the client factory path (default 25); MongoDB caps the driver pool with it (default 100).
- The two test fakes of `DatabaseClient` outside this module (health-events-analyzer, platform-connectors) gain the three methods so their tests keep compiling. A small test pins that `APP_NAME` reaches the MongoDB driver's appName, which the connector relies on to identify itself.

### What is not in this PR

The deployment platform connector, the Helm chart, the publishers and the documentation come in the other PRs of the series.

### Tests

- `mongodb_idempotency_test.go`: bulk write classification (duplicate with the index name, from the message or the key pattern; a non-duplicate keeps the server's message; write concern and non-bulk errors are not classified); the resuming insert (a resend stores its missing events in order with one round trip per duplicate, a real failure stops the insert, a duplicate on another index after a resume stops it, a duplicate at the end costs no extra round trip); index specification checks; the pool cap reaching the driver options.
- `postgresql_idempotency_test.go`: the one-at-a-time insert (a resend continues, another constraint stops it, a transport failure fails the batch, a duplicate on another index stops it), SQLSTATE classification including an administrator shutdown, and literal-preserving SQL normalisation.
- `database_client_idempotency_test.go`: a duplicate met through the health-event insert route, the pool resolver and pool configuration.
- `datastore/idempotency_test.go` and `config_test.go`: the constants that form the schema contract, the failure message, `DuplicateOn`, `AsBulkWriteFailure`, `MaxConnections` and option loading.

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [x] Core Services
- [ ] Health Monitors
- [ ] Fault Management
- [ ] Deployment/Config
- [ ] API/Interface
- [ ] Preflight
- [ ] Plugins
- [ ] Janitor
- [ ] Documentation/CI
- [ ] Other: ____________

## Testing
- [x] Tests pass locally
- [ ] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added idempotent health-event batch insertion for MongoDB and PostgreSQL.
  - Duplicate events are skipped and counted, while other write failures include document-level details.
  - Added automatic creation, verification, and repair of health-event idempotency indexes.
  - Added configurable database connection-pool limits through configuration options or environment variables.
  - MongoDB and PostgreSQL clients apply configured pool limits while retaining safe defaults.
  - Event processing continues after duplicate entries while preserving insertion order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->