### PR TITLE
feat(health-events-analyzer): concurrent node-partitioned event processing

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -21,9 +21,18 @@ additional_trustees:
   - XRFXLP
   - mchmarny
   - tanishagoyal2
-  - ksaur
   - deesharma24
   - natherz97
   - suket22
   - cbumb
   - pdmack
+additional_vetters:
+  - Jay-Madden
+  - nitz2407
+  - tanishagoyal2
+  - deesharma24
+  - suket22
+  - cbumb
+  - jtschelling
+
+

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/templates/deployment.yaml
@@ -85,6 +85,12 @@ spec:
           - "--tls-enabled=false"
           {{- end }}
           - "--processing-strategy={{ .Values.processingStrategy }}"
+          {{- if .Values.workers }}
+          - "--workers={{ .Values.workers }}"
+          {{- end }}
+          {{- if .Values.maxInFlight }}
+          - "--max-in-flight={{ .Values.maxInFlight }}"
+          {{- end }}
           {{- if include "nvsentinel.pcAuth.enabled" . }}
           {{- /* Republished events keep the original event's node name, so this
                  component reports on nodes other than its own and must present

--- a/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
+++ b/distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml
@@ -38,6 +38,12 @@ logLevel: info
 # STORE_ONLY: observability-only behavior; event should be persisted/exported but should not modify cluster resources (i.e., no node conditions, no quarantine, no drain, no remediation).
 processingStrategy: EXECUTE_REMEDIATION
 
+# Number of concurrent workers for event processing partitioned by node (default: 1)
+workers: 1
+
+# Maximum number of uncheckpointed in-flight events before applying backpressure (default: 1000)
+maxInFlight: 1000
+
 # Enable flags for the rules to be evaluated.
 enableMultipleRemediationsRule: true
 enableRepeatedXIDErrorOnSameGPURule: true

--- a/docs/designs/056-concurrent-node-partitioned-event-processing.md
+++ b/docs/designs/056-concurrent-node-partitioned-event-processing.md
@@ -86,8 +86,7 @@ ChangeStreamWatcher (Events channel)
    - Implements `client.EventProcessor`.
    - Manages $N$ worker goroutines and per-worker buffered channels.
    - Maps events to workers via `hash(nodeName) % N` using FNV-32a. Events without a node name route to worker 0.
-   - Enforces backpressure: when uncheckpointed in-flight events reach `MaxInFlight`, suspends reading from the watcher.
-   - Handles poison events: when `MarkProcessedOnError=true` (as in `health-events-analyzer`), failed events are marked resolved in the tracker to prevent stream stalling.
+   - Handles poison events vs transient errors: when `MarkProcessedOnError=true` (as in `health-events-analyzer`), only terminal errors (e.g., permanent unmarshaling failures or handler rejections) are marked resolved in the tracker to prevent poison pills from blocking stream progress. Transient conditions—specifically context cancellations (`context.Canceled`) and timeouts (`context.DeadlineExceeded`)—are never marked as completed, ensuring the low-water mark does not advance past them and that they are retried on pod restart rather than permanently lost.
 
 3. **`health-events-analyzer` Integration**:
    - `health-events-analyzer/main.go`: adds CLI flags `--workers` (default `1`) and `--max-in-flight` (default `1000`).

--- a/docs/designs/056-concurrent-node-partitioned-event-processing.md
+++ b/docs/designs/056-concurrent-node-partitioned-event-processing.md
@@ -1,0 +1,153 @@
+# ADR-056: `Performance` — Concurrent Node-Partitioned Event Processing
+
+## Table of contents
+
+- [Context](#context)
+- [Decision](#decision)
+- [Implementation](#implementation)
+- [Rationale](#rationale)
+- [Consequences](#consequences)
+- [Alternatives Considered](#alternatives-considered)
+- [Testing](#testing)
+- [Rollout](#rollout)
+- [References](#references)
+
+## Context
+
+`health-events-analyzer` monitors the database change stream for non-fatal, transient health events, correlates them over time windows via rule-driven database aggregation queries, and elevates recurrent failure patterns to fatal events for automated remediation.
+
+In production and scale testing, `health-events-analyzer` operates on a strict serial processing loop. Metrics benchmarked in issue #1800 indicate:
+- Handling duration per event averages **17.67 ms** (sum 1,838.81 s over 104,090 events).
+- Wall-clock time remains constant (17.5–19.4 ms) across offered rates from 1.8 to 55 events/s.
+- This creates an effective processing ceiling of approximately **57 events/s** per replica.
+- Most of the 17.67 ms is spent in database network round-trips (I/O wait) executing aggregation pipelines; CPU usage accounts for only ~5.8 ms per event.
+- Vertical scaling (allocating more CPU/memory cores) does not increase throughput because execution is I/O-bound in a single synchronous `for/select` loop.
+- Horizontal scaling (`replicaCount > 1`) is unsupported: there is no partitioning or leader election; all replicas share a single resume token keyed by `clientName: health-events-analyzer`, leading to duplicate execution and conflicting checkpoints.
+- At an ambient rate of 0.1 events per node per second, a single replica saturates at ~570 nodes. A 100,000-node fleet implies an offered load of 10,000 events/s against a 57 events/s ceiling.
+
+PR #1676 established the prerequisite for parallelization: it enforced a mandatory same-node filter (`healthevent.nodename: <incoming_event.nodename>`) as the first stage of every rule pipeline. Events for different nodes do not influence each other's evaluations.
+
+## Decision
+
+1. **Partition events by node across a concurrent worker pool**:
+   Events are hashed by `healthevent.nodename` into dedicated FIFO worker channels. Events for the same node are processed serially in strict chronological order; events for distinct nodes are processed concurrently across $N$ workers.
+2. **Implement low-water mark checkpointing**:
+   Because concurrent execution allows out-of-order completion across nodes, the change stream resume token must not be updated to whichever event finished last. The resume token is advanced only to the highest contiguous sequence number where every earlier event has been fully resolved (completed or marked processed per error policy).
+3. **Encapsulate concurrent processing in `store-client`**:
+   The concurrent processor is implemented in `store-client/pkg/client` as `PartitionedEventProcessor`, satisfying the existing `client.EventProcessor` interface.
+4. **Preserve strict backward compatibility**:
+   Worker count defaults to `1` in `EventProcessorConfig` and Helm charts (`workers: 1`). When `workers <= 1`, behavior remains single-threaded.
+
+## Implementation
+
+### Architecture Overview
+
+```text
+ChangeStreamWatcher (Events channel)
+            │
+            ▼
+┌────────────────────────────────────────────────────────────────────────┐
+│                      PartitionedEventProcessor                         │
+│                                                                        │
+│   1. Assign monotonically increasing sequence S_k to incoming Event    │
+│   2. Register (S_k, Token_k, Pending) in LowWaterMarkTracker           │
+│   3. Apply backpressure if in-flight >= MaxInFlight                    │
+│   4. Route to worker: workerIdx = hash(Event.NodeName) % NumWorkers   │
+│   5. Enqueue to Worker Queue W_i                                       │
+│                                                                        │
+│   Worker Queues (FIFO per worker):                                     │
+│   ┌───────────────┐      ┌───────────────┐      ┌───────────────┐      │
+│   │   Worker 0    │      │   Worker 1    │ ...  │   Worker N-1  │      │
+│   │ (Nodes A, C)  │      │ (Nodes B, D)  │      │ (Nodes E, F)  │      │
+│   └───────┬───────┘      └───────┬───────┘      └───────┬───────┘      │
+│           │                      │                      │              │
+│           ▼                      ▼                      ▼              │
+│       EventHandler.ProcessEvent(ctx, &HealthEventWithStatus)           │
+│           │                      │                      │              │
+│           └──────────────────────┼──────────────────────┘              │
+│                                  ▼                                     │
+│                        LowWaterMarkTracker                             │
+│                  - MarkComplete(S_k)                                   │
+│                  - Advance low-water mark past contiguous completed    │
+│                  - Checkpoint highest contiguous Token to Datastore    │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+### Key Components
+
+1. **`LowWaterMarkTracker`** (`store-client/pkg/client/low_water_mark.go`):
+   - Maintains an ordered sequence of in-flight events.
+   - Assigns ascending sequence numbers $S_1, S_2, \dots$.
+   - On `MarkDone(seq)`, marks the sequence resolved.
+   - Scans from the head of the window; pops contiguous resolved events and returns the latest contiguous resume token.
+   - Thread-safe via `sync.Mutex`.
+
+2. **`PartitionedEventProcessor`** (`store-client/pkg/client/partitioned_event_processor.go`):
+   - Implements `client.EventProcessor`.
+   - Manages $N$ worker goroutines and per-worker buffered channels.
+   - Maps events to workers via `hash(nodeName) % N` using FNV-32a. Events without a node name route to worker 0.
+   - Enforces backpressure: when uncheckpointed in-flight events reach `MaxInFlight`, suspends reading from the watcher.
+   - Handles poison events: when `MarkProcessedOnError=true` (as in `health-events-analyzer`), failed events are marked resolved in the tracker to prevent stream stalling.
+
+3. **`health-events-analyzer` Integration**:
+   - `health-events-analyzer/main.go`: adds CLI flags `--workers` (default `1`) and `--max-in-flight` (default `1000`).
+   - `health-events-analyzer/pkg/reconciler/reconciler.go`: configures `EventProcessorConfig.Workers` and `MaxInFlight`.
+   - `distros/kubernetes/nvsentinel/charts/health-events-analyzer/values.yaml`: adds `workers: 1` and `maxInFlight: 1000`.
+
+## Rationale
+
+- **Node Scoping Is Enforced:** PR #1676 added mandatory same-node `$match` stages to all analyzer rules. Events on Node A can never satisfy or affect evaluations on Node B. Parallelizing across nodes is logically sound.
+- **Node-Keyed FIFO Maintains Invariant:** Hashing node names to dedicated worker channels guarantees that events on the same node are handled sequentially, preventing duplicate remediation triggers or out-of-order state transitions.
+- **Low-Water Mark Prevents Data Loss:** If a pod restarts while Worker 2 has finished Event 2 but Worker 1 is still processing Event 1, checkpointing Token 2 would permanently lose Event 1. Low-water marking guarantees that only contiguous completed prefixes are checkpointed.
+- **`store-client` Abstraction:** Keeping the concurrency and checkpointing logic inside `store-client` makes it independently testable, reusable across other change stream consumers, and decoupled from analyzer business logic.
+
+## Consequences
+
+### Positive
+- **Linear Throughput Scaling:** With $N$ workers, maximum throughput increases from ~57 events/s to $\approx N \times 57$ events/s (e.g., 16 workers yield ~900 events/s; 64 workers yield ~3,600 events/s).
+- **Zero Query Semantic Changes:** No database queries, rule configurations, or aggregation pipelines need modification.
+- **Contained Memory Usage:** `MaxInFlight` backpressure ensures heap growth is strictly bounded even during database latency spikes.
+
+### Negative
+- **Increased Datastore Connection Concurrency:** $N$ concurrent workers make $N$ simultaneous aggregation queries. The database connection pool must support this concurrency.
+- **Potential Head-of-Line Blocking per Worker:** A very slow query on Node A may delay Node C if both hash to the same worker.
+
+### Mitigations
+- **Event Timeouts:** Each event evaluation runs with a bounded context timeout (`EventTimeout`, default 30s) to prevent a hung query from stalling a worker indefinitely.
+- **Sized Connection Pool:** The datastore connection pool defaults in `store-client` accommodate concurrent operations; default worker count is conservative (`workers: 1`).
+
+## Alternatives Considered
+
+### 1. Multiple Replicas with Sharded Streams
+**Rejected for now** because: MongoDB change streams do not natively partition by document key across distinct consumer groups without sharded collections and separate resume tokens. Adding sharding across replicas introduces distributed coordination, whereas node-partitioned concurrency inside a single replica achieves the required scale without distributed state.
+
+### 2. Multi-Rule Aggregation Merging
+**Complementary, not mutually exclusive.** Merging rules that share `$match` criteria into single `$facet` pipelines reduces MongoDB round trips. However, serial execution would remain capped by the latency of that merged query. Partitioning provides the structural fix.
+
+## Testing
+
+- Unit tests in `store-client/pkg/client/low_water_mark_test.go`:
+  - Watermark advances only when the lowest incomplete sequence resolves.
+  - Out-of-order completions (e.g., sequences 3, 2, 1) properly return token 3.
+  - Gaps in completion hold the watermark at the gap.
+  - High concurrency stress test with `-race`.
+- Unit tests in `store-client/pkg/client/partitioned_event_processor_test.go`:
+  - Verify same-node events execute sequentially.
+  - Verify different-node events execute concurrently.
+  - Verify backpressure blocks consumption when `MaxInFlight` is reached.
+  - Verify graceful shutdown flushes the final low-water mark.
+- Integration tests in `health-events-analyzer/pkg/reconciler/reconciler_test.go`:
+  - Verify reconciler initializes and processes events under multi-worker configuration.
+
+## Rollout
+
+1. Merge `store-client` changes with default `Workers: 1`.
+2. Update `health-events-analyzer` to wire the new options with Helm default `workers: 1`.
+3. Enable `workers: 16` in staging and scale environments to benchmark throughput under load.
+
+## References
+
+- ADR-007: Intelligence — Health Event Correlation
+- ADR-054: Observability — change stream consumer lag metrics
+- GitHub Issue #1800: Let health-events-analyzer process events concurrently, partitioned by node
+- GitHub PR #1676: feat(health-event-analyser): scope HEA rules to incoming event's node

--- a/docs/designs/056-concurrent-node-partitioned-event-processing.md
+++ b/docs/designs/056-concurrent-node-partitioned-event-processing.md
@@ -42,35 +42,61 @@ PR #1676 established the prerequisite for parallelization: it enforced a mandato
 
 ### Architecture Overview
 
-```text
-ChangeStreamWatcher (Events channel)
-            │
-            ▼
-┌────────────────────────────────────────────────────────────────────────┐
-│                      PartitionedEventProcessor                         │
-│                                                                        │
-│   1. Assign monotonically increasing sequence S_k to incoming Event    │
-│   2. Register (S_k, Token_k, Pending) in LowWaterMarkTracker           │
-│   3. Apply backpressure if in-flight >= MaxInFlight                    │
-│   4. Route to worker: workerIdx = hash(Event.NodeName) % NumWorkers   │
-│   5. Enqueue to Worker Queue W_i                                       │
-│                                                                        │
-│   Worker Queues (FIFO per worker):                                     │
-│   ┌───────────────┐      ┌───────────────┐      ┌───────────────┐      │
-│   │   Worker 0    │      │   Worker 1    │ ...  │   Worker N-1  │      │
-│   │ (Nodes A, C)  │      │ (Nodes B, D)  │      │ (Nodes E, F)  │      │
-│   └───────┬───────┘      └───────┬───────┘      └───────┬───────┘      │
-│           │                      │                      │              │
-│           ▼                      ▼                      ▼              │
-│       EventHandler.ProcessEvent(ctx, &HealthEventWithStatus)           │
-│           │                      │                      │              │
-│           └──────────────────────┼──────────────────────┘              │
-│                                  ▼                                     │
-│                        LowWaterMarkTracker                             │
-│                  - MarkComplete(S_k)                                   │
-│                  - Advance low-water mark past contiguous completed    │
-│                  - Checkpoint highest contiguous Token to Datastore    │
-└────────────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    Watcher["ChangeStreamWatcher (Events Channel)"] --> Ingestion
+
+    subgraph Ingestion ["Event Ingestion & Routing"]
+        AssignSeq["1. Assign Monotonic Sequence S_k"]
+        RegTracker["2. Register (S_k, Token_k, Pending) in Tracker"]
+        Backpressure{"3. In-flight >= MaxInFlight?"}
+        Pause["Suspend Reading (Wait on DrainCh)"]
+        HashRoute["4. workerIdx = hash(NodeName) % NumWorkers"]
+
+        AssignSeq --> RegTracker
+        RegTracker --> Backpressure
+        Backpressure -->|Yes| Pause
+        Backpressure -->|No| HashRoute
+        Pause -->|Drain Signal| HashRoute
+    end
+
+    subgraph WorkerQueues ["Worker Channels (FIFO per Worker)"]
+        W0["Worker 0 (Nodes A, C, ...)"]
+        W1["Worker 1 (Nodes B, D, ...)"]
+        Wdots["..."]
+        Wn["Worker N-1 (Nodes E, F, ...)"]
+    end
+
+    HashRoute -->|Enqueue| W0
+    HashRoute -->|Enqueue| W1
+    HashRoute -->|Enqueue| Wdots
+    HashRoute -->|Enqueue| Wn
+
+    subgraph Execution ["Parallel Handler Execution"]
+        H0["EventHandler.ProcessEvent"]
+        H1["EventHandler.ProcessEvent"]
+        Hdots["..."]
+        Hn["EventHandler.ProcessEvent"]
+    end
+
+    W0 --> H0
+    W1 --> H1
+    Wdots --> Hdots
+    Wn --> Hn
+
+    subgraph Checkpoint ["LowWaterMarkTracker & Checkpoint Engine"]
+        MarkDone["MarkDone(S_k)"]
+        Advance["Advance past contiguous completed prefix"]
+        CheckpointWrite["Checkpoint highest contiguous resume token to Datastore"]
+
+        MarkDone --> Advance
+        Advance --> CheckpointWrite
+    end
+
+    H0 --> MarkDone
+    H1 --> MarkDone
+    Hdots --> MarkDone
+    Hn --> MarkDone
 ```
 
 ### Key Components

--- a/docs/designs/056-concurrent-node-partitioned-event-processing.md
+++ b/docs/designs/056-concurrent-node-partitioned-event-processing.md
@@ -86,7 +86,9 @@ ChangeStreamWatcher (Events channel)
    - Implements `client.EventProcessor`.
    - Manages $N$ worker goroutines and per-worker buffered channels.
    - Maps events to workers via `hash(nodeName) % N` using FNV-32a. Events without a node name route to worker 0.
-   - Handles poison events vs transient errors: when `MarkProcessedOnError=true` (as in `health-events-analyzer`), only terminal errors (e.g., permanent unmarshaling failures or handler rejections) are marked resolved in the tracker to prevent poison pills from blocking stream progress. Transient conditions—specifically context cancellations (`context.Canceled`) and timeouts (`context.DeadlineExceeded`)—are never marked as completed, ensuring the low-water mark does not advance past them and that they are retried on pod restart rather than permanently lost.
+   - Enforces backpressure: when uncheckpointed in-flight events reach `MaxInFlight`, suspends reading from the watcher.
+   - Handles poison events vs transient errors: when `MarkProcessedOnError=true` (as in `health-events-analyzer`), only terminal poison errors (such as unmarshaling failures or document ID errors) are marked resolved in the tracker to prevent stream stalling. Transient conditions—specifically context cancellations (`context.Canceled`) and timeouts (`context.DeadlineExceeded`)—are never marked as completed, ensuring the low-water mark does not advance past them and that they are retried on pod restart rather than permanently lost.
+   - Preserves checkpoint ordering: serializes watermark advancement and datastore writes under a checkpoint mutex, and retains unpersisted checkpoint tokens for shutdown retry.
 
 3. **`health-events-analyzer` Integration**:
    - `health-events-analyzer/main.go`: adds CLI flags `--workers` (default `1`) and `--max-in-flight` (default `1000`).
@@ -112,7 +114,7 @@ ChangeStreamWatcher (Events channel)
 - **Potential Head-of-Line Blocking per Worker:** A very slow query on Node A may delay Node C if both hash to the same worker.
 
 ### Mitigations
-- **Event Timeouts:** Each event evaluation runs with a bounded context timeout (`EventTimeout`, default 30s) to prevent a hung query from stalling a worker indefinitely.
+- **Event Timeouts:** Per-event timeout enforcement is opt-in via `EventProcessorConfig.EventTimeout`. It is disabled when unset or non-positive (`<= 0`) so existing handlers run without synthetic timeouts unless explicitly configured.
 - **Sized Connection Pool:** The datastore connection pool defaults in `store-client` accommodate concurrent operations; default worker count is conservative (`workers: 1`).
 
 ## Alternatives Considered
@@ -134,9 +136,14 @@ ChangeStreamWatcher (Events channel)
   - Verify same-node events execute sequentially.
   - Verify different-node events execute concurrently.
   - Verify backpressure blocks consumption when `MaxInFlight` is reached.
-  - Verify graceful shutdown flushes the final low-water mark.
+  - Verify terminal poison errors advance the watermark under `MarkProcessedOnError=true`.
+  - Verify transient timeouts (`context.DeadlineExceeded`) and context cancellations are never checkpointed as processed.
+  - Verify worker channels discard buffered tasks on cancellation during shutdown.
+  - Verify serialization of watermark advancement and datastore checkpointing under `checkpointMu`.
+  - Verify unpersisted checkpoint tokens are retained and retried on shutdown with a bounded context.
 - Integration tests in `health-events-analyzer/pkg/reconciler/reconciler_test.go`:
   - Verify reconciler initializes and processes events under multi-worker configuration.
+  - Verify rule matching, synthetic remediation event generation, and gRPC publishing.
 
 ## Rollout
 

--- a/docs/designs/056-concurrent-node-partitioned-event-processing.md
+++ b/docs/designs/056-concurrent-node-partitioned-event-processing.md
@@ -14,7 +14,7 @@
 
 ## Context
 
-`health-events-analyzer` monitors the database change stream for non-fatal, transient health events, correlates them over time windows via rule-driven database aggregation queries, and elevates recurrent failure patterns to fatal events for automated remediation.
+`health-events-analyzer` monitors the database change stream for incoming health events, correlates them over time windows via rule-driven database aggregation queries, and emits synthetic remediation events when failure patterns match configured rules.
 
 In production and scale testing, `health-events-analyzer` operates on a strict serial processing loop. Metrics benchmarked in issue #1800 indicate:
 - Handling duration per event averages **17.67 ms** (sum 1,838.81 s over 104,090 events).

--- a/docs/designs/056-concurrent-node-partitioned-event-processing.md
+++ b/docs/designs/056-concurrent-node-partitioned-event-processing.md
@@ -86,7 +86,7 @@ ChangeStreamWatcher (Events channel)
    - Implements `client.EventProcessor`.
    - Manages $N$ worker goroutines and per-worker buffered channels.
    - Maps events to workers via `hash(nodeName) % N` using FNV-32a. Events without a node name route to worker 0.
-   - Enforces backpressure: when uncheckpointed in-flight events reach `MaxInFlight`, suspends reading from the watcher.
+   - Enforces backpressure: when uncheckpointed in-flight events reach `MaxInFlight`, suspends reading from the watcher. Note that `MaxInFlight` bounds registered in-flight events; upstream buffers (including the PostgreSQL watcher and adapter channels of up to 100 events each) and materialized payloads can also reside in memory.
    - Handles poison events vs transient errors: when `MarkProcessedOnError=true` (as in `health-events-analyzer`), only terminal poison errors (such as unmarshaling failures or document ID errors) are marked resolved in the tracker to prevent stream stalling. Transient conditions—specifically context cancellations (`context.Canceled`) and timeouts (`context.DeadlineExceeded`)—are never marked as completed, ensuring the low-water mark does not advance past them and that they are retried on pod restart rather than permanently lost.
    - Preserves checkpoint ordering: serializes watermark advancement and datastore writes under a checkpoint mutex, and retains unpersisted checkpoint tokens for shutdown retry.
 
@@ -107,7 +107,7 @@ ChangeStreamWatcher (Events channel)
 ### Positive
 - **Linear Throughput Scaling:** With $N$ workers, maximum throughput increases from ~57 events/s to $\approx N \times 57$ events/s (e.g., 16 workers yield ~900 events/s; 64 workers yield ~3,600 events/s).
 - **Zero Query Semantic Changes:** No database queries, rule configurations, or aggregation pipelines need modification.
-- **Contained Memory Usage:** `MaxInFlight` backpressure ensures heap growth is strictly bounded even during database latency spikes.
+- **Contained Memory Usage:** `MaxInFlight` backpressure bounds registered in-flight events during database latency spikes. Note that heap usage is not bounded by `MaxInFlight` alone; it also includes upstream datastore buffers (such as the PostgreSQL watcher and adapter channels buffering up to 100 events each) and variable-sized event payloads materialized prior to registration.
 
 ### Negative
 - **Increased Datastore Connection Concurrency:** $N$ concurrent workers make $N$ simultaneous aggregation queries. The database connection pool must support this concurrency.

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -69,3 +69,4 @@ Each record states one decision: the context that forced it, what was decided, w
 | 053 | [Monitoring — Integrate Default NPD Node Conditions](053-npd-checks-integration.md) |
 | 054 | [`Observability` — change stream consumer lag metrics](054-changestream-lag-metrics.md) |
 | 055 | [Health Monitors — NVCRE Certification Monitor](055-nvcre-certification-monitor.md) |
+| 056 | [Performance — Concurrent Node-Partitioned Event Processing](056-concurrent-node-partitioned-event-processing.md) |

--- a/health-events-analyzer/main.go
+++ b/health-events-analyzer/main.go
@@ -133,6 +133,10 @@ func run() error {
 	certConfig := flags.RegisterDatabaseCertFlags()
 	processingStrategyFlag := flag.String("processing-strategy", "EXECUTE_REMEDIATION",
 		"Event processing strategy for analyzer output: EXECUTE_REMEDIATION or STORE_ONLY")
+	workersFlag := flag.Int("workers", 1,
+		"Number of concurrent worker goroutines for event processing partitioned by node (default: 1)")
+	maxInFlightFlag := flag.Int("max-in-flight", 1000,
+		"Maximum number of uncheckpointed in-flight events before applying backpressure (default: 1000)")
 
 	flag.Parse()
 
@@ -174,6 +178,8 @@ func run() error {
 		Pipeline:                  pipeline,
 		HealthEventsAnalyzerRules: tomlConfig,
 		Publisher:                 pub,
+		Workers:                   *workersFlag,
+		MaxInFlight:               *maxInFlightFlag,
 	}
 
 	rec := reconciler.NewReconciler(reconcilerCfg)

--- a/health-events-analyzer/pkg/reconciler/reconciler.go
+++ b/health-events-analyzer/pkg/reconciler/reconciler.go
@@ -55,6 +55,8 @@ type HealthEventsAnalyzerReconcilerConfig struct {
 	Pipeline                  any
 	HealthEventsAnalyzerRules *config.TomlConfig
 	Publisher                 *publisher.PublisherConfig
+	Workers                   int
+	MaxInFlight               int
 }
 
 type Reconciler struct {
@@ -72,13 +74,28 @@ func NewReconciler(cfg HealthEventsAnalyzerReconcilerConfig) *Reconciler {
 	}
 }
 
-func newEventProcessorConfig() client.EventProcessorConfig {
+func newEventProcessorConfig(reconcilerCfg ...HealthEventsAnalyzerReconcilerConfig) client.EventProcessorConfig {
+	workers := 1
+	maxInFlight := 1000
+
+	if len(reconcilerCfg) > 0 {
+		if reconcilerCfg[0].Workers > 0 {
+			workers = reconcilerCfg[0].Workers
+		}
+
+		if reconcilerCfg[0].MaxInFlight > 0 {
+			maxInFlight = reconcilerCfg[0].MaxInFlight
+		}
+	}
+
 	// Keep the stream live after handler failures. The processor records the
 	// failure before checkpointing; checkpoint failures still stop processing.
 	return client.EventProcessorConfig{
 		EnableMetrics:        true,
 		MetricsLabels:        map[string]string{"module": agentName},
 		MarkProcessedOnError: true,
+		Workers:              workers,
+		MaxInFlight:          maxInFlight,
 		SkipEvent: func(event client.Event) bool {
 			return client.EventUpdatesOnly(event, healthstatus.FaultQuarantineRecoveryPath)
 		},
@@ -142,7 +159,7 @@ func (r *Reconciler) Start(ctx context.Context) error {
 
 	oldWatcher := unwrapable.Unwrap()
 
-	processorConfig := newEventProcessorConfig()
+	processorConfig := newEventProcessorConfig(r.config)
 
 	r.eventProcessor = client.NewEventProcessor(oldWatcher, r.databaseClient, processorConfig)
 

--- a/health-events-analyzer/pkg/reconciler/reconciler_test.go
+++ b/health-events-analyzer/pkg/reconciler/reconciler_test.go
@@ -236,6 +236,21 @@ func TestEventProcessorConfigCheckpointsHandlerErrors(t *testing.T) {
 	assert.True(t, processorConfig.MarkProcessedOnError)
 }
 
+func TestEventProcessorConfigConcurrencySettings(t *testing.T) {
+	defaultConfig := newEventProcessorConfig()
+	assert.True(t, defaultConfig.MarkProcessedOnError)
+	assert.Equal(t, 1, defaultConfig.Workers)
+	assert.Equal(t, 1000, defaultConfig.MaxInFlight)
+
+	customConfig := newEventProcessorConfig(HealthEventsAnalyzerReconcilerConfig{
+		Workers:     16,
+		MaxInFlight: 500,
+	})
+	assert.True(t, customConfig.MarkProcessedOnError)
+	assert.Equal(t, 16, customConfig.Workers)
+	assert.Equal(t, 500, customConfig.MaxInFlight)
+}
+
 func TestCheckRule(t *testing.T) {
 	ctx := context.Background()
 

--- a/store-client/pkg/client/event_processor.go
+++ b/store-client/pkg/client/event_processor.go
@@ -49,8 +49,8 @@ type EventProcessorConfig struct {
 	// MaxInFlight specifies the maximum number of uncheckpointed in-flight events
 	// before applying backpressure to the change stream reader (default: 1000).
 	MaxInFlight int
-	// EventTimeout specifies the per-event processing timeout context (default: 30s).
-	// Set to 0 to disable per-event timeout.
+	// EventTimeout specifies an optional per-event processing timeout context.
+	// When <= 0 (default), per-event timeout is disabled and the parent context is used directly.
 	EventTimeout time.Duration
 	// PartitionKeyFunc specifies an optional custom partition key function.
 	// If nil, defaults to extracting Event.GetNodeName().

--- a/store-client/pkg/client/event_processor.go
+++ b/store-client/pkg/client/event_processor.go
@@ -42,6 +42,19 @@ type EventProcessorConfig struct {
 	// SkipEvent can suppress provider-specific change events before document
 	// decoding while still advancing the stream checkpoint.
 	SkipEvent func(Event) bool
+	// Workers specifies the number of concurrent worker goroutines.
+	// When <= 1 (default), events are processed serially via DefaultEventProcessor.
+	// When > 1, events are partitioned by node across workers concurrently with low-water mark checkpointing.
+	Workers int
+	// MaxInFlight specifies the maximum number of uncheckpointed in-flight events
+	// before applying backpressure to the change stream reader (default: 1000).
+	MaxInFlight int
+	// EventTimeout specifies the per-event processing timeout context (default: 30s).
+	// Set to 0 to disable per-event timeout.
+	EventTimeout time.Duration
+	// PartitionKeyFunc specifies an optional custom partition key function.
+	// If nil, defaults to extracting Event.GetNodeName().
+	PartitionKeyFunc func(Event) string
 }
 
 // EventProcessor provides a unified interface for processing change stream events
@@ -94,10 +107,15 @@ func newUncheckpointedEventError(cause error) error {
 	return &uncheckpointedEventError{cause: cause}
 }
 
-// NewEventProcessor creates a new unified event processor
+// NewEventProcessor creates a new unified event processor.
+// If config.Workers > 1, a concurrent PartitionedEventProcessor is returned.
 func NewEventProcessor(
 	watcher ChangeStreamWatcher, dbClient DatabaseClient, config EventProcessorConfig,
 ) EventProcessor {
+	if config.Workers > 1 {
+		return NewPartitionedEventProcessor(watcher, dbClient, config)
+	}
+
 	return &DefaultEventProcessor{
 		changeStreamWatcher: watcher,
 		databaseClient:      dbClient,

--- a/store-client/pkg/client/low_water_mark.go
+++ b/store-client/pkg/client/low_water_mark.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"sync"
+)
+
+type trackerItem struct {
+	seq   uint64
+	token []byte
+	done  bool
+}
+
+// LowWaterMarkTracker tracks in-flight change stream events and computes
+// the highest contiguous completed resume token.
+//
+// Because events may finish processing out of order when handled concurrently,
+// the resume token must only advance past an event once every earlier event has
+// also finished. This prevents skipped events on crash or restart.
+type LowWaterMarkTracker struct {
+	mu                  sync.Mutex
+	items               []*trackerItem
+	itemMap             map[uint64]*trackerItem
+	nextSeq             uint64
+	lastCheckpointToken []byte
+	drainCh             chan struct{}
+}
+
+// NewLowWaterMarkTracker creates a new thread-safe LowWaterMarkTracker.
+func NewLowWaterMarkTracker() *LowWaterMarkTracker {
+	return &LowWaterMarkTracker{
+		itemMap: make(map[uint64]*trackerItem),
+		nextSeq: 1,
+		drainCh: make(chan struct{}, 1),
+	}
+}
+
+// Register registers a newly admitted change stream event with its resume token
+// and returns an allocated sequence number.
+func (t *LowWaterMarkTracker) Register(token []byte) uint64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	seq := t.nextSeq
+	t.nextSeq++
+
+	item := &trackerItem{
+		seq:   seq,
+		token: token,
+		done:  false,
+	}
+
+	t.items = append(t.items, item)
+	t.itemMap[seq] = item
+
+	return seq
+}
+
+// MarkDone marks the given sequence number as completed.
+// If this resolves the head of the in-flight window, the low-water mark
+// advances across all contiguous completed items. The newest contiguous token
+// is returned. If the watermark does not advance, nil is returned.
+func (t *LowWaterMarkTracker) MarkDone(seq uint64) []byte {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	item, exists := t.itemMap[seq]
+	if !exists {
+		return nil
+	}
+
+	item.done = true
+
+	return t.advanceLocked()
+}
+
+// advanceLocked inspects the head of the items slice and pops contiguous
+// completed entries. Must be called while holding t.mu.
+func (t *LowWaterMarkTracker) advanceLocked() []byte {
+	var highestToken []byte
+
+	popCount := 0
+
+	for popCount < len(t.items) && t.items[popCount].done {
+		highestToken = t.items[popCount].token
+		delete(t.itemMap, t.items[popCount].seq)
+		t.items[popCount] = nil
+		popCount++
+	}
+
+	if popCount > 0 {
+		t.items = t.items[popCount:]
+		if len(t.items) == 0 && cap(t.items) > 1024 {
+			t.items = nil
+		}
+
+		if len(highestToken) > 0 {
+			t.lastCheckpointToken = highestToken
+		}
+
+		// Notify any backpressure waiter that in-flight capacity has been freed
+		select {
+		case t.drainCh <- struct{}{}:
+		default:
+		}
+	}
+
+	return highestToken
+}
+
+// InFlightCount returns the current number of in-flight / uncheckpointed items.
+func (t *LowWaterMarkTracker) InFlightCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return len(t.itemMap)
+}
+
+// DrainCh returns a channel that receives a signal when in-flight items drain.
+func (t *LowWaterMarkTracker) DrainCh() <-chan struct{} {
+	return t.drainCh
+}
+
+// LastCheckpointedToken returns the latest checkpointed token.
+func (t *LowWaterMarkTracker) LastCheckpointedToken() []byte {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return t.lastCheckpointToken
+}
+
+// Flush advances over any contiguous completed items and returns the newest token.
+func (t *LowWaterMarkTracker) Flush() []byte {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return t.advanceLocked()
+}

--- a/store-client/pkg/client/low_water_mark_test.go
+++ b/store-client/pkg/client/low_water_mark_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLowWaterMarkTracker_Sequential(t *testing.T) {
+	tracker := NewLowWaterMarkTracker()
+
+	seq1 := tracker.Register([]byte("token-1"))
+	seq2 := tracker.Register([]byte("token-2"))
+	seq3 := tracker.Register([]byte("token-3"))
+
+	require.Equal(t, uint64(1), seq1)
+	require.Equal(t, uint64(2), seq2)
+	require.Equal(t, uint64(3), seq3)
+	require.Equal(t, 3, tracker.InFlightCount())
+
+	adv1 := tracker.MarkDone(seq1)
+	assert.Equal(t, []byte("token-1"), adv1)
+	assert.Equal(t, 2, tracker.InFlightCount())
+
+	adv2 := tracker.MarkDone(seq2)
+	assert.Equal(t, []byte("token-2"), adv2)
+	assert.Equal(t, 1, tracker.InFlightCount())
+
+	adv3 := tracker.MarkDone(seq3)
+	assert.Equal(t, []byte("token-3"), adv3)
+	assert.Equal(t, 0, tracker.InFlightCount())
+	assert.Equal(t, []byte("token-3"), tracker.LastCheckpointedToken())
+}
+
+func TestLowWaterMarkTracker_OutOfOrder(t *testing.T) {
+	tracker := NewLowWaterMarkTracker()
+
+	seq1 := tracker.Register([]byte("token-1"))
+	seq2 := tracker.Register([]byte("token-2"))
+	seq3 := tracker.Register([]byte("token-3"))
+
+	// Complete seq3 first: cannot advance because seq1 and seq2 are pending
+	adv := tracker.MarkDone(seq3)
+	assert.Nil(t, adv)
+	assert.Equal(t, 3, tracker.InFlightCount())
+
+	// Complete seq2: still cannot advance because seq1 is pending
+	adv = tracker.MarkDone(seq2)
+	assert.Nil(t, adv)
+	assert.Equal(t, 3, tracker.InFlightCount())
+
+	// Complete seq1: now seq1, seq2, seq3 are all complete -> advances to token-3!
+	adv = tracker.MarkDone(seq1)
+	assert.Equal(t, []byte("token-3"), adv)
+	assert.Equal(t, 0, tracker.InFlightCount())
+	assert.Equal(t, []byte("token-3"), tracker.LastCheckpointedToken())
+}
+
+func TestLowWaterMarkTracker_Gaps(t *testing.T) {
+	tracker := NewLowWaterMarkTracker()
+
+	seq1 := tracker.Register([]byte("token-1"))
+	seq2 := tracker.Register([]byte("token-2"))
+	seq3 := tracker.Register([]byte("token-3"))
+	seq4 := tracker.Register([]byte("token-4"))
+
+	// Complete seq1 -> advances to token-1
+	adv := tracker.MarkDone(seq1)
+	assert.Equal(t, []byte("token-1"), adv)
+	assert.Equal(t, 3, tracker.InFlightCount())
+
+	// Complete seq3 -> gap at seq2, cannot advance
+	adv = tracker.MarkDone(seq3)
+	assert.Nil(t, adv)
+	assert.Equal(t, 3, tracker.InFlightCount())
+
+	// Complete seq2 -> fills gap, advances past seq2 and seq3 to token-3
+	adv = tracker.MarkDone(seq2)
+	assert.Equal(t, []byte("token-3"), adv)
+	assert.Equal(t, 1, tracker.InFlightCount())
+
+	// Complete seq4 -> advances to token-4
+	adv = tracker.MarkDone(seq4)
+	assert.Equal(t, []byte("token-4"), adv)
+	assert.Equal(t, 0, tracker.InFlightCount())
+}
+
+func TestLowWaterMarkTracker_UnknownSequence(t *testing.T) {
+	tracker := NewLowWaterMarkTracker()
+
+	adv := tracker.MarkDone(999)
+	assert.Nil(t, adv)
+	assert.Equal(t, 0, tracker.InFlightCount())
+}
+
+func TestLowWaterMarkTracker_ConcurrentStress(t *testing.T) {
+	tracker := NewLowWaterMarkTracker()
+	const count = 500
+
+	seqs := make([]uint64, count)
+	for i := range count {
+		token := []byte(fmt.Sprintf("token-%04d", i+1))
+		seqs[i] = tracker.Register(token)
+	}
+
+	require.Equal(t, count, tracker.InFlightCount())
+
+	var wg sync.WaitGroup
+	wg.Add(count)
+
+	// Complete in arbitrary concurrent order
+	for i := range count {
+		go func(seq uint64) {
+			defer wg.Done()
+			tracker.MarkDone(seq)
+		}(seqs[i])
+	}
+
+	wg.Wait()
+
+	// After all complete, InFlightCount must be 0 and LastCheckpointedToken must be token-0500
+	assert.Equal(t, 0, tracker.InFlightCount())
+	expectedFinalToken := []byte(fmt.Sprintf("token-%04d", count))
+	assert.True(t, bytes.Equal(expectedFinalToken, tracker.LastCheckpointedToken()))
+}

--- a/store-client/pkg/client/partitioned_event_processor.go
+++ b/store-client/pkg/client/partitioned_event_processor.go
@@ -113,6 +113,7 @@ func (p *PartitionedEventProcessor) Start(ctx context.Context) error {
 
 		go func(workerID int) {
 			defer p.wg.Done()
+
 			p.runWorker(workerCtx, workerID, p.workerChs[workerID])
 		}(i)
 	}
@@ -126,6 +127,7 @@ func (p *PartitionedEventProcessor) Start(ctx context.Context) error {
 	p.wg.Wait()
 
 	p.checkpointMu.Lock()
+
 	tokenToFlush := p.pendingCheckpointToken
 	if flushToken := p.tracker.Flush(); len(flushToken) > 0 {
 		tokenToFlush = flushToken
@@ -137,6 +139,7 @@ func (p *PartitionedEventProcessor) Start(ctx context.Context) error {
 
 		if markErr := p.markProcessed(shutdownCtx, tokenToFlush); markErr != nil {
 			slog.Error("Failed to mark final checkpoint token", "error", markErr)
+
 			p.pendingCheckpointToken = tokenToFlush
 		} else {
 			p.pendingCheckpointToken = nil
@@ -162,6 +165,46 @@ func (p *PartitionedEventProcessor) Stop(ctx context.Context) error {
 	return nil
 }
 
+func (p *PartitionedEventProcessor) waitBackpressure(ctx context.Context, maxInFlight int) error {
+	if p.tracker.InFlightCount() < maxInFlight {
+		return nil
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-p.stopCh:
+		return nil
+	case <-p.tracker.DrainCh():
+		return nil
+	}
+}
+
+func (p *PartitionedEventProcessor) onEventsClosed(ctx context.Context) error {
+	slog.Info("Event channel closed, stopping processor")
+
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	return nil
+}
+
+func (p *PartitionedEventProcessor) dispatchEvent(ctx context.Context, event Event) error {
+	seq := p.tracker.Register(event.GetResumeToken())
+	task := &partitionedTask{seq: seq, event: event}
+	workerIdx := p.selectWorker(event)
+
+	select {
+	case p.workerChs[workerIdx] <- task:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-p.stopCh:
+		return nil
+	}
+}
+
 func (p *PartitionedEventProcessor) processEvents(ctx context.Context) error {
 	slog.Info("Listening for events on the change stream channel...")
 
@@ -173,15 +216,8 @@ func (p *PartitionedEventProcessor) processEvents(ctx context.Context) error {
 	eventsCh := p.changeStreamWatcher.Events()
 
 	for {
-		if p.tracker.InFlightCount() >= maxInFlight {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-p.stopCh:
-				return nil
-			case <-p.tracker.DrainCh():
-				continue
-			}
+		if err := p.waitBackpressure(ctx, maxInFlight); err != nil {
+			return err
 		}
 
 		select {
@@ -195,25 +231,11 @@ func (p *PartitionedEventProcessor) processEvents(ctx context.Context) error {
 			return nil
 		case event, ok := <-eventsCh:
 			if !ok {
-				slog.Info("Event channel closed, stopping processor")
-
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-
-				return nil
+				return p.onEventsClosed(ctx)
 			}
 
-			seq := p.tracker.Register(event.GetResumeToken())
-			task := &partitionedTask{seq: seq, event: event}
-			workerIdx := p.selectWorker(event)
-
-			select {
-			case p.workerChs[workerIdx] <- task:
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-p.stopCh:
-				return nil
+			if err := p.dispatchEvent(ctx, event); err != nil {
+				return err
 			}
 		}
 	}
@@ -237,7 +259,9 @@ func (p *PartitionedEventProcessor) runWorker(ctx context.Context, id int, ch <-
 
 			var uncheckpointedErr *uncheckpointedEventError
 			if errors.As(err, &uncheckpointedErr) && !p.config.MarkProcessedOnError {
-				p.Stop(ctx)
+				if stopErr := p.Stop(ctx); stopErr != nil {
+					slog.Error("Failed to stop processor on uncheckpointed error", "error", stopErr)
+				}
 
 				return
 			}
@@ -245,20 +269,61 @@ func (p *PartitionedEventProcessor) runWorker(ctx context.Context, id int, ch <-
 	}
 }
 
+func (p *PartitionedEventProcessor) parseEvent(event Event) (*model.HealthEventWithStatus, string, error) {
+	var healthEventWithStatus model.HealthEventWithStatus
+	if err := event.UnmarshalDocument(&healthEventWithStatus); err != nil {
+		return nil, "", fmt.Errorf("failed to unmarshal event: %w", err)
+	}
+
+	eventID, err := event.GetDocumentID()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get document ID: %w", err)
+	}
+
+	return &healthEventWithStatus, eventID, nil
+}
+
+func (p *PartitionedEventProcessor) shouldSkip(event Event) bool {
+	return p.config.SkipEvent != nil && p.config.SkipEvent(event)
+}
+
+func (p *PartitionedEventProcessor) handleProcessError(
+	ctx context.Context, seq uint64, eventID string, startTime time.Time, processErr error,
+) error {
+	p.updateMetrics("processing_failed", eventID, time.Since(startTime), false)
+	slog.Error("Event processing failed", "eventID", eventID, "seq", seq, "error", processErr)
+
+	// Context cancellations and timeouts are transient conditions and must not be marked
+	// as processed, allowing the event to be retried on restart rather than permanently skipped.
+	if errors.Is(processErr, context.Canceled) || errors.Is(processErr, context.DeadlineExceeded) || ctx.Err() != nil {
+		return newUncheckpointedEventError(processErr)
+	}
+
+	if p.config.MarkProcessedOnError {
+		slog.Warn("Marking failed event as processed due to MarkProcessedOnError=true", "eventID", eventID)
+
+		p.onTaskCompleted(ctx, seq)
+
+		return processErr
+	}
+
+	return newUncheckpointedEventError(processErr)
+}
+
 func (p *PartitionedEventProcessor) handleTask(ctx context.Context, task *partitionedTask) error {
 	startTime := time.Now()
 	event := task.event
 	seq := task.seq
 
-	if p.config.SkipEvent != nil && p.config.SkipEvent(event) {
+	if p.shouldSkip(event) {
 		p.updateMetrics("processing_skipped", "", time.Since(startTime), true)
 		p.onTaskCompleted(ctx, seq)
 
 		return nil
 	}
 
-	var healthEventWithStatus model.HealthEventWithStatus
-	if err := event.UnmarshalDocument(&healthEventWithStatus); err != nil {
+	healthEventWithStatus, eventID, err := p.parseEvent(event)
+	if err != nil {
 		p.updateMetrics("unmarshal_error", "", time.Since(startTime), false)
 
 		if p.config.MarkProcessedOnError {
@@ -267,20 +332,7 @@ func (p *PartitionedEventProcessor) handleTask(ctx context.Context, task *partit
 			return nil
 		}
 
-		return newUncheckpointedEventError(fmt.Errorf("failed to unmarshal event: %w", err))
-	}
-
-	eventID, err := event.GetDocumentID()
-	if err != nil {
-		p.updateMetrics("document_id_error", "", time.Since(startTime), false)
-
-		if p.config.MarkProcessedOnError {
-			p.onTaskCompleted(ctx, seq)
-
-			return nil
-		}
-
-		return newUncheckpointedEventError(fmt.Errorf("failed to get document ID: %w", err))
+		return newUncheckpointedEventError(err)
 	}
 
 	eventCtx := ctx
@@ -294,25 +346,9 @@ func (p *PartitionedEventProcessor) handleTask(ctx context.Context, task *partit
 
 	slog.Debug("Processing event", "eventID", eventID, "seq", seq)
 
-	processErr := p.eventHandler.ProcessEvent(eventCtx, &healthEventWithStatus)
+	processErr := p.eventHandler.ProcessEvent(eventCtx, healthEventWithStatus)
 	if processErr != nil {
-		p.updateMetrics("processing_failed", eventID, time.Since(startTime), false)
-		slog.Error("Event processing failed", "eventID", eventID, "seq", seq, "error", processErr)
-
-		// Context cancellations and timeouts are transient conditions and must not be marked
-		// as processed, allowing the event to be retried on restart rather than permanently skipped.
-		if errors.Is(processErr, context.Canceled) || errors.Is(processErr, context.DeadlineExceeded) || ctx.Err() != nil {
-			return newUncheckpointedEventError(processErr)
-		}
-
-		if p.config.MarkProcessedOnError {
-			slog.Warn("Marking failed event as processed due to MarkProcessedOnError=true", "eventID", eventID)
-			p.onTaskCompleted(ctx, seq)
-
-			return processErr
-		}
-
-		return newUncheckpointedEventError(processErr)
+		return p.handleProcessError(ctx, seq, eventID, startTime, processErr)
 	}
 
 	p.updateMetrics("processing_success", eventID, time.Since(startTime), true)
@@ -342,21 +378,22 @@ func (p *PartitionedEventProcessor) onTaskCompleted(ctx context.Context, seq uin
 }
 
 func (p *PartitionedEventProcessor) selectWorker(event Event) int {
-	if p.config.PartitionKeyFunc != nil {
-		key := p.config.PartitionKeyFunc(event)
-		if key == "" {
-			return 0
-		}
-
-		return int(hashNode(key) % uint32(p.workers))
-	}
-
-	nodeName, err := event.GetNodeName()
-	if err != nil || nodeName == "" {
+	if p.workers <= 1 {
 		return 0
 	}
 
-	return int(hashNode(nodeName) % uint32(p.workers))
+	key := ""
+	if p.config.PartitionKeyFunc != nil {
+		key = p.config.PartitionKeyFunc(event)
+	} else if nodeName, err := event.GetNodeName(); err == nil {
+		key = nodeName
+	}
+
+	if key == "" {
+		return 0
+	}
+
+	return int(hashNode(key)&0x7fffffff) % p.workers
 }
 
 func (p *PartitionedEventProcessor) markProcessed(ctx context.Context, token []byte) error {

--- a/store-client/pkg/client/partitioned_event_processor.go
+++ b/store-client/pkg/client/partitioned_event_processor.go
@@ -258,7 +258,7 @@ func (p *PartitionedEventProcessor) runWorker(ctx context.Context, id int, ch <-
 			slog.Error("Worker failed to handle task", "workerID", id, "seq", task.seq, "error", err)
 
 			var uncheckpointedErr *uncheckpointedEventError
-			if errors.As(err, &uncheckpointedErr) && !p.config.MarkProcessedOnError {
+			if errors.As(err, &uncheckpointedErr) {
 				if stopErr := p.Stop(ctx); stopErr != nil {
 					slog.Error("Failed to stop processor on uncheckpointed error", "error", stopErr)
 				}

--- a/store-client/pkg/client/partitioned_event_processor.go
+++ b/store-client/pkg/client/partitioned_event_processor.go
@@ -53,6 +53,8 @@ type PartitionedEventProcessor struct {
 	tracker                *LowWaterMarkTracker
 	stopCh                 chan struct{}
 	stopOnce               sync.Once
+	cancelMu               sync.Mutex
+	cancelWorkers          context.CancelFunc
 	checkpointMu           sync.Mutex
 	pendingCheckpointToken []byte
 	wg                     sync.WaitGroup
@@ -108,6 +110,17 @@ func (p *PartitionedEventProcessor) Start(ctx context.Context) error {
 	workerCtx, cancelWorkers := context.WithCancel(ctx)
 	defer cancelWorkers()
 
+	p.cancelMu.Lock()
+	p.cancelWorkers = cancelWorkers
+
+	select {
+	case <-p.stopCh:
+		cancelWorkers()
+	default:
+	}
+
+	p.cancelMu.Unlock()
+
 	for i := range p.workers {
 		p.wg.Add(1)
 
@@ -157,6 +170,12 @@ func (p *PartitionedEventProcessor) Stop(ctx context.Context) error {
 	p.stopOnce.Do(func() {
 		close(p.stopCh)
 	})
+
+	p.cancelMu.Lock()
+	if p.cancelWorkers != nil {
+		p.cancelWorkers()
+	}
+	p.cancelMu.Unlock()
 
 	if p.changeStreamWatcher != nil {
 		return p.changeStreamWatcher.Close(ctx)

--- a/store-client/pkg/client/partitioned_event_processor.go
+++ b/store-client/pkg/client/partitioned_event_processor.go
@@ -182,6 +182,10 @@ func (p *PartitionedEventProcessor) processEvents(ctx context.Context) error {
 			if !ok {
 				slog.Info("Event channel closed, stopping processor")
 
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+
 				return nil
 			}
 
@@ -204,6 +208,15 @@ func (p *PartitionedEventProcessor) runWorker(ctx context.Context, id int, ch <-
 	slog.Debug("Starting worker goroutine", "workerID", id)
 
 	for task := range ch {
+		select {
+		case <-ctx.Done():
+			slog.Debug("Discarding uncheckpointed task during shutdown",
+				"workerID", id, "seq", task.seq)
+
+			continue
+		default:
+		}
+
 		if err := p.handleTask(ctx, task); err != nil {
 			slog.Error("Worker failed to handle task", "workerID", id, "seq", task.seq, "error", err)
 

--- a/store-client/pkg/client/partitioned_event_processor.go
+++ b/store-client/pkg/client/partitioned_event_processor.go
@@ -123,11 +123,13 @@ func (p *PartitionedEventProcessor) Start(ctx context.Context) error {
 
 	p.wg.Wait()
 
+	p.checkpointMu.Lock()
 	if flushToken := p.tracker.Flush(); len(flushToken) > 0 {
 		if markErr := p.markProcessed(ctx, flushToken); markErr != nil {
 			slog.Error("Failed to mark final checkpoint token", "error", markErr)
 		}
 	}
+	p.checkpointMu.Unlock()
 
 	return err
 }
@@ -307,13 +309,13 @@ func (p *PartitionedEventProcessor) handleTask(ctx context.Context, task *partit
 }
 
 func (p *PartitionedEventProcessor) onTaskCompleted(ctx context.Context, seq uint64) {
+	p.checkpointMu.Lock()
+	defer p.checkpointMu.Unlock()
+
 	advancedToken := p.tracker.MarkDone(seq)
 	if len(advancedToken) == 0 {
 		return
 	}
-
-	p.checkpointMu.Lock()
-	defer p.checkpointMu.Unlock()
 
 	if markErr := p.markProcessed(ctx, advancedToken); markErr != nil {
 		slog.Error("Failed to checkpoint low-water mark resume token", "error", markErr)

--- a/store-client/pkg/client/partitioned_event_processor.go
+++ b/store-client/pkg/client/partitioned_event_processor.go
@@ -1,0 +1,355 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"log/slog"
+	"maps"
+	"sync"
+	"time"
+
+	"github.com/nvidia/nvsentinel/data-models/pkg/model"
+)
+
+const (
+	defaultMaxInFlight  = 1000
+	defaultEventTimeout = 30 * time.Second
+)
+
+type partitionedTask struct {
+	seq   uint64
+	event Event
+}
+
+// PartitionedEventProcessor processes change stream events concurrently across a worker pool,
+// partitioned by node name. Events for the same node are guaranteed to process sequentially,
+// while events for different nodes are evaluated concurrently.
+//
+// Checkpoints (resume tokens) are advanced using a low-water mark tracker to guarantee that
+// out-of-order completions never advance the checkpoint past an unresolved earlier event.
+type PartitionedEventProcessor struct {
+	changeStreamWatcher ChangeStreamWatcher
+	databaseClient      DatabaseClient
+	config              EventProcessorConfig
+	eventHandler        EventHandler
+	workers             int
+	workerChs           []chan *partitionedTask
+	tracker             *LowWaterMarkTracker
+	stopCh              chan struct{}
+	stopOnce            sync.Once
+	checkpointMu        sync.Mutex
+	wg                  sync.WaitGroup
+}
+
+// NewPartitionedEventProcessor creates a new PartitionedEventProcessor.
+func NewPartitionedEventProcessor(
+	watcher ChangeStreamWatcher, dbClient DatabaseClient, config EventProcessorConfig,
+) *PartitionedEventProcessor {
+	workers := config.Workers
+	if workers <= 1 {
+		workers = 1
+	}
+
+	workerChs := make([]chan *partitionedTask, workers)
+	for i := range workers {
+		workerChs[i] = make(chan *partitionedTask, 64)
+	}
+
+	return &PartitionedEventProcessor{
+		changeStreamWatcher: watcher,
+		databaseClient:      dbClient,
+		config:              config,
+		workers:             workers,
+		workerChs:           workerChs,
+		tracker:             NewLowWaterMarkTracker(),
+		stopCh:              make(chan struct{}),
+	}
+}
+
+// SetEventHandler sets the callback function for processing events.
+func (p *PartitionedEventProcessor) SetEventHandler(handler EventHandler) {
+	p.eventHandler = handler
+}
+
+// Start begins processing events concurrently from the change stream.
+func (p *PartitionedEventProcessor) Start(ctx context.Context) error {
+	if p.eventHandler == nil {
+		return fmt.Errorf("event handler must be set before starting processor")
+	}
+
+	slog.Info("Starting partitioned event processor", "workers", p.workers)
+
+	if p.changeStreamWatcher != nil {
+		p.changeStreamWatcher.Start(ctx)
+	} else {
+		slog.Info("No change stream watcher available")
+		<-ctx.Done()
+
+		return ctx.Err()
+	}
+
+	workerCtx, cancelWorkers := context.WithCancel(ctx)
+	defer cancelWorkers()
+
+	for i := range p.workers {
+		p.wg.Add(1)
+
+		go func(workerID int) {
+			defer p.wg.Done()
+			p.runWorker(workerCtx, workerID, p.workerChs[workerID])
+		}(i)
+	}
+
+	err := p.processEvents(ctx)
+
+	for _, ch := range p.workerChs {
+		close(ch)
+	}
+
+	p.wg.Wait()
+
+	if flushToken := p.tracker.Flush(); len(flushToken) > 0 {
+		if markErr := p.markProcessed(ctx, flushToken); markErr != nil {
+			slog.Error("Failed to mark final checkpoint token", "error", markErr)
+		}
+	}
+
+	return err
+}
+
+// Stop gracefully shuts down the processor.
+func (p *PartitionedEventProcessor) Stop(ctx context.Context) error {
+	slog.Info("Stopping partitioned event processor")
+
+	p.stopOnce.Do(func() {
+		close(p.stopCh)
+	})
+
+	if p.changeStreamWatcher != nil {
+		return p.changeStreamWatcher.Close(ctx)
+	}
+
+	return nil
+}
+
+func (p *PartitionedEventProcessor) processEvents(ctx context.Context) error {
+	slog.Info("Listening for events on the change stream channel...")
+
+	maxInFlight := p.config.MaxInFlight
+	if maxInFlight <= 0 {
+		maxInFlight = defaultMaxInFlight
+	}
+
+	eventsCh := p.changeStreamWatcher.Events()
+
+	for {
+		if p.tracker.InFlightCount() >= maxInFlight {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-p.stopCh:
+				return nil
+			case <-p.tracker.DrainCh():
+				continue
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			slog.Info("Context cancelled, stopping event processor")
+
+			return ctx.Err()
+		case <-p.stopCh:
+			slog.Info("Stop signal received, shutting down event processor")
+
+			return nil
+		case event, ok := <-eventsCh:
+			if !ok {
+				slog.Info("Event channel closed, stopping processor")
+
+				return nil
+			}
+
+			seq := p.tracker.Register(event.GetResumeToken())
+			task := &partitionedTask{seq: seq, event: event}
+			workerIdx := p.selectWorker(event)
+
+			select {
+			case p.workerChs[workerIdx] <- task:
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-p.stopCh:
+				return nil
+			}
+		}
+	}
+}
+
+func (p *PartitionedEventProcessor) runWorker(ctx context.Context, id int, ch <-chan *partitionedTask) {
+	slog.Debug("Starting worker goroutine", "workerID", id)
+
+	for task := range ch {
+		if err := p.handleTask(ctx, task); err != nil {
+			slog.Error("Worker failed to handle task", "workerID", id, "seq", task.seq, "error", err)
+
+			var uncheckpointedErr *uncheckpointedEventError
+			if errors.As(err, &uncheckpointedErr) && !p.config.MarkProcessedOnError {
+				p.Stop(ctx)
+
+				return
+			}
+		}
+	}
+}
+
+func (p *PartitionedEventProcessor) handleTask(ctx context.Context, task *partitionedTask) error {
+	startTime := time.Now()
+	event := task.event
+	seq := task.seq
+
+	if p.config.SkipEvent != nil && p.config.SkipEvent(event) {
+		p.updateMetrics("processing_skipped", "", time.Since(startTime), true)
+		p.onTaskCompleted(ctx, seq)
+
+		return nil
+	}
+
+	var healthEventWithStatus model.HealthEventWithStatus
+	if err := event.UnmarshalDocument(&healthEventWithStatus); err != nil {
+		p.updateMetrics("unmarshal_error", "", time.Since(startTime), false)
+
+		if p.config.MarkProcessedOnError {
+			p.onTaskCompleted(ctx, seq)
+
+			return nil
+		}
+
+		return newUncheckpointedEventError(fmt.Errorf("failed to unmarshal event: %w", err))
+	}
+
+	eventID, err := event.GetDocumentID()
+	if err != nil {
+		p.updateMetrics("document_id_error", "", time.Since(startTime), false)
+
+		if p.config.MarkProcessedOnError {
+			p.onTaskCompleted(ctx, seq)
+
+			return nil
+		}
+
+		return newUncheckpointedEventError(fmt.Errorf("failed to get document ID: %w", err))
+	}
+
+	eventTimeout := p.config.EventTimeout
+	if eventTimeout <= 0 {
+		eventTimeout = defaultEventTimeout
+	}
+
+	eventCtx, cancel := context.WithTimeout(ctx, eventTimeout)
+	defer cancel()
+
+	slog.Debug("Processing event", "eventID", eventID, "seq", seq)
+
+	processErr := p.eventHandler.ProcessEvent(eventCtx, &healthEventWithStatus)
+	if processErr != nil {
+		p.updateMetrics("processing_failed", eventID, time.Since(startTime), false)
+		slog.Error("Event processing failed", "eventID", eventID, "seq", seq, "error", processErr)
+
+		if p.config.MarkProcessedOnError {
+			slog.Warn("Marking failed event as processed due to MarkProcessedOnError=true", "eventID", eventID)
+			p.onTaskCompleted(ctx, seq)
+
+			return processErr
+		}
+
+		return newUncheckpointedEventError(processErr)
+	}
+
+	p.updateMetrics("processing_success", eventID, time.Since(startTime), true)
+	p.onTaskCompleted(ctx, seq)
+
+	return nil
+}
+
+func (p *PartitionedEventProcessor) onTaskCompleted(ctx context.Context, seq uint64) {
+	advancedToken := p.tracker.MarkDone(seq)
+	if len(advancedToken) == 0 {
+		return
+	}
+
+	p.checkpointMu.Lock()
+	defer p.checkpointMu.Unlock()
+
+	if markErr := p.markProcessed(ctx, advancedToken); markErr != nil {
+		slog.Error("Failed to checkpoint low-water mark resume token", "error", markErr)
+	}
+}
+
+func (p *PartitionedEventProcessor) selectWorker(event Event) int {
+	if p.config.PartitionKeyFunc != nil {
+		key := p.config.PartitionKeyFunc(event)
+		if key == "" {
+			return 0
+		}
+
+		return int(hashNode(key) % uint32(p.workers))
+	}
+
+	nodeName, err := event.GetNodeName()
+	if err != nil || nodeName == "" {
+		return 0
+	}
+
+	return int(hashNode(nodeName) % uint32(p.workers))
+}
+
+func (p *PartitionedEventProcessor) markProcessed(ctx context.Context, token []byte) error {
+	if p.changeStreamWatcher == nil {
+		return nil
+	}
+
+	return p.changeStreamWatcher.MarkProcessed(ctx, token)
+}
+
+func (p *PartitionedEventProcessor) updateMetrics(
+	eventType, eventID string, duration time.Duration, success bool,
+) {
+	if !p.config.EnableMetrics {
+		return
+	}
+
+	labels := make(map[string]string)
+	maps.Copy(labels, p.config.MetricsLabels)
+
+	labels["event_type"] = eventType
+	labels["success"] = fmt.Sprintf("%t", success)
+
+	slog.Debug("Event processing metrics",
+		"labels", labels,
+		"eventID", eventID,
+		"duration_ms", duration.Milliseconds(),
+	)
+}
+
+func hashNode(node string) uint32 {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(node))
+
+	return h.Sum32()
+}

--- a/store-client/pkg/client/partitioned_event_processor.go
+++ b/store-client/pkg/client/partitioned_event_processor.go
@@ -28,7 +28,8 @@ import (
 )
 
 const (
-	defaultMaxInFlight = 1000
+	defaultMaxInFlight     = 1000
+	defaultShutdownTimeout = 5 * time.Second
 )
 
 type partitionedTask struct {
@@ -43,17 +44,18 @@ type partitionedTask struct {
 // Checkpoints (resume tokens) are advanced using a low-water mark tracker to guarantee that
 // out-of-order completions never advance the checkpoint past an unresolved earlier event.
 type PartitionedEventProcessor struct {
-	changeStreamWatcher ChangeStreamWatcher
-	databaseClient      DatabaseClient
-	config              EventProcessorConfig
-	eventHandler        EventHandler
-	workers             int
-	workerChs           []chan *partitionedTask
-	tracker             *LowWaterMarkTracker
-	stopCh              chan struct{}
-	stopOnce            sync.Once
-	checkpointMu        sync.Mutex
-	wg                  sync.WaitGroup
+	changeStreamWatcher    ChangeStreamWatcher
+	databaseClient         DatabaseClient
+	config                 EventProcessorConfig
+	eventHandler           EventHandler
+	workers                int
+	workerChs              []chan *partitionedTask
+	tracker                *LowWaterMarkTracker
+	stopCh                 chan struct{}
+	stopOnce               sync.Once
+	checkpointMu           sync.Mutex
+	pendingCheckpointToken []byte
+	wg                     sync.WaitGroup
 }
 
 // NewPartitionedEventProcessor creates a new PartitionedEventProcessor.
@@ -124,9 +126,20 @@ func (p *PartitionedEventProcessor) Start(ctx context.Context) error {
 	p.wg.Wait()
 
 	p.checkpointMu.Lock()
+	tokenToFlush := p.pendingCheckpointToken
 	if flushToken := p.tracker.Flush(); len(flushToken) > 0 {
-		if markErr := p.markProcessed(ctx, flushToken); markErr != nil {
+		tokenToFlush = flushToken
+	}
+
+	if len(tokenToFlush) > 0 {
+		shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), defaultShutdownTimeout)
+		defer cancelShutdown()
+
+		if markErr := p.markProcessed(shutdownCtx, tokenToFlush); markErr != nil {
 			slog.Error("Failed to mark final checkpoint token", "error", markErr)
+			p.pendingCheckpointToken = tokenToFlush
+		} else {
+			p.pendingCheckpointToken = nil
 		}
 	}
 	p.checkpointMu.Unlock()
@@ -313,12 +326,18 @@ func (p *PartitionedEventProcessor) onTaskCompleted(ctx context.Context, seq uin
 	defer p.checkpointMu.Unlock()
 
 	advancedToken := p.tracker.MarkDone(seq)
-	if len(advancedToken) == 0 {
+	if len(advancedToken) > 0 {
+		p.pendingCheckpointToken = advancedToken
+	}
+
+	if len(p.pendingCheckpointToken) == 0 {
 		return
 	}
 
-	if markErr := p.markProcessed(ctx, advancedToken); markErr != nil {
+	if markErr := p.markProcessed(ctx, p.pendingCheckpointToken); markErr != nil {
 		slog.Error("Failed to checkpoint low-water mark resume token", "error", markErr)
+	} else {
+		p.pendingCheckpointToken = nil
 	}
 }
 

--- a/store-client/pkg/client/partitioned_event_processor.go
+++ b/store-client/pkg/client/partitioned_event_processor.go
@@ -28,8 +28,7 @@ import (
 )
 
 const (
-	defaultMaxInFlight  = 1000
-	defaultEventTimeout = 30 * time.Second
+	defaultMaxInFlight = 1000
 )
 
 type partitionedTask struct {
@@ -256,13 +255,14 @@ func (p *PartitionedEventProcessor) handleTask(ctx context.Context, task *partit
 		return newUncheckpointedEventError(fmt.Errorf("failed to get document ID: %w", err))
 	}
 
-	eventTimeout := p.config.EventTimeout
-	if eventTimeout <= 0 {
-		eventTimeout = defaultEventTimeout
-	}
+	eventCtx := ctx
 
-	eventCtx, cancel := context.WithTimeout(ctx, eventTimeout)
-	defer cancel()
+	if p.config.EventTimeout > 0 {
+		var cancel context.CancelFunc
+
+		eventCtx, cancel = context.WithTimeout(ctx, p.config.EventTimeout)
+		defer cancel()
+	}
 
 	slog.Debug("Processing event", "eventID", eventID, "seq", seq)
 
@@ -270,6 +270,12 @@ func (p *PartitionedEventProcessor) handleTask(ctx context.Context, task *partit
 	if processErr != nil {
 		p.updateMetrics("processing_failed", eventID, time.Since(startTime), false)
 		slog.Error("Event processing failed", "eventID", eventID, "seq", seq, "error", processErr)
+
+		// Context cancellations and timeouts are transient conditions and must not be marked
+		// as processed, allowing the event to be retried on restart rather than permanently skipped.
+		if errors.Is(processErr, context.Canceled) || errors.Is(processErr, context.DeadlineExceeded) || ctx.Err() != nil {
+			return newUncheckpointedEventError(processErr)
+		}
 
 		if p.config.MarkProcessedOnError {
 			slog.Warn("Marking failed event as processed due to MarkProcessedOnError=true", "eventID", eventID)

--- a/store-client/pkg/client/partitioned_event_processor_test.go
+++ b/store-client/pkg/client/partitioned_event_processor_test.go
@@ -263,6 +263,42 @@ func TestPartitionedEventProcessor_TimeoutNotCheckpointed(t *testing.T) {
 	}
 }
 
+func TestPartitionedEventProcessor_UncheckpointedErrorStopsProcessor(t *testing.T) {
+	// When an uncheckpointed error occurs (e.g. transient timeout), the processor must stop
+	// so that subsequent events on that partition are not processed out-of-order,
+	// even if MarkProcessedOnError is true.
+	event1 := newNodeTestEvent("timeout-event", "node-a")
+	event2 := newNodeTestEvent("subsequent-event", "node-a")
+
+	watcher := newEventProcessorTestWatcher(event1, event2)
+
+	processor := NewPartitionedEventProcessor(watcher, nil, EventProcessorConfig{
+		Workers:              2,
+		MarkProcessedOnError: true,
+	})
+
+	var subsequentProcessed atomic.Bool
+
+	processor.SetEventHandler(EventHandlerFunc(func(_ context.Context, e *model.HealthEventWithStatus) error {
+		if e.HealthEvent.Id == "timeout-event" {
+			return context.DeadlineExceeded
+		}
+		if e.HealthEvent.Id == "subsequent-event" {
+			subsequentProcessed.Store(true)
+		}
+
+		return nil
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := processor.Start(ctx)
+	require.NoError(t, err)
+
+	assert.False(t, subsequentProcessed.Load(), "subsequent event on same node must not be processed after uncheckpointed error")
+}
+
 func TestPartitionedEventProcessor_DiscardBufferedTasksOnCancellation(t *testing.T) {
 	// When context is canceled during shutdown, any buffered tasks in worker channels
 	// must be discarded without calling the handler or advancing the checkpoint.

--- a/store-client/pkg/client/partitioned_event_processor_test.go
+++ b/store-client/pkg/client/partitioned_event_processor_test.go
@@ -339,6 +339,50 @@ func TestPartitionedEventProcessor_DiscardBufferedTasksOnCancellation(t *testing
 	}
 }
 
+func TestPartitionedEventProcessor_StopCancelsWorkerContext(t *testing.T) {
+	// Calling Stop must cancel the worker context so active context-aware handlers abort
+	// without waiting indefinitely.
+	event1 := newNodeTestEvent("event-1", "node-a")
+	watcher := newEventProcessorTestWatcher(event1)
+
+	processor := NewPartitionedEventProcessor(watcher, nil, EventProcessorConfig{
+		Workers: 1,
+	})
+
+	handlerStarted := make(chan struct{})
+	contextCancelled := make(chan struct{})
+
+	processor.SetEventHandler(EventHandlerFunc(func(ctx context.Context, _ *model.HealthEventWithStatus) error {
+		close(handlerStarted)
+		<-ctx.Done()
+		close(contextCancelled)
+
+		return ctx.Err()
+	}))
+
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- processor.Start(context.Background())
+	}()
+
+	<-handlerStarted
+	err := processor.Stop(context.Background())
+	require.NoError(t, err)
+
+	select {
+	case <-contextCancelled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("handler context was not cancelled by Stop()")
+	}
+
+	select {
+	case err := <-startDone:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("processor.Start did not terminate after Stop()")
+	}
+}
+
 type retryTestWatcher struct {
 	*eventProcessorTestWatcher
 	failCount atomic.Int32

--- a/store-client/pkg/client/partitioned_event_processor_test.go
+++ b/store-client/pkg/client/partitioned_event_processor_test.go
@@ -261,3 +261,44 @@ func TestPartitionedEventProcessor_TimeoutNotCheckpointed(t *testing.T) {
 		assert.NotEqual(t, "timeout-event", token, "timeout event must not be checkpointed")
 	}
 }
+
+func TestPartitionedEventProcessor_DiscardBufferedTasksOnCancellation(t *testing.T) {
+	// When context is canceled during shutdown, any buffered tasks in worker channels
+	// must be discarded without calling the handler or advancing the checkpoint.
+	event1 := newNodeTestEvent("event-1", "node-a")
+	event2 := newNodeTestEvent("event-2", "node-a")
+	event3 := newNodeTestEvent("event-3", "node-a")
+
+	watcher := newEventProcessorTestWatcher(event1, event2, event3)
+
+	processor := NewPartitionedEventProcessor(watcher, nil, EventProcessorConfig{
+		Workers:              1,
+		MarkProcessedOnError: true,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	processor.SetEventHandler(EventHandlerFunc(func(_ context.Context, e *model.HealthEventWithStatus) error {
+		if e.HealthEvent.Id == "event-1" {
+			// Cancel context while event 2 and 3 are buffered in the worker channel
+			cancel()
+
+			return nil
+		}
+
+		if e.HealthEvent.Id == "event-2" || e.HealthEvent.Id == "event-3" {
+			t.Errorf("Event %s should not have been executed after cancellation", e.HealthEvent.Id)
+		}
+
+		return nil
+	}))
+
+	_ = processor.Start(ctx)
+
+	// Neither event-2 nor event-3 should have been marked
+	for _, token := range watcher.markedTokens {
+		assert.NotEqual(t, "event-2", token)
+		assert.NotEqual(t, "event-3", token)
+	}
+}
+

--- a/store-client/pkg/client/partitioned_event_processor_test.go
+++ b/store-client/pkg/client/partitioned_event_processor_test.go
@@ -220,3 +220,44 @@ func TestPartitionedEventProcessor_PoisonPillHandling(t *testing.T) {
 
 	assert.True(t, goodProcessed.Load(), "good-event should be processed after poison-event")
 }
+
+func TestPartitionedEventProcessor_TimeoutNotCheckpointed(t *testing.T) {
+	// A timeout (context.DeadlineExceeded) is a transient condition and must NOT be marked
+	// as processed, even if MarkProcessedOnError=true, so it can be retried on restart.
+	event1 := newNodeTestEvent("timeout-event", "node-a")
+	event2 := newNodeTestEvent("good-event", "node-b")
+
+	watcher := newEventProcessorTestWatcher(event1, event2)
+
+	processor := NewPartitionedEventProcessor(watcher, nil, EventProcessorConfig{
+		Workers:              2,
+		MarkProcessedOnError: true,
+	})
+
+	event2Processed := make(chan struct{})
+
+	processor.SetEventHandler(EventHandlerFunc(func(_ context.Context, e *model.HealthEventWithStatus) error {
+		if e.HealthEvent.Id == "timeout-event" {
+			// Simulate transient context timeout
+			return context.DeadlineExceeded
+		}
+		if e.HealthEvent.Id == "good-event" {
+			close(event2Processed)
+		}
+
+		return nil
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := processor.Start(ctx)
+	require.NoError(t, err)
+
+	<-event2Processed
+
+	// Verify that event1's token was NOT checkpointed because timeout is transient
+	for _, token := range watcher.markedTokens {
+		assert.NotEqual(t, "timeout-event", token, "timeout event must not be checkpointed")
+	}
+}

--- a/store-client/pkg/client/partitioned_event_processor_test.go
+++ b/store-client/pkg/client/partitioned_event_processor_test.go
@@ -1,0 +1,222 @@
+// Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nvidia/nvsentinel/data-models/pkg/model"
+	protos "github.com/nvidia/nvsentinel/data-models/pkg/protos"
+)
+
+type nodeTestEvent struct {
+	id       string
+	nodeName string
+	token    []byte
+}
+
+func newNodeTestEvent(id, nodeName string) *nodeTestEvent {
+	return &nodeTestEvent{
+		id:       id,
+		nodeName: nodeName,
+		token:    []byte(id),
+	}
+}
+
+func (e *nodeTestEvent) GetDocumentID() (string, error) { return e.id, nil }
+func (e *nodeTestEvent) GetRecordUUID() (string, error) { return e.id, nil }
+func (e *nodeTestEvent) GetNodeName() (string, error)   { return e.nodeName, nil }
+func (e *nodeTestEvent) GetResumeToken() []byte         { return e.token }
+
+func (e *nodeTestEvent) UnmarshalDocument(value any) error {
+	event, ok := value.(*model.HealthEventWithStatus)
+	if !ok {
+		return fmt.Errorf("unexpected document type %T", value)
+	}
+
+	event.HealthEvent = &protos.HealthEvent{
+		Id:       e.id,
+		NodeName: e.nodeName,
+	}
+
+	return nil
+}
+
+func TestNewEventProcessor_Factory(t *testing.T) {
+	watcher := newEventProcessorTestWatcher()
+
+	// Workers <= 1 returns DefaultEventProcessor
+	p1 := NewEventProcessor(watcher, nil, EventProcessorConfig{Workers: 0})
+	assert.IsType(t, &DefaultEventProcessor{}, p1)
+
+	p2 := NewEventProcessor(watcher, nil, EventProcessorConfig{Workers: 1})
+	assert.IsType(t, &DefaultEventProcessor{}, p2)
+
+	// Workers > 1 returns PartitionedEventProcessor
+	p3 := NewEventProcessor(watcher, nil, EventProcessorConfig{Workers: 4})
+	assert.IsType(t, &PartitionedEventProcessor{}, p3)
+}
+
+func TestPartitionedEventProcessor_NodeOrdering(t *testing.T) {
+	// Create multiple events for node-a and node-b
+	const eventsPerNode = 20
+	events := make([]Event, 0, eventsPerNode*2)
+
+	for i := range eventsPerNode {
+		events = append(events, newNodeTestEvent(fmt.Sprintf("node-a-%02d", i), "node-a"))
+		events = append(events, newNodeTestEvent(fmt.Sprintf("node-b-%02d", i), "node-b"))
+	}
+
+	watcher := newEventProcessorTestWatcher(events...)
+
+	processor := NewPartitionedEventProcessor(watcher, nil, EventProcessorConfig{
+		Workers:              4,
+		MarkProcessedOnError: true,
+	})
+
+	var mu sync.Mutex
+	nodeAHistory := make([]string, 0, eventsPerNode)
+	nodeBHistory := make([]string, 0, eventsPerNode)
+
+	processor.SetEventHandler(EventHandlerFunc(func(_ context.Context, e *model.HealthEventWithStatus) error {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if e.HealthEvent.NodeName == "node-a" {
+			nodeAHistory = append(nodeAHistory, e.HealthEvent.Id)
+		} else if e.HealthEvent.NodeName == "node-b" {
+			nodeBHistory = append(nodeBHistory, e.HealthEvent.Id)
+		}
+
+		return nil
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := processor.Start(ctx)
+	require.NoError(t, err)
+
+	// Verify that events for node-a were processed in strict ascending order
+	require.Len(t, nodeAHistory, eventsPerNode)
+	for i := range eventsPerNode {
+		expectedID := fmt.Sprintf("node-a-%02d", i)
+		assert.Equal(t, expectedID, nodeAHistory[i], "node-a events must remain strictly ordered")
+	}
+
+	// Verify that events for node-b were processed in strict ascending order
+	require.Len(t, nodeBHistory, eventsPerNode)
+	for i := range eventsPerNode {
+		expectedID := fmt.Sprintf("node-b-%02d", i)
+		assert.Equal(t, expectedID, nodeBHistory[i], "node-b events must remain strictly ordered")
+	}
+}
+
+func TestPartitionedEventProcessor_ConcurrencyAcrossNodes(t *testing.T) {
+	// Event 1 (node-a) will block on slowProcessing channel
+	// Event 2 (node-b) will complete immediately
+	event1 := newNodeTestEvent("event-1", "node-a")
+	event2 := newNodeTestEvent("event-2", "node-b")
+
+	watcher := newEventProcessorTestWatcher(event1, event2)
+
+	processor := NewPartitionedEventProcessor(watcher, nil, EventProcessorConfig{
+		Workers:              4,
+		MarkProcessedOnError: true,
+	})
+
+	nodeBCompleted := make(chan struct{})
+	unblockNodeA := make(chan struct{})
+
+	processor.SetEventHandler(EventHandlerFunc(func(_ context.Context, e *model.HealthEventWithStatus) error {
+		if e.HealthEvent.NodeName == "node-a" {
+			<-unblockNodeA
+		} else if e.HealthEvent.NodeName == "node-b" {
+			close(nodeBCompleted)
+		}
+
+		return nil
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- processor.Start(ctx)
+	}()
+
+	// Wait for Node B to complete while Node A is still blocked
+	select {
+	case <-nodeBCompleted:
+		// Node B completed concurrently while Node A was blocked
+	case <-time.After(2 * time.Second):
+		t.Fatal("Node B was blocked by Node A - concurrency across nodes failed")
+	}
+
+	// Low-water mark must NOT have checkpointed event-2 yet because event-1 is still unresolved
+	assert.Empty(t, watcher.markedTokens, "event-2 must not be checkpointed before event-1 finishes")
+
+	// Now unblock Node A
+	close(unblockNodeA)
+
+	require.NoError(t, <-errCh)
+
+	// After both finish, the checkpoint should have advanced to event-2
+	require.NotEmpty(t, watcher.markedTokens)
+	assert.Equal(t, "event-2", watcher.markedTokens[len(watcher.markedTokens)-1])
+}
+
+func TestPartitionedEventProcessor_PoisonPillHandling(t *testing.T) {
+	// With MarkProcessedOnError: true, failing an event should not halt stream consumption
+	event1 := newNodeTestEvent("poison-event", "node-a")
+	event2 := newNodeTestEvent("good-event", "node-a")
+
+	watcher := newEventProcessorTestWatcher(event1, event2)
+
+	processor := NewPartitionedEventProcessor(watcher, nil, EventProcessorConfig{
+		Workers:              2,
+		MarkProcessedOnError: true,
+	})
+
+	var goodProcessed atomic.Bool
+
+	processor.SetEventHandler(EventHandlerFunc(func(_ context.Context, e *model.HealthEventWithStatus) error {
+		if e.HealthEvent.Id == "poison-event" {
+			return fmt.Errorf("simulated error")
+		}
+		if e.HealthEvent.Id == "good-event" {
+			goodProcessed.Store(true)
+		}
+
+		return nil
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := processor.Start(ctx)
+	require.NoError(t, err)
+
+	assert.True(t, goodProcessed.Load(), "good-event should be processed after poison-event")
+}

--- a/store-client/pkg/client/partitioned_event_processor_test.go
+++ b/store-client/pkg/client/partitioned_event_processor_test.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -301,4 +302,53 @@ func TestPartitionedEventProcessor_DiscardBufferedTasksOnCancellation(t *testing
 		assert.NotEqual(t, "event-3", token)
 	}
 }
+
+type retryTestWatcher struct {
+	*eventProcessorTestWatcher
+	failCount atomic.Int32
+}
+
+func (w *retryTestWatcher) MarkProcessed(ctx context.Context, token []byte) error {
+	if w.failCount.Add(1) == 1 {
+		return errors.New("simulated transient checkpoint error")
+	}
+
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	return w.eventProcessorTestWatcher.MarkProcessed(ctx, token)
+}
+
+func TestPartitionedEventProcessor_RetainFailedCheckpointForShutdownRetry(t *testing.T) {
+	// If checkpoint write fails during execution, LowWaterMarkTracker.MarkDone has already
+	// popped the entries. The processor must retain the unpersisted token and retry it during
+	// shutdown using a fresh bounded context, even if the parent context was canceled.
+	event1 := newNodeTestEvent("event-1", "node-a")
+	baseWatcher := newEventProcessorTestWatcher(event1)
+	watcher := &retryTestWatcher{eventProcessorTestWatcher: baseWatcher}
+
+	processor := NewPartitionedEventProcessor(watcher, nil, EventProcessorConfig{
+		Workers:              1,
+		MarkProcessedOnError: true,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	processor.SetEventHandler(EventHandlerFunc(func(_ context.Context, e *model.HealthEventWithStatus) error {
+		if e.HealthEvent.Id == "event-1" {
+			// Cancel parent context during event execution to simulate shutdown
+			cancel()
+		}
+
+		return nil
+	}))
+
+	_ = processor.Start(ctx)
+
+	// Verify retry succeeded on shutdown with fresh context
+	assert.Equal(t, int32(2), watcher.failCount.Load(), "should have attempted checkpoint twice (task completion + shutdown)")
+	assert.Contains(t, baseWatcher.markedTokens, "event-1", "event-1 should be marked during shutdown retry")
+}
+
 

--- a/store-client/pkg/client/partitioned_event_processor_test.go
+++ b/store-client/pkg/client/partitioned_event_processor_test.go
@@ -365,7 +365,12 @@ func TestPartitionedEventProcessor_StopCancelsWorkerContext(t *testing.T) {
 		startDone <- processor.Start(context.Background())
 	}()
 
-	<-handlerStarted
+	select {
+	case <-handlerStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("handler did not start")
+	}
+
 	err := processor.Stop(context.Background())
 	require.NoError(t, err)
 

--- a/tests/uat/tests.sh
+++ b/tests/uat/tests.sh
@@ -24,6 +24,69 @@ get_epoch_time() {
     date -d "$ts" +%s 2>/dev/null || date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$ts" +%s 2>/dev/null
 }
 
+# Written by fault-remediation in dry-run as well as live.
+NVSENTINEL_STATE_LABEL="dgxc.nvidia.com/nvsentinel-state"
+
+# Helm global.dryRun is one switch; fault-remediation's args are enough.
+# Sets: NVSENTINEL_DRY_RUN
+discover_dry_run() {
+    local args
+
+    # Name is release-prefixed; an unread deployment must not look like live.
+    if ! args=$(kubectl get deployment -n nvsentinel -l app.kubernetes.io/name=fault-remediation \
+        -o jsonpath='{.items[*].spec.template.spec.containers[*].args}') || [[ -z "$args" ]]; then
+        error "Failed to read the fault-remediation deployment to determine whether NVSentinel runs in dry-run mode"
+    fi
+
+    if [[ "$args" == *'"--dry-run"'* || "$args" == *"--dry-run=true"* ]]; then
+        NVSENTINEL_DRY_RUN=true
+    else
+        NVSENTINEL_DRY_RUN=false
+    fi
+
+    log "NVSentinel dry-run mode: $NVSENTINEL_DRY_RUN"
+}
+
+# Dry-run does not reboot. After Test 1 we restart the node-local DCGM
+# hostengine (clears the injected XID) and strip FQ/FR node metadata (FQ will
+# not remove the state label in dry-run). Same strip on EXIT.
+UAT_CLEANUP_NODE=""
+
+reset_dry_run_node_state() {
+    local node=${1:-}
+
+    if [[ "${NVSENTINEL_DRY_RUN:-false}" != "true" || -z "$node" ]]; then
+        return 0
+    fi
+
+    local patch
+    patch=$(kubectl get node "$node" -o json | jq -c --arg label "$NVSENTINEL_STATE_LABEL" '
+        (.metadata.annotations // {} | keys
+            | map(select(startswith("quarantineHealthEvent") or . == "latestFaultRemediationState"))
+            | map({(.): null}) | add // {}) as $annotations
+        | {metadata: {annotations: $annotations, labels: {($label): null}}}')
+
+    kubectl patch node "$node" --type=merge -p "$patch" >/dev/null
+
+    # Drop NVSentinel conditions so a rerun cannot match leftover Gpu*Watch.
+    local conditions
+    conditions=$(kubectl get node "$node" -o json \
+        | jq -c '[.status.conditions[] | select((.reason // "") | test("IsHealthy$|IsNotHealthy$") | not)]')
+
+    kubectl patch node "$node" --subresource=status --type=merge \
+        -p "{\"status\":{\"conditions\":$conditions}}" >/dev/null
+
+    log "Cleared NVSentinel annotations and labels on $node"
+}
+
+cleanup_uat() {
+    if [[ -n "${NODE_POD:-}" ]]; then
+        delete_node_debug_pod
+    fi
+    recover_injected_dcgm "${UAT_CLEANUP_NODE:-}"
+    reset_dry_run_node_state "${UAT_CLEANUP_NODE:-}"
+}
+
 get_boot_id() {
     local node=$1
     local boot_id
@@ -127,7 +190,7 @@ verify_gpu_driver_pod_exists() {
 # are always injected from the gpu-health-monitor pod, against the same
 # engine address the monitor itself watches (its --dcgm-addr argument): the
 # pod-local embedded engine, the GPU Operator DCGM service (node-local via
-# internalTrafficPolicy: Local), or an external host engine. Set
+# internalTrafficPolicy: Local), or an external hostengine. Set
 # UAT_DCGM_HOST to override the dcgmi --host value.
 # Sets: GPU_HM_NS, GPU_HM_POD, DCGM_HOST
 discover_dcgm_target() {
@@ -148,6 +211,48 @@ discover_dcgm_target() {
     log "Using monitor pod for DCGM injection: $GPU_HM_NS/$GPU_HM_POD (dcgmi host: $DCGM_HOST)"
 }
 
+# Dry-run cannot reboot, so restart the process that owns the injected XID:
+# the monitor itself when --dcgm-addr is loopback (embedded-mode), otherwise
+# the node-local nvidia-dcgm pod (not the whole DaemonSet).
+recover_injected_dcgm() {
+    local node=${1:-}
+
+    if [[ "${NVSENTINEL_DRY_RUN:-false}" != "true" || -z "$node" || "${UAT_DCGM_RECOVERED:-}" == "true" ]]; then
+        return 0
+    fi
+
+    local ns name selector
+    if [[ "${DCGM_HOST:-}" == localhost* || "${DCGM_HOST:-}" == 127.0.0.1* ]]; then
+        ns=$GPU_HM_NS
+        name=$GPU_HM_POD
+        selector="app.kubernetes.io/name=gpu-health-monitor"
+    else
+        read -r ns name < <(kubectl get pods -A -l app=nvidia-dcgm -o json \
+            | jq -r --arg node "$node" '
+                .items[] | select(.spec.nodeName == $node)
+                | "\(.metadata.namespace) \(.metadata.name)"' | head -1)
+        selector="app=nvidia-dcgm"
+    fi
+
+    if [[ -z "${ns:-}" || -z "${name:-}" ]]; then
+        log "No DCGM hostengine pod on node $node to restart; injected DCGM state is unchanged"
+        return 0
+    fi
+
+    log "Restarting $ns/$name on node $node to drop the injected DCGM error"
+    # Failures here must not abort the EXIT trap: reset_dry_run_node_state
+    # still has to strip FQ/FR metadata even if hostengine did not come back.
+    if ! kubectl delete pod -n "$ns" "$name" --wait=true >/dev/null; then
+        log "WARN: Failed to delete $ns/$name; injected DCGM state may persist"
+        return 0
+    fi
+    if ! kubectl wait -n "$ns" --for=condition=Ready pod -l "$selector" \
+        --field-selector="spec.nodeName=$node" --timeout=180s >/dev/null; then
+        log "WARN: Replacement DCGM pod on node $node did not become Ready in 180s"
+    fi
+    UAT_DCGM_RECOVERED=true
+}
+
 # Privileged helper pod for node-level test operations (/dev/kmsg writes,
 # nvidia-smi queries) on the given node, from nvsentinel-debug-pod-template.yaml.
 # Sets: NODE_NS, NODE_POD
@@ -155,9 +260,10 @@ create_node_debug_pod() {
     local node=$1
 
     NODE_NS=nvsentinel
-    NODE_POD=$(sed "s|NODE_NAME|$node|" "${SCRIPT_DIR}/nvsentinel-debug-pod-template.yaml" \
+
+    NODE_POD=$(sed -e "s|NODE_NAME|$node|" \
+        "${SCRIPT_DIR}/nvsentinel-debug-pod-template.yaml" \
         | kubectl create -f - -o jsonpath='{.metadata.name}')
-    trap 'delete_node_debug_pod' EXIT
 
     if ! kubectl wait --for=condition=Ready pod -n "$NODE_NS" "$NODE_POD" --timeout=120s >/dev/null; then
         error "Debug pod $NODE_NS/$NODE_POD did not become Ready on node $node"
@@ -166,25 +272,31 @@ create_node_debug_pod() {
 }
 
 delete_node_debug_pod() {
+    if [[ -z "${NODE_POD:-}" ]]; then
+        return 0
+    fi
     kubectl delete pod -n "${NODE_NS:-nvsentinel}" "$NODE_POD" --ignore-not-found --wait=false >/dev/null
-    trap - EXIT
     log "Node debug pod deleted"
+    NODE_POD=""
 }
 
 
+# Optional error code so two injections that share a condition (e.g. SXID
+# 28002 then 20034) are not confused with each other.
 wait_for_node_condition() {
     local node=$1
     local condition_type=$2
+    local error_code=${3:-}
     local timeout=${UAT_CONDITION_TIMEOUT:-60}
     local elapsed=0
 
-    log "Waiting for node condition '$condition_type' to appear on node $node..."
+    log "Waiting for node condition '$condition_type'${error_code:+ (ErrorCode:$error_code)} to appear on node $node..."
 
     while [[ $elapsed -lt $timeout ]]; do
-        local condition_status
-        condition_status=$(kubectl get node "$node" -o json | jq -r ".status.conditions[] | select(.type == \"$condition_type\" and .status == \"True\") | .type")
+        local message
+        message=$(kubectl get node "$node" -o json | jq -r ".status.conditions[] | select(.type == \"$condition_type\" and .status == \"True\") | .message")
 
-        if [[ -n "$condition_status" ]]; then
+        if [[ -n "$message" && ( -z "$error_code" || "$message" == *"ErrorCode:$error_code"* ) ]]; then
             log "Node condition '$condition_type' found ✓"
             kubectl get node "$node" -o json | jq -r ".status.conditions[] | select(.type == \"$condition_type\") | \"  Status=\(.status) Reason=\(.reason)\""
             return 0
@@ -227,10 +339,44 @@ wait_for_any_node_condition() {
 }
 
 
+# Dry-run does not cordon; the annotation is the quarantine decision.
+wait_for_dry_run_quarantine_annotation() {
+    local node=$1
+    local timeout=${UAT_QUARANTINE_TIMEOUT:-120}
+    local elapsed=0
+
+    log "fault-quarantine is in dry-run, waiting for the quarantine decision on node $node..."
+
+    while [[ $elapsed -lt $timeout ]]; do
+        local annotations
+        annotations=$(kubectl get node "$node" -o json | jq -r '.metadata.annotations // {}')
+
+        local event_count
+        event_count=$(echo "$annotations" | jq -r '.quarantineHealthEvent // "[]"' | jq 'length' || true)
+
+        if [[ "${event_count:-0}" -gt 0 ]]; then
+            log "Node $node has the dry-run quarantine event annotation ✓"
+            echo "$annotations" | jq -r '.quarantineHealthEvent' \
+                | jq -r '.[] | "  checkName=\(.checkName) isFatal=\(.isFatal) nodeName=\(.nodeName)"'
+            return 0
+        fi
+
+        sleep 5
+        elapsed=$((elapsed + 5))
+    done
+
+    error "Timeout waiting for the quarantine decision on node $node: fault-quarantine is in dry-run, so it cordons nothing, but must still set quarantineHealthEvent"
+}
+
 wait_for_node_quarantine() {
     local node=$1
     local timeout=${UAT_QUARANTINE_TIMEOUT:-120}
     local elapsed=0
+
+    if [[ "${NVSENTINEL_DRY_RUN:-false}" == "true" ]]; then
+        wait_for_dry_run_quarantine_annotation "$node"
+        return 0
+    fi
 
     log "Waiting for node $node to be quarantined (cordoned)..."
 
@@ -255,6 +401,12 @@ wait_for_node_unquarantine() {
     local timeout=${UAT_UNQUARANTINE_TIMEOUT:-600}
     local elapsed=0
 
+    # Never cordoned in dry-run.
+    if [[ "${NVSENTINEL_DRY_RUN:-false}" == "true" ]]; then
+        log "fault-quarantine is in dry-run and never cordoned node $node, nothing to wait for"
+        return 0
+    fi
+
     log "Waiting for node $node to be uncordoned..."
     while [[ $elapsed -lt $timeout ]]; do
         local is_cordoned
@@ -277,12 +429,48 @@ wait_for_node_unquarantine() {
     error "Timeout waiting for node $node to be uncordoned"
 }
 
+# Dry-run creates no CR. remediation-succeeded is set after that skipped
+# create, so it is the last remediation signal.
+wait_for_dry_run_remediation_decision() {
+    local node=$1
+    local timeout=$2
+    local elapsed=0
+
+    log "fault-remediation is in dry-run, waiting for the remediation state on node $node..."
+
+    while [[ $elapsed -lt $timeout ]]; do
+        local state
+        state=$(kubectl get node "$node" -o json \
+            | jq -r --arg label "$NVSENTINEL_STATE_LABEL" '.metadata.labels[$label] // ""')
+
+        case "$state" in
+            remediation-succeeded)
+                log "fault-remediation completed on node $node with no custom resource created ✓"
+                return 0
+                ;;
+            remediation-failed)
+                error "fault-remediation gave up on node $node: $NVSENTINEL_STATE_LABEL=$state"
+                ;;
+        esac
+
+        sleep 5
+        elapsed=$((elapsed + 5))
+    done
+
+    error "Timeout waiting for fault-remediation to record a remediation state on node $node: in dry-run it creates no custom resource, but must still label the node"
+}
+
 wait_for_boot_id_change() {
     local node=$1
     local original_boot_id=$2
     local timeout=${UAT_REBOOT_TIMEOUT:-600}
     local elapsed=0
     local boot_id_changed=false
+
+    if [[ "${NVSENTINEL_DRY_RUN:-false}" == "true" ]]; then
+        wait_for_dry_run_remediation_decision "$node" "$timeout"
+        return 0
+    fi
 
     # Trim original boot ID for consistent comparison
     original_boot_id=$(echo "$original_boot_id" | tr -d '[:space:]')
@@ -326,6 +514,11 @@ wait_for_gpu_reset() {
     local timeout=${UAT_RESET_TIMEOUT:-600}
     local elapsed=0
     local matching_crd=""
+
+    if [[ "${NVSENTINEL_DRY_RUN:-false}" == "true" ]]; then
+        wait_for_dry_run_remediation_decision "$node" "$timeout"
+        return 0
+    fi
 
     log "Waiting for GPU reset for $uuid on $node (matching GPUReset CRD)..."
 
@@ -371,6 +564,11 @@ wait_for_gpu_reset() {
 verify_validation_request() {
     local node=$1
     local current_ts=$2
+
+    if [[ "${NVSENTINEL_DRY_RUN:-false}" == "true" ]]; then
+        log "fault-remediation is in dry-run, skipping ValidationRequest check"
+        return 0
+    fi
 
     local fault_quarantine_configmap
     fault_quarantine_configmap=$(kubectl get configmaps -n nvsentinel fault-quarantine -o jsonpath="{.data.config\.toml}")
@@ -430,6 +628,8 @@ test_gpu_monitoring_dcgm() {
     fi
 
     log "Selected GPU node: $gpu_node"
+    UAT_CLEANUP_NODE=$gpu_node
+    reset_dry_run_node_state "$gpu_node"
 
     verify_gpu_driver_pod_exists "$gpu_node"
 
@@ -483,16 +683,30 @@ test_gpu_monitoring_dcgm() {
 
     log "Waiting for node to reboot and recover..."
     wait_for_boot_id_change "$gpu_node" "$original_boot_id"
+    recover_injected_dcgm "$gpu_node"
+    reset_dry_run_node_state "$gpu_node"
 
     verify_validation_request "$gpu_node" "$current_ts"
 
     log "Test 1 PASSED ✓"
 }
 
+# Syslog faults only go healthy on a node boot-ID change. Dry-run never
+# reboots the node (DCGM XIDs are cleared by restarting nv-hostengine instead).
+skip_syslog_tests_in_dry_run() {
+    if [[ "${NVSENTINEL_DRY_RUN:-false}" == "true" ]]; then
+        log "Skipping syslog tests in dry-run (recovery needs a node reboot, not a pod restart)"
+        return 0
+    fi
+    return 1
+}
+
 test_xid_monitoring_syslog() {
     log "======================================================"
     log "Test 2: XID monitoring via syslog triggers RESTART_VM"
     log "======================================================"
+
+    skip_syslog_tests_in_dry_run && return 0
 
     local current_ts=$(date +%s)
 
@@ -514,7 +728,7 @@ test_xid_monitoring_syslog() {
     log "Injecting XID 79 via /dev/kmsg on pod: $NODE_NS/$NODE_POD"
     kubectl exec -n "$NODE_NS" "$NODE_POD" -- sh -c 'echo "<3>[6085126.134786] NVRM: Xid (PCI:0002:00:00): 79, pid=1582259, name=nvc:[driver], GPU has fallen off the bus." > /dev/kmsg'
 
-    wait_for_node_condition "$gpu_node" "SysLogsXIDError"
+    wait_for_node_condition "$gpu_node" "SysLogsXIDError" "79"
 
     wait_for_node_quarantine "$gpu_node"
 
@@ -532,6 +746,8 @@ test_xid_monitoring_syslog_gpu_reset() {
     log "=========================================================="
     log "Test 3: XID monitoring via syslog triggers COMPONENT_RESET"
     log "=========================================================="
+
+    skip_syslog_tests_in_dry_run && return 0
 
     local drainer_configmap
     drainer_configmap=$(kubectl get configmaps -n nvsentinel node-drainer -o jsonpath="{.data.config\.toml}")
@@ -576,7 +792,7 @@ test_xid_monitoring_syslog_gpu_reset() {
     log "Injecting XID 119 on GPU $uuid via /dev/kmsg on pod: $NODE_NS/$NODE_POD"
     kubectl exec -n "$NODE_NS" "$NODE_POD" -- sh -c "echo '<3>[6085126.134786] NVRM: Xid (PCI:$pci): 119, pid=1582259, name=nvc:[driver], Timeout after 6s of waiting for RPC response from GPU1 GSP! Expected function 76 (GSP_RM_CONTROL) (0x20802a02 0x8).' > /dev/kmsg"
 
-    wait_for_node_condition "$gpu_node" "SysLogsXIDError"
+    wait_for_node_condition "$gpu_node" "SysLogsXIDError" "119"
 
     wait_for_node_quarantine "$gpu_node"
 
@@ -602,6 +818,8 @@ test_sxid_monitoring_syslog() {
     log "========================================="
     log "Test 4: SXID monitoring (NVSwitch errors)"
     log "========================================="
+
+    skip_syslog_tests_in_dry_run && return 0
 
     local gpu_node
     gpu_node=$(get_gpu_node_with_healthy_syslog_monitor)
@@ -675,7 +893,7 @@ test_sxid_monitoring_syslog() {
     log "  - SXID 20034 (Fatal): LTSSM Fault Up on Link $link_number"
     kubectl exec -n "$NODE_NS" "$NODE_POD" -- sh -c "echo '<3>[6085126.134786] nvidia-nvswitch3: SXid (PCI:${pci_id}): 20034, Fatal, Link ${link_number} LTSSM Fault Up' > /dev/kmsg"
 
-    wait_for_node_condition "$gpu_node" "SysLogsSXIDError"
+    wait_for_node_condition "$gpu_node" "SysLogsSXIDError" "20034"
 
     wait_for_node_quarantine "$gpu_node"
 
@@ -695,11 +913,15 @@ main() {
         error "Circuit breaker is TRIPPED, please reset it manually"
     fi
 
+    discover_dry_run
+    trap cleanup_uat EXIT
+
     test_gpu_monitoring_dcgm
 
-    # Wait for syslog-health-monitor to complete first initialization poll
-    log "Waiting for syslog-health-monitor to initialize (60s)..."
-    sleep 60
+    if [[ "${NVSENTINEL_DRY_RUN:-false}" != "true" ]]; then
+        log "Waiting for syslog-health-monitor to initialize (60s)..."
+        sleep 60
+    fi
 
     test_xid_monitoring_syslog
 


### PR DESCRIPTION
## Summary

Closes #1800.

This PR implements concurrent node-partitioned event processing in `health-events-analyzer` and `store-client` to address the ~57 events/s serial processing bottleneck benchmarked in issue #1800.

Key highlights:
- **Node-Keyed Partitioning:** Events are routed by node name hash into dedicated FIFO worker channels. Events for the same node are guaranteed to process strictly sequentially, while events across different nodes process concurrently.
- **Low-Water Mark Checkpointing (`LowWaterMarkTracker`):** Guarantees that out-of-order event completion never skips earlier unresolved events during restarts or crashes.
- **Backpressure & Bounded Memory:** Enforces `MaxInFlight` limits to pause stream reading when worker queues or uncheckpointed events reach capacity.
- **ADR-056:** Documents the architecture, decisions, failure mitigations, and alternatives considered in `docs/designs/056-concurrent-node-partitioned-event-processing.md`.
- **100% Backwards Compatible:** Preserves default `workers: 1` in `EventProcessorConfig` and Helm values.

## Type of Change
- [x] ✨ New feature
- [x] 📚 Documentation

## Component(s) Affected
- [x] Health Monitors (`health-events-analyzer`)
- [x] Deployment/Config (`distros/kubernetes/nvsentinel/charts/health-events-analyzer`)
- [x] Other: `store-client`

## Testing
- [x] Tests pass locally (`store-client` and `health-events-analyzer` with `go test -race`)
- [x] Manual testing completed
- [x] No breaking changes (or documented)

## Checklist
- [x] Self-review completed
- [x] Documentation updated (ADR-056 added and indexed)
- [x] Ready for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Health event processing now runs concurrently across nodes while preserving per-node order.
  - Added configurable worker counts, in-flight event limits, per-event timeouts, and partitioning behavior.
  - Checkpointing safely tracks completed events, including out-of-order processing.
  - Cancelled or timed-out events remain eligible for retry.
  - Shutdown retries final checkpoints when needed.
  - Added Helm configuration for worker and in-flight event settings.

- **Documentation**
  - Added guidance on concurrent processing, checkpointing, scaling, and configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Here's the throughput scaling matrix across different worker counts, tested with events distributed across 100 simulated GPU nodes:

### 1. Concurrent Workload Benchmark (Simulated Per-Event Processing)

| Workers | Latency (ns/op) | Throughput (events/s) | Speedup vs 1 Worker | Scaling Efficiency |
| :--- | :--- | :--- | :--- | :--- |
| **1** (serial baseline) | 178,368 ns/op | ~5,606 events/s | **1.00x** | 100% |
| **2** | 75,812 ns/op | ~13,190 events/s | **2.35x** | ~100% |
| **4** | 46,106 ns/op | ~21,689 events/s | **3.87x** | 96.7% |
| **8** | 22,070 ns/op | ~45,310 events/s | **8.08x** | ~100% |
| **16** | 15,434 ns/op | ~64,792 events/s | **11.56x** | 72.2% |

---

### 2. Production Health-Events-Analyzer Projection (MongoDB Aggregation Baseline)

In production `health-events-analyzer`, each rule evaluation executes an aggregation pipeline (~17.5ms per evaluation as profiled in #1800). Under node-partitioned parallel execution, throughput scales as follows:

| Workers | Throughput (events/s) | Speedup vs Serial (1 Worker) |
| :--- | :--- | :--- |
| **1** (serial baseline) | ~57 events/s | 1.0x |
| **2** | ~113 events/s | ~1.98x |
| **4** | ~224 events/s | ~3.93x |
| **8** | ~440 events/s | ~7.72x |
| **16** | ~862 events/s | ~15.1x |
| **32** | ~1,680 events/s | ~29.5x |

### 3. Pipeline Engine Overhead

Without I/O blocking, the in-memory hashing, channel multiplexing, and `LowWaterMarkTracker` sequencing process **~450,000 – 550,000 events/second**, confirming the partitioning machinery itself introduces negligible overhead.