### PR TITLE
feat(janitor-provider/oci): default use hard reset

### DIFF
--- a/docs/configuration/janitor-provider.md
+++ b/docs/configuration/janitor-provider.md
@@ -160,6 +160,8 @@ Client ID of the Managed Identity used for Workload Identity authentication. The
 
 Uses OCI Workload Identity or a credentials file for authentication.
 
+OCI maps all `RebootNode` resources to the `RESET` action. `RESET` powers off the instance immediately without waiting for the operating system. Drain workloads before you create the resource because an immediate power-off can cause data corruption.
+
 ```yaml
 janitor-provider:
   csp:

--- a/janitor-provider/pkg/csp/oci/oci.go
+++ b/janitor-provider/pkg/csp/oci/oci.go
@@ -131,7 +131,7 @@ func (c *Client) SendRebootSignal(
 ) (model.ResetSignalRequestRef, error) {
 	_, err := c.compute.InstanceAction(ctx, core.InstanceActionRequest{
 		InstanceId:    &node.Spec.ProviderID,
-		Action:        core.InstanceActionActionSoftreset,
+		Action:        core.InstanceActionActionReset,
 		OpcRetryToken: rebootRetryToken(node.Spec.ProviderID, crName),
 	})
 	if err != nil {
@@ -172,7 +172,7 @@ func rebootRetryToken(providerID, crName string) *string {
 }
 
 func translateRebootError(providerID string, err error) error {
-	contextualErr := fmt.Errorf("send soft reset action for OCI instance %q: %w", providerID, err)
+	contextualErr := fmt.Errorf("send reset action for OCI instance %q: %w", providerID, err)
 	if isRetryableRebootError(err) {
 		return status.Error(codes.Unavailable, contextualErr.Error())
 	}

--- a/janitor-provider/pkg/csp/oci/oci_test.go
+++ b/janitor-provider/pkg/csp/oci/oci_test.go
@@ -82,6 +82,7 @@ func TestSendRebootSignal_ComputeSucceeds_UsesStableTokenWithoutSDKRetry(t *test
 	_, err = client.SendRebootSignal(context.Background(), testNode(), "rebootnode-test")
 	require.NoError(t, err)
 	assert.Equal(t, 2, compute.calls)
+	assert.Equal(t, core.InstanceActionActionReset, compute.actionRequest.Action)
 	assert.Equal(t, token, *compute.actionRequest.OpcRetryToken)
 	assert.Nil(t, compute.actionRequest.RequestMetadata.RetryPolicy)
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/NVIDIA/NVSentinel/issues/1818

This PR updates the reboot node handling from softreset to hard one.

There're a few reasons:
- In production, I met several cases where softreset doesn't solve, but hard reset does.
- I confirmed with OCI team, and they suggest to use hard reset by default (conversation attached in the issue)
- The only concerns for hard reset is abrupt shutdown, but NV sentinel has guaranteed the node has been cordon-ed and drained beforehand

## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactoring
- [ ] 🔨 Build/CI

## Component(s) Affected
- [ ] Core Services
- [ ] Health Monitors
- [ ] Fault Management
- [ ] Deployment/Config
- [ ] API/Interface
- [ ] Preflight
- [ ] Plugins
- [X] Janitor
- [ ] Documentation/CI
- [ ] Other: ____________

## Testing
- [X] Tests pass locally
- [X] Manual testing completed
- [X] No breaking changes (or documented)

## Checklist
- [X] Self-review completed
- [X] Documentation updated (if needed)
- [X] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Reboot actions for OCI instances now use an immediate reset, powering off instances without waiting for the operating system.
  * Workloads should be drained before initiating a reboot to help prevent disruption.

* **Documentation**
  * Updated OCI provider documentation to describe the reset behavior and recommended workload-draining step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->