### PR TITLE
docs(release): require a callout when bundled datastore versions change

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -79,6 +79,60 @@ All releases must pass:
 - **Unit tests**: All Go modules and Python packages
 - **Container builds**: All component images must build successfully
 - **E2E tests**: Integration testing (on PR/push)
+- **Bundled datastore versions**: if they changed, the release notes carry the callout described in [Release Notes](#release-notes)
+
+## Release Notes
+
+### Bundled datastore version changes
+
+The chart bundles the Percona Server for MongoDB operator and its `PerconaServerMongoDB`
+custom resource as subcharts. Their versions are independent of the NVSentinel release number,
+so a release can move them without that being visible from the version alone.
+
+**If a release changes any of these four values, the release notes must say so explicitly:**
+
+| Value | Subchart |
+| --- | --- |
+| operator image tag | `charts/mongodb-store/charts/psmdb-operator` |
+| `crVersion` | `charts/mongodb-store/charts/psmdb-db` |
+| mongod image tag | `charts/mongodb-store/charts/psmdb-db` |
+| init image tag | `charts/mongodb-store/charts/psmdb-db` |
+
+The callout must cover three things:
+
+1. **Whether the replica set will roll.** `crVersion`, `initImage` and the mongod image are all
+   fields of the `PerconaServerMongoDB` resource, so changing any of them makes the operator run
+   SmartUpdate over every member: secondaries first, then a primary step-down. Say it plainly, in
+   the form "this will roll your replica set". An operator adopting a release to pick up a
+   monitoring fix has no reason to expect their health-event datastore to fail over, and that
+   datastore holds every health event.
+2. **That the operator upgrade cannot skip a minor version.** Percona's
+   [upgrade documentation](https://docs.percona.com/percona-operator-for-mongodb/update-operator.html)
+   permits moving only to the nearest `major.minor`. A deployment more than one minor behind the
+   new bundled operator cannot adopt the release directly: it needs intermediate hops, one minor
+   at a time, moving `crVersion` with the operator. Name the versions involved so a reader can
+   tell whether this applies to them.
+3. **Which mongod version the new operator certifies.** Operator and mongod compatibility is a
+   matrix, published at `https://check.percona.com/versions/v1/psmdb-operator/<version>`. Moving
+   one without the other can produce an uncertified pairing that renders and runs without
+   complaint.
+
+### Finding the bundled versions
+
+The NVSentinel release number says nothing about them. Read the subchart directly:
+
+```bash
+helm pull oci://ghcr.io/nvidia/nvsentinel --version <release> --untar
+grep -E 'version|appVersion' nvsentinel/charts/mongodb-store/charts/psmdb-db/Chart.yaml
+grep -E 'crVersion|tag:' nvsentinel/charts/mongodb-store/charts/psmdb-db/values.yaml
+```
+
+`charts/mongodb-store/Chart.yaml` also carries the rule that `psmdb-operator` and `psmdb-db` must
+be bumped together and kept matched.
+
+The v1.22.0 note for #1741 is the precedent to follow: that release moved `psmdb-db` and did carry
+an upgrade warning, which is how at least one deployment caught the skipped minor before syncing
+it.
 
 ## Troubleshooting
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -100,12 +100,26 @@ so a release can move them without that being visible from the version alone.
 
 The callout must cover three things:
 
-1. **Whether the replica set will roll.** `crVersion`, `initImage` and the mongod image are all
-   fields of the `PerconaServerMongoDB` resource, so changing any of them makes the operator run
-   SmartUpdate over every member: secondaries first, then a primary step-down. Say it plainly, in
-   the form "this will roll your replica set". An operator adopting a release to pick up a
-   monitoring fix has no reason to expect their health-event datastore to fail over, and that
-   datastore holds every health event.
+1. **Whether the replica set will roll, and say which of the four changed.** `crVersion`,
+   `initImage` and the mongod image are fields of the `PerconaServerMongoDB` resource, so changing
+   any of them restarts every replica-set member. The **operator image tag is different**: it
+   changes only the operator Deployment, so on its own it restarts the operator pod and leaves the
+   replica set alone. Distinguishing the two is the most useful thing the note can do, because it
+   tells a reader whether they are taking a datastore outage or not.
+
+   Where the members do roll, the order depends on `spec.updateStrategy` on the resource, which the
+   chart sets to `SmartUpdate` by default but which an operator can override:
+
+   - **`SmartUpdate`** (chart default): the operator drives it, secondaries first, then a primary
+     step-down, so the exposure is one brief election.
+   - **`RollingUpdate`**: Kubernetes drives the StatefulSet rollout, with no primary step-down
+     coordination.
+   - **`OnDelete`**: nothing restarts until the pods are deleted by hand, so the new version does
+     not take effect on adoption at all.
+
+   Say it plainly, in the form "this will roll your replica set". An operator adopting a release to
+   pick up a monitoring fix has no reason to expect their health-event datastore to fail over, and
+   that datastore holds every health event.
 2. **That the operator upgrade cannot skip a minor version.** Percona's
    [upgrade documentation](https://docs.percona.com/percona-operator-for-mongodb/update-operator.html)
    permits moving only to the nearest `major.minor`. A deployment more than one minor behind the
@@ -119,13 +133,31 @@ The callout must cover three things:
 
 ### Finding the bundled versions
 
-The NVSentinel release number says nothing about them. Read the subchart directly:
+The NVSentinel release number says nothing about them. Unpack the published chart and read the two
+subcharts directly:
 
 ```bash
 helm pull oci://ghcr.io/nvidia/nvsentinel --version <release> --untar
-grep -E 'version|appVersion' nvsentinel/charts/mongodb-store/charts/psmdb-db/Chart.yaml
-grep -E 'crVersion|tag:' nvsentinel/charts/mongodb-store/charts/psmdb-db/values.yaml
+C=nvsentinel/charts/mongodb-store/charts
 ```
+
+| Value | File | Key |
+| --- | --- | --- |
+| operator image tag | `$C/psmdb-operator/values.yaml` | top-level `image.tag` |
+| `crVersion` | `$C/psmdb-db/values.yaml` | top-level `crVersion` |
+| mongod image tag | `$C/psmdb-db/values.yaml` | top-level `image.tag` |
+| init image tag | `$C/psmdb-db/values.yaml` | top-level `initImage.tag` |
+| subchart versions | `$C/psmdb-{operator,db}/Chart.yaml` | `version`, `appVersion` |
+
+**Read the top-level keys, not a grep for `tag:`.** `psmdb-db/values.yaml` contains several other
+`image:` blocks further down for the backup, PMM and fluentbit sidecars, so a bare `grep 'tag:'`
+returns those too and it is easy to report the wrong one. The mongod tag is the one inside the
+top-level `image:` block.
+
+Note also that `initImage` is commented out by default. Left unset, the operator derives the
+reference itself from `crVersion`, which resolves to a public registry and will therefore fail on a
+mirror-only or air-gapped cluster. If a release changes `crVersion`, that implicitly changes the
+init image those deployments need.
 
 `charts/mongodb-store/Chart.yaml` also carries the rule that `psmdb-operator` and `psmdb-db` must
 be bumped together and kept matched.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -102,20 +102,24 @@ The callout must cover three things:
 
 1. **Whether the replica set will roll, and say which of the four changed.** `crVersion`,
    `initImage` and the mongod image are fields of the `PerconaServerMongoDB` resource, so changing
-   any of them restarts every replica-set member. The **operator image tag is different**: it
-   changes only the operator Deployment, so on its own it restarts the operator pod and leaves the
-   replica set alone. Distinguishing the two is the most useful thing the note can do, because it
-   tells a reader whether they are taking a datastore outage or not.
+   any of them changes the desired state of every replica-set member. The **operator image tag is
+   different**: it changes only the operator Deployment, so on its own it restarts the operator pod
+   and leaves the replica set alone. Distinguishing the two is the most useful thing the note can
+   do, because it tells a reader whether they are taking a datastore outage or not.
 
-   Where the members do roll, the order depends on `spec.updateStrategy` on the resource, which the
-   chart sets to `SmartUpdate` by default but which an operator can override:
+   When the members do change, whether and when they actually restart depends on
+   `spec.updateStrategy` on the resource, which the chart sets to `SmartUpdate` by default but
+   which an operator can override:
 
-   - **`SmartUpdate`** (chart default): the operator drives it, secondaries first, then a primary
-     step-down, so the exposure is one brief election.
+   - **`SmartUpdate`** (chart default): the operator drives the rollout, secondaries first, then a
+     primary step-down, so the exposure is one brief election.
    - **`RollingUpdate`**: Kubernetes drives the StatefulSet rollout, with no primary step-down
      coordination.
-   - **`OnDelete`**: nothing restarts until the pods are deleted by hand, so the new version does
-     not take effect on adoption at all.
+   - **`OnDelete`**: existing pods are left alone. The new values apply only as each pod is deleted
+     by hand, so adopting the release changes nothing until an operator acts.
+
+   Scope the claim accordingly rather than promising a restart: under `OnDelete` a reader who
+   expects one will not get it, and a reader who expects none under `SmartUpdate` will.
 
    Say it plainly, in the form "this will roll your replica set". An operator adopting a release to
    pick up a monitoring fix has no reason to expect their health-event datastore to fail over, and
@@ -154,10 +158,21 @@ C=nvsentinel/charts/mongodb-store/charts
 returns those too and it is easy to report the wrong one. The mongod tag is the one inside the
 top-level `image:` block.
 
-Note also that `initImage` is commented out by default. Left unset, the operator derives the
-reference itself from `crVersion`, which resolves to a public registry and will therefore fail on a
-mirror-only or air-gapped cluster. If a release changes `crVersion`, that implicitly changes the
-init image those deployments need.
+Note also that `initImage` is commented out by default, and what the operator derives when it is
+unset depends on whether `crVersion` matches the operator's own version
+(`pkg/psmdb/init/init.go`):
+
+- **Versions match:** the init container uses the **operator pod's own image**, verbatim. A
+  deployment that mirrors the operator image therefore needs nothing extra.
+- **Versions differ:** the operator keeps its own image *repository* but substitutes the tag,
+  giving `<operator-repository>:<crVersion>`.
+
+The second case is the one worth a release note, because it is exactly the state an existing
+deployment lands in when a release bumps the bundled operator ahead of a pinned `crVersion`. The
+repository is whatever the operator runs from, so it stays inside a private mirror, but the **tag
+is one a mirror-only deployment has no reason to have mirrored**, since operators mirror the
+versions they run rather than older `crVersion` values. Say so when a release changes either
+version, and note that pinning `initImage` explicitly avoids the question entirely.
 
 `charts/mongodb-store/Chart.yaml` also carries the rule that `psmdb-operator` and `psmdb-db` must
 be bumped together and kept matched.


### PR DESCRIPTION
Ask 1 of #1797, which @lalitadithya approved ("agreed on 1 and 2a").

Documentation only. No code, no chart, no behaviour change.

## Why

The chart bundles the Percona operator and its `PerconaServerMongoDB` resource as subcharts, and their versions are independent of the NVSentinel release number. Two consequences an operator cannot see from the release version alone:

- A change to `crVersion`, `initImage` or the mongod image is a change to a field of the `PerconaServerMongoDB` resource, so the operator runs SmartUpdate over every replica-set member. Adopting a release to pick up a monitoring fix can fail over the datastore that holds every health event.
- The operator cannot skip a minor version, per [Percona's upgrade documentation](https://docs.percona.com/percona-operator-for-mongodb/update-operator.html). A deployment more than one minor behind the new bundled operator cannot adopt the release directly.

#1797 has the full analysis. This PR covers only the cheapest of its three asks: making the release-note obligation explicit so the next bundled-version change is announced rather than discovered.

## What this adds

A **Release Notes** section to `RELEASE.md` saying that if a release changes any of the four bundled version values, the notes must state:

1. whether the replica set will roll, in the form "this will roll your replica set";
2. that the operator upgrade cannot skip a minor, naming the versions so a reader can tell if it applies to them;
3. which mongod version the new operator certifies, since that is a matrix and moving one without the other can produce an uncertified pairing that renders and runs without complaint.

Plus how to read the bundled versions out of the packaged chart, since the release number does not reveal them, and one **Quality Gates** bullet pointing at the new section.

It cites the v1.22.0 note for #1741 as the precedent, because that release did carry an upgrade warning, and that warning is how we caught a skipped minor before syncing it.

## Notes for review

- `charts/mongodb-store/Chart.yaml` already carries a comment stating that `psmdb-operator` and `psmdb-db` must be bumped together and kept matched. This makes the operator-facing half of that rule explicit too.
- I put the obligation in its own section rather than inside Quality Gates, because the existing bullets there are all automated checks and this one is a release-authoring step. The Quality Gates entry is a pointer so it is not missed.
- Happy to reword anything. I have no attachment to the phrasing, only to the three facts being stated somewhere a release author will see them.

Asks 2a and 3 are separate and I have open questions on #1797 about their scope before I write them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified release-note guidance for replica-set behavior under `SmartUpdate`, `RollingUpdate`, and `OnDelete`, including when resource changes roll pods and when manual deletion is required.
  - Documented that operator-only changes leave the replica set untouched.
  - Added init-image guidance covering version matching, repository and tag derivation, mirror implications, and explicit image pinning.
  - Expanded guidance on version inspection, rollout behavior, operator upgrades, and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->